### PR TITLE
Channels: inbound dispatch phases 3–7 + tool-posture hardening + cross-audit

### DIFF
--- a/crates/wcore-agent/Cargo.toml
+++ b/crates/wcore-agent/Cargo.toml
@@ -132,6 +132,12 @@ base64.workspace = true
 # state + PKCE verifier generation are runtime paths, not test paths.
 hyper.workspace        = true
 hyper-util.workspace   = true
+# Inbound webhook host (`inbound_webhook.rs`) — axum 0.7 Router over a
+# tokio TcpListener routes `POST/GET /webhooks/:channel` to the matching
+# channel's `Channel::ingest_webhook`. Already in the workspace lockfile via
+# wcore-cli / wcore-acp (both declare axum 0.7 directly), so this adds no
+# new transitive deps.
+axum = "0.7"
 open.workspace         = true
 urlencoding.workspace  = true
 subtle.workspace       = true

--- a/crates/wcore-agent/src/bootstrap.rs
+++ b/crates/wcore-agent/src/bootstrap.rs
@@ -141,6 +141,12 @@ pub struct AgentBootstrap {
     /// turns. Off by default so per-session / sub-agent / ACP builds never
     /// spawn it.
     enable_inbound_dispatch: bool,
+    /// Channel tool posture for THIS engine. `Some` only for per-session
+    /// engines built by `ChannelTurnDispatcher` — it reduces/jails the
+    /// toolset so a remote channel sender cannot reach host filesystem /
+    /// shell tools. `None` (the default, and always the case for the local
+    /// CLI / TUI / json-stream engines) leaves the full toolset intact.
+    channel_tool_posture: Option<crate::channel_tools::ChannelToolScope>,
 }
 
 impl AgentBootstrap {
@@ -156,7 +162,21 @@ impl AgentBootstrap {
             span_sink: None,
             without_channels: false,
             enable_inbound_dispatch: false,
+            channel_tool_posture: None,
         }
+    }
+
+    /// Restrict (and, for `Workspace`, jail) the toolset of a
+    /// channel-originated engine. Set only by `ChannelTurnDispatcher` for
+    /// its per-session engines; the local CLI/TUI/json-stream engines leave
+    /// this `None` and keep the full toolset. See
+    /// [`crate::channel_tools::apply_posture`].
+    pub fn channel_tool_posture(
+        mut self,
+        scope: crate::channel_tools::ChannelToolScope,
+    ) -> Self {
+        self.channel_tool_posture = Some(scope);
+        self
     }
 
     /// Phase 1B-2 — skip the entire channel block (registration, start_all,
@@ -1750,6 +1770,22 @@ impl AgentBootstrap {
             }
         };
 
+        // Channel tool posture — for a per-session channel engine, reduce
+        // (and, in `Workspace`, jail) the toolset BEFORE it moves into the
+        // engine, so a remote sender cannot reach host filesystem/shell
+        // tools. No-op for the local CLI/TUI/json-stream engines (posture
+        // `None`) and for `Full`. Runs after all built-in registration; MCP
+        // tools survive every posture, so post-construction MCP wiring is
+        // unaffected.
+        if let Some(scope) = self.channel_tool_posture.as_ref() {
+            crate::channel_tools::apply_posture(&mut registry, scope);
+            tracing::info!(
+                target: "wcore_agent::bootstrap",
+                posture = ?scope.posture,
+                "channel engine tool posture applied"
+            );
+        }
+
         let mut engine = if let Some(session) = self.resume_session {
             AgentEngine::resume_with_provider(
                 provider.clone(),
@@ -2118,23 +2154,57 @@ impl AgentBootstrap {
             // early inbound event is dropped by the broadcast. Only when the
             // caller opted in via `enable_inbound_dispatch`.
             inbound_subscriber = if self.enable_inbound_dispatch {
-                // Per-channel inbound policies, keyed by channel name. A channel
-                // absent from this map uses the fail-closed default.
-                let policies: std::collections::HashMap<
-                    String,
-                    wcore_channels::InboundPolicy,
-                > = wcore_channels::config::ChannelConfigLoader::new(
+                // Load each channel's config ONCE, then derive two maps from
+                // it: the per-channel access policy (for the subscriber) and
+                // the per-channel tool posture (for the dispatcher's
+                // per-session engines). A channel absent from these maps uses
+                // the fail-closed access default and the safe Conversational
+                // tool posture respectively.
+                let channel_configs = wcore_channels::config::ChannelConfigLoader::new(
                     wcore_channels::config::ChannelConfigLoader::default_root(),
                 )
                 .load_all()
-                .map(|v| v.into_iter().map(|c| (c.name, c.inbound)).collect())
                 .unwrap_or_default();
+
+                // Resolve each channel's tool posture into a concrete scope.
+                // `Workspace` jails to the channel's `tool_workspace_root`
+                // when set, else this engine's working directory.
+                let postures: std::collections::HashMap<
+                    String,
+                    crate::channel_tools::ChannelToolScope,
+                > = channel_configs
+                    .iter()
+                    .map(|c| {
+                        let root = c
+                            .inbound
+                            .tool_workspace_root
+                            .clone()
+                            .map(std::path::PathBuf::from)
+                            .unwrap_or_else(|| std::path::PathBuf::from(&self.workspace));
+                        (
+                            c.name.clone(),
+                            crate::channel_tools::ChannelToolScope {
+                                posture: c.inbound.tools,
+                                workspace_root: root,
+                            },
+                        )
+                    })
+                    .collect();
+
+                let policies: std::collections::HashMap<
+                    String,
+                    wcore_channels::InboundPolicy,
+                > = channel_configs
+                    .into_iter()
+                    .map(|c| (c.name, c.inbound))
+                    .collect();
 
                 let dispatcher: Arc<dyn crate::channel_inbound::TurnDispatcher> =
                     Arc::new(crate::channel_dispatch::ChannelTurnDispatcher::new(
                         config_for_dispatch,
                         self.workspace.clone(),
                         provider.clone(),
+                        postures,
                     ));
                 let subscriber = crate::channel_inbound::InboundSubscriber::new(
                     std::sync::Arc::clone(&lifted),

--- a/crates/wcore-agent/src/bootstrap.rs
+++ b/crates/wcore-agent/src/bootstrap.rs
@@ -84,6 +84,14 @@ pub struct BootstrapResult {
     /// the handle does NOT stop the task; aborting it does. `None` for every
     /// per-session / sub-agent / ACP build.
     pub inbound_subscriber: Option<tokio::task::JoinHandle<()>>,
+    /// Inbound webhook host task + its shutdown sender. `Some` only when
+    /// `[inbound_webhook] enabled = true` AND channels were not skipped.
+    /// **Hold the sender for the session lifetime** — dropping it closes the
+    /// watch channel and gracefully stops the host.
+    pub inbound_webhook: Option<(
+        tokio::task::JoinHandle<()>,
+        tokio::sync::watch::Sender<bool>,
+    )>,
 }
 
 /// Wave OL: plugin-provider router. Called after plugin discovery + init
@@ -1755,6 +1763,10 @@ impl AgentBootstrap {
         // `enable_inbound_dispatch` is set; the clone is cheap relative to
         // bootstrap and `self.config` is unavailable after the move.
         let config_for_dispatch = self.config.clone();
+        // Inbound webhook host config — captured before `self.config` moves
+        // into the engine. The host (Slack/WhatsApp/Twilio inbound POSTs) is
+        // spawned in the channel block below when enabled.
+        let inbound_webhook_cfg = self.config.inbound_webhook.clone();
 
         let channel_credentials: Option<
             std::sync::Arc<dyn wcore_config::credentials::CredentialsStore>,
@@ -2100,6 +2112,14 @@ impl AgentBootstrap {
         let channel_manager: std::sync::Arc<tokio::sync::Mutex<wcore_channels::ChannelManager>>;
         let channels_auto_registered: usize;
         let inbound_subscriber: Option<tokio::task::JoinHandle<()>>;
+        // Inbound webhook host handle + shutdown sender. The sender MUST be
+        // held for the session lifetime: dropping it closes the watch channel
+        // and triggers the host's graceful shutdown. Carried in
+        // `BootstrapResult` so the caller keeps it alive.
+        let inbound_webhook: Option<(
+            tokio::task::JoinHandle<()>,
+            tokio::sync::watch::Sender<bool>,
+        )>;
 
         if !self.without_channels {
             // Register adapters on the inner manager.
@@ -2243,6 +2263,21 @@ impl AgentBootstrap {
                 );
             }
 
+            // Inbound webhook host — when enabled, bind an HTTP listener that
+            // routes platform webhook POSTs (Slack / WhatsApp / Twilio SMS) to
+            // each channel's signature-verifying `ingest_webhook`. Off by
+            // default; only the signature-verified connectors override the
+            // trait method, so msteams' unauthenticated parse stays unexposed.
+            inbound_webhook =
+                crate::inbound_webhook::spawn(std::sync::Arc::clone(&lifted), &inbound_webhook_cfg);
+            if inbound_webhook.is_some() {
+                tracing::info!(
+                    target: "wcore_agent::bootstrap",
+                    bind = %inbound_webhook_cfg.bind,
+                    "inbound webhook host listening"
+                );
+            }
+
             // FleetDispatcher-class fix (audit 2026-05-24): SendMessageTool was
             // registered above with the boot-default `NullMessageTransport` so
             // its schema reaches the LLM from the start of the session. Now that
@@ -2277,11 +2312,13 @@ impl AgentBootstrap {
             // inbound subscriber is spawned (recursion guard).
             let _ = channel_credentials;
             let _ = config_for_dispatch;
+            let _ = inbound_webhook_cfg;
             channel_manager = std::sync::Arc::new(tokio::sync::Mutex::new(
                 wcore_channels::ChannelManager::new(),
             ));
             channels_auto_registered = 0;
             inbound_subscriber = None;
+            inbound_webhook = None;
         }
 
         // v0.8.1 U7 — spawn the cron runner. Errors resolving the
@@ -2429,6 +2466,7 @@ impl AgentBootstrap {
             channels_auto_registered,
             cron_runner,
             inbound_subscriber,
+            inbound_webhook,
         })
     }
 }

--- a/crates/wcore-agent/src/bootstrap.rs
+++ b/crates/wcore-agent/src/bootstrap.rs
@@ -77,6 +77,13 @@ pub struct BootstrapResult {
     /// background tokio task. `Option` so the boot path can leave it
     /// `None` when the store path can't be resolved.
     pub cron_runner: Option<wcore_cron::CronRunner>,
+    /// Phase 1B-2 — handle to the spawned `InboundSubscriber` task that
+    /// turns inbound channel messages into agent turns. `Some` only when the
+    /// caller opted in via `AgentBootstrap::enable_inbound_dispatch(true)`
+    /// AND channels were not skipped (`without_channels(false)`). Dropping
+    /// the handle does NOT stop the task; aborting it does. `None` for every
+    /// per-session / sub-agent / ACP build.
+    pub inbound_subscriber: Option<tokio::task::JoinHandle<()>>,
 }
 
 /// Wave OL: plugin-provider router. Called after plugin discovery + init
@@ -124,6 +131,16 @@ pub struct AgentBootstrap {
     ///
     /// Default `None` keeps pre-M5 behaviour: both bridges stay dormant.
     span_sink: Option<Arc<dyn SpanSink>>,
+    /// Phase 1B-2 — skip the entire channel block (registration, start_all,
+    /// transport upgrade, inbound subscriber). Set by per-session engines
+    /// built by `ChannelTurnDispatcher` so they don't re-register channels
+    /// or recurse. Default `false`.
+    without_channels: bool,
+    /// Phase 1B-2 — primary session entry points opt in to spawn the
+    /// `InboundSubscriber` that turns inbound channel messages into agent
+    /// turns. Off by default so per-session / sub-agent / ACP builds never
+    /// spawn it.
+    enable_inbound_dispatch: bool,
 }
 
 impl AgentBootstrap {
@@ -137,7 +154,27 @@ impl AgentBootstrap {
             extra_skill_dirs: Vec::new(),
             plugin_provider_router: None,
             span_sink: None,
+            without_channels: false,
+            enable_inbound_dispatch: false,
         }
+    }
+
+    /// Phase 1B-2 — skip the entire channel block (registration, start_all,
+    /// transport upgrade, inbound subscriber). Set by per-session engines
+    /// built by `ChannelTurnDispatcher` so they don't re-register channels
+    /// or recurse.
+    pub fn without_channels(mut self, v: bool) -> Self {
+        self.without_channels = v;
+        self
+    }
+
+    /// Phase 1B-2 — primary session entry points opt in to spawn the
+    /// `InboundSubscriber` that turns inbound channel messages into agent
+    /// turns. Off by default so per-session / sub-agent / ACP builds never
+    /// spawn it.
+    pub fn enable_inbound_dispatch(mut self, v: bool) -> Self {
+        self.enable_inbound_dispatch = v;
+        self
     }
 
     /// M5.bootstrap-wiring — install an `Arc<dyn SpanSink>` that bootstrap
@@ -1692,6 +1729,13 @@ impl AgentBootstrap {
         // below can hand the same store to every adapter's factory.
         // Failure here means we skip channel auto-registration; the
         // engine itself starts fine.
+        // Phase 1B-2 — clone the resolved config BEFORE it is moved into the
+        // engine below. The inbound dispatcher needs an owned `Config` to
+        // build its per-session engines. Only used when
+        // `enable_inbound_dispatch` is set; the clone is cheap relative to
+        // bootstrap and `self.config` is unavailable after the move.
+        let config_for_dispatch = self.config.clone();
+
         let channel_credentials: Option<
             std::sync::Arc<dyn wcore_config::credentials::CredentialsStore>,
         > = match self.config.open_credentials_store() {
@@ -2002,93 +2046,172 @@ impl AgentBootstrap {
             });
 
         // F-014 (CRIT, Aud-4/Aud-11): construct ChannelManager, auto-register
-        // adapters, call start_all to spawn per-channel inbound poll tasks, and
-        // lift the manager to Arc<Mutex<ChannelManager>> so the cron handler
-        // (and any future inbound-event subscriber in the CLI) can hold a clone.
+        // adapters, lift the manager to Arc<Mutex<ChannelManager>>, (optionally)
+        // subscribe the inbound dispatcher, then call start_all to spawn
+        // per-channel inbound poll tasks.
         //
-        // Previously bootstrap stopped at `auto_register_from_user_config` and
-        // never called `start_all`, so inbound messages were never polled on
-        // any configured channel.
+        // Phase 1B-2 — the WHOLE block is skipped when `without_channels` is
+        // set (per-session engines built by `ChannelTurnDispatcher`): they must
+        // not re-register channels, spawn pollers, upgrade the transport, or
+        // spawn another inbound subscriber (recursion guard). In that case the
+        // result still needs a `channel_manager` value, so we construct an
+        // empty one the per-session engine never touches.
         //
-        // start_all is idempotent (already-started channels skip re-start).
-        // Errors from individual channel start() calls are surfaced as
-        // ChannelError and bubble up; non-fatal channels that fail independently
-        // already return Ok from their start() impl — this is the same contract
-        // as the channels crate manager tests.
-        let mut channel_manager_inner = wcore_channels::ChannelManager::new();
-        let channels_auto_registered = if let Some(creds) = channel_credentials {
-            match wcore_channels_registry::auto_register_from_user_config(
-                &mut channel_manager_inner,
-                creds,
-            )
-            .await
-            {
-                Ok(count) => {
-                    tracing::info!(
-                        target: "wcore_agent::bootstrap",
-                        count,
-                        "F-014: channels auto-registered from ~/.wayland/channels"
-                    );
-                    count
-                }
-                Err(e) => {
-                    tracing::warn!(
-                        target: "wcore_agent::bootstrap",
-                        error = %e,
-                        "F-014: channel auto-register failed; continuing with empty ChannelManager"
-                    );
-                    0
-                }
-            }
-        } else {
-            0
-        };
-        // Call start_all to arm inbound poll tasks. Best-effort: if start_all
-        // returns an error we warn and continue (session still works, channels
-        // just won't deliver inbound messages).
-        if let Err(e) = channel_manager_inner.start_all().await {
-            tracing::warn!(
-                target: "wcore_agent::bootstrap",
-                error = %e,
-                "F-014: channel_manager.start_all() failed; inbound polling may be partial"
-            );
-        } else {
-            tracing::info!(
-                target: "wcore_agent::bootstrap",
-                "F-014: channel_manager.start_all() complete — inbound polling active"
-            );
-        }
-        // Lift to Arc<tokio::sync::Mutex<>> so the cron handler and future
-        // CLI inbound subscribers can hold a clone across async boundaries.
-        // tokio Mutex is required because ChannelManager::send_to is async
-        // and the guard must survive an await point in the cron channel arm.
-        let channel_manager: std::sync::Arc<tokio::sync::Mutex<wcore_channels::ChannelManager>> =
-            std::sync::Arc::new(tokio::sync::Mutex::new(channel_manager_inner));
+        // Ordering (when channels are enabled): register → lift → subscribe →
+        // start_all. Subscribing BEFORE start_all closes the broadcast-ordering
+        // gap: tokio broadcast drops events emitted before a receiver exists,
+        // so the subscriber must acquire its receiver before polling begins.
+        let channel_manager: std::sync::Arc<tokio::sync::Mutex<wcore_channels::ChannelManager>>;
+        let channels_auto_registered: usize;
+        let inbound_subscriber: Option<tokio::task::JoinHandle<()>>;
 
-        // FleetDispatcher-class fix (audit 2026-05-24): SendMessageTool was
-        // registered above with the boot-default `NullMessageTransport` so
-        // its schema reaches the LLM from the start of the session. Now that
-        // `channel_manager` is lifted to `Arc<Mutex<>>`, replace the tool's
-        // transport with the real `ChannelManagerTransport` adapter so the
-        // LLM's `send_message` calls route through user-configured channels
-        // (Telegram/Discord/Slack/Email/etc.) instead of returning the Null
-        // transport's loud "no transport configured" error on every call.
-        if let Some(reg) = engine.registry_mut() {
-            let transport =
-                std::sync::Arc::new(crate::channel_send_transport::ChannelManagerTransport::new(
-                    std::sync::Arc::clone(&channel_manager),
-                ));
-            reg.replace_by_name(Box::new(wcore_tools::send_message::SendMessageTool::new(
-                transport,
-            )));
+        if !self.without_channels {
+            // Register adapters on the inner manager.
+            //
+            // Previously bootstrap stopped at `auto_register_from_user_config`
+            // and never called `start_all`, so inbound messages were never
+            // polled on any configured channel.
+            //
+            // start_all is idempotent (already-started channels skip re-start).
+            // Errors from individual channel start() calls are surfaced as
+            // ChannelError and bubble up; non-fatal channels that fail
+            // independently already return Ok from their start() impl — same
+            // contract as the channels crate manager tests.
+            let mut channel_manager_inner = wcore_channels::ChannelManager::new();
+            channels_auto_registered = if let Some(creds) = channel_credentials {
+                match wcore_channels_registry::auto_register_from_user_config(
+                    &mut channel_manager_inner,
+                    creds,
+                )
+                .await
+                {
+                    Ok(count) => {
+                        tracing::info!(
+                            target: "wcore_agent::bootstrap",
+                            count,
+                            "F-014: channels auto-registered from ~/.wayland/channels"
+                        );
+                        count
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            target: "wcore_agent::bootstrap",
+                            error = %e,
+                            "F-014: channel auto-register failed; continuing with empty ChannelManager"
+                        );
+                        0
+                    }
+                }
+            } else {
+                0
+            };
+
+            // Lift to Arc<tokio::sync::Mutex<>> so the cron handler, the
+            // inbound subscriber, and the send-message transport can each hold
+            // a clone across async boundaries. tokio Mutex is required because
+            // ChannelManager::send_to is async and the guard must survive an
+            // await point.
+            let lifted: std::sync::Arc<tokio::sync::Mutex<wcore_channels::ChannelManager>> =
+                std::sync::Arc::new(tokio::sync::Mutex::new(channel_manager_inner));
+
+            // Phase 1B-2 — spawn the inbound subscriber BEFORE start_all so no
+            // early inbound event is dropped by the broadcast. Only when the
+            // caller opted in via `enable_inbound_dispatch`.
+            inbound_subscriber = if self.enable_inbound_dispatch {
+                // Per-channel inbound policies, keyed by channel name. A channel
+                // absent from this map uses the fail-closed default.
+                let policies: std::collections::HashMap<
+                    String,
+                    wcore_channels::InboundPolicy,
+                > = wcore_channels::config::ChannelConfigLoader::new(
+                    wcore_channels::config::ChannelConfigLoader::default_root(),
+                )
+                .load_all()
+                .map(|v| v.into_iter().map(|c| (c.name, c.inbound)).collect())
+                .unwrap_or_default();
+
+                let dispatcher: Arc<dyn crate::channel_inbound::TurnDispatcher> =
+                    Arc::new(crate::channel_dispatch::ChannelTurnDispatcher::new(
+                        config_for_dispatch,
+                        self.workspace.clone(),
+                        provider.clone(),
+                    ));
+                let subscriber = crate::channel_inbound::InboundSubscriber::new(
+                    std::sync::Arc::clone(&lifted),
+                    dispatcher,
+                    policies,
+                    60_000,
+                    1024,
+                );
+                let handle = subscriber.spawn().await;
+                tracing::info!(
+                    target: "wcore_agent::bootstrap",
+                    "Phase 1B-2: inbound channel subscriber spawned"
+                );
+                Some(handle)
+            } else {
+                // Channels are enabled but inbound dispatch was not opted in:
+                // the dispatcher config clone goes unused on this path.
+                let _ = config_for_dispatch;
+                None
+            };
+
+            // Call start_all to arm inbound poll tasks (now that the subscriber
+            // is listening). Best-effort: if start_all returns an error we warn
+            // and continue (session still works, channels just won't deliver
+            // inbound messages).
+            if let Err(e) = lifted.lock().await.start_all().await {
+                tracing::warn!(
+                    target: "wcore_agent::bootstrap",
+                    error = %e,
+                    "F-014: channel_manager.start_all() failed; inbound polling may be partial"
+                );
+            } else {
+                tracing::info!(
+                    target: "wcore_agent::bootstrap",
+                    "F-014: channel_manager.start_all() complete — inbound polling active"
+                );
+            }
+
+            // FleetDispatcher-class fix (audit 2026-05-24): SendMessageTool was
+            // registered above with the boot-default `NullMessageTransport` so
+            // its schema reaches the LLM from the start of the session. Now that
+            // `channel_manager` is lifted to `Arc<Mutex<>>`, replace the tool's
+            // transport with the real `ChannelManagerTransport` adapter so the
+            // LLM's `send_message` calls route through user-configured channels
+            // (Telegram/Discord/Slack/Email/etc.) instead of returning the Null
+            // transport's loud "no transport configured" error on every call.
+            if let Some(reg) = engine.registry_mut() {
+                let transport = std::sync::Arc::new(
+                    crate::channel_send_transport::ChannelManagerTransport::new(
+                        std::sync::Arc::clone(&lifted),
+                    ),
+                );
+                reg.replace_by_name(Box::new(wcore_tools::send_message::SendMessageTool::new(
+                    transport,
+                )));
+            } else {
+                tracing::warn!(
+                    target: "wcore_agent::bootstrap",
+                    "send_message transport upgrade skipped: engine.registry_mut() \
+                     returned None (a stale Arc clone of the tools registry is held \
+                     somewhere). send_message will continue to use NullMessageTransport \
+                     and fail loudly on every call."
+                );
+            }
+
+            channel_manager = lifted;
         } else {
-            tracing::warn!(
-                target: "wcore_agent::bootstrap",
-                "send_message transport upgrade skipped: engine.registry_mut() \
-                 returned None (a stale Arc clone of the tools registry is held \
-                 somewhere). send_message will continue to use NullMessageTransport \
-                 and fail loudly on every call."
-            );
+            // Per-session engine path: no channel runtime. The result field is
+            // populated with an empty manager the engine never uses, and no
+            // inbound subscriber is spawned (recursion guard).
+            let _ = channel_credentials;
+            let _ = config_for_dispatch;
+            channel_manager = std::sync::Arc::new(tokio::sync::Mutex::new(
+                wcore_channels::ChannelManager::new(),
+            ));
+            channels_auto_registered = 0;
+            inbound_subscriber = None;
         }
 
         // v0.8.1 U7 — spawn the cron runner. Errors resolving the
@@ -2235,6 +2358,7 @@ impl AgentBootstrap {
             channel_manager,
             channels_auto_registered,
             cron_runner,
+            inbound_subscriber,
         })
     }
 }

--- a/crates/wcore-agent/src/channel_dispatch.rs
+++ b/crates/wcore-agent/src/channel_dispatch.rs
@@ -43,6 +43,7 @@
 //   later enhancement.
 
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -55,6 +56,7 @@ use crate::bootstrap::AgentBootstrap;
 use crate::channel_inbound::TurnDispatcher;
 use crate::engine::AgentEngine;
 use crate::output::OutputSink;
+use crate::session::SessionManager;
 
 /// Engine-backed dispatcher: one [`AgentEngine`] per channel session,
 /// pooled by the hashed session id, all sharing a single provider.
@@ -139,15 +141,34 @@ impl ChannelTurnDispatcher {
         let mut config = self.config.clone();
         config.tools.auto_approve = false;
 
-        let bootstrap = AgentBootstrap::new(config, self.cwd.clone(), output)
+        // Load-or-create the session for this id. `init_session` CREATES a
+        // session and hard-errors ("Session ID '…' already exists") if the id
+        // is already on disk — which happens whenever a prior process
+        // persisted this conversation (the in-memory pool only dedupes within
+        // one process). So probe the session store first: if the session
+        // exists, RESUME it (preserving history across restarts); otherwise
+        // create it fresh.
+        let session_mgr = SessionManager::new(
+            PathBuf::from(&self.config.session.directory),
+            self.config.session.max_sessions,
+        );
+        let existing = session_mgr.load(hashed_id).ok();
+        let is_new = existing.is_none();
+
+        let mut bootstrap = AgentBootstrap::new(config, self.cwd.clone(), output)
             .provider(self.provider.clone())
             // MANDATORY: stop the per-session engine from re-registering
             // channels / spawning pollers / spawning another subscriber.
             .without_channels(true);
+        if let Some(session) = existing {
+            bootstrap = bootstrap.resume(session);
+        }
         let result = bootstrap.build().await?;
         let mut engine = result.engine;
 
-        engine.init_session(&self.config.provider_label, &self.cwd, Some(hashed_id))?;
+        if is_new {
+            engine.init_session(&self.config.provider_label, &self.cwd, Some(hashed_id))?;
+        }
         engine.rebind_memory_session().await;
         engine.run_session_start_hooks().await;
         // No `set_approval_manager` / `set_protocol_writer`: see the posture

--- a/crates/wcore-agent/src/channel_dispatch.rs
+++ b/crates/wcore-agent/src/channel_dispatch.rs
@@ -49,11 +49,13 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use sha2::{Digest, Sha256};
 use tokio::sync::Mutex;
+use wcore_channels::ChannelToolPosture;
 use wcore_config::config::Config;
 use wcore_providers::LlmProvider;
 
 use crate::bootstrap::AgentBootstrap;
 use crate::channel_inbound::TurnDispatcher;
+use crate::channel_tools::ChannelToolScope;
 use crate::engine::AgentEngine;
 use crate::output::OutputSink;
 use crate::session::SessionManager;
@@ -64,6 +66,11 @@ pub struct ChannelTurnDispatcher {
     config: Config,
     cwd: String,
     provider: Arc<dyn LlmProvider>,
+    /// Per-channel tool posture, keyed by `channel_name`. A channel absent
+    /// from this map falls back to the safe `Conversational` posture rooted
+    /// at `cwd` — so an unconfigured channel can never accidentally get host
+    /// filesystem/shell access.
+    postures: HashMap<String, ChannelToolScope>,
     /// Pool keyed by the HASHED session id (not the raw kernel session key,
     /// which contains colons the `SessionManager` rejects). Each value is an
     /// `Arc<Mutex<AgentEngine>>` so concurrent turns for the SAME session
@@ -73,15 +80,34 @@ pub struct ChannelTurnDispatcher {
 
 impl ChannelTurnDispatcher {
     /// Build a dispatcher over a resolved [`Config`], the working directory
-    /// new sessions run in, and the shared provider. Tool auto-approval is
-    /// always forced OFF for the per-session engines (see [`Self::engine_for`]).
-    pub fn new(config: Config, cwd: String, provider: Arc<dyn LlmProvider>) -> Self {
+    /// new sessions run in, the shared provider, and the per-channel tool
+    /// postures. Tool auto-approval is always forced OFF for the per-session
+    /// engines (see [`Self::engine_for`]); the posture additionally
+    /// reduces/jails the toolset itself.
+    pub fn new(
+        config: Config,
+        cwd: String,
+        provider: Arc<dyn LlmProvider>,
+        postures: HashMap<String, ChannelToolScope>,
+    ) -> Self {
         Self {
             config,
             cwd,
             provider,
+            postures,
             engines: Arc::new(Mutex::new(HashMap::new())),
         }
+    }
+
+    /// Resolve the tool scope for `channel_name`, defaulting to the safe
+    /// `Conversational` posture rooted at `cwd` for an unconfigured channel.
+    fn scope_for(&self, channel_name: &str) -> ChannelToolScope {
+        self.postures.get(channel_name).cloned().unwrap_or_else(|| {
+            ChannelToolScope {
+                posture: ChannelToolPosture::Conversational,
+                workspace_root: std::path::PathBuf::from(&self.cwd),
+            }
+        })
     }
 
     /// Map a kernel session key (e.g. `agent:main:slack:dm:c1`) to a session
@@ -110,7 +136,11 @@ impl ChannelTurnDispatcher {
 
     /// Fetch (or build + cache) the engine for `hashed_id`. One engine per
     /// session preserves conversation history across turns.
-    async fn engine_for(&self, hashed_id: &str) -> anyhow::Result<Arc<Mutex<AgentEngine>>> {
+    async fn engine_for(
+        &self,
+        hashed_id: &str,
+        scope: &ChannelToolScope,
+    ) -> anyhow::Result<Arc<Mutex<AgentEngine>>> {
         {
             let pool = self.engines.lock().await;
             if let Some(existing) = pool.get(hashed_id) {
@@ -159,7 +189,10 @@ impl ChannelTurnDispatcher {
             .provider(self.provider.clone())
             // MANDATORY: stop the per-session engine from re-registering
             // channels / spawning pollers / spawning another subscriber.
-            .without_channels(true);
+            .without_channels(true)
+            // SECURITY — reduce/jail the toolset for this REMOTE sender so
+            // a channel turn cannot reach host filesystem/shell tools.
+            .channel_tool_posture(scope.clone());
         if let Some(session) = existing {
             bootstrap = bootstrap.resume(session);
         }
@@ -196,11 +229,13 @@ impl TurnDispatcher for ChannelTurnDispatcher {
         msg: &wcore_channels::IncomingMessage,
     ) -> anyhow::Result<Option<String>> {
         let hashed = Self::hashed_session_id(session_key);
+        let scope = self.scope_for(channel_name);
         tracing::debug!(
             channel = %channel_name,
+            posture = ?scope.posture,
             "channel turn dispatch"
         );
-        let engine = self.engine_for(&hashed).await?;
+        let engine = self.engine_for(&hashed, &scope).await?;
         // The inbound message id doubles as the turn's msg_id (stable per
         // inbound event); the dedupe cache upstream already guarantees one
         // dispatch per id.

--- a/crates/wcore-agent/src/channel_dispatch.rs
+++ b/crates/wcore-agent/src/channel_dispatch.rs
@@ -1,0 +1,236 @@
+//! `ChannelTurnDispatcher` — the real engine-backed [`TurnDispatcher`].
+//!
+//! The inbound subscriber ([`crate::channel_inbound::InboundSubscriber`])
+//! decides admit/observe/drop and routes a session key; this dispatcher is
+//! the seam that turns an admitted inbound message into an actual agent
+//! turn and returns the reply text. It mirrors the production
+//! `EngineTurnEngine` pattern from `wcore-cli`'s ACP server: a per-session
+//! engine pool sharing one provider, building a fresh engine per session
+//! via [`AgentBootstrap`] and pooling the `Arc`.
+//!
+//! It differs from the ACP engine in three deliberate ways:
+//!
+//! 1. **Silent sink.** Channel turns use [`crate::output::null_sink::NullSink`]
+//!    so nothing streams to the CLI/host UI — the only output that matters is
+//!    the reply text, which the subscriber sends back through the channel.
+//! 2. **No protocol/relay machinery.** There is no protocol writer and no
+//!    relay; the reply is the `run()` return value.
+//! 3. **Safer tool posture.** Channel senders are remote, so the per-session
+//!    engine is built with tool auto-approval FORCED OFF (see
+//!    [`ChannelTurnDispatcher::engine_for`]).
+//!
+//! ## No channel recursion
+//!
+//! Every per-session engine is built with `.without_channels(true)`, so it
+//! does NOT re-register channels, call `start_all`, upgrade the
+//! send-message transport, or spawn another inbound subscriber. Without
+//! this, each conversation would spin up a fresh channel fleet (and another
+//! Telegram poller), recursing without bound.
+//
+// TODO(phase): (1) the engine pool is unbounded — add LRU / idle eviction so
+//   a flood of distinct conversations cannot grow memory without limit.
+// TODO(phase): (2) each new session re-runs the full `AgentBootstrap`
+//   (re-initialising MCP, plugins, skills per conversation) — heavyweight;
+//   share the expensive sub-systems across sessions later.
+// TODO(phase): (3) history is in-memory only (lost on process restart unless
+//   disk-resume is wired). With `DefaultHasher` the hashed id is also NOT
+//   stable across runs, so cross-restart disk resume would not match even if
+//   wired — see `hashed_session_id`.
+// TODO(phase): (4) per-session engines carry the boot-default
+//   `NullMessageTransport` (no outbound send_message transport of their own);
+//   replies go back via the subscriber's `send_to`, which is sufficient for
+//   v1. Wiring the outer channel transport into the per-session engine is a
+//   later enhancement.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use sha2::{Digest, Sha256};
+use tokio::sync::Mutex;
+use wcore_config::config::Config;
+use wcore_providers::LlmProvider;
+
+use crate::bootstrap::AgentBootstrap;
+use crate::channel_inbound::TurnDispatcher;
+use crate::engine::AgentEngine;
+use crate::output::OutputSink;
+
+/// Engine-backed dispatcher: one [`AgentEngine`] per channel session,
+/// pooled by the hashed session id, all sharing a single provider.
+pub struct ChannelTurnDispatcher {
+    config: Config,
+    cwd: String,
+    provider: Arc<dyn LlmProvider>,
+    /// Pool keyed by the HASHED session id (not the raw kernel session key,
+    /// which contains colons the `SessionManager` rejects). Each value is an
+    /// `Arc<Mutex<AgentEngine>>` so concurrent turns for the SAME session
+    /// serialise on the inner mutex while different sessions run freely.
+    engines: Arc<Mutex<HashMap<String, Arc<Mutex<AgentEngine>>>>>,
+}
+
+impl ChannelTurnDispatcher {
+    /// Build a dispatcher over a resolved [`Config`], the working directory
+    /// new sessions run in, and the shared provider. Tool auto-approval is
+    /// always forced OFF for the per-session engines (see [`Self::engine_for`]).
+    pub fn new(config: Config, cwd: String, provider: Arc<dyn LlmProvider>) -> Self {
+        Self {
+            config,
+            cwd,
+            provider,
+            engines: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    /// Map a kernel session key (e.g. `agent:main:slack:dm:c1`) to a session
+    /// id the [`crate::session::SessionManager`] accepts.
+    ///
+    /// The manager validates ids against `[a-f0-9-]{6,40}` and rejects the
+    /// colons the kernel key carries, so we hash the key to a stable
+    /// lowercase-hex string. SHA-256 (already a crate dependency) gives a
+    /// deterministic 32-byte digest; we hex-encode the first 20 bytes (40
+    /// chars) to stay within the manager's length bound. Same input → same id
+    /// (stable within and across runs), so a future disk-resume path keyed on
+    /// this id would match.
+    fn hashed_session_id(session_key: &str) -> String {
+        use std::fmt::Write;
+        let digest = Sha256::digest(session_key.as_bytes());
+        // First 20 bytes → 40 lowercase-hex chars: the upper bound of the
+        // manager's 6..=40 pattern, carrying the full first 160 bits of the
+        // SHA-256 digest. `GenericArray<u8, _>` has no `LowerHex`, so format
+        // each byte (mirrors `file_history::path_bucket`).
+        let mut out = String::with_capacity(40);
+        for b in &digest[..20] {
+            let _ = write!(&mut out, "{b:02x}");
+        }
+        out
+    }
+
+    /// Fetch (or build + cache) the engine for `hashed_id`. One engine per
+    /// session preserves conversation history across turns.
+    async fn engine_for(&self, hashed_id: &str) -> anyhow::Result<Arc<Mutex<AgentEngine>>> {
+        {
+            let pool = self.engines.lock().await;
+            if let Some(existing) = pool.get(hashed_id) {
+                return Ok(existing.clone());
+            }
+        }
+
+        // Silent sink: channel turns must not stream to the CLI/host UI. The
+        // reply text is the `run()` return value, sent back by the subscriber.
+        let output: Arc<dyn OutputSink> = Arc::new(crate::output::null_sink::NullSink);
+
+        // SECURITY — tool posture. Channel senders are REMOTE, so we never
+        // auto-approve mutating tools (Bash/Write/Spawn) for them. We DO NOT
+        // install a `ToolApprovalManager`: the engine's protocol-approval path
+        // `.expect()`s a protocol writer (engine.rs `approval_channel`
+        // builder), which channel turns deliberately lack — installing a
+        // manager without a writer would panic every turn. Instead we drive
+        // the engine through its default `ToolConfirmer` path with
+        // `tools.auto_approve` FORCED OFF in the per-session config clone
+        // below. With auto-approve off, read-only tools (Read/Grep/Glob, which
+        // are on the default allow_list) still run, while mutating tools fall
+        // through to confirmation. There is no interactive approver on a
+        // channel, so a mutating tool gate-then-denies (or, if stdin is a TTY,
+        // would block waiting for input it never gets) — both outcomes are the
+        // intended safe behaviour for v1: a channel user cannot silently run a
+        // shell or write files. Operators who set `--auto-approve` for their
+        // local CLI do NOT thereby grant it to channel senders.
+        let mut config = self.config.clone();
+        config.tools.auto_approve = false;
+
+        let bootstrap = AgentBootstrap::new(config, self.cwd.clone(), output)
+            .provider(self.provider.clone())
+            // MANDATORY: stop the per-session engine from re-registering
+            // channels / spawning pollers / spawning another subscriber.
+            .without_channels(true);
+        let result = bootstrap.build().await?;
+        let mut engine = result.engine;
+
+        engine.init_session(&self.config.provider_label, &self.cwd, Some(hashed_id))?;
+        engine.rebind_memory_session().await;
+        engine.run_session_start_hooks().await;
+        // No `set_approval_manager` / `set_protocol_writer`: see the posture
+        // note above. The engine keeps `approval_manager = None` and uses the
+        // non-auto-approve `ToolConfirmer`.
+
+        let session = Arc::new(Mutex::new(engine));
+
+        let mut pool = self.engines.lock().await;
+        // Another turn may have built the engine concurrently; keep the first
+        // to preserve a single conversation history.
+        let entry = pool
+            .entry(hashed_id.to_string())
+            .or_insert_with(|| session.clone());
+        Ok(entry.clone())
+    }
+}
+
+#[async_trait]
+impl TurnDispatcher for ChannelTurnDispatcher {
+    async fn dispatch(
+        &self,
+        session_key: &str,
+        channel_name: &str,
+        msg: &wcore_channels::IncomingMessage,
+    ) -> anyhow::Result<Option<String>> {
+        let hashed = Self::hashed_session_id(session_key);
+        tracing::debug!(
+            channel = %channel_name,
+            "channel turn dispatch"
+        );
+        let engine = self.engine_for(&hashed).await?;
+        // The inbound message id doubles as the turn's msg_id (stable per
+        // inbound event); the dedupe cache upstream already guarantees one
+        // dispatch per id.
+        let msg_id = msg.id.clone();
+        let result = {
+            let mut guard = engine.lock().await;
+            guard.run(&msg.text, &msg_id).await?
+        };
+        if result.text.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(result.text))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hashed_session_id_is_stable() {
+        let key = "agent:main:slack:dm:c1";
+        assert_eq!(
+            ChannelTurnDispatcher::hashed_session_id(key),
+            ChannelTurnDispatcher::hashed_session_id(key),
+            "same input must hash to the same id"
+        );
+    }
+
+    #[test]
+    fn hashed_session_id_matches_session_manager_pattern() {
+        // The SessionManager accepts only `[a-f0-9-]{6,40}`.
+        let id = ChannelTurnDispatcher::hashed_session_id("agent:main:telegram:group:42");
+        assert!(id.len() >= 6 && id.len() <= 40, "len {} out of bounds", id.len());
+        assert!(
+            id.chars().all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()),
+            "id must be lowercase hex: {id}"
+        );
+    }
+
+    #[test]
+    fn hashed_session_id_differs_for_distinct_keys() {
+        let a = ChannelTurnDispatcher::hashed_session_id("agent:main:slack:dm:c1");
+        let b = ChannelTurnDispatcher::hashed_session_id("agent:main:slack:dm:c2");
+        assert_ne!(a, b, "distinct session keys must hash to distinct ids");
+    }
+
+    #[test]
+    fn hashed_session_id_is_forty_hex_chars() {
+        let id = ChannelTurnDispatcher::hashed_session_id("anything");
+        assert_eq!(id.len(), 40, "first-40-hex-chars of the SHA-256 digest");
+    }
+}

--- a/crates/wcore-agent/src/channel_dispatch.rs
+++ b/crates/wcore-agent/src/channel_dispatch.rs
@@ -220,6 +220,36 @@ impl ChannelTurnDispatcher {
     }
 }
 
+/// Build the prompt text for a channel turn from an inbound message.
+///
+/// The agent's input is the raw message text plus — when the message
+/// carried media — a concise, clearly-delimited summary of each attachment
+/// so the model knows files arrived and can decide how to respond (the raw
+/// download is a separate, per-connector concern). The attachment lines are
+/// untrusted, agent-facing context, NOT system instructions; they describe
+/// the kind/type/url the connector populated. A text-only message returns
+/// its text unchanged (byte-identical to the pre-media behaviour).
+fn build_turn_prompt(msg: &wcore_channels::IncomingMessage) -> String {
+    if msg.attachments.is_empty() {
+        return msg.text.clone();
+    }
+    let mut out = msg.text.clone();
+    out.push_str("\n\n[attachments received with this message:");
+    for (i, att) in msg.attachments.iter().enumerate() {
+        let kind = format!("{:?}", att.kind);
+        let ty = att.content_type.as_deref().unwrap_or("unknown type");
+        // Prefer the transcription when present (e.g. a voice note already
+        // transcribed by the connector); else describe the media reference.
+        if let Some(t) = att.transcribed.as_deref() {
+            out.push_str(&format!("\n  {}. {kind} ({ty}) — transcript: {t}", i + 1));
+        } else {
+            out.push_str(&format!("\n  {}. {kind} ({ty}) — {}", i + 1, att.url));
+        }
+    }
+    out.push(']');
+    out
+}
+
 #[async_trait]
 impl TurnDispatcher for ChannelTurnDispatcher {
     async fn dispatch(
@@ -240,9 +270,10 @@ impl TurnDispatcher for ChannelTurnDispatcher {
         // inbound event); the dedupe cache upstream already guarantees one
         // dispatch per id.
         let msg_id = msg.id.clone();
+        let prompt = build_turn_prompt(msg);
         let result = {
             let mut guard = engine.lock().await;
-            guard.run(&msg.text, &msg_id).await?
+            guard.run(&prompt, &msg_id).await?
         };
         if result.text.is_empty() {
             Ok(None)
@@ -255,6 +286,35 @@ impl TurnDispatcher for ChannelTurnDispatcher {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn turn_prompt_is_text_only_without_attachments() {
+        let msg = wcore_channels::IncomingMessage::new("m1", "c1", "alice", "hello", 0);
+        assert_eq!(build_turn_prompt(&msg), "hello");
+    }
+
+    #[test]
+    fn turn_prompt_summarizes_attachments() {
+        let mut msg = wcore_channels::IncomingMessage::new("m1", "c1", "alice", "look", 0);
+        msg.attachments = vec![
+            wcore_channels::Attachment {
+                url: "https://x/a.png".into(),
+                content_type: Some("image/png".into()),
+                kind: wcore_channels::MediaKind::Image,
+                ..Default::default()
+            },
+            wcore_channels::Attachment {
+                kind: wcore_channels::MediaKind::Audio,
+                transcribed: Some("hi there".into()),
+                ..Default::default()
+            },
+        ];
+        let p = build_turn_prompt(&msg);
+        assert!(p.starts_with("look\n\n[attachments received"));
+        assert!(p.contains("Image (image/png) — https://x/a.png"));
+        assert!(p.contains("Audio (unknown type) — transcript: hi there"));
+        assert!(p.trim_end().ends_with(']'));
+    }
 
     #[test]
     fn hashed_session_id_is_stable() {

--- a/crates/wcore-agent/src/channel_inbound.rs
+++ b/crates/wcore-agent/src/channel_inbound.rs
@@ -1,0 +1,601 @@
+//! `InboundSubscriber` — the inbound consumer for channel traffic.
+//!
+//! Structurally, the channel stack already had three of four parts wired:
+//! the `Channel` adapters poll their platforms, the `ChannelManager` fans
+//! every `ChannelEvent` onto a broadcast, and the pure dispatch kernel
+//! (`wcore_channels::evaluate`) decides admit / observe / drop + routes a
+//! session key. The fourth part — the consumer that actually *subscribes*
+//! to that broadcast, runs the kernel, and drives an agent turn on admit —
+//! was missing. This module is that consumer.
+//!
+//! The subscriber owns no engine logic itself: it drives turns through the
+//! [`TurnDispatcher`] trait seam. The real engine-backed dispatcher is a
+//! separate later increment; here we build the seam, the subscriber loop,
+//! and tests against a mock dispatcher.
+//!
+//! ## Concurrency model
+//!
+//! Dispatch is `await`ed inline in the receive loop, so channel turns are
+//! naturally SERIALIZED — one turn runs to completion (and its reply is
+//! sent) before the next inbound event is processed. This is intentional:
+//! it matches the single-engine constraint of the future real dispatcher
+//! and keeps per-conversation ordering deterministic. The cost is that a
+//! slow turn back-pressures the broadcast (which is bounded), so a long
+//! turn can cause `Lagged` for very bursty channels — that is logged and
+//! tolerated, not fatal.
+//!
+//! ## Subscribe-before-start ordering
+//!
+//! tokio's broadcast drops events emitted before a receiver exists. The
+//! subscriber acquires its receiver in [`InboundSubscriber::spawn`], so
+//! callers should `spawn` the subscriber BEFORE (or around) the
+//! `ChannelManager::start_all` call — otherwise early inbound events
+//! emitted between `start_all` and `spawn` are lost.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use tokio::sync::{broadcast, Mutex};
+use wcore_channels::{
+    evaluate, ChannelEvent, ChannelManager, DedupeCache, InboundPolicy, IncomingMessage,
+    OutgoingMessage, TurnAdmission,
+};
+
+/// Seam between the inbound subscriber and the agent engine.
+///
+/// An implementation drives one agent turn for `session_key` from the
+/// inbound `msg` (arriving on `channel_name`) and returns the reply text
+/// to send back to the conversation, or `None` to send nothing. The real
+/// engine-backed implementation lands in a later increment; the subscriber
+/// only depends on this trait.
+#[async_trait]
+pub trait TurnDispatcher: Send + Sync {
+    /// Drive one agent turn for `session_key` from `msg` arriving on
+    /// `channel_name`. Return `Some(reply_text)` to send back to the
+    /// conversation, or `None` to send nothing. Errors are logged by the
+    /// subscriber and do not kill the loop.
+    async fn dispatch(
+        &self,
+        session_key: &str,
+        channel_name: &str,
+        msg: &IncomingMessage,
+    ) -> anyhow::Result<Option<String>>;
+}
+
+/// Subscribes to the channel broadcast, runs the dispatch kernel per
+/// event, and on admit drives an agent turn through a [`TurnDispatcher`],
+/// then sends the reply back through the originating channel.
+pub struct InboundSubscriber {
+    manager: Arc<Mutex<ChannelManager>>,
+    dispatcher: Arc<dyn TurnDispatcher>,
+    /// Per-channel access policy, keyed by `channel_name`. A channel ABSENT
+    /// from this map uses [`InboundPolicy::default`] — which is fail-closed,
+    /// so unknown channels deny everything rather than getting an open
+    /// policy.
+    policies: HashMap<String, InboundPolicy>,
+    /// Shared duplicate-suppression cache. Its key already namespaces by
+    /// platform / account / message-id, so one cache covers all channels.
+    dedupe: DedupeCache,
+    /// Runtime kill switch. When `false`, inbound events are drained (to
+    /// keep the broadcast from lagging) but processed no further.
+    enabled: Arc<AtomicBool>,
+}
+
+impl InboundSubscriber {
+    /// Construct a subscriber. `dedupe_ttl_ms` / `dedupe_max_size` size the
+    /// shared [`DedupeCache`] (see its docs for the `== 0` "disabled"
+    /// semantics).
+    pub fn new(
+        manager: Arc<Mutex<ChannelManager>>,
+        dispatcher: Arc<dyn TurnDispatcher>,
+        policies: HashMap<String, InboundPolicy>,
+        dedupe_ttl_ms: u64,
+        dedupe_max_size: usize,
+    ) -> Self {
+        Self {
+            manager,
+            dispatcher,
+            policies,
+            dedupe: DedupeCache::new(dedupe_ttl_ms, dedupe_max_size),
+            enabled: Arc::new(AtomicBool::new(true)),
+        }
+    }
+
+    /// Clone of the kill switch so the host can disable the subscriber at
+    /// runtime. Setting it to `false` stops dispatch (events keep draining
+    /// so the broadcast does not lag); setting it back to `true` resumes.
+    pub fn kill_switch(&self) -> Arc<AtomicBool> {
+        Arc::clone(&self.enabled)
+    }
+
+    /// Spawn the subscribe loop. Consumes `self` and returns the task
+    /// handle.
+    ///
+    /// The broadcast receiver is acquired ONCE here (the manager lock is
+    /// dropped immediately afterward — it is never held across the loop).
+    /// Because tokio broadcast drops events emitted before a receiver
+    /// exists, callers should `spawn` BEFORE/around `ChannelManager::
+    /// start_all` so early inbound events are not missed.
+    pub async fn spawn(self) -> tokio::task::JoinHandle<()> {
+        // Acquire the broadcast receiver once, then drop the manager lock.
+        let mut rx = {
+            let guard = self.manager.lock().await;
+            guard.subscribe()
+        };
+
+        // Monotonic clock base; per-event millis are derived from this.
+        let start = std::time::Instant::now();
+
+        let manager = self.manager;
+        let dispatcher = self.dispatcher;
+        let policies = self.policies;
+        let enabled = self.enabled;
+        // The loop owns the dedupe cache (mutated per non-short-circuited
+        // event).
+        let mut dedupe = self.dedupe;
+
+        tokio::spawn(async move {
+            loop {
+                match rx.recv().await {
+                    Ok(tagged) => {
+                        // Kill switch: keep draining so the broadcast does
+                        // not lag, but process nothing.
+                        if !enabled.load(Ordering::Relaxed) {
+                            continue;
+                        }
+
+                        // Only message events drive turns; lifecycle
+                        // variants are ignored.
+                        let msg = match tagged.event {
+                            ChannelEvent::MessageReceived { msg } => msg,
+                            _ => continue,
+                        };
+
+                        // Saturating cast of monotonic millis since base.
+                        let now_ms = start.elapsed().as_millis() as u64;
+
+                        // Absent channel -> fail-closed default policy.
+                        let policy = policies
+                            .get(&tagged.channel_name)
+                            .cloned()
+                            .unwrap_or_default();
+
+                        let outcome =
+                            evaluate(&tagged.channel_name, &msg, &policy, &mut dedupe, now_ms);
+
+                        match outcome.admission {
+                            TurnAdmission::Dispatch => {
+                                let session_key = match outcome.session_key {
+                                    Some(k) => k,
+                                    None => {
+                                        // Kernel contract: Dispatch always
+                                        // carries a session key. Defensive.
+                                        tracing::error!(
+                                            channel = %tagged.channel_name,
+                                            "dispatch admission without a session key; skipping"
+                                        );
+                                        continue;
+                                    }
+                                };
+
+                                match dispatcher
+                                    .dispatch(&session_key, &tagged.channel_name, &msg)
+                                    .await
+                                {
+                                    Ok(Some(reply)) => {
+                                        let outgoing = OutgoingMessage {
+                                            conversation_id: msg.conversation_id.clone(),
+                                            text: reply,
+                                            reply_to: msg.thread_id.clone(),
+                                            attachments: Vec::new(),
+                                        };
+                                        let guard = manager.lock().await;
+                                        if let Err(e) =
+                                            guard.send_to(&tagged.channel_name, outgoing).await
+                                        {
+                                            tracing::warn!(
+                                                channel = %tagged.channel_name,
+                                                error = %e,
+                                                "failed to send inbound reply"
+                                            );
+                                        }
+                                        drop(guard);
+                                    }
+                                    Ok(None) => {
+                                        // Turn produced no reply; nothing to
+                                        // send.
+                                    }
+                                    Err(e) => {
+                                        tracing::warn!(error = %e, "inbound turn dispatch failed");
+                                    }
+                                }
+                            }
+                            TurnAdmission::ObserveOnly => {
+                                tracing::debug!(
+                                    channel = %tagged.channel_name,
+                                    "observed, no turn"
+                                );
+                                // TODO(phase): record observe-only into session history
+                            }
+                            TurnAdmission::Drop { .. } => {
+                                // Never log message content or sender ids —
+                                // only the channel name + content-free
+                                // reason.
+                                if let Some(reason) = outcome.deny_reason {
+                                    tracing::info!(
+                                        channel = %tagged.channel_name,
+                                        reason = %reason,
+                                        "inbound denied"
+                                    );
+                                } else {
+                                    tracing::trace!(
+                                        channel = %tagged.channel_name,
+                                        "inbound dropped"
+                                    );
+                                }
+                            }
+                            TurnAdmission::Handled => {
+                                // Already handled upstream; take no action.
+                            }
+                        }
+                    }
+                    Err(broadcast::error::RecvError::Lagged(n)) => {
+                        tracing::warn!(skipped = n, "inbound subscriber lagged");
+                        continue;
+                    }
+                    Err(broadcast::error::RecvError::Closed) => {
+                        // Manager dropped its sender — no more events will
+                        // ever arrive. End the task.
+                        break;
+                    }
+                }
+            }
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::collections::VecDeque;
+    use std::sync::atomic::AtomicUsize;
+    use std::time::Duration;
+
+    use wcore_channels::{
+        Channel, ChannelError, ChatType, DmPolicy, MessageReceipt,
+    };
+
+    /// Shared outbound log handle — what a `CapturingChannel` records.
+    type OutboundLog = Arc<Mutex<Vec<OutgoingMessage>>>;
+
+    /// Test channel that emits a fixed queue of inbound messages (one per
+    /// `poll_events` call, in order) and records every outbound into a
+    /// shared log that the test clones out BEFORE registration. Unlike
+    /// `MockChannel.sent`, the log is reachable once the channel is boxed.
+    struct CapturingChannel {
+        name: String,
+        started: bool,
+        inbound: VecDeque<IncomingMessage>,
+        outbound: OutboundLog,
+        next_id: u64,
+    }
+
+    impl CapturingChannel {
+        fn new(name: &str, inbound: VecDeque<IncomingMessage>) -> (Self, OutboundLog) {
+            let outbound: OutboundLog = Arc::new(Mutex::new(Vec::new()));
+            let ch = Self {
+                name: name.to_string(),
+                started: false,
+                inbound,
+                outbound: Arc::clone(&outbound),
+                next_id: 0,
+            };
+            (ch, outbound)
+        }
+    }
+
+    #[async_trait]
+    impl Channel for CapturingChannel {
+        fn name(&self) -> &str {
+            &self.name
+        }
+
+        fn platform(&self) -> &str {
+            "mock"
+        }
+
+        async fn start(&mut self) -> Result<(), ChannelError> {
+            self.started = true;
+            Ok(())
+        }
+
+        async fn stop(&mut self) -> Result<(), ChannelError> {
+            self.started = false;
+            Ok(())
+        }
+
+        async fn poll_events(&mut self) -> Result<Vec<ChannelEvent>, ChannelError> {
+            if !self.started && self.inbound.is_empty() {
+                return Err(ChannelError::NotStarted);
+            }
+            // Emit one queued inbound per poll, then nothing.
+            match self.inbound.pop_front() {
+                Some(msg) => Ok(vec![ChannelEvent::MessageReceived { msg }]),
+                None => Ok(Vec::new()),
+            }
+        }
+
+        async fn send_message(
+            &mut self,
+            msg: OutgoingMessage,
+        ) -> Result<MessageReceipt, ChannelError> {
+            let id = format!("cap-out-{}", self.next_id);
+            self.next_id += 1;
+            let receipt = MessageReceipt {
+                id,
+                conversation_id: msg.conversation_id.clone(),
+                ts_secs: 0,
+            };
+            self.outbound.lock().await.push(msg);
+            Ok(receipt)
+        }
+
+        fn config_schema(&self) -> &str {
+            r#"{"name":"string","platform":"mock"}"#
+        }
+    }
+
+    /// `(session_key, channel_name)` recorded per dispatcher call.
+    type CallLog = Arc<Mutex<Vec<(String, String)>>>;
+    /// Dispatcher invocation counter.
+    type CallCount = Arc<AtomicUsize>;
+
+    /// Records `(session_key, channel_name)` per call + a counter, and
+    /// always returns `Ok(Some("pong"))`.
+    struct MockDispatcher {
+        calls: CallLog,
+        count: CallCount,
+    }
+
+    impl MockDispatcher {
+        fn new() -> (Self, CallLog, CallCount) {
+            let calls = Arc::new(Mutex::new(Vec::new()));
+            let count = Arc::new(AtomicUsize::new(0));
+            let d = Self {
+                calls: Arc::clone(&calls),
+                count: Arc::clone(&count),
+            };
+            (d, calls, count)
+        }
+    }
+
+    #[async_trait]
+    impl TurnDispatcher for MockDispatcher {
+        async fn dispatch(
+            &self,
+            session_key: &str,
+            channel_name: &str,
+            _msg: &IncomingMessage,
+        ) -> anyhow::Result<Option<String>> {
+            self.calls
+                .lock()
+                .await
+                .push((session_key.to_string(), channel_name.to_string()));
+            self.count.fetch_add(1, Ordering::SeqCst);
+            Ok(Some("pong".into()))
+        }
+    }
+
+    /// Build a Direct (DM) inbound with the given id.
+    fn dm(id: &str) -> IncomingMessage {
+        let mut m = IncomingMessage::new(id, "c1", "alice", "ping", 0);
+        m.sender_id = "u1".into();
+        m.chat_type = ChatType::Direct;
+        m
+    }
+
+    /// Register a `CapturingChannel` with the queued inbound, build a
+    /// subscriber over the given policy map, and spawn it. Returns the
+    /// shared manager, the outbound log, the dispatcher call log, and the
+    /// dispatch counter.
+    async fn harness(
+        channel_name: &str,
+        inbound: VecDeque<IncomingMessage>,
+        policies: HashMap<String, InboundPolicy>,
+        pre_spawn: impl FnOnce(&InboundSubscriber),
+    ) -> (
+        Arc<Mutex<ChannelManager>>,
+        OutboundLog,
+        Arc<Mutex<Vec<(String, String)>>>,
+        Arc<AtomicUsize>,
+        tokio::task::JoinHandle<()>,
+    ) {
+        let (ch, outbound) = CapturingChannel::new(channel_name, inbound);
+
+        // Fast poll so the queued inbound surfaces quickly under test.
+        let mgr = ChannelManager::new().with_poll_interval(Duration::from_millis(10));
+        let manager = Arc::new(Mutex::new(mgr));
+
+        let (dispatcher, calls, count) = MockDispatcher::new();
+        let subscriber = InboundSubscriber::new(
+            Arc::clone(&manager),
+            Arc::new(dispatcher),
+            policies,
+            60_000,
+            1024,
+        );
+        pre_spawn(&subscriber);
+
+        // Spawn the subscriber BEFORE start_all so no early event is lost.
+        let handle = subscriber.spawn().await;
+
+        {
+            let mut guard = manager.lock().await;
+            guard.register(Box::new(ch)).await;
+            guard.start_all().await.unwrap();
+        }
+
+        (manager, outbound, calls, count, handle)
+    }
+
+    /// Poll a shared `Vec` log until it reaches `want` len or the deadline
+    /// elapses. Returns the final length observed.
+    async fn wait_for_len<T>(log: &Arc<Mutex<Vec<T>>>, want: usize, within: Duration) -> usize {
+        let deadline = std::time::Instant::now() + within;
+        loop {
+            let len = log.lock().await.len();
+            if len >= want || std::time::Instant::now() >= deadline {
+                return len;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    }
+
+    fn open_dm_policy() -> InboundPolicy {
+        InboundPolicy {
+            dm: DmPolicy::Open,
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn allowed_dm_dispatches_and_replies() {
+        let mut policies = HashMap::new();
+        policies.insert("slack".to_string(), open_dm_policy());
+
+        let mut q = VecDeque::new();
+        q.push_back(dm("m1"));
+
+        let (manager, outbound, calls, count, handle) =
+            harness("slack", q, policies, |_| {}).await;
+
+        // Wait for the dispatcher to be called and the reply to be sent.
+        let dispatched = wait_for_len(&calls, 1, Duration::from_secs(2)).await;
+        let replied = wait_for_len(&outbound, 1, Duration::from_secs(2)).await;
+
+        assert_eq!(count.load(Ordering::SeqCst), 1, "dispatched exactly once");
+        assert_eq!(dispatched, 1);
+        assert_eq!(replied, 1, "exactly one reply sent");
+
+        let calls = calls.lock().await;
+        assert_eq!(
+            calls[0],
+            (
+                "agent:main:slack:dm:c1".to_string(),
+                "slack".to_string()
+            )
+        );
+
+        let out = outbound.lock().await;
+        assert_eq!(out[0].text, "pong");
+        assert_eq!(out[0].conversation_id, "c1");
+
+        manager.lock().await.stop_all().await.unwrap();
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn denied_dm_not_dispatched() {
+        // Empty policy map -> fail-closed default for the channel.
+        let policies = HashMap::new();
+
+        let mut q = VecDeque::new();
+        q.push_back(dm("m1"));
+
+        let (manager, outbound, calls, count, handle) =
+            harness("slack", q, policies, |_| {}).await;
+
+        // Give the loop ample time to process and (not) dispatch.
+        let dispatched = wait_for_len(&calls, 1, Duration::from_millis(500)).await;
+
+        assert_eq!(count.load(Ordering::SeqCst), 0, "fail-closed: no dispatch");
+        assert_eq!(dispatched, 0);
+        assert_eq!(outbound.lock().await.len(), 0, "no reply sent");
+
+        manager.lock().await.stop_all().await.unwrap();
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn duplicate_id_dispatched_once() {
+        let mut policies = HashMap::new();
+        policies.insert("slack".to_string(), open_dm_policy());
+
+        // Same message id twice — across two polls.
+        let mut q = VecDeque::new();
+        q.push_back(dm("m1"));
+        q.push_back(dm("m1"));
+
+        let (manager, _outbound, calls, count, handle) =
+            harness("slack", q, policies, |_| {}).await;
+
+        // Wait for the first dispatch, then give the duplicate time to be
+        // (correctly) suppressed.
+        let _ = wait_for_len(&calls, 1, Duration::from_secs(2)).await;
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        assert_eq!(
+            count.load(Ordering::SeqCst),
+            1,
+            "duplicate id deduped to a single dispatch"
+        );
+
+        manager.lock().await.stop_all().await.unwrap();
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn self_message_not_dispatched() {
+        let mut policies = HashMap::new();
+        policies.insert("slack".to_string(), open_dm_policy());
+
+        let mut self_msg = dm("m1");
+        self_msg.is_self = true;
+        let mut q = VecDeque::new();
+        q.push_back(self_msg);
+
+        let (manager, outbound, calls, count, handle) =
+            harness("slack", q, policies, |_| {}).await;
+
+        let dispatched = wait_for_len(&calls, 1, Duration::from_millis(500)).await;
+
+        assert_eq!(count.load(Ordering::SeqCst), 0, "loop-guard: no dispatch");
+        assert_eq!(dispatched, 0);
+        assert_eq!(outbound.lock().await.len(), 0);
+
+        manager.lock().await.stop_all().await.unwrap();
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn kill_switch_disables_dispatch() {
+        let mut policies = HashMap::new();
+        policies.insert("slack".to_string(), open_dm_policy());
+
+        let mut q = VecDeque::new();
+        q.push_back(dm("m1"));
+
+        // Flip the kill switch OFF before the event is injected/processed.
+        let (manager, outbound, calls, count, handle) =
+            harness("slack", q, policies, |sub| {
+                sub.kill_switch().store(false, Ordering::Relaxed);
+            })
+            .await;
+
+        let dispatched = wait_for_len(&calls, 1, Duration::from_millis(500)).await;
+
+        assert_eq!(
+            count.load(Ordering::SeqCst),
+            0,
+            "kill switch off: event drained, not dispatched"
+        );
+        assert_eq!(dispatched, 0);
+        assert_eq!(outbound.lock().await.len(), 0);
+
+        manager.lock().await.stop_all().await.unwrap();
+        handle.abort();
+    }
+}

--- a/crates/wcore-agent/src/channel_inbound.rs
+++ b/crates/wcore-agent/src/channel_inbound.rs
@@ -180,10 +180,60 @@ impl InboundSubscriber {
                                     }
                                 };
 
-                                match dispatcher
+                                // Ack state machine (best-effort, never
+                                // fatal): 👀 on receipt, a typing keepalive
+                                // while the turn runs, then ✅/❌ on
+                                // completion — gated by the channel's ack mode.
+                                let ack = policy.ack;
+                                if ack.reactions() {
+                                    let g = manager.lock().await;
+                                    if let Err(e) = g
+                                        .react_on(
+                                            &tagged.channel_name,
+                                            &msg.conversation_id,
+                                            &msg.id,
+                                            "👀",
+                                        )
+                                        .await
+                                    {
+                                        tracing::debug!(
+                                            channel = %tagged.channel_name,
+                                            error = %e,
+                                            "ack 'seen' reaction failed (non-fatal)"
+                                        );
+                                    }
+                                }
+                                let typing_handle = if ack.typing() {
+                                    Some(spawn_typing_keepalive(
+                                        std::sync::Arc::clone(&manager),
+                                        tagged.channel_name.clone(),
+                                        msg.conversation_id.clone(),
+                                    ))
+                                } else {
+                                    None
+                                };
+
+                                let dispatch_result = dispatcher
                                     .dispatch(&session_key, &tagged.channel_name, &msg)
-                                    .await
-                                {
+                                    .await;
+
+                                if let Some(h) = typing_handle {
+                                    h.abort();
+                                }
+                                if ack.reactions() {
+                                    let emoji = if dispatch_result.is_ok() { "✅" } else { "❌" };
+                                    let g = manager.lock().await;
+                                    let _ = g
+                                        .react_on(
+                                            &tagged.channel_name,
+                                            &msg.conversation_id,
+                                            &msg.id,
+                                            emoji,
+                                        )
+                                        .await;
+                                }
+
+                                match dispatch_result {
                                     Ok(Some(reply)) => {
                                         let outgoing = OutgoingMessage {
                                             conversation_id: msg.conversation_id.clone(),
@@ -254,6 +304,27 @@ impl InboundSubscriber {
             }
         })
     }
+}
+
+/// Spawn a best-effort typing-indicator keepalive for `conversation_id` on
+/// `channel`. Sends a typing signal immediately, then refreshes every 5s
+/// until the returned handle is aborted (the subscriber aborts it the moment
+/// the turn completes). Each send locks the manager only briefly; failures
+/// (platform has no typing API, transient error) are ignored.
+fn spawn_typing_keepalive(
+    manager: Arc<Mutex<ChannelManager>>,
+    channel: String,
+    conversation_id: String,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        loop {
+            {
+                let guard = manager.lock().await;
+                let _ = guard.send_typing_to(&channel, &conversation_id).await;
+            }
+            tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+        }
+    })
 }
 
 #[cfg(test)]

--- a/crates/wcore-agent/src/channel_inbound.rs
+++ b/crates/wcore-agent/src/channel_inbound.rs
@@ -203,23 +203,24 @@ impl InboundSubscriber {
                                         );
                                     }
                                 }
-                                let typing_handle = if ack.typing() {
-                                    Some(spawn_typing_keepalive(
+                                // Abort-on-drop guard: the keepalive is killed
+                                // the instant the turn completes AND if this
+                                // subscriber task is itself cancelled
+                                // mid-dispatch (a bare JoinHandle drop does NOT
+                                // abort the task; the guard's Drop does).
+                                let _typing_guard = ack.typing().then(|| {
+                                    AbortOnDrop(spawn_typing_keepalive(
                                         std::sync::Arc::clone(&manager),
                                         tagged.channel_name.clone(),
                                         msg.conversation_id.clone(),
                                     ))
-                                } else {
-                                    None
-                                };
+                                });
 
                                 let dispatch_result = dispatcher
                                     .dispatch(&session_key, &tagged.channel_name, &msg)
                                     .await;
 
-                                if let Some(h) = typing_handle {
-                                    h.abort();
-                                }
+                                drop(_typing_guard);
                                 if ack.reactions() {
                                     let emoji = if dispatch_result.is_ok() { "✅" } else { "❌" };
                                     let g = manager.lock().await;
@@ -306,11 +307,23 @@ impl InboundSubscriber {
     }
 }
 
+/// Aborts the wrapped task when dropped. Used for the typing keepalive so it
+/// is killed both on normal turn completion (explicit `drop`) and if the
+/// owning subscriber task is cancelled mid-turn (a dropped `JoinHandle` alone
+/// does NOT abort the task it refers to).
+struct AbortOnDrop(tokio::task::JoinHandle<()>);
+
+impl Drop for AbortOnDrop {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
+}
+
 /// Spawn a best-effort typing-indicator keepalive for `conversation_id` on
 /// `channel`. Sends a typing signal immediately, then refreshes every 5s
-/// until the returned handle is aborted (the subscriber aborts it the moment
-/// the turn completes). Each send locks the manager only briefly; failures
-/// (platform has no typing API, transient error) are ignored.
+/// until the wrapping [`AbortOnDrop`] guard is dropped (on turn completion or
+/// subscriber cancellation). Each send locks the manager only briefly;
+/// failures (platform has no typing API, transient error) are ignored.
 fn spawn_typing_keepalive(
     manager: Arc<Mutex<ChannelManager>>,
     channel: String,

--- a/crates/wcore-agent/src/channel_tools.rs
+++ b/crates/wcore-agent/src/channel_tools.rs
@@ -1,0 +1,309 @@
+//! Channel tool posture enforcement.
+//!
+//! A channel-originated agent turn runs a real [`AgentEngine`] on the host.
+//! The sender is REMOTE, so that engine must NOT inherit the local CLI's
+//! full host access — otherwise an (allowlisted-but-untrusted, or
+//! compromised) chat user could `Read`/`Grep` host secrets and have the
+//! reply ship them back. This module maps a per-channel
+//! [`ChannelToolPosture`] onto a concrete, reduced toolset:
+//!
+//! - **Conversational** (default): drop every built-in host filesystem /
+//!   shell tool. Keep only the fail-closed [`CONVERSATIONAL_SAFE`] allowlist
+//!   (conversational + network tools) plus operator-wired MCP tools.
+//! - **Workspace**: as Conversational, but add the vfs-jailable filesystem
+//!   tools ([`WORKSPACE_FS_TOOLS`]) back and pin a [`SandboxedFs`] jail on
+//!   the registry so they cannot escape the configured workspace root.
+//!   Shell/exec tools stay dropped — they bypass the jail.
+//! - **Full**: no filtering, no jail — identical to a local CLI session.
+//!
+//! Enforcement is at the [`ToolRegistry`] (not just the LLM schema): a
+//! dropped tool is un-dispatchable, so even a hallucinated call cannot
+//! reach it.
+//!
+//! [`AgentEngine`]: crate::engine::AgentEngine
+//! [`SandboxedFs`]: wcore_tools::vfs::SandboxedFs
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use wcore_channels::ChannelToolPosture;
+use wcore_protocol::events::ToolCategory;
+use wcore_tools::registry::ToolRegistry;
+use wcore_tools::Tool;
+
+/// Resolved tool posture for one channel: the posture plus the concrete
+/// workspace root the `Workspace` jail confines filesystem tools to.
+#[derive(Debug, Clone)]
+pub struct ChannelToolScope {
+    pub posture: ChannelToolPosture,
+    pub workspace_root: PathBuf,
+}
+
+/// Built-in tools provably free of host filesystem / shell access — safe to
+/// expose to a remote channel sender in `Conversational` posture.
+///
+/// **Fail-closed allowlist.** A tool NOT named here (and not an
+/// operator-wired MCP tool) is DROPPED. A newly-added host-touching built-in
+/// therefore can never silently leak to channels: it stays dropped until
+/// someone deliberately adds it here. (Network tools `web`/`WebFetch` reach
+/// the network, not the host fs; SSRF is gated separately by the egress
+/// policy.)
+const CONVERSATIONAL_SAFE: &[&str] = &[
+    "send_message",
+    "todo",
+    "clarify",
+    "AskUserQuestion",
+    "markdown_table",
+    "web",
+    "WebFetch",
+    "ToolSearch",
+];
+
+/// Filesystem tools added back in `Workspace` posture. Every one honours
+/// `ctx.vfs`, so a [`SandboxedFs`](wcore_tools::vfs::SandboxedFs) jail
+/// confines it. Tools that touch the host fs/shell WITHOUT routing through
+/// `ctx.vfs` (Bash, Git, RepoMap, pdf_extract, kubectl, gcloud, aws_cli,
+/// sql_query, Script, …) are deliberately absent and stay unavailable —
+/// they would escape the jail.
+const WORKSPACE_FS_TOOLS: &[&str] = &["Read", "Write", "Edit", "Grep", "Glob"];
+
+/// Operator-wired MCP tools are kept under restricted postures: they are
+/// deliberate, named extensions the operator installed, not ambient host
+/// access. (Caveat: an MCP server that itself exposes host filesystem
+/// access should be threat-modeled as `Full`-equivalent for that channel.)
+fn is_mcp(t: &dyn Tool) -> bool {
+    matches!(t.category(), ToolCategory::Mcp)
+}
+
+/// Whether `tool` survives under `posture`.
+fn keep_under(posture: ChannelToolPosture, tool: &dyn Tool) -> bool {
+    match posture {
+        ChannelToolPosture::Full => true,
+        ChannelToolPosture::Conversational => {
+            CONVERSATIONAL_SAFE.contains(&tool.name()) || is_mcp(tool)
+        }
+        ChannelToolPosture::Workspace => {
+            CONVERSATIONAL_SAFE.contains(&tool.name())
+                || WORKSPACE_FS_TOOLS.contains(&tool.name())
+                || is_mcp(tool)
+        }
+    }
+}
+
+/// Apply a channel tool scope to a freshly-built registry: drop the tools
+/// the posture forbids and, for `Workspace`, install the `SandboxedFs` jail
+/// so the surviving filesystem tools cannot escape `scope.workspace_root`.
+///
+/// A no-op for [`ChannelToolPosture::Full`] (and never called for a local
+/// CLI engine, which has no scope). Must run AFTER the full toolset —
+/// including MCP tools — is registered, and BEFORE the registry is moved
+/// into the engine.
+pub fn apply_posture(registry: &mut ToolRegistry, scope: &ChannelToolScope) {
+    if scope.posture != ChannelToolPosture::Full {
+        let posture = scope.posture;
+        registry.retain(|t| keep_under(posture, t));
+    }
+    if scope.posture == ChannelToolPosture::Workspace {
+        let jail =
+            wcore_tools::vfs::SandboxedFs::new(wcore_tools::vfs::RealFs, scope.workspace_root.clone());
+        registry.set_tool_vfs(Arc::new(jail));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use wcore_types::tool::ToolResult;
+
+    struct FakeTool {
+        name: String,
+        category: ToolCategory,
+    }
+
+    #[async_trait]
+    impl Tool for FakeTool {
+        fn name(&self) -> &str {
+            &self.name
+        }
+        fn description(&self) -> &str {
+            "fake"
+        }
+        fn input_schema(&self) -> serde_json::Value {
+            serde_json::json!({"type": "object"})
+        }
+        fn is_concurrency_safe(&self, _input: &serde_json::Value) -> bool {
+            true
+        }
+        async fn execute(&self, _input: serde_json::Value) -> ToolResult {
+            ToolResult {
+                content: "ok".into(),
+                is_error: false,
+            }
+        }
+        fn category(&self) -> ToolCategory {
+            self.category
+        }
+    }
+
+    fn tool(name: &str, category: ToolCategory) -> FakeTool {
+        FakeTool {
+            name: name.into(),
+            category,
+        }
+    }
+
+    /// The real built-in roster (name, category) as registered in
+    /// `bootstrap.rs`. Drives the fail-closed enforcement assertions below.
+    /// `Info` here is the broad "read/info" bucket the real tools use; the
+    /// allowlist — not the category — is what protects against the
+    /// Info-category host-fs readers (Read/Grep/Glob/RepoMap/pdf_extract).
+    fn builtin_roster() -> Vec<FakeTool> {
+        use ToolCategory::*;
+        [
+            // Host filesystem / shell / exec — MUST be dropped in conversational.
+            ("Read", Info),
+            ("Write", Edit),
+            ("Edit", Edit),
+            ("Grep", Info),
+            ("Glob", Info),
+            ("Bash", Exec),
+            ("Git", Info),
+            ("RepoMap", Info),
+            ("pdf_extract", Info),
+            ("Archive", Info),
+            ("image_inspect", Info),
+            ("email_parse", Info),
+            ("Jsonl", Info),
+            ("Script", Exec),
+            ("kubectl", Exec),
+            ("gcloud", Exec),
+            ("aws_cli", Exec),
+            ("sql_query", Info),
+            ("postgres_schema", Info),
+            ("session_search", Info),
+            ("cronjob", Info),
+            ("Delegate", Info),
+            // Conversational / network — safe to keep.
+            ("send_message", Info),
+            ("todo", Info),
+            ("clarify", Info),
+            ("AskUserQuestion", Info),
+            ("markdown_table", Info),
+            ("web", Info),
+            ("WebFetch", Info),
+            ("ToolSearch", Info),
+            // Operator-wired MCP — kept under restricted postures.
+            ("some_mcp_tool", Mcp),
+        ]
+        .into_iter()
+        .map(|(n, c)| tool(n, c))
+        .collect()
+    }
+
+    /// Tools that must NEVER survive `Conversational` (host fs/shell/exec).
+    const HOST_TOOLS: &[&str] = &[
+        "Read",
+        "Write",
+        "Edit",
+        "Grep",
+        "Glob",
+        "Bash",
+        "Git",
+        "RepoMap",
+        "pdf_extract",
+        "Archive",
+        "image_inspect",
+        "email_parse",
+        "Jsonl",
+        "Script",
+        "kubectl",
+        "gcloud",
+        "aws_cli",
+        "sql_query",
+        "postgres_schema",
+        "session_search",
+        "cronjob",
+        "Delegate",
+    ];
+
+    #[test]
+    fn conversational_drops_every_host_tool() {
+        for t in builtin_roster() {
+            if HOST_TOOLS.contains(&t.name()) {
+                assert!(
+                    !keep_under(ChannelToolPosture::Conversational, &t),
+                    "host tool '{}' must be dropped in conversational posture",
+                    t.name()
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn conversational_keeps_safe_and_mcp_tools() {
+        for t in builtin_roster() {
+            if CONVERSATIONAL_SAFE.contains(&t.name()) || matches!(t.category(), ToolCategory::Mcp) {
+                assert!(
+                    keep_under(ChannelToolPosture::Conversational, &t),
+                    "safe/mcp tool '{}' must survive conversational posture",
+                    t.name()
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn workspace_adds_back_only_vfs_jailable_fs_tools() {
+        // The five vfs-jailable fs tools come back…
+        for name in WORKSPACE_FS_TOOLS {
+            assert!(
+                keep_under(ChannelToolPosture::Workspace, &tool(name, ToolCategory::Info)),
+                "workspace must expose vfs-jailable fs tool '{name}'"
+            );
+        }
+        // …but shell/exec and non-vfs fs readers stay dropped.
+        for name in ["Bash", "Git", "RepoMap", "pdf_extract", "kubectl", "Script"] {
+            assert!(
+                !keep_under(ChannelToolPosture::Workspace, &tool(name, ToolCategory::Exec)),
+                "workspace must NOT expose host-escaping tool '{name}'"
+            );
+        }
+    }
+
+    #[test]
+    fn full_keeps_everything() {
+        for t in builtin_roster() {
+            assert!(
+                keep_under(ChannelToolPosture::Full, &t),
+                "full posture keeps every tool, including '{}'",
+                t.name()
+            );
+        }
+    }
+
+    #[test]
+    fn apply_posture_workspace_installs_jail() {
+        let mut reg = ToolRegistry::new();
+        let scope = ChannelToolScope {
+            posture: ChannelToolPosture::Workspace,
+            workspace_root: PathBuf::from("/tmp"),
+        };
+        apply_posture(&mut reg, &scope);
+        assert!(reg.tool_vfs().is_some(), "workspace posture pins a SandboxedFs jail");
+    }
+
+    #[test]
+    fn apply_posture_conversational_no_jail() {
+        let mut reg = ToolRegistry::new();
+        let scope = ChannelToolScope {
+            posture: ChannelToolPosture::Conversational,
+            workspace_root: PathBuf::from("/tmp"),
+        };
+        apply_posture(&mut reg, &scope);
+        assert!(
+            reg.tool_vfs().is_none(),
+            "conversational posture installs no vfs (fs tools are dropped, not jailed)"
+        );
+    }
+}

--- a/crates/wcore-agent/src/channel_tools.rs
+++ b/crates/wcore-agent/src/channel_tools.rs
@@ -59,13 +59,21 @@ const CONVERSATIONAL_SAFE: &[&str] = &[
     "ToolSearch",
 ];
 
-/// Filesystem tools added back in `Workspace` posture. Every one honours
-/// `ctx.vfs`, so a [`SandboxedFs`](wcore_tools::vfs::SandboxedFs) jail
-/// confines it. Tools that touch the host fs/shell WITHOUT routing through
-/// `ctx.vfs` (Bash, Git, RepoMap, pdf_extract, kubectl, gcloud, aws_cli,
-/// sql_query, Script, …) are deliberately absent and stay unavailable —
-/// they would escape the jail.
-const WORKSPACE_FS_TOOLS: &[&str] = &["Read", "Write", "Edit", "Grep", "Glob"];
+/// Filesystem tools added back in `Workspace` posture. Every one routes its
+/// reads/writes through `ctx.vfs`, so a
+/// [`SandboxedFs`](wcore_tools::vfs::SandboxedFs) jail genuinely confines it.
+///
+/// `Grep`/`Glob` are deliberately EXCLUDED: they only probe the top-level
+/// path argument through `ctx.vfs` and then shell out (`rg`/`grep`) or walk
+/// the glob crate against the real filesystem at the process cwd — the
+/// recursive scan is NOT confined by the jail, so a `Grep`/`Glob` with the
+/// default `path="."` (or a symlink inside the workspace) would escape it.
+/// Until their subprocess cwd is pinned to the jail root and symlink
+/// following is disabled, they stay unavailable in `Workspace` (and `Full`
+/// remains the escape hatch for unconfined search). Likewise Bash, Git,
+/// RepoMap, pdf_extract, kubectl, gcloud, aws_cli, sql_query, Script touch
+/// the host fs/shell outside `ctx.vfs` and stay unavailable.
+const WORKSPACE_FS_TOOLS: &[&str] = &["Read", "Write", "Edit"];
 
 /// Operator-wired MCP tools are kept under restricted postures: they are
 /// deliberate, named extensions the operator installed, not ambient host
@@ -262,10 +270,13 @@ mod tests {
                 "workspace must expose vfs-jailable fs tool '{name}'"
             );
         }
-        // …but shell/exec and non-vfs fs readers stay dropped.
-        for name in ["Bash", "Git", "RepoMap", "pdf_extract", "kubectl", "Script"] {
+        // …but shell/exec, non-vfs fs readers, AND the shell-out search
+        // tools (Grep/Glob — not confined by the vfs jail) stay dropped.
+        for name in [
+            "Bash", "Git", "RepoMap", "pdf_extract", "kubectl", "Script", "Grep", "Glob",
+        ] {
             assert!(
-                !keep_under(ChannelToolPosture::Workspace, &tool(name, ToolCategory::Exec)),
+                !keep_under(ChannelToolPosture::Workspace, &tool(name, ToolCategory::Info)),
                 "workspace must NOT expose host-escaping tool '{name}'"
             );
         }

--- a/crates/wcore-agent/src/confirm.rs
+++ b/crates/wcore-agent/src/confirm.rs
@@ -1,5 +1,5 @@
 use std::collections::HashSet;
-use std::io::{self, BufRead, Write};
+use std::io::{self, BufRead, IsTerminal, Write};
 
 pub struct ToolConfirmer {
     auto_approve: bool,
@@ -36,6 +36,23 @@ impl ToolConfirmer {
     pub fn check(&mut self, tool_name: &str, tool_input_display: &str) -> ConfirmResult {
         if self.auto_approve || self.allow_list.contains(tool_name) {
             return ConfirmResult::Approved;
+        }
+
+        // No interactive terminal — a daemon, a piped invocation, or a
+        // channel-driven turn (the inbound subscriber runs turns with no
+        // TTY). There is no human to answer the prompt, and a blocking
+        // `read_line` on a stdin that never reaches EOF (e.g. a held-open
+        // pipe keeping a daemon alive) would hang the turn forever. Fail
+        // closed: a tool that needs confirmation but cannot get it is denied.
+        // Auto-approve and allow-listed tools are already handled above, so
+        // this only gates tools that would otherwise prompt.
+        if !io::stdin().is_terminal() {
+            tracing::debug!(
+                target: "wcore_agent::confirm",
+                tool = %tool_name,
+                "tool needs confirmation but stdin is not a terminal; denying (no interactive approver)"
+            );
+            return ConfirmResult::Denied;
         }
 
         eprint!(

--- a/crates/wcore-agent/src/engine.rs
+++ b/crates/wcore-agent/src/engine.rs
@@ -2101,10 +2101,17 @@ impl AgentEngine {
     /// `call_id` is left empty in the snapshot; production dispatch
     /// substitutes the live ToolUse id per call.
     pub fn current_tool_context(&self) -> wcore_tools::context::ToolContext {
+        // Mirror the production dispatcher: build the context with the
+        // registry's configured vfs (a `SandboxedFs` jail for a channel
+        // `Workspace` engine), falling back to unconfined `RealFs`.
+        let vfs = self
+            .tools
+            .tool_vfs()
+            .unwrap_or_else(|| std::sync::Arc::new(wcore_tools::vfs::RealFs));
         let mut ctx = wcore_tools::context::ToolContext::new(
             String::new(),
             wcore_tools::context::ToolContext::test_default().cancel,
-            std::sync::Arc::new(wcore_tools::vfs::RealFs),
+            vfs,
             None,
             std::sync::Arc::new(wcore_tools::NullToolOutputSink),
         );

--- a/crates/wcore-agent/src/inbound_webhook.rs
+++ b/crates/wcore-agent/src/inbound_webhook.rs
@@ -1,0 +1,414 @@
+//! Inbound webhook HTTP host.
+//!
+//! Stands up an `axum` listener that accepts platform webhook deliveries
+//! (Slack Events API, WhatsApp Cloud API, Twilio SMS) and routes each one
+//! to the matching channel's signature-verifying
+//! [`Channel::ingest_webhook`](wcore_channels::Channel::ingest_webhook) via
+//! [`ChannelManager::ingest_webhook`]. The host owns NO signature logic of
+//! its own: it normalizes the live HTTP request into a
+//! [`WebhookRequest`] and lets the connector verify → parse → enqueue, then
+//! writes the connector's [`WebhookResponse`] back.
+//!
+//! Routes:
+//!   * `GET  /webhooks/:channel` — Meta (WhatsApp) `hub.challenge` handshake.
+//!   * `POST /webhooks/:channel` — runtime delivery for every connector.
+//!   * `GET  /healthz`           — liveness probe (`200 "ok"`).
+//!
+//! Security posture: the listener binds loopback (`127.0.0.1:8787`) by
+//! default — operators front it with a TLS-terminating reverse proxy for
+//! public exposure. Every request is gated by the connector's platform
+//! signature check; an unknown channel is a `404`, a signature/header
+//! failure a `401`, any other rejection a `400`. Denials are logged
+//! content-free (channel name + error only — never the body or headers).
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use axum::body::Bytes;
+use axum::extract::{OriginalUri, Path, State};
+use axum::http::{HeaderMap, Method, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::routing::get;
+use axum::Router;
+use tokio::sync::{watch, Mutex};
+use wcore_channels::{ChannelError, ChannelManager, WebhookRequest, WebhookResponse};
+use wcore_config::config::InboundWebhookConfig;
+
+/// Shared handle to the engine's channel registry.
+type SharedManager = Arc<Mutex<ChannelManager>>;
+
+/// Host state threaded through every request.
+#[derive(Clone)]
+struct HostState {
+    manager: SharedManager,
+    /// Public base URL (scheme + host) the platform calls. Set when the
+    /// host sits behind a proxy so signature schemes that sign the URL
+    /// (Twilio) verify against the real public URL rather than the local
+    /// bind address.
+    public_base_url: Option<String>,
+}
+
+/// Build the request seam exactly as the live handler does, as a pure
+/// function so it can be unit-tested without a socket.
+///
+/// `path_and_query` is the request target (path plus any `?query`).
+/// `host` is the `Host` header value (used only when `public_base_url` is
+/// `None`). `headers` and `query` are pre-extracted pairs.
+fn build_request(
+    method: &Method,
+    path_and_query: &str,
+    host: Option<&str>,
+    public_base_url: Option<&str>,
+    headers: Vec<(String, String)>,
+    query: Vec<(String, String)>,
+    body: String,
+) -> WebhookRequest {
+    let full_url = match public_base_url {
+        Some(base) => format!("{}{}", base.trim_end_matches('/'), path_and_query),
+        // No configured public URL: reconstruct from the Host header.
+        // Twilio signature verification REQUIRES `public_base_url` to be
+        // set to the exact public https URL — behind a proxy the local
+        // scheme/host differ from what the platform signed, so this
+        // best-effort `http://` reconstruction will not match.
+        None => {
+            let host = host.unwrap_or("localhost");
+            format!("http://{host}{path_and_query}")
+        }
+    };
+
+    WebhookRequest {
+        method: method.as_str().to_uppercase(),
+        full_url,
+        headers,
+        query,
+        body,
+    }
+}
+
+/// Lowercase every header name and keep only UTF-8 values (signature
+/// headers are ASCII; a non-UTF-8 value cannot be a valid signature).
+fn collect_headers(headers: &HeaderMap) -> Vec<(String, String)> {
+    headers
+        .iter()
+        .filter_map(|(name, value)| {
+            value
+                .to_str()
+                .ok()
+                .map(|v| (name.as_str().to_ascii_lowercase(), v.to_string()))
+        })
+        .collect()
+}
+
+/// Parse a URI query string into key/value pairs with percent-decoding.
+fn parse_query(query: Option<&str>) -> Vec<(String, String)> {
+    match query {
+        Some(q) => url::form_urlencoded::parse(q.as_bytes())
+            .map(|(k, v)| (k.into_owned(), v.into_owned()))
+            .collect(),
+        None => Vec::new(),
+    }
+}
+
+/// Map a connector result onto an HTTP response.
+fn response_for(channel: &str, result: Result<WebhookResponse, ChannelError>) -> Response {
+    match result {
+        Ok(resp) => {
+            let status =
+                StatusCode::from_u16(resp.status).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+            (status, resp.body.unwrap_or_default()).into_response()
+        }
+        // Unknown channel — the manager surfaces this as `Config`.
+        Err(e @ ChannelError::Config(_)) => {
+            tracing::warn!(channel, error = %e, "inbound webhook: unknown channel");
+            StatusCode::NOT_FOUND.into_response()
+        }
+        Err(e @ ChannelError::Auth(_)) => {
+            tracing::warn!(channel, error = %e, "inbound webhook: auth rejected");
+            StatusCode::UNAUTHORIZED.into_response()
+        }
+        Err(e) => {
+            tracing::warn!(channel, error = %e, "inbound webhook: rejected");
+            StatusCode::BAD_REQUEST.into_response()
+        }
+    }
+}
+
+/// Shared handler for both `GET` and `POST /webhooks/:channel`.
+async fn handle_webhook(
+    State(state): State<HostState>,
+    Path(channel): Path<String>,
+    method: Method,
+    headers: HeaderMap,
+    OriginalUri(uri): OriginalUri,
+    body: Bytes,
+) -> Response {
+    // Signature verification runs over the exact received bytes; a
+    // non-UTF-8 body can never be a valid signed payload, so reject early.
+    let body = match String::from_utf8(body.to_vec()) {
+        Ok(b) => b,
+        Err(_) => {
+            tracing::warn!(channel, "inbound webhook: non-UTF-8 body");
+            return StatusCode::BAD_REQUEST.into_response();
+        }
+    };
+
+    let path_and_query = uri
+        .path_and_query()
+        .map(|pq| pq.as_str())
+        .unwrap_or(uri.path());
+    let host = headers
+        .get(axum::http::header::HOST)
+        .and_then(|v| v.to_str().ok());
+
+    let req = build_request(
+        &method,
+        path_and_query,
+        host,
+        state.public_base_url.as_deref(),
+        collect_headers(&headers),
+        parse_query(uri.query()),
+        body,
+    );
+
+    let result = state.manager.lock().await.ingest_webhook(&channel, &req).await;
+    response_for(&channel, result)
+}
+
+/// Liveness probe.
+async fn healthz() -> impl IntoResponse {
+    (StatusCode::OK, "ok")
+}
+
+/// Build the router. Exposed for tests that drive it via `tower::oneshot`.
+fn router(state: HostState) -> Router {
+    Router::new()
+        .route(
+            "/webhooks/:channel",
+            get(handle_webhook).post(handle_webhook),
+        )
+        .route("/healthz", get(healthz))
+        .with_state(state)
+}
+
+/// Serve the inbound webhook host until `shutdown` flips to `true`.
+///
+/// Binds `bind`, routes `GET`/`POST /webhooks/:channel` to the matching
+/// channel's `ingest_webhook`, and shuts down gracefully when the watch
+/// channel reports `true`.
+pub async fn serve(
+    manager: Arc<Mutex<ChannelManager>>,
+    bind: SocketAddr,
+    public_base_url: Option<String>,
+    shutdown: watch::Receiver<bool>,
+) -> std::io::Result<()> {
+    let app = router(HostState {
+        manager,
+        public_base_url,
+    });
+    let listener = tokio::net::TcpListener::bind(bind).await?;
+    tracing::info!(%bind, "inbound webhook host listening");
+    axum::serve(listener, app)
+        .with_graceful_shutdown(async move {
+            let mut sd = shutdown;
+            // Wait until the flag is observed `true`; a closed sender
+            // (engine teardown) also ends the wait.
+            let _ = sd.wait_for(|v| *v).await;
+        })
+        .await
+}
+
+/// Spawn the host from config, returning the join handle + shutdown sender.
+///
+/// Returns `None` when the host is disabled or `config.bind` does not parse
+/// as a socket address (logged, non-fatal — the engine runs without it).
+pub fn spawn(
+    manager: Arc<Mutex<ChannelManager>>,
+    config: &InboundWebhookConfig,
+) -> Option<(tokio::task::JoinHandle<()>, watch::Sender<bool>)> {
+    if !config.enabled {
+        return None;
+    }
+    let bind: SocketAddr = match config.bind.parse() {
+        Ok(addr) => addr,
+        Err(e) => {
+            tracing::error!(
+                bind = %config.bind,
+                error = %e,
+                "inbound webhook host disabled: invalid bind address"
+            );
+            return None;
+        }
+    };
+
+    let (tx, rx) = watch::channel(false);
+    let public_base_url = config.public_base_url.clone();
+    let handle = tokio::spawn(async move {
+        if let Err(e) = serve(manager, bind, public_base_url, rx).await {
+            tracing::error!(%bind, error = %e, "inbound webhook host exited with error");
+        }
+    });
+    Some((handle, tx))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn headers_lc() -> Vec<(String, String)> {
+        vec![
+            ("x-slack-signature".to_string(), "v0=abc".to_string()),
+            ("content-type".to_string(), "application/json".to_string()),
+        ]
+    }
+
+    #[test]
+    fn build_request_uppercases_method() {
+        let req = build_request(
+            &Method::POST,
+            "/webhooks/slack",
+            Some("example.com"),
+            None,
+            vec![],
+            vec![],
+            "{}".to_string(),
+        );
+        assert_eq!(req.method, "POST");
+    }
+
+    #[test]
+    fn build_request_uses_public_base_url_and_strips_trailing_slash() {
+        let req = build_request(
+            &Method::POST,
+            "/webhooks/twilio?Foo=Bar",
+            Some("ignored.local"),
+            Some("https://public.example.com/"),
+            vec![],
+            vec![],
+            String::new(),
+        );
+        // Trailing slash on the base is trimmed; path+query is appended verbatim.
+        assert_eq!(
+            req.full_url,
+            "https://public.example.com/webhooks/twilio?Foo=Bar"
+        );
+    }
+
+    #[test]
+    fn build_request_reconstructs_from_host_when_no_public_base() {
+        let req = build_request(
+            &Method::POST,
+            "/webhooks/twilio",
+            Some("relay.internal:8787"),
+            None,
+            vec![],
+            vec![],
+            String::new(),
+        );
+        assert_eq!(req.full_url, "http://relay.internal:8787/webhooks/twilio");
+    }
+
+    #[test]
+    fn build_request_defaults_host_to_localhost() {
+        let req = build_request(
+            &Method::GET,
+            "/webhooks/wa",
+            None,
+            None,
+            vec![],
+            vec![],
+            String::new(),
+        );
+        assert_eq!(req.full_url, "http://localhost/webhooks/wa");
+    }
+
+    #[test]
+    fn build_request_preserves_lowercased_headers_and_lookup() {
+        let req = build_request(
+            &Method::POST,
+            "/webhooks/slack",
+            Some("h"),
+            None,
+            headers_lc(),
+            vec![],
+            "body".to_string(),
+        );
+        // Headers were already lowercased by the collector; case-insensitive
+        // lookup still resolves them.
+        assert_eq!(req.header("X-Slack-Signature"), Some("v0=abc"));
+        assert_eq!(req.body, "body");
+    }
+
+    #[test]
+    fn parse_query_percent_decodes_pairs() {
+        let q = parse_query(Some("hub.mode=subscribe&hub.challenge=ab%20cd"));
+        assert_eq!(q.len(), 2);
+        let req = WebhookRequest {
+            query: q,
+            ..Default::default()
+        };
+        assert_eq!(req.query_get("hub.mode"), Some("subscribe"));
+        // %20 decodes to a space.
+        assert_eq!(req.query_get("hub.challenge"), Some("ab cd"));
+    }
+
+    #[test]
+    fn parse_query_none_is_empty() {
+        assert!(parse_query(None).is_empty());
+    }
+
+    #[test]
+    fn collect_headers_lowercases_names() {
+        let mut hm = HeaderMap::new();
+        hm.insert("X-Slack-Signature", "v0=abc".parse().unwrap());
+        let pairs = collect_headers(&hm);
+        assert_eq!(pairs, vec![("x-slack-signature".to_string(), "v0=abc".to_string())]);
+    }
+
+    #[test]
+    fn response_for_unknown_channel_is_404() {
+        let resp = response_for(
+            "nope",
+            Err(ChannelError::Config("unknown channel: nope".to_string())),
+        );
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn response_for_auth_is_401() {
+        let resp = response_for("slack", Err(ChannelError::Auth("bad sig".to_string())));
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[test]
+    fn response_for_rejected_is_400() {
+        let resp = response_for(
+            "slack",
+            Err(ChannelError::Rejected("malformed".to_string())),
+        );
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn response_for_challenge_echoes_body_with_200() {
+        let resp = response_for("wa", Ok(WebhookResponse::challenge("12345")));
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[test]
+    fn spawn_returns_none_when_disabled() {
+        let mgr = Arc::new(Mutex::new(ChannelManager::new()));
+        let cfg = InboundWebhookConfig::default(); // enabled = false
+        assert!(spawn(mgr, &cfg).is_none());
+    }
+
+    #[test]
+    fn spawn_returns_none_on_bad_bind() {
+        let mgr = Arc::new(Mutex::new(ChannelManager::new()));
+        let cfg = InboundWebhookConfig {
+            enabled: true,
+            bind: "not-an-address".to_string(),
+            public_base_url: None,
+        };
+        assert!(spawn(mgr, &cfg).is_none());
+    }
+}

--- a/crates/wcore-agent/src/lib.rs
+++ b/crates/wcore-agent/src/lib.rs
@@ -49,6 +49,10 @@ pub mod file_history;
 // `/v1/models` with 5s cap) for the `/doctor` TUI diagnostics surface.
 pub mod health;
 pub mod hooks;
+// Inbound webhook HTTP host — routes platform webhook POSTs (Slack /
+// WhatsApp / Twilio SMS) to each channel's signature-verifying
+// `Channel::ingest_webhook` via the `ChannelManager`.
+pub mod inbound_webhook;
 pub mod mcp_curator;
 pub mod orchestration;
 pub mod output;

--- a/crates/wcore-agent/src/lib.rs
+++ b/crates/wcore-agent/src/lib.rs
@@ -20,6 +20,10 @@ pub mod cancel;
 // drives an agent turn through the TurnDispatcher seam, then sends the
 // reply back. Completes the inbound path that was structurally missing.
 pub mod channel_inbound;
+// Channel tool posture: maps a per-channel `ChannelToolPosture` onto a
+// reduced/jailed toolset for channel-originated engines (closes remote
+// host-secret exfiltration). Consumed by `bootstrap` + `channel_dispatch`.
+pub mod channel_tools;
 // Phase 1B-2 — the real engine-backed `TurnDispatcher`. Builds one
 // per-session `AgentEngine` (via AgentBootstrap, `.without_channels(true)`
 // to avoid channel recursion) and drives an agent turn from each admitted

--- a/crates/wcore-agent/src/lib.rs
+++ b/crates/wcore-agent/src/lib.rs
@@ -15,6 +15,11 @@ pub mod budget;
 pub mod cache_diagnostics;
 // W8a A.2: cooperative cancellation primitives (re-export of tokio-util).
 pub mod cancel;
+// Inbound channel consumer: subscribes to the ChannelManager broadcast,
+// runs the pure dispatch kernel (wcore_channels::evaluate), and on admit
+// drives an agent turn through the TurnDispatcher seam, then sends the
+// reply back. Completes the inbound path that was structurally missing.
+pub mod channel_inbound;
 // FleetDispatcher-class fix (audit 2026-05-24): bridges SendMessageTool's
 // `MessageTransport` boundary to the host's `ChannelManager` so the LLM
 // can drive Telegram/Discord/Slack/etc. through user-configured channels.

--- a/crates/wcore-agent/src/lib.rs
+++ b/crates/wcore-agent/src/lib.rs
@@ -20,6 +20,11 @@ pub mod cancel;
 // drives an agent turn through the TurnDispatcher seam, then sends the
 // reply back. Completes the inbound path that was structurally missing.
 pub mod channel_inbound;
+// Phase 1B-2 — the real engine-backed `TurnDispatcher`. Builds one
+// per-session `AgentEngine` (via AgentBootstrap, `.without_channels(true)`
+// to avoid channel recursion) and drives an agent turn from each admitted
+// inbound message, returning the reply text the subscriber sends back.
+pub mod channel_dispatch;
 // FleetDispatcher-class fix (audit 2026-05-24): bridges SendMessageTool's
 // `MessageTransport` boundary to the host's `ChannelManager` so the LLM
 // can drive Telegram/Discord/Slack/etc. through user-configured channels.

--- a/crates/wcore-agent/src/orchestration/mod.rs
+++ b/crates/wcore-agent/src/orchestration/mod.rs
@@ -672,10 +672,18 @@ async fn execute_single_with_streaming(
             // giving a cooperative tool the chance to wind down before
             // the future is dropped.
             let call_cancel = cancel.child_token();
+            // The filesystem tools see is the registry's configured vfs when
+            // one is installed (e.g. a channel `Workspace` engine pins a
+            // `SandboxedFs` jail here), else an unconfined `RealFs` — the
+            // local-CLI default. Carried on the registry so no new parameter
+            // has to thread through the whole dispatch stack.
+            let tool_vfs = registry
+                .tool_vfs()
+                .unwrap_or_else(|| std::sync::Arc::new(wcore_tools::vfs::RealFs));
             let mut tool_ctx = wcore_tools::context::ToolContext::new(
                 id.clone(),
                 call_cancel.clone(),
-                std::sync::Arc::new(wcore_tools::vfs::RealFs),
+                tool_vfs,
                 None,
                 std::sync::Arc::new(wcore_tools::NullToolOutputSink),
             );

--- a/crates/wcore-agent/tests/channel_tool_posture_test.rs
+++ b/crates/wcore-agent/tests/channel_tool_posture_test.rs
@@ -1,0 +1,136 @@
+//! End-to-end proof that a channel-originated engine's tool posture is
+//! enforced by the production `AgentBootstrap::build` path.
+//!
+//! The production gate this closes: a channel turn runs a real engine on
+//! the host, so without scoping, a remote chat sender could `Read`/`Grep`
+//! host secrets. These tests drive the real bootstrap (same path
+//! `ChannelTurnDispatcher` uses for its per-session engines) and assert:
+//!
+//!   1. Default (no posture) — the local CLI engine keeps the FULL toolset
+//!      (`Read` AND `Bash` present). Proves the change is opt-in and does
+//!      not regress local sessions.
+//!   2. `Conversational` — every host filesystem/shell tool is GONE from
+//!      the registry (un-dispatchable, not merely hidden); a conversational
+//!      tool survives.
+//!   3. `Workspace` — `Read` is present but the engine's tool `vfs` is a
+//!      `SandboxedFs` jail: a read inside the workspace root succeeds, a
+//!      read outside it is refused. `Bash` (non-jailable) stays gone.
+
+use std::sync::Arc;
+
+use tempfile::tempdir;
+use wcore_agent::bootstrap::AgentBootstrap;
+use wcore_agent::channel_tools::ChannelToolScope;
+use wcore_agent::output::null_sink::NullSink;
+use wcore_agent::output::OutputSink;
+use wcore_channels::ChannelToolPosture;
+use wcore_config::compat::ProviderCompat;
+use wcore_config::config::{Config, ProviderType};
+
+fn bootstrap_config() -> Config {
+    // Dead URL: `build()` never connects, the tests only inspect the engine.
+    Config {
+        provider_label: "openai".into(),
+        provider: ProviderType::OpenAI,
+        api_key: "sk-test".into(),
+        base_url: "http://localhost:0".into(),
+        model: "gpt-test-model".into(),
+        max_tokens: 1024,
+        max_turns: Some(1),
+        compat: ProviderCompat::openai_defaults(),
+        ..Default::default()
+    }
+}
+
+const HOST_TOOLS: &[&str] = &["Read", "Grep", "Glob", "Write", "Edit", "Bash"];
+
+#[tokio::test]
+async fn default_posture_keeps_full_toolset() {
+    let tmp = tempdir().unwrap();
+    let ws = tmp.path().to_str().unwrap().to_string();
+    let sink: Arc<dyn OutputSink> = Arc::new(NullSink);
+
+    let result = AgentBootstrap::new(bootstrap_config(), ws, sink)
+        .without_channels(true)
+        .build()
+        .await
+        .expect("bootstrap");
+
+    let names = result.engine.tool_names();
+    assert!(names.iter().any(|n| n == "Read"), "local engine keeps Read");
+    assert!(names.iter().any(|n| n == "Bash"), "local engine keeps Bash");
+}
+
+#[tokio::test]
+async fn conversational_posture_drops_all_host_tools() {
+    let tmp = tempdir().unwrap();
+    let ws = tmp.path().to_str().unwrap().to_string();
+    let sink: Arc<dyn OutputSink> = Arc::new(NullSink);
+
+    let result = AgentBootstrap::new(bootstrap_config(), ws.clone(), sink)
+        .without_channels(true)
+        .channel_tool_posture(ChannelToolScope {
+            posture: ChannelToolPosture::Conversational,
+            workspace_root: ws.into(),
+        })
+        .build()
+        .await
+        .expect("bootstrap");
+
+    let names = result.engine.tool_names();
+    for host in HOST_TOOLS {
+        assert!(
+            !names.iter().any(|n| n == host),
+            "conversational posture must drop host tool '{host}', got: {names:?}"
+        );
+    }
+    // A conversational tool still works (registry isn't simply emptied).
+    assert!(
+        names.iter().any(|n| n == "todo"),
+        "conversational tools survive, got: {names:?}"
+    );
+}
+
+#[tokio::test]
+async fn workspace_posture_jails_filesystem_reads() {
+    let inside = tempdir().unwrap();
+    let outside = tempdir().unwrap();
+    let inside_file = inside.path().join("inside.txt");
+    let outside_file = outside.path().join("outside.txt");
+    std::fs::write(&inside_file, b"in").unwrap();
+    std::fs::write(&outside_file, b"out").unwrap();
+
+    let ws = inside.path().to_str().unwrap().to_string();
+    let sink: Arc<dyn OutputSink> = Arc::new(NullSink);
+
+    let result = AgentBootstrap::new(bootstrap_config(), ws.clone(), sink)
+        .without_channels(true)
+        .channel_tool_posture(ChannelToolScope {
+            posture: ChannelToolPosture::Workspace,
+            workspace_root: inside.path().to_path_buf(),
+        })
+        .build()
+        .await
+        .expect("bootstrap");
+
+    let names = result.engine.tool_names();
+    // Jailable fs tools come back…
+    assert!(names.iter().any(|n| n == "Read"), "workspace exposes Read");
+    assert!(names.iter().any(|n| n == "Grep"), "workspace exposes Grep");
+    // …but non-jailable shell/exec tools stay gone.
+    assert!(
+        !names.iter().any(|n| n == "Bash"),
+        "workspace must NOT expose Bash, got: {names:?}"
+    );
+
+    // The engine's tool vfs is a SandboxedFs jailed to the workspace root.
+    let ctx = result.engine.current_tool_context();
+    assert!(
+        ctx.vfs.read(&inside_file).await.is_ok(),
+        "read inside the workspace root must succeed"
+    );
+    assert!(
+        ctx.vfs.read(&outside_file).await.is_err(),
+        "read OUTSIDE the workspace root must be refused by the jail"
+    );
+}

--- a/crates/wcore-agent/tests/channel_tool_posture_test.rs
+++ b/crates/wcore-agent/tests/channel_tool_posture_test.rs
@@ -114,14 +114,17 @@ async fn workspace_posture_jails_filesystem_reads() {
         .expect("bootstrap");
 
     let names = result.engine.tool_names();
-    // Jailable fs tools come back…
+    // Vfs-jailable fs tools come back…
     assert!(names.iter().any(|n| n == "Read"), "workspace exposes Read");
-    assert!(names.iter().any(|n| n == "Grep"), "workspace exposes Grep");
-    // …but non-jailable shell/exec tools stay gone.
-    assert!(
-        !names.iter().any(|n| n == "Bash"),
-        "workspace must NOT expose Bash, got: {names:?}"
-    );
+    assert!(names.iter().any(|n| n == "Edit"), "workspace exposes Edit");
+    // …but non-jailable shell/exec tools stay gone — including Grep/Glob,
+    // which shell out and would escape the jail with a default `path="."`.
+    for gone in ["Bash", "Grep", "Glob"] {
+        assert!(
+            !names.iter().any(|n| n == gone),
+            "workspace must NOT expose non-jailable tool '{gone}', got: {names:?}"
+        );
+    }
 
     // The engine's tool vfs is a SandboxedFs jailed to the workspace root.
     let ctx = result.engine.current_tool_context();

--- a/crates/wcore-channel-discord/src/gateway.rs
+++ b/crates/wcore-channel-discord/src/gateway.rs
@@ -7,9 +7,15 @@
 //!    tests can exercise the protocol without standing up a fake gateway
 //!    server.
 //! 2. **WebSocket driver** — `gateway_loop` connects to Discord, sends
-//!    IDENTIFY, runs HEARTBEATs on an interval, and pushes
-//!    `MESSAGE_CREATE` events into the inbox. Reconnect-on-drop is plain
-//!    re-IDENTIFY; full resume is deferred (commented).
+//!    IDENTIFY (or RESUME on a resumable reconnect), runs HEARTBEATs on
+//!    an interval, and pushes `MESSAGE_CREATE` events into the inbox.
+//!    After READY we capture `session_id`, `resume_gateway_url`, and the
+//!    latest dispatch sequence; on a resumable disconnect (op 7, a
+//!    dropped socket, or op 9 with `d == true`) the next session connects
+//!    to `resume_gateway_url` and sends a RESUME (op 6) so Discord
+//!    replays the events buffered during the gap. A non-resumable op 9
+//!    (`d == false`) clears the session and falls back to a fresh
+//!    IDENTIFY after the Discord-required 1–5s wait.
 
 use std::collections::{HashSet, VecDeque};
 use std::sync::Arc;
@@ -31,6 +37,7 @@ use wcore_channels::event::{
 pub const OP_DISPATCH: u64 = 0;
 pub const OP_HEARTBEAT: u64 = 1;
 pub const OP_IDENTIFY: u64 = 2;
+pub const OP_RESUME: u64 = 6;
 pub const OP_RECONNECT: u64 = 7;
 pub const OP_INVALID_SESSION: u64 = 9;
 pub const OP_HELLO: u64 = 10;
@@ -56,6 +63,19 @@ pub struct GatewayPayload {
 #[derive(Debug, Clone, Deserialize)]
 pub struct HelloData {
     pub heartbeat_interval: u64,
+}
+
+/// READY payload (`d` for op=0 t="READY"). Carries the session handle
+/// Discord wants echoed back on a RESUME plus the dedicated resume host.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ReadyData {
+    /// Opaque session identifier — required field of the RESUME payload.
+    pub session_id: String,
+    /// Host to reconnect to when resuming. Discord recommends using this
+    /// instead of the normal gateway URL for resumes; absent on older
+    /// gateway versions, in which case we fall back to the normal URL.
+    #[serde(default)]
+    pub resume_gateway_url: Option<String>,
 }
 
 /// MESSAGE_CREATE payload (`d` for op=0 t="MESSAGE_CREATE").
@@ -167,6 +187,25 @@ struct IdentifyProperties<'a> {
     device: &'a str,
 }
 
+// -----------------------------------------------------------------------------
+// RESUME (sent by client)
+// -----------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize)]
+struct ResumePayload<'a> {
+    op: u64,
+    d: ResumeData<'a>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct ResumeData<'a> {
+    token: &'a str,
+    session_id: &'a str,
+    /// Last dispatch sequence number we processed. Discord replays every
+    /// event after this seq.
+    seq: i64,
+}
+
 #[derive(Debug, Clone, Serialize)]
 struct HeartbeatPayload {
     op: u64,
@@ -198,6 +237,20 @@ pub(crate) fn heartbeat_frame(seq: Option<i64>) -> String {
     .expect("HeartbeatPayload always serialises")
 }
 
+/// Build a RESUME (op 6) frame echoing the session handle and the last
+/// dispatch sequence so Discord replays everything buffered since `seq`.
+pub(crate) fn resume_frame(token: &str, session_id: &str, seq: i64) -> String {
+    serde_json::to_string(&ResumePayload {
+        op: OP_RESUME,
+        d: ResumeData {
+            token,
+            session_id,
+            seq,
+        },
+    })
+    .expect("ResumePayload always serialises")
+}
+
 // =============================================================================
 // Pure parsing + mapping (unit-testable without IO)
 // =============================================================================
@@ -222,6 +275,30 @@ pub(crate) fn parse_message_create(payload: &GatewayPayload) -> Option<MessageCr
         return None;
     }
     serde_json::from_value(payload.d.clone()).ok()
+}
+
+/// Decode the `d` of a `op=0 t="READY"` dispatch into the session handle
+/// and resume host. `None` for any other frame.
+pub(crate) fn parse_ready(payload: &GatewayPayload) -> Option<ReadyData> {
+    if payload.op != OP_DISPATCH || payload.t.as_deref() != Some("READY") {
+        return None;
+    }
+    serde_json::from_value(payload.d.clone()).ok()
+}
+
+/// True when the payload is `op=0 t="RESUMED"` — Discord's signal that a
+/// RESUME succeeded and the buffered events have been (or are being)
+/// replayed as normal dispatches.
+pub(crate) fn is_resumed(payload: &GatewayPayload) -> bool {
+    payload.op == OP_DISPATCH && payload.t.as_deref() == Some("RESUMED")
+}
+
+/// Interpret the `d` of an `op=9 Invalid Session` frame. Discord encodes
+/// resumability as a bare boolean: `true` → the session can still be
+/// resumed (retry RESUME), `false` → it is gone (must re-IDENTIFY).
+/// Defaults to non-resumable when `d` is malformed.
+pub(crate) fn invalid_session_resumable(payload: &GatewayPayload) -> bool {
+    payload.d.as_bool().unwrap_or(false)
 }
 
 /// Translate a `MESSAGE_CREATE` payload into an `IncomingMessage`
@@ -448,6 +525,69 @@ impl HeartbeatTracker {
     }
 }
 
+// -----------------------------------------------------------------------------
+// Resume state + handshake decision (pure, unit-testable)
+// -----------------------------------------------------------------------------
+
+/// Everything needed to RESUME a prior session. Populated from READY and
+/// kept across reconnects so the outer loop can replay instead of
+/// re-identifying. Cleared whenever the session becomes non-resumable.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ResumeState {
+    /// Opaque session id from READY (echoed in the RESUME payload).
+    pub session_id: String,
+    /// Dedicated resume host from READY, if Discord supplied one. When
+    /// `None` the caller resumes against the normal gateway URL.
+    pub resume_gateway_url: Option<String>,
+    /// Last dispatch sequence number we have processed.
+    pub seq: i64,
+}
+
+/// Which handshake a (re)connect should perform after HELLO.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum Handshake {
+    /// Fresh login: clear any session and send IDENTIFY.
+    Identify,
+    /// Replay: send RESUME with the carried session + seq.
+    Resume,
+}
+
+/// Why a session ended, as far as the resume decision cares. Lets the
+/// outer loop pick RESUME-vs-IDENTIFY without re-deriving the reason.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ReconnectReason {
+    /// op 7 Reconnect, or the socket dropped / heartbeat lapsed — the
+    /// session itself is still valid, so resume if we have state.
+    Resumable,
+    /// op 9 Invalid Session with `d == true` — Discord says retry RESUME.
+    InvalidSessionResumable,
+    /// op 9 Invalid Session with `d == false` — session is gone.
+    InvalidSessionFatal,
+}
+
+/// Decide the next handshake given the carried session state and why the
+/// last session ended. Pure so the policy is unit-testable in isolation
+/// from the socket.
+///
+/// - We can only RESUME when we actually hold a `session_id`.
+/// - A fatal Invalid Session forces a fresh IDENTIFY regardless of state.
+/// - Everything else resumes when state is present, else IDENTIFYs.
+pub(crate) fn decide_handshake(
+    have_session: bool,
+    reason: &ReconnectReason,
+) -> Handshake {
+    match reason {
+        ReconnectReason::InvalidSessionFatal => Handshake::Identify,
+        ReconnectReason::Resumable | ReconnectReason::InvalidSessionResumable => {
+            if have_session {
+                Handshake::Resume
+            } else {
+                Handshake::Identify
+            }
+        }
+    }
+}
+
 // =============================================================================
 // Gateway driver
 // =============================================================================
@@ -467,9 +607,21 @@ pub(crate) struct GatewayArgs {
     pub bot_id: Option<String>,
 }
 
+/// Append `?v=10&encoding=json` to a bare gateway host if it lacks a
+/// query string. Idempotent — a URL that already carries query params is
+/// returned untouched.
+fn with_gateway_query(base: &str) -> String {
+    if base.contains('?') {
+        base.to_string()
+    } else {
+        format!("{base}?v=10&encoding=json")
+    }
+}
+
 /// Drive one or more gateway connection cycles until shutdown is
-/// signalled. On disconnect / heartbeat-timeout / op=7 / op=9 we tear
-/// down the WS and re-connect with a short backoff.
+/// signalled. On op=7 / dropped socket / heartbeat-timeout we RESUME
+/// (replaying buffered events); on a fatal op=9 we fall back to a fresh
+/// IDENTIFY. Reconnects use a short backoff.
 pub(crate) async fn gateway_loop(args: GatewayArgs) {
     let GatewayArgs {
         gateway_url,
@@ -482,17 +634,36 @@ pub(crate) async fn gateway_loop(args: GatewayArgs) {
         bot_id,
     } = args;
 
-    // Discord's gateway endpoint takes ?v=10&encoding=json.
-    let mut url = gateway_url.clone();
-    if !url.contains('?') {
-        url.push_str("?v=10&encoding=json");
-    }
+    // Normalised default gateway URL used for fresh IDENTIFYs and as the
+    // fallback when no resume host is known.
+    let identify_url = with_gateway_query(&gateway_url);
 
     let mut backoff_ms: u64 = 1_000;
+    // Carried session handle. `Some` once READY lands; cleared on a fatal
+    // Invalid Session so the next cycle re-IDENTIFYs from scratch.
+    let mut resume: Option<ResumeState> = None;
+    // How the *previous* session ended. The very first cycle has no prior
+    // session, so it IDENTIFYs (no resume state anyway).
+    let mut reason = ReconnectReason::Resumable;
 
     loop {
         if *shutdown.borrow() {
             break;
+        }
+
+        // Pick the handshake + connect URL for this cycle.
+        let handshake = decide_handshake(resume.is_some(), &reason);
+        let url = match (&handshake, &resume) {
+            (Handshake::Resume, Some(state)) => state
+                .resume_gateway_url
+                .clone()
+                .map(|u| with_gateway_query(&u))
+                .unwrap_or_else(|| identify_url.clone()),
+            _ => identify_url.clone(),
+        };
+        // A fresh IDENTIFY means any stale session is meaningless.
+        if handshake == Handshake::Identify {
+            resume = None;
         }
 
         match run_one_session(
@@ -504,11 +675,34 @@ pub(crate) async fn gateway_loop(args: GatewayArgs) {
             bot_id.as_deref(),
             &inbox,
             &mut shutdown,
+            &handshake,
+            &mut resume,
         )
         .await
         {
             Ok(SessionExit::Shutdown) => break,
-            Ok(SessionExit::Reconnect) => {
+            Ok(SessionExit::Reconnect(next_reason)) => {
+                // Surface Reconnecting so the manager/UI sees the gap.
+                inbox
+                    .lock()
+                    .await
+                    .push_back(ChannelEvent::ConnectionStateChanged {
+                        state: ConnectionState::Reconnecting,
+                    });
+                // op 9 may demand a fresh IDENTIFY after a random 1–5s
+                // delay; clear the session and wait before re-entering.
+                if matches!(next_reason, ReconnectReason::InvalidSessionFatal) {
+                    resume = None;
+                    let delay = invalid_session_backoff();
+                    let sleep = tokio::time::sleep(delay);
+                    tokio::pin!(sleep);
+                    tokio::select! {
+                        biased;
+                        _ = shutdown.changed() => { if *shutdown.borrow() { break; } }
+                        _ = &mut sleep => {}
+                    }
+                }
+                reason = next_reason;
                 backoff_ms = 1_000;
             }
             Err(e) => {
@@ -516,6 +710,7 @@ pub(crate) async fn gateway_loop(args: GatewayArgs) {
                     target: "wcore_channel_discord::gateway",
                     error = %e,
                     backoff_ms,
+                    resumable = resume.is_some(),
                     "gateway session ended; backing off before reconnect"
                 );
                 inbox
@@ -524,6 +719,9 @@ pub(crate) async fn gateway_loop(args: GatewayArgs) {
                     .push_back(ChannelEvent::ConnectionStateChanged {
                         state: ConnectionState::Reconnecting,
                     });
+                // A dropped socket / heartbeat lapse keeps the session
+                // valid — resume if we have state.
+                reason = ReconnectReason::Resumable;
                 // Bounded exponential backoff. Race against shutdown so
                 // stop() isn't blocked by the sleep.
                 let sleep = tokio::time::sleep(Duration::from_millis(backoff_ms));
@@ -541,11 +739,25 @@ pub(crate) async fn gateway_loop(args: GatewayArgs) {
     }
 }
 
+/// Discord requires a random 1–5s wait before re-IDENTIFYing after a
+/// fatal Invalid Session. Uses a cheap time-seeded pick — no extra RNG
+/// dependency, and the exact value is non-critical.
+fn invalid_session_backoff() -> Duration {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.subsec_nanos())
+        .unwrap_or(0);
+    // Map into the inclusive 1000..=5000 ms window.
+    let ms = 1_000 + u64::from(nanos % 4_001);
+    Duration::from_millis(ms)
+}
+
 enum SessionExit {
     /// `shutdown` watch flipped — exit the outer loop.
     Shutdown,
-    /// Clean reconnect requested (op=7 / op=9). Outer loop re-enters.
-    Reconnect,
+    /// Reconnect requested. The carried reason tells the outer loop
+    /// whether to RESUME or fall back to a fresh IDENTIFY.
+    Reconnect(ReconnectReason),
 }
 
 // One Gateway session carries many independent connection parameters;
@@ -560,6 +772,11 @@ async fn run_one_session(
     bot_id: Option<&str>,
     inbox: &Arc<Mutex<VecDeque<ChannelEvent>>>,
     shutdown: &mut watch::Receiver<bool>,
+    handshake: &Handshake,
+    // Shared session handle: updated in place as READY / dispatches
+    // arrive so the carried seq + session_id survive even when this
+    // function returns via Err (dropped socket).
+    resume: &mut Option<ResumeState>,
 ) -> Result<SessionExit, String> {
     let (ws, _) = tokio_tungstenite::connect_async(url)
         .await
@@ -594,16 +811,47 @@ async fn run_one_session(
 
     let interval_ms = hello.heartbeat_interval;
     let mut tracker = HeartbeatTracker::new(interval_ms, heartbeat_grace_ms);
-    let mut last_seq: Option<i64> = None;
+    // On a RESUME we continue heartbeating from the carried seq; on a
+    // fresh IDENTIFY there is nothing to acknowledge yet.
+    let mut last_seq: Option<i64> = match handshake {
+        Handshake::Resume => resume.as_ref().map(|s| s.seq),
+        Handshake::Identify => None,
+    };
 
-    // Send IDENTIFY.
-    sink.send(WsMessage::Text(identify_frame(bot_token, intents)))
-        .await
-        .map_err(|e| format!("identify send: {e}"))?;
+    // Send RESUME or IDENTIFY per the handshake decision.
+    match handshake {
+        Handshake::Resume => {
+            let state = resume
+                .as_ref()
+                .ok_or_else(|| "resume requested without session state".to_string())?;
+            sink.send(WsMessage::Text(resume_frame(
+                bot_token,
+                &state.session_id,
+                state.seq,
+            )))
+            .await
+            .map_err(|e| format!("resume send: {e}"))?;
+            tracing::debug!(
+                target: "wcore_channel_discord::gateway",
+                session_id = %state.session_id,
+                seq = state.seq,
+                "sent RESUME"
+            );
+        }
+        Handshake::Identify => {
+            sink.send(WsMessage::Text(identify_frame(bot_token, intents)))
+                .await
+                .map_err(|e| format!("identify send: {e}"))?;
+            tracing::debug!(
+                target: "wcore_channel_discord::gateway",
+                "sent IDENTIFY"
+            );
+        }
+    }
 
-    // Push Connected once we've handed IDENTIFY off; READY landing is
-    // the formal "live" moment but for routing it's close enough — the
-    // manager dedupes state-changes anyway.
+    // Push Connected once we've handed the handshake off; READY / RESUMED
+    // landing is the formal "live" moment but for routing it's close
+    // enough — the manager dedupes state-changes anyway.
     inbox
         .lock()
         .await
@@ -660,6 +908,12 @@ async fn run_one_session(
                 let Some(payload) = parse_payload(&text) else { continue };
                 if let Some(s) = payload.s {
                     last_seq = Some(s);
+                    // Keep the carried session's seq current so a later
+                    // RESUME asks Discord to replay from the right point —
+                    // even if this session ends via a dropped socket.
+                    if let Some(state) = resume.as_mut() {
+                        state.seq = s;
+                    }
                 }
 
                 match payload.op {
@@ -674,17 +928,48 @@ async fn run_one_session(
                         tracker.on_send(Instant::now());
                     }
                     OP_RECONNECT => {
-                        // 7: clean reconnect. (Full resume is deferred —
-                        // we re-IDENTIFY on the next session.)
-                        return Ok(SessionExit::Reconnect);
+                        // 7: Discord asks us to reconnect. The session is
+                        // still valid — RESUME (if we have state) on the
+                        // next cycle to replay buffered events.
+                        return Ok(SessionExit::Reconnect(ReconnectReason::Resumable));
                     }
                     OP_INVALID_SESSION => {
-                        // 9: session invalidated. Discord asks for a 1-5s
-                        // delay before re-identify; we reconnect after the
-                        // outer backoff.
-                        return Ok(SessionExit::Reconnect);
+                        // 9: session invalidated. `d == true` means the
+                        // session can still be resumed; `d == false` means
+                        // it's gone and we must re-IDENTIFY after a 1-5s
+                        // wait (handled by the outer loop). Note: op 9 can
+                        // also arrive right after IDENTIFY (always
+                        // non-resumable in that case), which this same
+                        // branch handles correctly.
+                        let reason = if invalid_session_resumable(&payload) {
+                            ReconnectReason::InvalidSessionResumable
+                        } else {
+                            ReconnectReason::InvalidSessionFatal
+                        };
+                        return Ok(SessionExit::Reconnect(reason));
                     }
                     OP_DISPATCH => {
+                        // Capture the session handle from READY so future
+                        // reconnects can RESUME instead of re-IDENTIFY.
+                        if let Some(ready) = parse_ready(&payload) {
+                            *resume = Some(ResumeState {
+                                session_id: ready.session_id,
+                                resume_gateway_url: ready.resume_gateway_url,
+                                seq: last_seq.unwrap_or(0),
+                            });
+                            tracing::debug!(
+                                target: "wcore_channel_discord::gateway",
+                                "READY received; session captured for resume"
+                            );
+                        } else if is_resumed(&payload) {
+                            // RESUME succeeded: buffered events follow as
+                            // normal MESSAGE_CREATE dispatches through the
+                            // mapping below — nothing else to do here.
+                            tracing::debug!(
+                                target: "wcore_channel_discord::gateway",
+                                "RESUMED received; replayed events will flow as dispatches"
+                            );
+                        }
                         if let Some(mc) = parse_message_create(&payload)
                             && let Some(im) =
                                 map_message_create(mc, allowed_channel_ids, bot_id)
@@ -694,8 +979,8 @@ async fn run_one_session(
                                 .await
                                 .push_back(ChannelEvent::MessageReceived { msg: im });
                         }
-                        // Other DISPATCH events (READY, GUILD_CREATE, …)
-                        // are not surfaced.
+                        // Other DISPATCH events (GUILD_CREATE, …) are not
+                        // surfaced.
                     }
                     other => {
                         tracing::trace!(
@@ -850,5 +1135,164 @@ mod tests {
         assert_eq!(v1["d"], 7);
         assert_eq!(v2["op"], 1);
         assert!(v2["d"].is_null());
+    }
+
+    // ---- RESUME support -------------------------------------------------
+
+    #[test]
+    fn resume_frame_carries_op6_token_session_and_seq() {
+        let raw = resume_frame("BOT-TOKEN", "sess-abc", 99);
+        let v: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        assert_eq!(v["op"], 6, "RESUME is opcode 6");
+        assert_eq!(v["d"]["token"], "BOT-TOKEN");
+        assert_eq!(v["d"]["session_id"], "sess-abc");
+        assert_eq!(v["d"]["seq"], 99);
+    }
+
+    #[test]
+    fn ready_parses_session_id_and_resume_url() {
+        let raw = r#"{
+            "op":0,"t":"READY","s":1,
+            "d":{
+                "session_id":"abc123",
+                "resume_gateway_url":"wss://resume.example.gg",
+                "user":{"id":"42"}
+            }
+        }"#;
+        let payload = parse_payload(raw).unwrap();
+        let ready = parse_ready(&payload).expect("READY parses");
+        assert_eq!(ready.session_id, "abc123");
+        assert_eq!(
+            ready.resume_gateway_url.as_deref(),
+            Some("wss://resume.example.gg")
+        );
+    }
+
+    #[test]
+    fn ready_tolerates_missing_resume_url() {
+        let raw = r#"{"op":0,"t":"READY","s":1,"d":{"session_id":"x"}}"#;
+        let payload = parse_payload(raw).unwrap();
+        let ready = parse_ready(&payload).expect("READY parses");
+        assert_eq!(ready.session_id, "x");
+        assert!(ready.resume_gateway_url.is_none());
+    }
+
+    #[test]
+    fn parse_ready_rejects_non_ready_dispatch() {
+        let raw = r#"{"op":0,"t":"MESSAGE_CREATE","s":1,"d":{"session_id":"x"}}"#;
+        let payload = parse_payload(raw).unwrap();
+        assert!(parse_ready(&payload).is_none());
+    }
+
+    #[test]
+    fn resumed_dispatch_detected() {
+        let resumed = parse_payload(r#"{"op":0,"t":"RESUMED","s":5,"d":{}}"#).unwrap();
+        assert!(is_resumed(&resumed));
+        let other = parse_payload(r#"{"op":0,"t":"READY","s":5,"d":{}}"#).unwrap();
+        assert!(!is_resumed(&other));
+    }
+
+    #[test]
+    fn invalid_session_resumability_reads_d_boolean() {
+        let yes = parse_payload(r#"{"op":9,"d":true}"#).unwrap();
+        let no = parse_payload(r#"{"op":9,"d":false}"#).unwrap();
+        // Discord may also send op 9 with a missing/null d (post-IDENTIFY)
+        // — treat that conservatively as non-resumable.
+        let bare = parse_payload(r#"{"op":9}"#).unwrap();
+        assert!(invalid_session_resumable(&yes));
+        assert!(!invalid_session_resumable(&no));
+        assert!(!invalid_session_resumable(&bare));
+    }
+
+    #[test]
+    fn decide_handshake_resumes_when_session_and_reason_allow() {
+        // op 7 / dropped socket with a live session → RESUME.
+        assert_eq!(
+            decide_handshake(true, &ReconnectReason::Resumable),
+            Handshake::Resume
+        );
+        // op 9 resumable=true with a live session → RESUME.
+        assert_eq!(
+            decide_handshake(true, &ReconnectReason::InvalidSessionResumable),
+            Handshake::Resume
+        );
+    }
+
+    #[test]
+    fn decide_handshake_identifies_without_session() {
+        // No session captured yet (e.g. very first connect, or dropped
+        // before READY) → IDENTIFY regardless of a resumable reason.
+        assert_eq!(
+            decide_handshake(false, &ReconnectReason::Resumable),
+            Handshake::Identify
+        );
+        assert_eq!(
+            decide_handshake(false, &ReconnectReason::InvalidSessionResumable),
+            Handshake::Identify
+        );
+    }
+
+    #[test]
+    fn decide_handshake_fatal_invalid_session_forces_identify() {
+        // op 9 with d == false → fresh IDENTIFY even if we still hold a
+        // session id.
+        assert_eq!(
+            decide_handshake(true, &ReconnectReason::InvalidSessionFatal),
+            Handshake::Identify
+        );
+        assert_eq!(
+            decide_handshake(false, &ReconnectReason::InvalidSessionFatal),
+            Handshake::Identify
+        );
+    }
+
+    #[test]
+    fn seq_tracking_advances_carried_resume_state() {
+        // Mirrors the driver's inbound-frame seq update: every dispatch
+        // with an `s` bumps the carried session's seq so a later RESUME
+        // replays from the correct point.
+        let mut resume = Some(ResumeState {
+            session_id: "s1".to_string(),
+            resume_gateway_url: None,
+            seq: 0,
+        });
+
+        for raw in [
+            r#"{"op":0,"t":"MESSAGE_CREATE","s":10,"d":{}}"#,
+            r#"{"op":11}"#, // HEARTBEAT_ACK: no `s`, seq unchanged.
+            r#"{"op":0,"t":"MESSAGE_CREATE","s":11,"d":{}}"#,
+        ] {
+            let payload = parse_payload(raw).unwrap();
+            if let Some(s) = payload.s
+                && let Some(state) = resume.as_mut()
+            {
+                state.seq = s;
+            }
+        }
+
+        assert_eq!(resume.unwrap().seq, 11, "seq tracks the latest dispatch s");
+    }
+
+    #[test]
+    fn invalid_session_backoff_in_discord_window() {
+        // Discord mandates a random 1–5s wait before re-IDENTIFY.
+        let d = invalid_session_backoff();
+        assert!(
+            d >= Duration::from_millis(1_000) && d <= Duration::from_millis(5_000),
+            "backoff {d:?} must sit in the 1–5s window"
+        );
+    }
+
+    #[test]
+    fn with_gateway_query_is_idempotent() {
+        assert_eq!(
+            with_gateway_query("wss://gateway.discord.gg"),
+            "wss://gateway.discord.gg?v=10&encoding=json"
+        );
+        // Already carries query params → untouched.
+        assert_eq!(
+            with_gateway_query("wss://resume.gg?v=10&encoding=json"),
+            "wss://resume.gg?v=10&encoding=json"
+        );
     }
 }

--- a/crates/wcore-channel-discord/src/gateway.rs
+++ b/crates/wcore-channel-discord/src/gateway.rs
@@ -20,7 +20,9 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::{Mutex, watch};
 use tokio_tungstenite::tungstenite::Message as WsMessage;
 
-use wcore_channels::event::{ChannelEvent, ConnectionState, IncomingMessage};
+use wcore_channels::event::{
+    Attachment, ChannelEvent, ChatType, ConnectionState, IncomingMessage, MediaKind, MentionKind,
+};
 
 // =============================================================================
 // Opcodes (https://discord.com/developers/docs/topics/gateway-events)
@@ -67,6 +69,24 @@ pub struct MessageCreate {
     pub timestamp: Option<String>,
     #[serde(default)]
     pub author: Option<MessageAuthor>,
+    /// Present on guild messages; absent for DMs and group DMs.
+    #[serde(default)]
+    pub guild_id: Option<String>,
+    /// Populated when the message is in a thread channel.
+    #[serde(default)]
+    pub thread: Option<MessageThread>,
+    /// File / media attachments.
+    #[serde(default)]
+    pub attachments: Vec<MessageAttachment>,
+    /// Users explicitly `@mention`ed in the message body.
+    #[serde(default)]
+    pub mentions: Vec<MessageMention>,
+    /// Inlined replied-to message (present when `message_type == 19`).
+    #[serde(default)]
+    pub referenced_message: Option<Box<ReferencedMessage>>,
+    /// Lightweight reply cross-reference (message_id / channel / guild).
+    #[serde(default)]
+    pub message_reference: Option<MessageReference>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -74,8 +94,53 @@ pub struct MessageAuthor {
     pub id: String,
     #[serde(default)]
     pub username: Option<String>,
+    /// Pomelo global display name (new username system, 2023+).
+    #[serde(default)]
+    pub global_name: Option<String>,
+    /// Legacy four-digit discriminator (`"0"` for migrated accounts).
+    #[serde(default)]
+    pub discriminator: Option<String>,
     #[serde(default)]
     pub bot: bool,
+}
+
+/// Minimal representation of a Discord attachment object.
+#[derive(Debug, Clone, Deserialize)]
+pub struct MessageAttachment {
+    /// CDN URL for the attachment.
+    pub url: String,
+    /// MIME type reported by Discord, if any.
+    #[serde(default)]
+    pub content_type: Option<String>,
+}
+
+/// Minimal mention entry — only the stable user id is needed.
+#[derive(Debug, Clone, Deserialize)]
+pub struct MessageMention {
+    pub id: String,
+}
+
+/// Inlined replied-to message — only the author id is needed for bot
+/// detection (`is_self` / `mention_kind`).
+#[derive(Debug, Clone, Deserialize)]
+pub struct ReferencedMessage {
+    pub id: String,
+    #[serde(default)]
+    pub author: Option<MessageAuthor>,
+}
+
+/// Lightweight reply cross-reference carried on the replying message.
+#[derive(Debug, Clone, Deserialize)]
+pub struct MessageReference {
+    #[serde(default)]
+    pub message_id: Option<String>,
+}
+
+/// Thread object embedded in MESSAGE_CREATE when the message is posted
+/// inside a thread. Only the id is used (as `thread_id`).
+#[derive(Debug, Clone, Deserialize)]
+pub struct MessageThread {
+    pub id: String,
 }
 
 // -----------------------------------------------------------------------------
@@ -165,9 +230,14 @@ pub(crate) fn parse_message_create(payload: &GatewayPayload) -> Option<MessageCr
 /// Returns `None` if the message is from a bot account (we don't echo
 /// our own messages back through `poll_events`) or if the channel ID is
 /// not in `allowed_channel_ids` (when non-empty).
+///
+/// `bot_id` — the stable user id of the receiving bot (from the READY
+/// event). When `Some`, `is_self` and mention detection are precise.
+/// When `None`, both default conservatively to `false`.
 pub(crate) fn map_message_create(
     msg: MessageCreate,
     allowed_channel_ids: &HashSet<String>,
+    bot_id: Option<&str>,
 ) -> Option<IncomingMessage> {
     if !allowed_channel_ids.is_empty() && !allowed_channel_ids.contains(&msg.channel_id) {
         return None;
@@ -176,24 +246,152 @@ pub(crate) fn map_message_create(
     if author_is_bot {
         return None;
     }
-    let author_str = msg
+
+    // ---- Sender identity ------------------------------------------------
+    let sender_id = msg
         .author
         .as_ref()
-        .and_then(|a| a.username.clone().or_else(|| Some(a.id.clone())))
+        .map(|a| a.id.clone())
         .unwrap_or_else(|| "unknown".to_string());
+
+    // global_name is the preferred display name (Pomelo); fall back to
+    // username, then the raw id.
+    let sender_display = msg
+        .author
+        .as_ref()
+        .and_then(|a| a.global_name.clone().or_else(|| a.username.clone()));
+
+    // @username#discriminator — omit discriminator when "0" (migrated acct)
+    // or absent (same thing in the new system).
+    let sender_handle = msg.author.as_ref().and_then(|a| {
+        let uname = a.username.as_deref()?;
+        let disc = a.discriminator.as_deref().unwrap_or("0");
+        if disc == "0" || disc.is_empty() {
+            Some(uname.to_string())
+        } else {
+            Some(format!("{uname}#{disc}"))
+        }
+    });
+
+    // Human-facing author label: global_name > username > id.
+    let author_str = sender_display
+        .clone()
+        .unwrap_or_else(|| sender_id.clone());
+
+    let is_self = bot_id.is_some_and(|bid| bid == sender_id);
+
     let ts_secs = msg
         .timestamp
         .as_deref()
         .map(crate::rest::parse_iso8601_to_epoch)
         .unwrap_or(0);
+
+    // ---- Chat type -------------------------------------------------------
+    // guild_id present → guild text channel (Channel).
+    // guild_id absent  → DM or group DM.
+    //   Discord MESSAGE_CREATE does not include `channel_type` directly,
+    //   so we cannot distinguish 1:1 DM (type=1) from group DM (type=3)
+    //   without a separate channel fetch. We default absent-guild to Direct;
+    //   group DMs are uncommon for bots and the distinction is low-risk here.
+    let chat_type = if msg.guild_id.is_some() {
+        ChatType::Channel
+    } else {
+        ChatType::Direct
+    };
+
+    // ---- Thread context --------------------------------------------------
+    let thread_id = msg.thread.as_ref().map(|t| t.id.clone());
+
+    // ---- Attachments -----------------------------------------------------
+    let attachments: Vec<Attachment> = msg
+        .attachments
+        .into_iter()
+        .map(|a| {
+            let kind = media_kind_from_content_type(a.content_type.as_deref());
+            Attachment {
+                url: a.url,
+                content_type: a.content_type,
+                kind,
+                ..Default::default()
+            }
+        })
+        .collect();
+
+    // ---- Mention / addressing --------------------------------------------
+    // 1. Native @mention: bot's id appears in the `mentions` array.
+    // 2. ReplyToBot: the inlined `referenced_message` was authored by the bot.
+    let (was_mentioned, mention_kind) = if let Some(bid) = bot_id {
+        let native = msg.mentions.iter().any(|m| m.id == bid);
+        let reply_to_bot = msg
+            .referenced_message
+            .as_deref()
+            .and_then(|r| r.author.as_ref())
+            .is_some_and(|a| a.id == bid);
+        match (native, reply_to_bot) {
+            (true, _) => (true, Some(MentionKind::Native)),
+            (false, true) => (true, Some(MentionKind::ReplyToBot)),
+            _ => (false, None),
+        }
+    } else {
+        (false, None)
+    };
+
+    // ---- Reply / quote ---------------------------------------------------
+    // Prefer the richer inlined object; fall back to the lightweight ref.
+    let reply_to_message_id = msg
+        .referenced_message
+        .as_deref()
+        .map(|r| r.id.clone())
+        .or_else(|| {
+            msg.message_reference
+                .as_ref()
+                .and_then(|r| r.message_id.clone())
+        });
+    // referenced_message body is not captured in the struct (would bloat the
+    // payload deserialization for limited value). A future REST-enrichment
+    // pass can fill this in; leave None for now.
+    let reply_to_text: Option<String> = None;
+
     Some(IncomingMessage {
         id: msg.id,
-        conversation_id: msg.channel_id,
+        conversation_id: msg.channel_id.clone(),
         author: author_str,
         text: msg.content,
         ts_secs,
-        attachments: Vec::new(),
+        attachments,
+        sender_id,
+        sender_display,
+        sender_handle,
+        sender_alt_id: None,
+        is_bot: false, // already filtered above — only non-bot messages reach here
+        is_self,
+        chat_type,
+        chat_name: None,    // not in MESSAGE_CREATE; requires channel GET
+        space_id: msg.guild_id,
+        thread_id,
+        parent_chat_id: None, // thread's parent channel not in this payload
+        account_id: None,     // single-account connector; not tracked
+        platform: Some("discord".into()),
+        was_mentioned,
+        mention_kind,
+        reply_to_message_id,
+        reply_to_text,
     })
+}
+
+/// Coarsely classify a MIME type string into a [`MediaKind`].
+fn media_kind_from_content_type(ct: Option<&str>) -> MediaKind {
+    match ct {
+        Some(s) if s.starts_with("image/") => MediaKind::Image,
+        Some(s) if s.starts_with("video/") => MediaKind::Video,
+        Some(s) if s.starts_with("audio/") => MediaKind::Audio,
+        Some(s)
+            if s.starts_with("application/") || s.starts_with("text/") =>
+        {
+            MediaKind::Document
+        }
+        _ => MediaKind::Other,
+    }
 }
 
 // -----------------------------------------------------------------------------
@@ -263,6 +461,10 @@ pub(crate) struct GatewayArgs {
     pub allowed_channel_ids: HashSet<String>,
     pub inbox: Arc<Mutex<VecDeque<ChannelEvent>>>,
     pub shutdown: watch::Receiver<bool>,
+    /// Stable user id of this bot (from Discord READY). Used for
+    /// `is_self` detection and `was_mentioned` classification.
+    /// `None` until the connector resolves it (e.g. via `/users/@me`).
+    pub bot_id: Option<String>,
 }
 
 /// Drive one or more gateway connection cycles until shutdown is
@@ -277,6 +479,7 @@ pub(crate) async fn gateway_loop(args: GatewayArgs) {
         allowed_channel_ids,
         inbox,
         mut shutdown,
+        bot_id,
     } = args;
 
     // Discord's gateway endpoint takes ?v=10&encoding=json.
@@ -298,6 +501,7 @@ pub(crate) async fn gateway_loop(args: GatewayArgs) {
             intents,
             heartbeat_grace_ms,
             &allowed_channel_ids,
+            bot_id.as_deref(),
             &inbox,
             &mut shutdown,
         )
@@ -344,12 +548,16 @@ enum SessionExit {
     Reconnect,
 }
 
+// One Gateway session carries many independent connection parameters;
+// grouping them into a struct would add indirection without clarity.
+#[allow(clippy::too_many_arguments)]
 async fn run_one_session(
     url: &str,
     bot_token: &str,
     intents: u64,
     heartbeat_grace_ms: u64,
     allowed_channel_ids: &HashSet<String>,
+    bot_id: Option<&str>,
     inbox: &Arc<Mutex<VecDeque<ChannelEvent>>>,
     shutdown: &mut watch::Receiver<bool>,
 ) -> Result<SessionExit, String> {
@@ -478,7 +686,8 @@ async fn run_one_session(
                     }
                     OP_DISPATCH => {
                         if let Some(mc) = parse_message_create(&payload)
-                            && let Some(im) = map_message_create(mc, allowed_channel_ids)
+                            && let Some(im) =
+                                map_message_create(mc, allowed_channel_ids, bot_id)
                         {
                             inbox
                                 .lock()
@@ -536,7 +745,7 @@ mod tests {
         assert_eq!(payload.s, Some(42));
         let mc = parse_message_create(&payload).expect("message_create parses");
         let allowed = HashSet::new();
-        let im = map_message_create(mc, &allowed).expect("mapper produces an event");
+        let im = map_message_create(mc, &allowed, None).expect("mapper produces an event");
         assert_eq!(im.id, "123456789");
         assert_eq!(im.conversation_id, "55555");
         assert_eq!(im.author, "alice");
@@ -556,7 +765,7 @@ mod tests {
         let mc = parse_message_create(&payload).unwrap();
         let allowed = HashSet::new();
         assert!(
-            map_message_create(mc, &allowed).is_none(),
+            map_message_create(mc, &allowed, None).is_none(),
             "bot messages should be dropped"
         );
     }
@@ -573,7 +782,7 @@ mod tests {
         let mut allowed = HashSet::new();
         allowed.insert("ALLOWED".to_string());
         assert!(
-            map_message_create(mc, &allowed).is_none(),
+            map_message_create(mc, &allowed, None).is_none(),
             "channel_id outside allow-list should be dropped"
         );
     }

--- a/crates/wcore-channel-discord/src/lib.rs
+++ b/crates/wcore-channel-discord/src/lib.rs
@@ -17,9 +17,11 @@
 //!      grace window.
 //!   5. Map every `op=0 t="MESSAGE_CREATE"` to a `ChannelEvent::MessageReceived`
 //!      and queue it for `poll_events`.
-//!   6. On `op=7 RECONNECT` / `op=9 INVALID_SESSION` / socket error:
-//!      tear down + re-IDENTIFY on next session. Full RESUME (with
-//!      session_id) is deferred.
+//!   6. On `op=7 RECONNECT` / dropped socket / heartbeat lapse: tear
+//!      down and RESUME (op 6) against `resume_gateway_url`, replaying
+//!      events buffered during the gap. On `op=9 INVALID_SESSION`:
+//!      resume when `d == true`, else clear the session and fall back to
+//!      a fresh IDENTIFY after the Discord-required 1–5s wait.
 
 use std::collections::{HashSet, VecDeque};
 use std::sync::Arc;

--- a/crates/wcore-channel-discord/src/lib.rs
+++ b/crates/wcore-channel-discord/src/lib.rs
@@ -165,6 +165,10 @@ impl Channel for DiscordChannel {
             allowed_channel_ids: allowed,
             inbox: Arc::clone(&self.inbox),
             shutdown: rx,
+            // bot_id is populated from the READY event; pre-READY messages
+            // will have is_self=false and was_mentioned=false (conservative).
+            // A future pass can resolve via GET /users/@me at start() time.
+            bot_id: None,
         };
         let handle = tokio::spawn(gateway::gateway_loop(args));
         self.gateway_handle = Some(handle);

--- a/crates/wcore-channel-discord/src/lib.rs
+++ b/crates/wcore-channel-discord/src/lib.rs
@@ -250,6 +250,11 @@ impl Channel for DiscordChannel {
     fn config_schema(&self) -> &str {
         include_str!("schemas/discord.json")
     }
+
+    /// Discord caps a single message at 2000 characters.
+    fn max_message_len(&self) -> Option<usize> {
+        Some(2000)
+    }
 }
 
 // ===========================================================================
@@ -497,6 +502,13 @@ heartbeat_grace_ms = 8000
         assert_eq!(cfg.allowed_channel_ids, vec!["111", "222"]);
         assert_eq!(cfg.intents, 513);
         assert_eq!(cfg.heartbeat_grace_ms, 8_000);
+    }
+
+    #[test]
+    fn max_message_len_is_discord_cap() {
+        let creds = InMemoryCreds::with_token("discord.test.bot_token", TEST_TOKEN);
+        let ch = DiscordChannel::new("test", cfg(), creds);
+        assert_eq!(ch.max_message_len(), Some(2000));
     }
 
     // -----------------------------------------------------------------

--- a/crates/wcore-channel-email/src/imap.rs
+++ b/crates/wcore-channel-email/src/imap.rs
@@ -7,7 +7,7 @@ use std::sync::{Arc, Mutex as StdMutex};
 use std::time::Duration;
 
 use tokio::sync::{Mutex, watch};
-use wcore_channels::event::{ChannelEvent, IncomingMessage};
+use wcore_channels::event::{Attachment, ChannelEvent, ChatType, IncomingMessage};
 
 use crate::error::EmailError;
 
@@ -239,6 +239,7 @@ pub(crate) fn parse_basic_rfc5322(uid: u32, body: &[u8]) -> Result<IncomingMessa
     let mut subject: Option<String> = None;
     let mut date: Option<String> = None;
     let mut message_id: Option<String> = None;
+    let mut in_reply_to: Option<String> = None;
 
     // Header unfolding: a line starting with whitespace continues the
     // previous header.
@@ -281,6 +282,17 @@ pub(crate) fn parse_basic_rfc5322(uid: u32, body: &[u8]) -> Result<IncomingMessa
                     .trim_matches(|c| c == '<' || c == '>')
                     .to_string(),
             );
+        } else if let Some(rest) = h
+            .strip_prefix("In-Reply-To:")
+            .or_else(|| h.strip_prefix("in-reply-to:"))
+        {
+            let stripped = rest
+                .trim()
+                .trim_matches(|c| c == '<' || c == '>')
+                .to_string();
+            if !stripped.is_empty() {
+                in_reply_to = Some(stripped);
+            }
         }
     }
 
@@ -305,13 +317,43 @@ pub(crate) fn parse_basic_rfc5322(uid: u32, body: &[u8]) -> Result<IncomingMessa
     let ts_secs = date.and_then(parse_rfc2822_to_epoch).unwrap_or(0);
     let id = message_id.unwrap_or_else(|| format!("uid:{uid}"));
 
+    // Stable sender identity: the normalized addr-spec from the From header.
+    // `normalize_from_addr` strips the display name and lowercases, giving a
+    // consistent key that survives name changes and quoting variations.
+    let sender_id = normalize_from_addr(&author);
+
+    // Display name: present only when the From header is in "Name <addr>" form.
+    // We derive it by taking the text before the angle-addr, trimmed of quotes.
+    let sender_display = from.as_deref().and_then(extract_display_name);
+
+    // conversation_id: the stable addr-spec so all messages from a given
+    // sender map to one conversation, regardless of display-name drift.
+    let conversation_id = sender_id.clone();
+
     Ok(IncomingMessage {
         id,
-        conversation_id: author.clone(),
+        conversation_id,
         author,
         text: combined_text,
         ts_secs,
-        attachments: Vec::new(),
+        // No attachment extraction today — the parser discards non-text/plain
+        // MIME parts; Vec::new() is correct (not a stub, just reflects reality).
+        attachments: Vec::<Attachment>::new(),
+        sender_id,
+        sender_display,
+        // sender_handle, sender_alt_id: no handle/alt-id concept in email.
+        // is_bot, is_self: not determinable without knowing our own address here.
+        chat_type: ChatType::Direct,
+        chat_name: subject,
+        // space_id, parent_chat_id: no enclosing workspace in email.
+        // thread_id: References-based root is not parsed; would require scanning
+        //   the full References chain. Leave None until thread extraction lands.
+        // account_id: receiving mailbox not passed into this fn; caller sets it.
+        platform: Some("email".into()),
+        // was_mentioned, mention_kind: N/A for email.
+        reply_to_message_id: in_reply_to,
+        // reply_to_text: we don't inline quoted-reply bodies; leave None.
+        ..Default::default()
     })
 }
 
@@ -339,6 +381,25 @@ pub(crate) fn is_sender_allowed(
     match allow_set {
         None => true,
         Some(set) => set.contains(&normalize_from_addr(raw_from)),
+    }
+}
+
+/// Extract the display name from a `From:`-style header value, returning
+/// `None` when no display name is present (bare addr-spec form).
+///
+/// `Alice <alice@acme.com>`        -> `Some("Alice")`
+/// `"Carol D" <carol@acme.com>`    -> `Some("Carol D")`
+/// `bob@acme.com`                  -> `None`
+fn extract_display_name(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    let angle = trimmed.find('<')?;
+    let name = trimmed[..angle]
+        .trim()
+        .trim_matches(|c| c == '"' || c == '\'');
+    if name.is_empty() {
+        None
+    } else {
+        Some(name.to_string())
     }
 }
 

--- a/crates/wcore-channel-email/src/imap.rs
+++ b/crates/wcore-channel-email/src/imap.rs
@@ -325,7 +325,7 @@ pub(crate) fn parse_message(
     let MimeResult {
         text: body_text,
         attachments,
-    } = walk_mime(&headers, body_part);
+    } = walk_mime(&headers, body_part, 0);
 
     // Prepend the subject so consumers can use it as a thread hint, mirroring
     // the prior behavior (and Slack's subject-in-text convention).
@@ -461,7 +461,13 @@ struct ContentType {
 ///
 /// Guarantees a non-empty `text` whenever any renderable text part exists
 /// anywhere in the tree.
-fn walk_mime(headers: &[String], body: &str) -> MimeResult {
+/// Maximum MIME nesting depth walked. A hostile sender can craft a message
+/// with thousands of nested `multipart/*` levels; without a cap the
+/// recursion would overflow the stack and crash the poll thread. Past this
+/// depth a part is surfaced as raw text rather than recursed into.
+const MAX_MIME_DEPTH: usize = 20;
+
+fn walk_mime(headers: &[String], body: &str, depth: usize) -> MimeResult {
     let ct = parse_content_type(headers);
     let disposition = headers
         .iter()
@@ -483,7 +489,15 @@ fn walk_mime(headers: &[String], body: &str) -> MimeResult {
         || (filename.is_some() && !ct.mime.starts_with("text/"));
 
     if ct.mime.starts_with("multipart/") {
-        return walk_multipart(&ct, body);
+        if depth >= MAX_MIME_DEPTH {
+            // Pathologically nested multipart — stop recursing and surface the
+            // raw body as text rather than risk a stack overflow.
+            return MimeResult {
+                text: body.trim().to_string(),
+                attachments: Vec::new(),
+            };
+        }
+        return walk_multipart(&ct, body, depth);
     }
 
     if is_attachment {
@@ -510,7 +524,7 @@ fn walk_mime(headers: &[String], body: &str) -> MimeResult {
 
 /// Split a multipart body on its boundary and fold the sub-parts into a
 /// single `MimeResult`.
-fn walk_multipart(ct: &ContentType, body: &str) -> MimeResult {
+fn walk_multipart(ct: &ContentType, body: &str, depth: usize) -> MimeResult {
     let boundary = match &ct.boundary {
         Some(b) => b,
         // Malformed multipart with no boundary: best-effort treat the raw
@@ -532,7 +546,7 @@ fn walk_multipart(ct: &ContentType, body: &str) -> MimeResult {
     for raw_part in split_parts(body, boundary) {
         let (phead, pbody) = split_headers_body(raw_part);
         let pheaders = unfold_headers(phead);
-        let sub = walk_mime(&pheaders, pbody);
+        let sub = walk_mime(&pheaders, pbody, depth + 1);
         attachments.extend(sub.attachments);
 
         if sub.text.trim().is_empty() {

--- a/crates/wcore-channel-email/src/imap.rs
+++ b/crates/wcore-channel-email/src/imap.rs
@@ -2,14 +2,48 @@
 //! loop on `tokio::task::spawn_blocking`. New messages land in the
 //! shared `inbox` queue that `poll_events` drains.
 
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Mutex as StdMutex};
 use std::time::Duration;
 
 use tokio::sync::{Mutex, watch};
-use wcore_channels::event::{Attachment, ChannelEvent, ChatType, IncomingMessage};
+use wcore_channels::event::{Attachment, ChannelEvent, ChatType, IncomingMessage, MediaKind};
 
 use crate::error::EmailError;
+use crate::smtp::ReplyContext;
+
+/// Shared index mapping an inbound RFC `Message-ID` (== `IncomingMessage.id`)
+/// to the threading context needed to reply to it. Populated by the IMAP
+/// poll task on every accepted inbound message and read by the SMTP send
+/// path when an `OutgoingMessage.reply_to` names a known id. `std::Mutex`
+/// because the poll task is synchronous.
+pub(crate) type ReplyIndex = Arc<StdMutex<HashMap<String, ReplyContext>>>;
+
+/// Upper bound on the reply index so a long-lived channel can't grow it
+/// without bound. When exceeded we clear it wholesale; a dropped entry just
+/// means a later reply falls back to a single-id `References` chain (still
+/// correctly threaded via `In-Reply-To`), never an error.
+pub(crate) const REPLY_INDEX_CAP: usize = 4096;
+
+/// Insert one reply-threading entry, enforcing `REPLY_INDEX_CAP`. A
+/// synthesized `uid:N` id (no real Message-ID) is still recorded so a
+/// reply can at least carry `In-Reply-To`. Clears the map when it would
+/// exceed the cap (see `REPLY_INDEX_CAP`).
+pub(crate) fn record_reply_context(index: &ReplyIndex, id: String, ctx: ReplyContext) {
+    if id.is_empty() {
+        return;
+    }
+    let mut guard = match index.lock() {
+        Ok(g) => g,
+        // A poisoned lock would only happen if a holder panicked; threading
+        // metadata is non-critical, so we skip rather than propagate.
+        Err(_) => return,
+    };
+    if guard.len() >= REPLY_INDEX_CAP && !guard.contains_key(&id) {
+        guard.clear();
+    }
+    guard.insert(id, ctx);
+}
 
 /// Arguments for the blocking poll task. Cloneable plain data so the
 /// `spawn_blocking` closure owns its own copy.
@@ -27,6 +61,9 @@ pub(crate) struct ImapPollArgs {
     pub allowed_senders: Vec<String>,
     pub inbox: Arc<Mutex<VecDeque<ChannelEvent>>>,
     pub last_seen_uid: Arc<StdMutex<u32>>,
+    /// Shared reply-threading index; the poll task records one entry per
+    /// accepted inbound message so the send path can thread replies.
+    pub reply_index: ReplyIndex,
     pub shutdown: watch::Receiver<bool>,
     /// Tokio handle used so the sync task can enqueue events via
     /// `block_on(inbox.lock())`. Falls back to constructing one if `None`.
@@ -46,6 +83,7 @@ pub(crate) fn imap_poll_blocking(args: ImapPollArgs) {
         allowed_senders,
         inbox,
         last_seen_uid,
+        reply_index,
         mut shutdown,
         runtime_handle,
     } = args;
@@ -74,6 +112,7 @@ pub(crate) fn imap_poll_blocking(args: ImapPollArgs) {
             allow_set.as_ref(),
             &inbox,
             &last_seen_uid,
+            &reply_index,
             &runtime_handle,
         ) {
             Ok(_) => {}
@@ -115,6 +154,7 @@ fn poll_once(
     allow_set: Option<&std::collections::HashSet<String>>,
     inbox: &Arc<Mutex<VecDeque<ChannelEvent>>>,
     last_seen_uid: &Arc<StdMutex<u32>>,
+    reply_index: &ReplyIndex,
     runtime_handle: &tokio::runtime::Handle,
 ) -> Result<(), EmailError> {
     let tls =
@@ -163,8 +203,8 @@ fn poll_once(
                 Some(b) => b,
                 None => continue,
             };
-            match parse_basic_rfc5322(uid, body) {
-                Ok(msg) => {
+            match parse_message(uid, body) {
+                Ok((msg, reply_ctx)) => {
                     // Sender allow-list. `msg.author` is the raw `From:`
                     // header value (display name + addr-spec); compare its
                     // normalized addr-spec against the configured set.
@@ -178,6 +218,10 @@ fn poll_once(
                         );
                         continue;
                     }
+                    // Record threading context so a later reply can set
+                    // In-Reply-To / References / Re: subject. Keyed by the
+                    // RFC Message-ID (== msg.id).
+                    record_reply_context(reply_index, msg.id.clone(), reply_ctx);
                     new_events.push(ChannelEvent::MessageReceived { msg });
                 }
                 Err(e) => {
@@ -217,32 +261,146 @@ fn poll_once(
     Ok(())
 }
 
-/// Minimal RFC 5322 parser — enough to surface From, Subject, and a
-/// text/plain body. We treat anything that doesn't look like text/plain
-/// as "body = empty string" rather than decoding MIME; the channel is a
-/// message-passing surface, not an email client.
+/// RFC 5322 / MIME parser — surfaces From, Subject, Message-ID,
+/// In-Reply-To, References, a non-empty text body (walking the MIME tree
+/// and converting HTML-only mail to text), and typed attachments.
+///
+/// We operate on a lossy-UTF-8 view of the raw message: RFC822 headers and
+/// base64/quoted-printable bodies are ASCII, so the only bytes lost are
+/// raw-8bit body octets we surface as metadata anyway. This keeps the
+/// parser robust against the odd non-UTF-8 byte instead of erroring out.
+/// Test-only convenience wrapper that drops the `ReplyContext` returned by
+/// [`parse_message`]; production code uses `parse_message` directly.
+#[cfg(test)]
 pub(crate) fn parse_basic_rfc5322(uid: u32, body: &[u8]) -> Result<IncomingMessage, EmailError> {
-    let text = std::str::from_utf8(body)
-        .map_err(|e| EmailError::Decode(format!("utf-8: {e}")))?
-        .to_string();
-    // Split headers / body on the first blank line. Accept CRLFCRLF
-    // (per RFC) or bare LFLF (real-world MTAs are sloppy).
-    let (head, body_part) = match text.find("\r\n\r\n") {
-        Some(i) => (&text[..i], &text[i + 4..]),
-        None => match text.find("\n\n") {
-            Some(i) => (&text[..i], &text[i + 2..]),
-            None => (text.as_str(), ""),
-        },
-    };
+    parse_message(uid, body).map(|(msg, _)| msg)
+}
+
+/// Parse a raw RFC822 message into the inbound `IncomingMessage` plus the
+/// `ReplyContext` (Message-ID + Subject + References) that the SMTP send
+/// path needs to thread a reply. The reply context is keyed downstream by
+/// the inbound message id (`IncomingMessage.id`, which is the RFC
+/// Message-ID when present).
+pub(crate) fn parse_message(
+    uid: u32,
+    body: &[u8],
+) -> Result<(IncomingMessage, ReplyContext), EmailError> {
+    let text = String::from_utf8_lossy(body).into_owned();
+    let (head, body_part) = split_headers_body(&text);
+    let headers = unfold_headers(head);
 
     let mut from: Option<String> = None;
     let mut subject: Option<String> = None;
     let mut date: Option<String> = None;
     let mut message_id: Option<String> = None;
     let mut in_reply_to: Option<String> = None;
+    let mut references: Option<String> = None;
 
-    // Header unfolding: a line starting with whitespace continues the
-    // previous header.
+    for h in &headers {
+        if let Some(rest) = header_value(h, "From") {
+            from = Some(rest.to_string());
+        } else if let Some(rest) = header_value(h, "Subject") {
+            subject = Some(rest.to_string());
+        } else if let Some(rest) = header_value(h, "Date") {
+            date = Some(rest.to_string());
+        } else if let Some(rest) = header_value(h, "Message-ID") {
+            message_id = Some(rest.trim_matches(|c| c == '<' || c == '>').to_string());
+        } else if let Some(rest) = header_value(h, "In-Reply-To") {
+            let stripped = rest.trim_matches(|c| c == '<' || c == '>').to_string();
+            if !stripped.is_empty() {
+                in_reply_to = Some(stripped);
+            }
+        } else if let Some(rest) = header_value(h, "References")
+            && !rest.is_empty()
+        {
+            references = Some(rest.to_string());
+        }
+    }
+
+    let author = from.clone().unwrap_or_else(|| format!("unknown@uid-{uid}"));
+
+    // Walk the MIME tree for a plain-text body + typed attachments. The
+    // walk prefers text/plain, falls back to HTML→text, and pulls any
+    // attachment parts out as metadata.
+    let MimeResult {
+        text: body_text,
+        attachments,
+    } = walk_mime(&headers, body_part);
+
+    // Prepend the subject so consumers can use it as a thread hint, mirroring
+    // the prior behavior (and Slack's subject-in-text convention).
+    let body_trimmed = body_text.trim_end_matches(['\n', '\r']);
+    let combined_text = match &subject {
+        Some(s) if !s.is_empty() => {
+            if body_trimmed.is_empty() {
+                s.clone()
+            } else {
+                format!("{s}\n\n{body_trimmed}")
+            }
+        }
+        _ => body_trimmed.to_string(),
+    };
+
+    let ts_secs = date.and_then(parse_rfc2822_to_epoch).unwrap_or(0);
+    let id = message_id.unwrap_or_else(|| format!("uid:{uid}"));
+
+    // Threading context for any reply to this message: its Message-ID,
+    // Subject (for `Re: <subj>`), and References chain (for `References`).
+    let reply_ctx = ReplyContext {
+        message_id: id.clone(),
+        subject: subject.clone(),
+        references,
+    };
+
+    // Stable sender identity: the normalized addr-spec from the From header.
+    let sender_id = normalize_from_addr(&author);
+    let sender_display = from.as_deref().and_then(extract_display_name);
+    let conversation_id = sender_id.clone();
+
+    let msg = IncomingMessage {
+        id,
+        conversation_id,
+        author,
+        text: combined_text,
+        ts_secs,
+        attachments,
+        sender_id,
+        sender_display,
+        // sender_handle, sender_alt_id: no handle/alt-id concept in email.
+        // is_bot, is_self: not determinable without knowing our own address here.
+        chat_type: ChatType::Direct,
+        chat_name: subject,
+        // space_id, parent_chat_id: no enclosing workspace in email.
+        // thread_id: References-based root is not parsed; would require scanning
+        //   the full References chain. Leave None until thread extraction lands.
+        // account_id: receiving mailbox not passed into this fn; caller sets it.
+        platform: Some("email".into()),
+        // was_mentioned, mention_kind: N/A for email.
+        reply_to_message_id: in_reply_to,
+        // reply_to_text: we don't inline quoted-reply bodies; leave None.
+        ..Default::default()
+    };
+    Ok((msg, reply_ctx))
+}
+
+/// Split a raw message into (headers, body) on the first blank line.
+/// Accepts `CRLFCRLF` (per RFC) or bare `LFLF` (real-world MTAs are
+/// sloppy). When no blank line exists, the whole input is treated as
+/// headers with an empty body.
+fn split_headers_body(text: &str) -> (&str, &str) {
+    match text.find("\r\n\r\n") {
+        Some(i) => (&text[..i], &text[i + 4..]),
+        None => match text.find("\n\n") {
+            Some(i) => (&text[..i], &text[i + 2..]),
+            None => (text, ""),
+        },
+    }
+}
+
+/// Unfold a header block: a line starting with whitespace continues the
+/// previous header (RFC 5322 §2.2.3). Returns one logical header per
+/// entry, each still in `Name: value` form.
+fn unfold_headers(head: &str) -> Vec<String> {
     let mut current: Option<String> = None;
     let mut headers: Vec<String> = Vec::new();
     for line in head.lines() {
@@ -261,114 +419,457 @@ pub(crate) fn parse_basic_rfc5322(uid: u32, body: &[u8]) -> Result<IncomingMessa
     if let Some(prev) = current.take() {
         headers.push(prev);
     }
+    headers
+}
 
-    for h in &headers {
-        if let Some(rest) = h.strip_prefix("From:").or_else(|| h.strip_prefix("from:")) {
-            from = Some(rest.trim().to_string());
-        } else if let Some(rest) = h
-            .strip_prefix("Subject:")
-            .or_else(|| h.strip_prefix("subject:"))
-        {
-            subject = Some(rest.trim().to_string());
-        } else if let Some(rest) = h.strip_prefix("Date:").or_else(|| h.strip_prefix("date:")) {
-            date = Some(rest.trim().to_string());
-        } else if let Some(rest) = h
-            .strip_prefix("Message-ID:")
-            .or_else(|| h.strip_prefix("Message-Id:"))
-            .or_else(|| h.strip_prefix("message-id:"))
-        {
-            message_id = Some(
-                rest.trim()
-                    .trim_matches(|c| c == '<' || c == '>')
-                    .to_string(),
-            );
-        } else if let Some(rest) = h
-            .strip_prefix("In-Reply-To:")
-            .or_else(|| h.strip_prefix("in-reply-to:"))
-        {
-            let stripped = rest
-                .trim()
-                .trim_matches(|c| c == '<' || c == '>')
-                .to_string();
-            if !stripped.is_empty() {
-                in_reply_to = Some(stripped);
+/// Case-insensitively match a single unfolded header line against `name`
+/// and return its trimmed value, or `None` if it's a different header.
+fn header_value<'a>(line: &'a str, name: &str) -> Option<&'a str> {
+    let colon = line.find(':')?;
+    if line[..colon].trim().eq_ignore_ascii_case(name) {
+        Some(line[colon + 1..].trim())
+    } else {
+        None
+    }
+}
+
+/// Result of walking a message's MIME tree: the best plain-text body we
+/// could extract plus any attachment parts surfaced as metadata.
+struct MimeResult {
+    text: String,
+    attachments: Vec<Attachment>,
+}
+
+/// Parsed `Content-Type` of a MIME part.
+struct ContentType {
+    /// Lowercased `type/subtype` (e.g. `text/plain`, `multipart/mixed`).
+    mime: String,
+    /// `boundary` parameter for multipart types, if present.
+    boundary: Option<String>,
+}
+
+/// Walk a MIME body given its (unfolded) headers and raw body text.
+///
+/// Dispatch:
+/// - `multipart/*` — split on the boundary, recurse into each sub-part.
+///   For `multipart/alternative` prefer the richest text we can render
+///   (plain over html-converted-to-text); for `mixed`/`related` collect
+///   the first non-empty text part and accumulate attachments.
+/// - `text/plain` — decoded body as-is.
+/// - `text/html` — tags stripped to a readable plain body.
+/// - anything with a filename / `attachment` disposition — an Attachment.
+///
+/// Guarantees a non-empty `text` whenever any renderable text part exists
+/// anywhere in the tree.
+fn walk_mime(headers: &[String], body: &str) -> MimeResult {
+    let ct = parse_content_type(headers);
+    let disposition = headers
+        .iter()
+        .find_map(|h| header_value(h, "Content-Disposition"));
+    let cte = headers
+        .iter()
+        .find_map(|h| header_value(h, "Content-Transfer-Encoding"))
+        .map(|s| s.to_ascii_lowercase());
+
+    // Attachment parts are surfaced as metadata, not body text. Treat a
+    // part as an attachment when it declares `Content-Disposition:
+    // attachment`, or when it carries a filename, or when it's a non-text
+    // part that isn't multipart.
+    let filename = disposition
+        .and_then(parse_filename)
+        .or_else(|| ct_param(headers, "name"));
+    let is_attachment = disposition
+        .is_some_and(|d| d.trim().to_ascii_lowercase().starts_with("attachment"))
+        || (filename.is_some() && !ct.mime.starts_with("text/"));
+
+    if ct.mime.starts_with("multipart/") {
+        return walk_multipart(&ct, body);
+    }
+
+    if is_attachment {
+        let name = filename.unwrap_or_else(|| "attachment".to_string());
+        return MimeResult {
+            text: String::new(),
+            attachments: vec![attachment_from(&ct.mime, &name)],
+        };
+    }
+
+    // Leaf text part.
+    let decoded = decode_transfer(body, cte.as_deref());
+    let text = if ct.mime == "text/html" || (ct.mime.is_empty() && looks_like_html(&decoded)) {
+        html_to_text(&decoded)
+    } else {
+        // text/plain (the default per RFC 2045 when no Content-Type).
+        decoded
+    };
+    MimeResult {
+        text,
+        attachments: Vec::new(),
+    }
+}
+
+/// Split a multipart body on its boundary and fold the sub-parts into a
+/// single `MimeResult`.
+fn walk_multipart(ct: &ContentType, body: &str) -> MimeResult {
+    let boundary = match &ct.boundary {
+        Some(b) => b,
+        // Malformed multipart with no boundary: best-effort treat the raw
+        // body as text so we don't silently drop content.
+        None => {
+            return MimeResult {
+                text: body.trim().to_string(),
+                attachments: Vec::new(),
+            };
+        }
+    };
+
+    let alternative = ct.mime == "multipart/alternative";
+    let mut plain: Option<String> = None;
+    let mut html: Option<String> = None;
+    let mut other_text: Option<String> = None;
+    let mut attachments: Vec<Attachment> = Vec::new();
+
+    for raw_part in split_parts(body, boundary) {
+        let (phead, pbody) = split_headers_body(raw_part);
+        let pheaders = unfold_headers(phead);
+        let sub = walk_mime(&pheaders, pbody);
+        attachments.extend(sub.attachments);
+
+        if sub.text.trim().is_empty() {
+            continue;
+        }
+        let part_ct = parse_content_type(&pheaders);
+        match part_ct.mime.as_str() {
+            "text/plain" => {
+                if plain.is_none() {
+                    plain = Some(sub.text);
+                }
+            }
+            "text/html" => {
+                if html.is_none() {
+                    html = Some(sub.text);
+                }
+            }
+            _ => {
+                // Nested multipart already rendered to text, or an
+                // untyped text leaf — keep the first non-empty.
+                if other_text.is_none() {
+                    other_text = Some(sub.text);
+                }
             }
         }
     }
 
-    let author = from.clone().unwrap_or_else(|| format!("unknown@uid-{uid}"));
-
-    // Prepend the subject so consumers can use it as a thread hint. The
-    // explicit text body still carries the message content; we mirror
-    // Slack's pattern of putting the subject into `text` with a separator
-    // when present.
-    let text_body = body_part.trim_end_matches('\n').trim_end_matches('\r');
-    let combined_text = match &subject {
-        Some(s) if !s.is_empty() => {
-            if text_body.is_empty() {
-                s.clone()
-            } else {
-                format!("{s}\n\n{text_body}")
-            }
-        }
-        _ => text_body.to_string(),
+    // multipart/alternative: prefer plain, then html. mixed/related/etc:
+    // concatenation isn't meaningful for a chat surface, so we take the
+    // first renderable text in priority order. Either way a non-empty text
+    // part anywhere yields a non-empty body.
+    let text = if alternative {
+        plain.or(html).or(other_text).unwrap_or_default()
+    } else {
+        plain.or(other_text).or(html).unwrap_or_default()
     };
 
-    let ts_secs = date.and_then(parse_rfc2822_to_epoch).unwrap_or(0);
-    let id = message_id.unwrap_or_else(|| format!("uid:{uid}"));
-
-    // Stable sender identity: the normalized addr-spec from the From header.
-    // `normalize_from_addr` strips the display name and lowercases, giving a
-    // consistent key that survives name changes and quoting variations.
-    let sender_id = normalize_from_addr(&author);
-
-    // Display name: present only when the From header is in "Name <addr>" form.
-    // We derive it by taking the text before the angle-addr, trimmed of quotes.
-    let sender_display = from.as_deref().and_then(extract_display_name);
-
-    // conversation_id: the stable addr-spec so all messages from a given
-    // sender map to one conversation, regardless of display-name drift.
-    let conversation_id = sender_id.clone();
-
-    Ok(IncomingMessage {
-        id,
-        conversation_id,
-        author,
-        text: combined_text,
-        ts_secs,
-        // No attachment extraction today — the parser discards non-text/plain
-        // MIME parts; Vec::new() is correct (not a stub, just reflects reality).
-        attachments: Vec::<Attachment>::new(),
-        sender_id,
-        sender_display,
-        // sender_handle, sender_alt_id: no handle/alt-id concept in email.
-        // is_bot, is_self: not determinable without knowing our own address here.
-        chat_type: ChatType::Direct,
-        chat_name: subject,
-        // space_id, parent_chat_id: no enclosing workspace in email.
-        // thread_id: References-based root is not parsed; would require scanning
-        //   the full References chain. Leave None until thread extraction lands.
-        // account_id: receiving mailbox not passed into this fn; caller sets it.
-        platform: Some("email".into()),
-        // was_mentioned, mention_kind: N/A for email.
-        reply_to_message_id: in_reply_to,
-        // reply_to_text: we don't inline quoted-reply bodies; leave None.
-        ..Default::default()
-    })
+    MimeResult { text, attachments }
 }
 
-/// Extract the bare `addr-spec` from a `From:`-style header value and
-/// lowercase it for case-insensitive comparison.
-///
-/// Handles the two real-world shapes:
-///   `Alice <alice@acme.com>`  -> `alice@acme.com`
-///   `bob@acme.com`            -> `bob@acme.com`
-///
-/// If an angle-addr is present we take its inner text; otherwise we take
-/// the whole trimmed value. We do not attempt full RFC 5322 group/comment
-/// parsing — the goal is a robust normalized key, and any leftover
-/// surrounding text simply won't match a clean allow-list entry (fail
-/// closed: an unparsable sender is dropped when an allow-list is set).
+/// Split a multipart body into raw sub-part slices delimited by
+/// `--<boundary>`. The preamble (before the first boundary) and the
+/// closing `--<boundary>--` epilogue are discarded per RFC 2046.
+fn split_parts<'a>(body: &'a str, boundary: &str) -> Vec<&'a str> {
+    let delim = format!("--{boundary}");
+    let mut parts = Vec::new();
+    // Skip everything up to (and including) the first delimiter line.
+    let mut rest = match body.find(&delim) {
+        Some(i) => &body[i + delim.len()..],
+        None => return parts,
+    };
+    loop {
+        // Each part starts after the CRLF following the delimiter.
+        let part_start = rest.find('\n').map_or(rest.len(), |i| i + 1);
+        let after = &rest[part_start..];
+        match after.find(&delim) {
+            Some(next) => {
+                let part = &after[..next];
+                // Closing delimiter is `--boundary--`; trailing chars after
+                // the part are trimmed by split_headers_body downstream.
+                parts.push(part.trim_end_matches(['\r', '\n']));
+                rest = &after[next + delim.len()..];
+                // `--` immediately after the delimiter marks the end.
+                if rest.starts_with("--") {
+                    break;
+                }
+            }
+            None => break,
+        }
+    }
+    parts
+}
+
+/// Parse a part's `Content-Type` header into a normalized struct. When the
+/// header is absent, `mime` is left empty; the leaf handler then treats it
+/// as `text/plain` per RFC 2045 (unless the body sniffs as HTML).
+fn parse_content_type(headers: &[String]) -> ContentType {
+    let raw = headers.iter().find_map(|h| header_value(h, "Content-Type"));
+    let raw = match raw {
+        Some(r) => r,
+        None => {
+            return ContentType {
+                mime: String::new(),
+                boundary: None,
+            };
+        }
+    };
+    let mime = raw
+        .split(';')
+        .next()
+        .unwrap_or("")
+        .trim()
+        .to_ascii_lowercase();
+    let boundary = ct_param_in(raw, "boundary");
+    ContentType { mime, boundary }
+}
+
+/// Extract a `Content-Type` parameter (e.g. `boundary`, `name`) from the
+/// full header value list.
+fn ct_param(headers: &[String], param: &str) -> Option<String> {
+    let raw = headers.iter().find_map(|h| header_value(h, "Content-Type"))?;
+    ct_param_in(raw, param)
+}
+
+/// Extract a parameter value from a raw `Content-Type` / disposition
+/// value, handling both quoted and bare forms (`name="a.png"` / `name=a`).
+fn ct_param_in(raw: &str, param: &str) -> Option<String> {
+    for seg in raw.split(';').skip(1) {
+        let seg = seg.trim();
+        let Some(eq) = seg.find('=') else { continue };
+        if seg[..eq].trim().eq_ignore_ascii_case(param) {
+            let val = seg[eq + 1..].trim().trim_matches('"');
+            if !val.is_empty() {
+                return Some(val.to_string());
+            }
+        }
+    }
+    None
+}
+
+/// Pull the `filename` out of a `Content-Disposition` value.
+fn parse_filename(disposition: &str) -> Option<String> {
+    ct_param_in(disposition, "filename")
+}
+
+/// Map a leaf part to a typed `Attachment`. For email there is no fetch
+/// URL, so `url` stays empty and the filename is surfaced via `path` so
+/// downstream consumers have a human-facing name. The raw bytes are not
+/// inlined (v1 surfaces metadata only); `content_type` + `kind` let a
+/// consumer decide whether to fetch later.
+fn attachment_from(mime: &str, filename: &str) -> Attachment {
+    let kind = if mime.starts_with("image/") {
+        MediaKind::Image
+    } else if mime.starts_with("audio/") {
+        MediaKind::Audio
+    } else if mime.starts_with("video/") {
+        MediaKind::Video
+    } else {
+        MediaKind::Document
+    };
+    Attachment {
+        url: String::new(),
+        path: Some(filename.to_string()),
+        content_type: if mime.is_empty() {
+            None
+        } else {
+            Some(mime.to_string())
+        },
+        kind,
+        transcribed: None,
+    }
+}
+
+/// Decode a leaf part body according to its `Content-Transfer-Encoding`.
+/// Handles `quoted-printable` and `base64`; `7bit`/`8bit`/`binary`/none
+/// pass through unchanged.
+fn decode_transfer(body: &str, cte: Option<&str>) -> String {
+    match cte {
+        Some("quoted-printable") => decode_quoted_printable(body),
+        Some("base64") => decode_base64_text(body),
+        _ => body.to_string(),
+    }
+}
+
+/// Decode a single ASCII hex digit to its nibble value.
+fn hex_val(b: u8) -> Option<u8> {
+    match b {
+        b'0'..=b'9' => Some(b - b'0'),
+        b'a'..=b'f' => Some(b - b'a' + 10),
+        b'A'..=b'F' => Some(b - b'A' + 10),
+        _ => None,
+    }
+}
+
+/// Minimal quoted-printable decoder (RFC 2045 §6.7): `=XX` hex escapes and
+/// `=`-at-end-of-line soft breaks. Unrecognized `=` sequences pass through.
+fn decode_quoted_printable(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    for line in input.split_inclusive('\n') {
+        let trimmed = line.trim_end_matches(['\r', '\n']);
+        // Soft line break: a trailing `=` joins to the next line.
+        let (content, soft_break) = match trimmed.strip_suffix('=') {
+            Some(rest) => (rest, true),
+            None => (trimmed, false),
+        };
+        let bytes = content.as_bytes();
+        let mut i = 0;
+        let mut buf: Vec<u8> = Vec::with_capacity(bytes.len());
+        while i < bytes.len() {
+            // `=XX` hex escape, decoded directly from bytes (no str slicing,
+            // so a malformed multibyte sequence can never panic).
+            if bytes[i] == b'='
+                && i + 2 < bytes.len()
+                && let (Some(hi), Some(lo)) = (hex_val(bytes[i + 1]), hex_val(bytes[i + 2]))
+            {
+                buf.push((hi << 4) | lo);
+                i += 3;
+                continue;
+            }
+            buf.push(bytes[i]);
+            i += 1;
+        }
+        out.push_str(&String::from_utf8_lossy(&buf));
+        if !soft_break {
+            // Preserve hard line breaks (normalize to \n).
+            if line.ends_with('\n') {
+                out.push('\n');
+            }
+        }
+    }
+    out
+}
+
+/// Minimal base64 decoder for text parts. Ignores whitespace/newlines and
+/// stops at padding. Returns a lossy-UTF-8 rendering of the decoded bytes.
+fn decode_base64_text(input: &str) -> String {
+    fn val(c: u8) -> Option<u8> {
+        match c {
+            b'A'..=b'Z' => Some(c - b'A'),
+            b'a'..=b'z' => Some(c - b'a' + 26),
+            b'0'..=b'9' => Some(c - b'0' + 52),
+            b'+' => Some(62),
+            b'/' => Some(63),
+            _ => None,
+        }
+    }
+    let mut out: Vec<u8> = Vec::with_capacity(input.len() * 3 / 4);
+    let mut acc: u32 = 0;
+    let mut bits = 0u32;
+    for &c in input.as_bytes() {
+        if c == b'=' {
+            break;
+        }
+        let Some(v) = val(c) else { continue };
+        acc = (acc << 6) | u32::from(v);
+        bits += 6;
+        if bits >= 8 {
+            bits -= 8;
+            out.push((acc >> bits) as u8);
+        }
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+/// Heuristic: does this body look like HTML even without a Content-Type?
+fn looks_like_html(s: &str) -> bool {
+    let low = s.trim_start().to_ascii_lowercase();
+    low.starts_with("<!doctype html") || low.starts_with("<html") || low.contains("<body")
+}
+
+/// Strip HTML to a readable plain-text body (v1: a minimal tag stripper,
+/// not a full renderer). Drops `<script>`/`<style>` contents entirely,
+/// removes all tags, decodes the handful of common entities, and collapses
+/// runs of blank lines. Adequate for surfacing the human-readable text of
+/// an HTML-only email on a chat surface.
+fn html_to_text(html: &str) -> String {
+    let mut out = String::with_capacity(html.len());
+    let lower = html.to_ascii_lowercase();
+    // Work on byte offsets but only ever slice at char boundaries: tag
+    // delimiters (`<`, `>`) are ASCII, so byte offsets at those points are
+    // always valid boundaries. Text between tags is copied char-by-char.
+    let mut i = 0;
+    while i < html.len() {
+        if html.as_bytes()[i] == b'<' {
+            // Drop the entire contents of <script>/<style> blocks.
+            let mut skipped = false;
+            for tag in ["script", "style"] {
+                if lower[i..].starts_with(&format!("<{tag}")) {
+                    let close = format!("</{tag}>");
+                    i = match lower[i..].find(&close) {
+                        Some(end) => i + end + close.len(),
+                        None => html.len(),
+                    };
+                    skipped = true;
+                    break;
+                }
+            }
+            if skipped {
+                continue;
+            }
+            // Map block-level tags to newlines so structure survives.
+            if lower[i..].starts_with("<br")
+                || lower[i..].starts_with("</p")
+                || lower[i..].starts_with("</div")
+                || lower[i..].starts_with("</tr")
+                || lower[i..].starts_with("</li")
+                || lower[i..].starts_with("</h")
+            {
+                out.push('\n');
+            }
+            // Skip to the end of the tag.
+            match html[i..].find('>') {
+                Some(end) => i += end + 1,
+                None => break,
+            }
+        } else {
+            // Copy one full UTF-8 char (handles multibyte safely).
+            let ch = html[i..].chars().next().unwrap_or('\u{FFFD}');
+            out.push(ch);
+            i += ch.len_utf8();
+        }
+    }
+    let decoded = decode_html_entities(&out);
+    collapse_blank_lines(&decoded)
+}
+
+/// Decode the small set of HTML entities that show up in real mail.
+fn decode_html_entities(s: &str) -> String {
+    s.replace("&nbsp;", " ")
+        .replace("&amp;", "&")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", "\"")
+        .replace("&#39;", "'")
+        .replace("&apos;", "'")
+}
+
+/// Trim each line and collapse runs of 2+ blank lines into one.
+fn collapse_blank_lines(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut blank_run = 0;
+    for line in s.lines() {
+        let t = line.trim();
+        if t.is_empty() {
+            blank_run += 1;
+            if blank_run <= 1 {
+                out.push('\n');
+            }
+        } else {
+            blank_run = 0;
+            out.push_str(t);
+            out.push('\n');
+        }
+    }
+    out.trim().to_string()
+}
+
 /// Decide whether an inbound message's raw `From:` value passes the
 /// sender allow-list. `None` allow-set means "no filtering" (allow all).
 /// A non-empty allow-set requires the normalized addr-spec to be present;
@@ -515,5 +1016,157 @@ mod tests {
         let legit = b"From: Alice <alice@acme.com>\r\nSubject: x\r\n\r\nbody";
         let msg = parse_basic_rfc5322(2, legit).unwrap();
         assert!(is_sender_allowed(Some(&set), &msg.author));
+    }
+
+    // -----------------------------------------------------------------
+    // MIME walk (FIX 2)
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn multipart_alternative_html_only_yields_nonempty_text() {
+        // multipart/alternative whose only renderable part is text/html.
+        let raw = b"From: a@b\r\n\
+Subject: Hi\r\n\
+Content-Type: multipart/alternative; boundary=\"BD\"\r\n\
+\r\n\
+--BD\r\n\
+Content-Type: text/html; charset=utf-8\r\n\
+\r\n\
+<html><body><p>Hello <b>world</b></p></body></html>\r\n\
+--BD--\r\n";
+        let m = parse_basic_rfc5322(1, raw).unwrap();
+        assert!(m.text.contains("Hello"), "text = {:?}", m.text);
+        assert!(m.text.contains("world"), "text = {:?}", m.text);
+        // Subject still prepended.
+        assert!(m.text.starts_with("Hi"), "text = {:?}", m.text);
+        // Tags stripped.
+        assert!(!m.text.contains('<'), "text should have no tags: {:?}", m.text);
+    }
+
+    #[test]
+    fn multipart_alternative_prefers_plain_over_html() {
+        let raw = b"From: a@b\r\n\
+Content-Type: multipart/alternative; boundary=\"X\"\r\n\
+\r\n\
+--X\r\n\
+Content-Type: text/plain\r\n\
+\r\n\
+plain body wins\r\n\
+--X\r\n\
+Content-Type: text/html\r\n\
+\r\n\
+<p>html body</p>\r\n\
+--X--\r\n";
+        let m = parse_basic_rfc5322(2, raw).unwrap();
+        assert!(m.text.contains("plain body wins"), "text = {:?}", m.text);
+        assert!(!m.text.contains("html body"), "text = {:?}", m.text);
+    }
+
+    #[test]
+    fn multipart_mixed_text_plus_attachment_yields_text_and_attachment() {
+        // multipart/mixed: a text/plain part + an attachment part.
+        let raw = b"From: a@b\r\n\
+Subject: report\r\n\
+Content-Type: multipart/mixed; boundary=\"MIX\"\r\n\
+\r\n\
+--MIX\r\n\
+Content-Type: text/plain\r\n\
+\r\n\
+see attached\r\n\
+--MIX\r\n\
+Content-Type: image/png; name=\"chart.png\"\r\n\
+Content-Disposition: attachment; filename=\"chart.png\"\r\n\
+Content-Transfer-Encoding: base64\r\n\
+\r\n\
+aGVsbG8=\r\n\
+--MIX--\r\n";
+        let m = parse_basic_rfc5322(3, raw).unwrap();
+        assert!(m.text.contains("see attached"), "text = {:?}", m.text);
+        assert_eq!(m.attachments.len(), 1, "attachments = {:?}", m.attachments);
+        let att = &m.attachments[0];
+        assert_eq!(att.kind, MediaKind::Image);
+        assert_eq!(att.content_type.as_deref(), Some("image/png"));
+        assert_eq!(att.path.as_deref(), Some("chart.png"));
+        assert!(att.url.is_empty(), "email attachments have no fetch url");
+    }
+
+    #[test]
+    fn attachment_kind_maps_from_content_type() {
+        assert_eq!(attachment_from("image/jpeg", "a.jpg").kind, MediaKind::Image);
+        assert_eq!(attachment_from("audio/mpeg", "a.mp3").kind, MediaKind::Audio);
+        assert_eq!(attachment_from("video/mp4", "a.mp4").kind, MediaKind::Video);
+        assert_eq!(
+            attachment_from("application/pdf", "a.pdf").kind,
+            MediaKind::Document
+        );
+    }
+
+    #[test]
+    fn quoted_printable_html_part_decodes_and_strips() {
+        let raw = b"From: a@b\r\n\
+Content-Type: text/html\r\n\
+Content-Transfer-Encoding: quoted-printable\r\n\
+\r\n\
+<p>caf=C3=A9 =26 more</p>\r\n";
+        let m = parse_basic_rfc5322(4, raw).unwrap();
+        // =C3=A9 -> é ; =26 -> & ; tags stripped.
+        assert!(m.text.contains("café"), "text = {:?}", m.text);
+        assert!(m.text.contains('&'), "text = {:?}", m.text);
+        assert!(!m.text.contains("<p>"), "text = {:?}", m.text);
+    }
+
+    #[test]
+    fn plain_text_single_part_unchanged() {
+        // Regression: a bare text/plain message still surfaces its body.
+        let raw = b"From: a@b\r\nSubject: s\r\n\r\njust text\r\n";
+        let m = parse_basic_rfc5322(5, raw).unwrap();
+        assert!(m.text.contains("just text"), "text = {:?}", m.text);
+        assert!(m.attachments.is_empty());
+    }
+
+    #[test]
+    fn html_strip_drops_script_and_decodes_entities() {
+        let html = "<html><head><style>p{color:red}</style></head>\
+<body><script>evil()</script><p>A &amp; B</p><p>line two</p></body></html>";
+        let text = html_to_text(html);
+        assert!(text.contains("A & B"), "text = {:?}", text);
+        assert!(text.contains("line two"), "text = {:?}", text);
+        assert!(!text.contains("evil"), "script body must be dropped: {:?}", text);
+        assert!(!text.contains("color:red"), "style body must be dropped: {:?}", text);
+    }
+
+    #[test]
+    fn parse_message_returns_reply_context() {
+        let raw = b"From: a@b\r\n\
+Subject: Original subject\r\n\
+Message-ID: <orig@host>\r\n\
+References: <root@host>\r\n\
+\r\n\
+hello";
+        let (msg, ctx) = parse_message(7, raw).unwrap();
+        assert_eq!(msg.id, "orig@host");
+        assert_eq!(ctx.message_id, "orig@host");
+        assert_eq!(ctx.subject.as_deref(), Some("Original subject"));
+        assert_eq!(ctx.references.as_deref(), Some("<root@host>"));
+    }
+
+    #[test]
+    fn record_reply_context_skips_empty_id_and_enforces_cap() {
+        let index: ReplyIndex = Arc::new(StdMutex::new(HashMap::new()));
+        // Empty id is ignored.
+        record_reply_context(&index, String::new(), ReplyContext::default());
+        assert_eq!(index.lock().unwrap().len(), 0);
+        // Normal insert.
+        record_reply_context(
+            &index,
+            "a@x".into(),
+            ReplyContext {
+                message_id: "a@x".into(),
+                subject: Some("s".into()),
+                references: None,
+            },
+        );
+        assert_eq!(index.lock().unwrap().len(), 1);
+        assert!(index.lock().unwrap().contains_key("a@x"));
     }
 }

--- a/crates/wcore-channel-email/src/lib.rs
+++ b/crates/wcore-channel-email/src/lib.rs
@@ -9,7 +9,7 @@
 //! Shape mirrors `wcore-channel-telegram` deliberately — same lifecycle,
 //! same inbox queue + shutdown watch, same retry policy on outbound.
 
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Mutex as StdMutex};
 
 use async_trait::async_trait;
@@ -50,6 +50,11 @@ pub struct EmailChannel {
     /// Monotonic high-water UID for IMAP. Shared with the blocking poll
     /// task; std Mutex because the task is sync.
     last_seen_uid: Arc<StdMutex<u32>>,
+    /// Reply-threading index: inbound RFC Message-ID -> threading context.
+    /// The IMAP poll task records entries; `send_message` reads them to set
+    /// In-Reply-To / References / Re: subject on outbound replies. Shared
+    /// `std::Mutex` because the poll task is synchronous.
+    reply_index: crate::imap::ReplyIndex,
     /// Credentials store used to resolve SMTP+IMAP creds at `start()`.
     creds: Arc<dyn CredentialsStore>,
     /// Optional test override — when set, `start()` reuses this sender
@@ -75,6 +80,7 @@ impl EmailChannel {
             poll_handle: None,
             shutdown: None,
             last_seen_uid: Arc::new(StdMutex::new(0)),
+            reply_index: Arc::new(StdMutex::new(HashMap::new())),
             creds,
             sender_override: None,
         }
@@ -202,6 +208,7 @@ impl Channel for EmailChannel {
                 poll_interval_secs: imap_cfg.poll_interval_secs,
                 inbox: Arc::clone(&self.inbox),
                 last_seen_uid: Arc::clone(&self.last_seen_uid),
+                reply_index: Arc::clone(&self.reply_index),
                 shutdown: rx,
                 runtime_handle: tokio::runtime::Handle::current(),
             };
@@ -251,9 +258,33 @@ impl Channel for EmailChannel {
 
     async fn send_message(&mut self, msg: OutgoingMessage) -> Result<MessageReceipt, ChannelError> {
         let sender = self.sender.clone().ok_or(ChannelError::NotStarted)?;
-        let envelope =
-            crate::smtp::build_message(&self.config.from_address, &msg.conversation_id, &msg.text)
-                .map_err(ChannelError::from)?;
+
+        // Reply threading: when the outbound names a reply target, look up
+        // the inbound message's threading context (Message-ID + Subject +
+        // References) so we can set In-Reply-To / References / Re: subject.
+        // If the id is unknown (e.g. the index was cleared), fall back to a
+        // single-id chain built from the reply_to id itself — still a valid,
+        // correctly-threaded reply, just without the original Subject.
+        let reply_ctx = msg.reply_to.as_ref().map(|rid| {
+            self.reply_index
+                .lock()
+                .ok()
+                .and_then(|idx| idx.get(rid).cloned())
+                .unwrap_or_else(|| crate::smtp::ReplyContext {
+                    message_id: rid.clone(),
+                    subject: None,
+                    references: None,
+                })
+        });
+
+        let envelope = crate::smtp::build_message(
+            &self.config.from_address,
+            &msg.conversation_id,
+            &msg.text,
+            reply_ctx.as_ref(),
+            None,
+        )
+        .map_err(ChannelError::from)?;
         let response = crate::smtp::send_with_retry(sender, envelope)
             .await
             .map_err(ChannelError::from)?;
@@ -558,6 +589,90 @@ password_credential_handle = "email.acme.smtp_pass"
             .await
             .expect_err("not started");
         assert!(matches!(err, ChannelError::NotStarted), "got {err:?}");
+    }
+
+    // -----------------------------------------------------------------
+    // Reply threading (FIX 1): a reply OutgoingMessage whose reply_to names
+    // a recorded inbound message produces In-Reply-To + References + a
+    // non-empty Re: subject on the outbound envelope.
+    // -----------------------------------------------------------------
+    #[tokio::test]
+    async fn reply_threads_with_in_reply_to_references_and_re_subject() {
+        let sender = RecordingSender::new(vec![RecordingSender::ok("QID-R")]);
+        let mut ch = EmailChannel::with_sender(
+            "test",
+            cfg_outbound_only(),
+            creds_for_outbound(),
+            sender.clone(),
+        );
+        ch.start().await.unwrap();
+
+        // Simulate an inbound message having been recorded by the poll loop.
+        crate::imap::record_reply_context(
+            &ch.reply_index,
+            "orig-99@acme.com".to_string(),
+            crate::smtp::ReplyContext {
+                message_id: "orig-99@acme.com".into(),
+                subject: Some("Quarterly plan".into()),
+                references: Some("<root@acme.com>".into()),
+            },
+        );
+
+        let out = OutgoingMessage {
+            conversation_id: "ops@acme.com".into(),
+            text: "here is my reply".into(),
+            reply_to: Some("orig-99@acme.com".into()),
+            attachments: Vec::new(),
+        };
+        ch.send_message(out).await.unwrap();
+
+        {
+            let sent = sender.sent.lock().unwrap();
+            assert_eq!(sent.len(), 1);
+            let rfc = String::from_utf8_lossy(&sent[0].formatted()).to_string();
+            assert!(
+                rfc.contains("In-Reply-To: <orig-99@acme.com>"),
+                "rfc = {rfc}"
+            );
+            assert!(
+                rfc.contains("References: <root@acme.com> <orig-99@acme.com>"),
+                "rfc = {rfc}"
+            );
+            assert!(rfc.contains("Subject: Re: Quarterly plan"), "rfc = {rfc}");
+        }
+        ch.stop().await.unwrap();
+    }
+
+    // -----------------------------------------------------------------
+    // Reply threading fallback: unknown reply_to id (index cleared / cold
+    // start) still threads via a single-id chain, never errors.
+    // -----------------------------------------------------------------
+    #[tokio::test]
+    async fn reply_to_unknown_id_falls_back_to_single_id_chain() {
+        let sender = RecordingSender::new(vec![RecordingSender::ok("QID-F")]);
+        let mut ch = EmailChannel::with_sender(
+            "test",
+            cfg_outbound_only(),
+            creds_for_outbound(),
+            sender.clone(),
+        );
+        ch.start().await.unwrap();
+        let out = OutgoingMessage {
+            conversation_id: "ops@acme.com".into(),
+            text: "reply to unknown".into(),
+            reply_to: Some("never-seen@x".into()),
+            attachments: Vec::new(),
+        };
+        ch.send_message(out).await.unwrap();
+        {
+            let sent = sender.sent.lock().unwrap();
+            let rfc = String::from_utf8_lossy(&sent[0].formatted()).to_string();
+            assert!(rfc.contains("In-Reply-To: <never-seen@x>"), "rfc = {rfc}");
+            assert!(rfc.contains("References: <never-seen@x>"), "rfc = {rfc}");
+            // Unknown subject -> bare "Re:".
+            assert!(rfc.contains("Subject: Re:"), "rfc = {rfc}");
+        }
+        ch.stop().await.unwrap();
     }
 
     // -----------------------------------------------------------------

--- a/crates/wcore-channel-email/src/smtp.rs
+++ b/crates/wcore-channel-email/src/smtp.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
+use lettre::message::header::{HeaderName, HeaderValue};
 use lettre::message::{Message, header::ContentType};
 use lettre::transport::smtp::AsyncSmtpTransport;
 use lettre::transport::smtp::authentication::Credentials;
@@ -106,21 +107,130 @@ fn classify_lettre_error(e: &lettre::transport::smtp::Error) -> SendError {
     }
 }
 
+/// Threading context for an outbound reply, captured from the inbound
+/// message it replies to. Populated on inbound (keyed by the inbound RFC
+/// `Message-ID`, which is `IncomingMessage.id`) and looked up on outbound
+/// when `OutgoingMessage.reply_to` names a known id.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct ReplyContext {
+    /// The inbound message's RFC `Message-ID` (without angle brackets).
+    pub message_id: String,
+    /// The inbound message's `Subject`, if any. Used to build `Re: <subj>`.
+    pub subject: Option<String>,
+    /// The inbound message's `References` header value (space-separated
+    /// `<id>` tokens, angle brackets retained), if present. Carried so the
+    /// reply's `References` chain stays well-formed.
+    pub references: Option<String>,
+}
+
+/// Build the `Subject` for a reply: `Re: <original>`, without
+/// double-prefixing when the original already starts with `Re:`
+/// (case-insensitive, optional surrounding whitespace). Falls back to a
+/// bare `Re:` when the original subject is unknown or empty.
+pub(crate) fn build_reply_subject(original: Option<&str>) -> String {
+    match original.map(str::trim).filter(|s| !s.is_empty()) {
+        Some(s) => {
+            // Detect an existing "Re:" prefix (case-insensitive). Compare the
+            // leading bytes so a multibyte subject can't panic on a non-char
+            // boundary slice.
+            let b = s.as_bytes();
+            let is_re = b.len() >= 3
+                && b[0].eq_ignore_ascii_case(&b'r')
+                && b[1].eq_ignore_ascii_case(&b'e')
+                && b[2] == b':';
+            if is_re { s.to_string() } else { format!("Re: {s}") }
+        }
+        None => "Re:".to_string(),
+    }
+}
+
+/// Build the `References` value for a reply, per RFC 5322 §3.6.4: append
+/// the parent's `Message-ID` to the parent's existing `References` chain
+/// (or start a fresh chain with just the parent id). Each id is wrapped in
+/// angle brackets. Returns `None` only when the parent id is empty.
+fn build_references(reply: &ReplyContext) -> Option<String> {
+    if reply.message_id.is_empty() {
+        return None;
+    }
+    let parent = format!("<{}>", reply.message_id);
+    match reply.references.as_deref().map(str::trim) {
+        Some(prev) if !prev.is_empty() => Some(format!("{prev} {parent}")),
+        _ => Some(parent),
+    }
+}
+
+/// Build the threading headers (`In-Reply-To`, `References`) for a reply.
+/// Returns an empty vec when the reply context carries no usable parent
+/// id (so the caller can unconditionally extend the builder). Header
+/// values are plain-ASCII `<message-id>` tokens; `HeaderValue::new` passes
+/// them through unencoded.
+fn reply_headers(reply: &ReplyContext) -> Vec<HeaderValue> {
+    if reply.message_id.is_empty() {
+        return Vec::new();
+    }
+    let mut out = Vec::with_capacity(2);
+    let in_reply_to = format!("<{}>", reply.message_id);
+    out.push(HeaderValue::new(
+        HeaderName::new_from_ascii_str("In-Reply-To"),
+        in_reply_to,
+    ));
+    if let Some(refs) = build_references(reply) {
+        out.push(HeaderValue::new(
+            HeaderName::new_from_ascii_str("References"),
+            refs,
+        ));
+    }
+    out
+}
+
 /// Build a minimal text/plain `lettre::Message` from the outbound
 /// envelope. `from` is the channel's configured From: address; `to` is
 /// the outbound conversation_id (one recipient per send — multi-recipient
 /// support lives behind a future enhancement).
-pub(crate) fn build_message(from: &str, to: &str, text: &str) -> Result<Message, EmailError> {
+///
+/// When `reply` is set, the message is threaded: `Subject` becomes
+/// `Re: <original>` and `In-Reply-To` / `References` headers are attached
+/// so MUAs group the reply with the original. When `reply` is `None` the
+/// subject falls back to `subject_override` (if any) or a bare default,
+/// preserving the prior outbound-only behavior.
+pub(crate) fn build_message(
+    from: &str,
+    to: &str,
+    text: &str,
+    reply: Option<&ReplyContext>,
+    subject_override: Option<&str>,
+) -> Result<Message, EmailError> {
     let from_addr = from
         .parse()
         .map_err(|e| EmailError::Envelope(format!("from {from}: {e}")))?;
     let to_addr = to
         .parse()
         .map_err(|e| EmailError::Envelope(format!("to {to}: {e}")))?;
-    Message::builder()
+
+    // Subject: reply threading wins, then an explicit override, then a
+    // sensible non-empty default (a blank subject reads as a malformed
+    // orphan in most MUAs).
+    let subject = match reply {
+        Some(r) => build_reply_subject(r.subject.as_deref()),
+        None => subject_override
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)
+            .unwrap_or_else(|| "(no subject)".to_string()),
+    };
+
+    let mut builder = Message::builder()
         .from(from_addr)
         .to(to_addr)
-        .subject("")
+        .subject(subject);
+
+    if let Some(r) = reply {
+        for hv in reply_headers(r) {
+            builder = builder.raw_header(hv);
+        }
+    }
+
+    builder
         .header(ContentType::TEXT_PLAIN)
         .body(text.to_string())
         .map_err(|e| EmailError::Envelope(format!("body: {e}")))
@@ -246,7 +356,7 @@ mod tests {
     #[tokio::test]
     async fn send_records_envelope_from_to_body() {
         let sender = RecordingSender::new(vec![RecordingSender::ok_with_queue_id("Q1")]);
-        let msg = build_message("bot@acme.com", "ops@acme.com", "hello body").unwrap();
+        let msg = build_message("bot@acme.com", "ops@acme.com", "hello body", None, None).unwrap();
         let resp = send_with_retry(sender.clone(), msg).await.unwrap();
         assert_eq!(response_message_id(&resp), "Q1");
         let sent = sender.sent.lock().unwrap();
@@ -264,7 +374,7 @@ mod tests {
             Err(SendError::Transient("conn reset".into())),
             RecordingSender::ok_with_queue_id("Q2"),
         ]);
-        let msg = build_message("bot@acme.com", "ops@acme.com", "after retry").unwrap();
+        let msg = build_message("bot@acme.com", "ops@acme.com", "after retry", None, None).unwrap();
         let resp = send_with_retry(sender.clone(), msg).await.unwrap();
         assert_eq!(response_message_id(&resp), "Q2");
         assert_eq!(sender.sent.lock().unwrap().len(), 3);
@@ -277,7 +387,8 @@ mod tests {
             // Outcome below must NOT be consumed.
             RecordingSender::ok_with_queue_id("Q3"),
         ]);
-        let msg = build_message("bot@acme.com", "ops@acme.com", "should not retry").unwrap();
+        let msg =
+            build_message("bot@acme.com", "ops@acme.com", "should not retry", None, None).unwrap();
         let err = send_with_retry(sender.clone(), msg)
             .await
             .expect_err("auth");
@@ -295,7 +406,7 @@ mod tests {
             Err(SendError::Permanent("550 user unknown".into())),
             RecordingSender::ok_with_queue_id("nope"),
         ]);
-        let msg = build_message("bot@acme.com", "ops@acme.com", "nope").unwrap();
+        let msg = build_message("bot@acme.com", "ops@acme.com", "nope", None, None).unwrap();
         let err = send_with_retry(sender.clone(), msg)
             .await
             .expect_err("permanent");
@@ -308,7 +419,7 @@ mod tests {
 
     #[test]
     fn build_message_rejects_bad_from() {
-        let err = build_message("not-an-email", "ops@acme.com", "x")
+        let err = build_message("not-an-email", "ops@acme.com", "x", None, None)
             .expect_err("expected envelope error");
         match err {
             EmailError::Envelope(_) => {}
@@ -329,5 +440,90 @@ mod tests {
         let r = Response::from_str("250 2.0.0 fine and dandy\r\n").unwrap();
         let id = response_message_id(&r);
         assert!(id.starts_with("smtp-"), "id = {id}");
+    }
+
+    #[test]
+    fn reply_subject_prefixes_re_once() {
+        assert_eq!(build_reply_subject(Some("Hello there")), "Re: Hello there");
+        // Already-Re subject is not double-prefixed (case-insensitive).
+        assert_eq!(build_reply_subject(Some("Re: Hello there")), "Re: Hello there");
+        assert_eq!(build_reply_subject(Some("RE: shouting")), "RE: shouting");
+        assert_eq!(build_reply_subject(Some("re: lower")), "re: lower");
+        // Whitespace-only / empty / unknown fall back to a bare "Re:".
+        assert_eq!(build_reply_subject(Some("   ")), "Re:");
+        assert_eq!(build_reply_subject(None), "Re:");
+    }
+
+    #[test]
+    fn references_appends_parent_to_existing_chain() {
+        let r = ReplyContext {
+            message_id: "msg-2@x".into(),
+            subject: None,
+            references: Some("<msg-0@x> <msg-1@x>".into()),
+        };
+        assert_eq!(
+            build_references(&r).unwrap(),
+            "<msg-0@x> <msg-1@x> <msg-2@x>"
+        );
+        // Fresh chain (no prior References) starts with just the parent.
+        let r2 = ReplyContext {
+            message_id: "root@x".into(),
+            subject: None,
+            references: None,
+        };
+        assert_eq!(build_references(&r2).unwrap(), "<root@x>");
+        // Empty parent id -> no References.
+        let r3 = ReplyContext::default();
+        assert!(build_references(&r3).is_none());
+    }
+
+    #[test]
+    fn reply_message_carries_threading_headers_and_subject() {
+        let reply = ReplyContext {
+            message_id: "orig-123@acme.com".into(),
+            subject: Some("Status update".into()),
+            references: Some("<root@acme.com>".into()),
+        };
+        let msg = build_message(
+            "bot@acme.com",
+            "ops@acme.com",
+            "thread reply body",
+            Some(&reply),
+            None,
+        )
+        .unwrap();
+        let rfc = String::from_utf8_lossy(&msg.formatted()).to_string();
+        assert!(
+            rfc.contains("In-Reply-To: <orig-123@acme.com>"),
+            "rfc = {rfc}"
+        );
+        assert!(
+            rfc.contains("References: <root@acme.com> <orig-123@acme.com>"),
+            "rfc = {rfc}"
+        );
+        assert!(rfc.contains("Subject: Re: Status update"), "rfc = {rfc}");
+        assert!(rfc.contains("thread reply body"), "rfc = {rfc}");
+    }
+
+    #[test]
+    fn non_reply_message_uses_default_subject_not_blank() {
+        let msg = build_message("bot@acme.com", "ops@acme.com", "fresh", None, None).unwrap();
+        let rfc = String::from_utf8_lossy(&msg.formatted()).to_string();
+        // A blank Subject reads as a malformed orphan; we emit a default.
+        assert!(rfc.contains("Subject: (no subject)"), "rfc = {rfc}");
+    }
+
+    #[test]
+    fn non_reply_message_honours_subject_override() {
+        let msg = build_message(
+            "bot@acme.com",
+            "ops@acme.com",
+            "fresh",
+            None,
+            Some("Weekly report"),
+        )
+        .unwrap();
+        let rfc = String::from_utf8_lossy(&msg.formatted()).to_string();
+        assert!(rfc.contains("Subject: Weekly report"), "rfc = {rfc}");
     }
 }

--- a/crates/wcore-channel-imessage/src/channel.rs
+++ b/crates/wcore-channel-imessage/src/channel.rs
@@ -186,7 +186,9 @@ impl Channel for IMessageChannel {
         result.map_err(ChannelError::from)?;
 
         let ts_secs = chrono::Utc::now().timestamp();
-        let id = resolve_sent_guid(db_path, pre_send_rowid, &msg.text, ts_secs).await;
+        let id =
+            resolve_sent_guid(db_path, pre_send_rowid, &msg.conversation_id, &msg.text, ts_secs)
+                .await;
 
         Ok(MessageReceipt {
             id,
@@ -311,6 +313,7 @@ async fn do_send(chat_id: &str, text: &str) -> Result<(), crate::error::IMessage
 async fn resolve_sent_guid(
     db_path: std::path::PathBuf,
     pre_send_rowid: Option<i64>,
+    chat_id: &str,
     sent_text: &str,
     ts_secs: i64,
 ) -> String {
@@ -324,7 +327,7 @@ async fn resolve_sent_guid(
         if attempt > 0 {
             tokio::time::sleep(std::time::Duration::from_millis(GUID_LOOKUP_INTERVAL_MS)).await;
         }
-        match fetch_outgoing_since(db_path.clone(), since_rowid).await {
+        match fetch_outgoing_since(db_path.clone(), since_rowid, chat_id.to_string()).await {
             Ok(rows) => {
                 if let Some(guid) = match_outgoing_guid(&rows, sent_text) {
                     return guid;

--- a/crates/wcore-channel-imessage/src/channel.rs
+++ b/crates/wcore-channel-imessage/src/channel.rs
@@ -23,10 +23,20 @@ use wcore_config::credentials::CredentialsStore;
 
 use crate::applescript::{build_send_script, run_osascript};
 use crate::config::IMessageConfig;
-use crate::db::{apple_ns_to_unix_secs, chat_db_path, fetch_new_messages, max_rowid};
+use crate::db::{
+    apple_ns_to_unix_secs, chat_db_path, fetch_new_messages, fetch_outgoing_since,
+    match_outgoing_guid, max_rowid,
+};
 
 const SEND_QUEUE_MAX: usize = 50;
 const OSASCRIPT_TIMEOUT_MS: u64 = 15_000;
+
+// Budget for resolving a just-sent message's real GUID from chat.db. The send
+// is committed by AppleScript before the row lands in SQLite, so we poll a few
+// times. Kept short so send_message stays responsive; on miss we fall back to a
+// clearly-named synthetic pending id (see `resolve_sent_guid`).
+const GUID_LOOKUP_ATTEMPTS: usize = 10;
+const GUID_LOOKUP_INTERVAL_MS: u64 = 100;
 
 pub struct IMessageChannel {
     name: String,
@@ -160,16 +170,28 @@ impl Channel for IMessageChannel {
             *self.send_queue_depth.lock().await += 1;
         }
 
+        let db_path = chat_db_path();
+        // Snapshot the rowid cursor BEFORE sending so the post-send lookup only
+        // considers messages produced by this send. A failure to read the
+        // cursor (e.g. Full Disk Access not granted) is non-fatal: we still
+        // send, then fall back to a synthetic pending id.
+        let pre_send_rowid = max_rowid(db_path.clone()).await.ok();
+
         let result = do_send(&msg.conversation_id, &msg.text).await;
 
         {
             *self.send_queue_depth.lock().await -= 1;
         }
 
-        result.map_err(ChannelError::from).map(|_| MessageReceipt {
-            id: format!("imessage-sent-{}", chrono::Utc::now().timestamp()),
+        result.map_err(ChannelError::from)?;
+
+        let ts_secs = chrono::Utc::now().timestamp();
+        let id = resolve_sent_guid(db_path, pre_send_rowid, &msg.text, ts_secs).await;
+
+        Ok(MessageReceipt {
+            id,
             conversation_id: msg.conversation_id.clone(),
-            ts_secs: chrono::Utc::now().timestamp(),
+            ts_secs,
         })
     }
 
@@ -270,6 +292,61 @@ async fn do_send(chat_id: &str, text: &str) -> Result<(), crate::error::IMessage
     let script = build_send_script(chat_id, text, None);
     run_osascript(&script, OSASCRIPT_TIMEOUT_MS).await?;
     Ok(())
+}
+
+/// Resolve the receipt id for a just-sent message.
+///
+/// AppleScript's `send` returns no message id, so the real `message.guid` must
+/// be read back from chat.db. The outgoing row is written asynchronously by
+/// Messages.app, so we poll briefly (`GUID_LOOKUP_ATTEMPTS` ×
+/// `GUID_LOOKUP_INTERVAL_MS`) for an outgoing row newer than `pre_send_rowid`
+/// whose text matches what we sent, and return its GUID. This GUID is the
+/// stable cross-event key, so a later inbound echo or read receipt for the same
+/// message correlates with this receipt for dedup.
+///
+/// Fallback: if the cursor could not be read (Full Disk Access not granted) or
+/// the row has not landed within the budget, return a clearly-named synthetic
+/// `imessage-pending-<unix>` id. It is deliberately NOT shaped like a real GUID
+/// so callers can tell a resolved receipt from an unresolved one.
+async fn resolve_sent_guid(
+    db_path: std::path::PathBuf,
+    pre_send_rowid: Option<i64>,
+    sent_text: &str,
+    ts_secs: i64,
+) -> String {
+    let fallback = || format!("imessage-pending-{ts_secs}");
+
+    let Some(since_rowid) = pre_send_rowid else {
+        return fallback();
+    };
+
+    for attempt in 0..GUID_LOOKUP_ATTEMPTS {
+        if attempt > 0 {
+            tokio::time::sleep(std::time::Duration::from_millis(GUID_LOOKUP_INTERVAL_MS)).await;
+        }
+        match fetch_outgoing_since(db_path.clone(), since_rowid).await {
+            Ok(rows) => {
+                if let Some(guid) = match_outgoing_guid(&rows, sent_text) {
+                    return guid;
+                }
+            }
+            Err(e) => {
+                // Read-back is best-effort; the message was already sent. Log
+                // once and keep retrying within the budget.
+                tracing::debug!(
+                    target: "wcore_channel_imessage",
+                    error = %e,
+                    "iMessage GUID read-back error; will retry"
+                );
+            }
+        }
+    }
+
+    tracing::debug!(
+        target: "wcore_channel_imessage",
+        "iMessage GUID not resolved within budget; returning synthetic pending id"
+    );
+    fallback()
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/wcore-channel-imessage/src/channel.rs
+++ b/crates/wcore-channel-imessage/src/channel.rs
@@ -15,7 +15,9 @@ use tokio::task::JoinHandle;
 
 use wcore_channels::Channel;
 use wcore_channels::error::ChannelError;
-use wcore_channels::event::{ChannelEvent, ConnectionState, IncomingMessage, MessageReceipt};
+use wcore_channels::event::{
+    ChannelEvent, ChatType, ConnectionState, IncomingMessage, MessageReceipt,
+};
 use wcore_channels::outgoing::OutgoingMessage;
 use wcore_config::credentials::CredentialsStore;
 
@@ -214,17 +216,33 @@ async fn poll_loop(
                         continue;
                     }
 
+                    let conversation_id = if row.chat_guid.is_empty() {
+                        row.sender_handle.clone()
+                    } else {
+                        row.chat_guid.clone()
+                    };
                     let msg = IncomingMessage {
                         id: row.rowid.to_string(),
-                        conversation_id: if row.chat_guid.is_empty() {
-                            row.sender_handle.clone()
-                        } else {
-                            row.chat_guid.clone()
-                        },
+                        conversation_id,
+                        // sender_handle is the phone/email handle from chat.db — the
+                        // stable identity key for access control and dedup.
+                        sender_id: row.sender_handle.clone(),
                         author: row.sender_handle.clone(),
+                        sender_handle: Some(row.sender_handle.clone()),
                         text: row.text,
                         ts_secs: apple_ns_to_unix_secs(row.ts_apple_ns),
-                        attachments: Vec::new(),
+                        // SQL query filters is_from_me = 0; these are never self-sent.
+                        is_self: false,
+                        // is_group is derived in SQL: c.style=43 OR chat_identifier LIKE 'chat%'
+                        chat_type: if row.is_group {
+                            ChatType::Group
+                        } else {
+                            ChatType::Direct
+                        },
+                        platform: Some("imessage".into()),
+                        // No attachment paths, reply guids, display names, or group names
+                        // are present in the chat.db row — leave at defaults.
+                        ..Default::default()
                     };
 
                     inbox

--- a/crates/wcore-channel-imessage/src/db.rs
+++ b/crates/wcore-channel-imessage/src/db.rs
@@ -48,6 +48,26 @@ pub async fn max_rowid(db_path: PathBuf) -> Result<i64, IMessageError> {
         .map_err(|e| IMessageError::Database(format!("spawn_blocking panic: {e}")))?
 }
 
+/// An outgoing (`is_from_me = 1`) message row, used to resolve the real
+/// `message.guid` that AppleScript's `send` does not return synchronously.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OutgoingRow {
+    pub rowid: i64,
+    pub guid: String,
+    pub text: String,
+}
+
+/// Fetch outgoing message rows newer than `since_rowid`. Runs on a blocking
+/// thread. Used to resolve a just-sent message's GUID after an AppleScript send.
+pub async fn fetch_outgoing_since(
+    db_path: PathBuf,
+    since_rowid: i64,
+) -> Result<Vec<OutgoingRow>, IMessageError> {
+    tokio::task::spawn_blocking(move || fetch_outgoing_since_blocking(&db_path, since_rowid))
+        .await
+        .map_err(|e| IMessageError::Database(format!("spawn_blocking panic: {e}")))?
+}
+
 // ---------------------------------------------------------------------------
 // Blocking implementations
 // ---------------------------------------------------------------------------
@@ -70,6 +90,62 @@ const SQL_NEW_MESSAGES: &str = "
     AND COALESCE(m.text, '') != ''
   ORDER BY m.rowid ASC
 ";
+
+// Outgoing messages to a specific handle, newer than the cursor. The handle
+// match keeps us from picking up a concurrent send to a different recipient;
+// `is_from_me = 1` restricts to messages we sent. Ordered DESC so the newest
+// (most likely our just-sent message) is considered first.
+const SQL_OUTGOING_SINCE: &str = "
+  SELECT
+    m.rowid           AS rowid,
+    COALESCE(m.guid, '') AS guid,
+    COALESCE(m.text, '') AS text
+  FROM message m
+  WHERE m.rowid > ?1
+    AND m.is_from_me = 1
+    AND COALESCE(m.text, '') != ''
+  ORDER BY m.rowid DESC
+";
+
+/// Pure matcher: from a set of outgoing rows (already filtered to `rowid >
+/// cursor`), pick the GUID of the row whose text equals `sent_text`. Returns
+/// the highest-rowid match so the most recent send wins when a recipient was
+/// sent the same text twice. Returns `None` when no row matches — the caller
+/// then falls back to a synthetic pending id.
+pub fn match_outgoing_guid(rows: &[OutgoingRow], sent_text: &str) -> Option<String> {
+    rows.iter()
+        .filter(|r| r.text == sent_text && !r.guid.is_empty())
+        .max_by_key(|r| r.rowid)
+        .map(|r| r.guid.clone())
+}
+
+fn fetch_outgoing_since_blocking(
+    db_path: &std::path::Path,
+    since_rowid: i64,
+) -> Result<Vec<OutgoingRow>, IMessageError> {
+    use rusqlite::{Connection, OpenFlags};
+
+    let conn = Connection::open_with_flags(db_path, OpenFlags::SQLITE_OPEN_READ_ONLY)
+        .map_err(|e| IMessageError::Database(format!("open chat.db: {e}")))?;
+
+    let mut stmt = conn
+        .prepare(SQL_OUTGOING_SINCE)
+        .map_err(|e| IMessageError::Database(format!("prepare: {e}")))?;
+
+    let rows = stmt
+        .query_map([since_rowid], |row| {
+            Ok(OutgoingRow {
+                rowid: row.get(0)?,
+                guid: row.get(1)?,
+                text: row.get(2)?,
+            })
+        })
+        .map_err(|e| IMessageError::Database(format!("query: {e}")))?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| IMessageError::Database(format!("row: {e}")))?;
+
+    Ok(rows)
+}
 
 fn fetch_new_messages_blocking(
     db_path: &std::path::Path,
@@ -120,4 +196,64 @@ pub fn apple_ns_to_unix_secs(apple_ns: i64) -> i64 {
     // Apple epoch offset: 2001-01-01 00:00:00 UTC = 978307200 Unix seconds.
     let apple_secs = apple_ns / 1_000_000_000;
     apple_secs + 978_307_200
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn row(rowid: i64, guid: &str, text: &str) -> OutgoingRow {
+        OutgoingRow {
+            rowid,
+            guid: guid.into(),
+            text: text.into(),
+        }
+    }
+
+    #[test]
+    fn match_outgoing_guid_picks_matching_text() {
+        let rows = vec![
+            row(10, "GUID-A", "hello there"),
+            row(11, "GUID-B", "different message"),
+        ];
+        assert_eq!(
+            match_outgoing_guid(&rows, "hello there"),
+            Some("GUID-A".to_string())
+        );
+    }
+
+    #[test]
+    fn match_outgoing_guid_prefers_highest_rowid_on_duplicate_text() {
+        let rows = vec![
+            row(10, "GUID-OLD", "ping"),
+            row(20, "GUID-NEW", "ping"),
+            row(15, "GUID-MID", "ping"),
+        ];
+        assert_eq!(
+            match_outgoing_guid(&rows, "ping"),
+            Some("GUID-NEW".to_string())
+        );
+    }
+
+    #[test]
+    fn match_outgoing_guid_none_when_no_text_match() {
+        let rows = vec![row(10, "GUID-A", "hello")];
+        assert_eq!(match_outgoing_guid(&rows, "goodbye"), None);
+    }
+
+    #[test]
+    fn match_outgoing_guid_skips_empty_guid() {
+        // A row whose text matches but whose guid is empty must not be returned;
+        // an empty guid is useless for cross-event correlation.
+        let rows = vec![row(10, "", "hello"), row(9, "GUID-REAL", "hello")];
+        assert_eq!(
+            match_outgoing_guid(&rows, "hello"),
+            Some("GUID-REAL".to_string())
+        );
+    }
+
+    #[test]
+    fn match_outgoing_guid_empty_rows_is_none() {
+        assert_eq!(match_outgoing_guid(&[], "anything"), None);
+    }
 }

--- a/crates/wcore-channel-imessage/src/db.rs
+++ b/crates/wcore-channel-imessage/src/db.rs
@@ -62,10 +62,13 @@ pub struct OutgoingRow {
 pub async fn fetch_outgoing_since(
     db_path: PathBuf,
     since_rowid: i64,
+    chat_id: String,
 ) -> Result<Vec<OutgoingRow>, IMessageError> {
-    tokio::task::spawn_blocking(move || fetch_outgoing_since_blocking(&db_path, since_rowid))
-        .await
-        .map_err(|e| IMessageError::Database(format!("spawn_blocking panic: {e}")))?
+    tokio::task::spawn_blocking(move || {
+        fetch_outgoing_since_blocking(&db_path, since_rowid, &chat_id)
+    })
+    .await
+    .map_err(|e| IMessageError::Database(format!("spawn_blocking panic: {e}")))?
 }
 
 // ---------------------------------------------------------------------------
@@ -91,18 +94,25 @@ const SQL_NEW_MESSAGES: &str = "
   ORDER BY m.rowid ASC
 ";
 
-// Outgoing messages to a specific handle, newer than the cursor. The handle
-// match keeps us from picking up a concurrent send to a different recipient;
-// `is_from_me = 1` restricts to messages we sent. Ordered DESC so the newest
-// (most likely our just-sent message) is considered first.
+// Outgoing messages in a specific CHAT, newer than the cursor. Scoping to
+// the chat (via the same chat_message_join → chat join the inbound query
+// uses) keeps a concurrent send to a DIFFERENT conversation from being
+// mis-matched as our just-sent message — without it, a same-text send
+// elsewhere could steal this send's GUID and corrupt receipt correlation.
+// `?2` matches either the chat guid or the chat_identifier (the
+// conversation_id can be in either form). `is_from_me = 1` restricts to
+// messages we sent. Ordered DESC so the newest (most likely ours) wins.
 const SQL_OUTGOING_SINCE: &str = "
   SELECT
     m.rowid           AS rowid,
     COALESCE(m.guid, '') AS guid,
     COALESCE(m.text, '') AS text
   FROM message m
+  LEFT JOIN chat_message_join cmj ON cmj.message_id = m.rowid
+  LEFT JOIN chat c ON c.rowid = cmj.chat_id
   WHERE m.rowid > ?1
     AND m.is_from_me = 1
+    AND (c.guid = ?2 OR c.chat_identifier = ?2)
     AND COALESCE(m.text, '') != ''
   ORDER BY m.rowid DESC
 ";
@@ -122,8 +132,9 @@ pub fn match_outgoing_guid(rows: &[OutgoingRow], sent_text: &str) -> Option<Stri
 fn fetch_outgoing_since_blocking(
     db_path: &std::path::Path,
     since_rowid: i64,
+    chat_id: &str,
 ) -> Result<Vec<OutgoingRow>, IMessageError> {
-    use rusqlite::{Connection, OpenFlags};
+    use rusqlite::{params, Connection, OpenFlags};
 
     let conn = Connection::open_with_flags(db_path, OpenFlags::SQLITE_OPEN_READ_ONLY)
         .map_err(|e| IMessageError::Database(format!("open chat.db: {e}")))?;
@@ -133,7 +144,7 @@ fn fetch_outgoing_since_blocking(
         .map_err(|e| IMessageError::Database(format!("prepare: {e}")))?;
 
     let rows = stmt
-        .query_map([since_rowid], |row| {
+        .query_map(params![since_rowid, chat_id], |row| {
             Ok(OutgoingRow {
                 rowid: row.get(0)?,
                 guid: row.get(1)?,

--- a/crates/wcore-channel-matrix/src/lib.rs
+++ b/crates/wcore-channel-matrix/src/lib.rs
@@ -1,7 +1,8 @@
-//! `wcore-channel-matrix` — Matrix CS API channel adapter (send-only MVP).
+//! `wcore-channel-matrix` — Matrix CS API channel adapter.
 //!
 //! **Scope**: Outbound send via `PUT /_matrix/client/v3/rooms/{roomId}/send/m.room.message/{txnId}`.
-//! Inbound poll (`/sync`) is deferred to v0.8.3 — `poll_events` always returns empty.
+//! Inbound via `GET /_matrix/client/v3/sync` long-poll on a background task
+//! spawned in `start()`; `poll_events` drains the shared inbox the task fills.
 //!
 //! Avoids `matrix-sdk` to keep build time down (`matrix-sdk` + crypto WASM
 //! adds >5 min to clean builds). Raw REST is sufficient for the send use-case.
@@ -15,12 +16,14 @@
 pub mod config;
 pub mod error;
 mod rest;
+mod sync;
 
 use std::collections::VecDeque;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, watch};
+use tokio::task::JoinHandle;
 
 use wcore_channels::Channel;
 use wcore_channels::error::ChannelError;
@@ -38,7 +41,12 @@ pub struct MatrixChannel {
     state: ConnectionState,
     access_token: Option<String>,
     http: wcore_egress::EgressClient,
+    /// Background `/sync` task pushes into this; `poll_events` drains it.
     inbox: Arc<Mutex<VecDeque<ChannelEvent>>>,
+    /// Handle to the background `/sync` long-poll task; `None` until started.
+    poll_handle: Option<JoinHandle<()>>,
+    /// Shutdown signal for the `/sync` task; `None` until started.
+    shutdown: Option<watch::Sender<bool>>,
     creds: Arc<dyn CredentialsStore>,
     /// Override for tests.
     api_base: String,
@@ -73,6 +81,8 @@ impl MatrixChannel {
             access_token: None,
             http,
             inbox: Arc::new(Mutex::new(VecDeque::new())),
+            poll_handle: None,
+            shutdown: None,
             creds,
             api_base,
         }
@@ -94,7 +104,8 @@ impl Channel for MatrixChannel {
     }
 
     async fn start(&mut self) -> Result<(), ChannelError> {
-        if self.access_token.is_some() {
+        if self.poll_handle.is_some() {
+            // Already running — idempotent.
             return Ok(());
         }
         self.state = ConnectionState::Connecting;
@@ -110,20 +121,53 @@ impl Channel for MatrixChannel {
                 ))
             })?;
 
-        self.access_token = Some(token);
-        self.state = ConnectionState::Connected;
+        self.access_token = Some(token.clone());
+
+        // Emit a Connected state-change so subscribers know the channel
+        // went live (the manager will tag and broadcast it).
         self.inbox
             .lock()
             .await
             .push_back(ChannelEvent::ConnectionStateChanged {
                 state: ConnectionState::Connected,
             });
+
+        // Spawn the /sync long-poll task.
+        let (tx, rx) = watch::channel(false);
+        let args = sync::SyncArgs {
+            http: self.http.clone(),
+            api_base: self.api_base.clone(),
+            access_token: token,
+            user_id: self.config.user_id.clone(),
+            inbox: Arc::clone(&self.inbox),
+            shutdown: rx,
+        };
+        let handle = tokio::spawn(sync::sync_loop(args));
+        self.poll_handle = Some(handle);
+        self.shutdown = Some(tx);
+        self.state = ConnectionState::Connected;
+
         Ok(())
     }
 
     async fn stop(&mut self) -> Result<(), ChannelError> {
-        if self.access_token.is_none() {
+        if self.poll_handle.is_none() {
             return Ok(());
+        }
+        if let Some(tx) = self.shutdown.take() {
+            let _ = tx.send(true);
+        }
+        if let Some(handle) = self.poll_handle.take() {
+            // Give the loop a brief moment to observe the shutdown signal
+            // and drop out; if it lingers past the grace window, abort.
+            let joined = tokio::time::timeout(std::time::Duration::from_secs(2), handle).await;
+            if joined.is_err() {
+                tracing::warn!(
+                    target: "wcore_channel_matrix",
+                    channel = %self.name,
+                    "/sync task did not exit within shutdown grace; aborted"
+                );
+            }
         }
         self.access_token = None;
         self.state = ConnectionState::Disconnected;
@@ -136,7 +180,7 @@ impl Channel for MatrixChannel {
         Ok(())
     }
 
-    /// Always empty — inbound /sync polling is deferred to v0.8.3.
+    /// Drains the shared inbox the background `/sync` task fills.
     async fn poll_events(&mut self) -> Result<Vec<ChannelEvent>, ChannelError> {
         Ok(self.inbox.lock().await.drain(..).collect())
     }

--- a/crates/wcore-channel-matrix/src/lib.rs
+++ b/crates/wcore-channel-matrix/src/lib.rs
@@ -158,15 +158,23 @@ impl Channel for MatrixChannel {
             let _ = tx.send(true);
         }
         if let Some(handle) = self.poll_handle.take() {
-            // Give the loop a brief moment to observe the shutdown signal
-            // and drop out; if it lingers past the grace window, abort.
-            let joined = tokio::time::timeout(std::time::Duration::from_secs(2), handle).await;
-            if joined.is_err() {
-                tracing::warn!(
-                    target: "wcore_channel_matrix",
-                    channel = %self.name,
-                    "/sync task did not exit within shutdown grace; aborted"
-                );
+            // Give the loop a brief moment to observe the shutdown signal and
+            // drop out; if it lingers past the grace window (e.g. parked in a
+            // long /sync read), abort it. `timeout(dur, handle)` would only
+            // DROP the handle on elapse — which DETACHES, not aborts, the task,
+            // leaking it — so race the join against a sleep and abort
+            // explicitly via the AbortHandle on the timeout arm.
+            let abort = handle.abort_handle();
+            tokio::select! {
+                _ = handle => {}
+                _ = tokio::time::sleep(std::time::Duration::from_secs(2)) => {
+                    abort.abort();
+                    tracing::warn!(
+                        target: "wcore_channel_matrix",
+                        channel = %self.name,
+                        "/sync task did not exit within shutdown grace; aborted"
+                    );
+                }
             }
         }
         self.access_token = None;

--- a/crates/wcore-channel-matrix/src/sync.rs
+++ b/crates/wcore-channel-matrix/src/sync.rs
@@ -1,0 +1,426 @@
+//! Background `/sync` long-poll task. Spawned by `MatrixChannel::start()`,
+//! signaled to exit by the watch channel held in `MatrixChannel`.
+//!
+//! Mirrors the Telegram `getUpdates` long-poll: a loop that races each API
+//! call against a shutdown signal, backs off on transient failure, and pushes
+//! decoded `MessageReceived` events into the shared inbox.
+//!
+//! **Initial-sync replay guard**: the first `/sync` (no `since` token) returns
+//! the full current room state plus a `next_batch` cursor. We store that cursor
+//! but DO NOT emit its timeline events — otherwise the bot would replay the
+//! entire room backlog on every startup. Only sync responses AFTER the first
+//! (once `since` is set) contribute `MessageReceived` events.
+
+use std::collections::VecDeque;
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde::Deserialize;
+use tokio::sync::{Mutex, watch};
+
+use wcore_channels::event::{ChannelEvent, ChatType, IncomingMessage};
+
+use crate::error::MatrixError;
+
+/// Long-poll timeout (ms) handed to the homeserver's `/sync`. The HTTP read
+/// timeout is this plus a buffer so a wedged proxy can't park us forever.
+const SYNC_TIMEOUT_MS: u64 = 30_000;
+
+/// Constructor arguments — flatter than a struct, easier to spawn.
+pub(crate) struct SyncArgs {
+    pub http: wcore_egress::EgressClient,
+    pub api_base: String,
+    pub access_token: String,
+    pub user_id: String,
+    pub inbox: Arc<Mutex<VecDeque<ChannelEvent>>>,
+    pub shutdown: watch::Receiver<bool>,
+}
+
+// ---------------------------------------------------------------------------
+// /sync response model — only the slice this adapter consumes. Matrix payloads
+// are large; `#[serde(default)]` keeps us tolerant of everything we ignore.
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Deserialize, Default)]
+struct SyncResponse {
+    next_batch: String,
+    #[serde(default)]
+    rooms: Rooms,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+struct Rooms {
+    #[serde(default)]
+    join: std::collections::HashMap<String, JoinedRoom>,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+struct JoinedRoom {
+    #[serde(default)]
+    timeline: Timeline,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+struct Timeline {
+    #[serde(default)]
+    events: Vec<TimelineEvent>,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+struct TimelineEvent {
+    #[serde(rename = "type", default)]
+    event_type: String,
+    #[serde(default)]
+    sender: String,
+    #[serde(default)]
+    event_id: String,
+    /// Matrix `origin_server_ts` is milliseconds since the epoch.
+    #[serde(default)]
+    origin_server_ts: i64,
+    #[serde(default)]
+    content: MessageContent,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+struct MessageContent {
+    #[serde(default)]
+    body: String,
+    /// `m.mentions` rich-mention block (MSC3952). We only read `user_ids`.
+    #[serde(rename = "m.mentions", default)]
+    mentions: Option<Mentions>,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+struct Mentions {
+    #[serde(default)]
+    user_ids: Vec<String>,
+}
+
+/// Drive `/sync` in a loop until the shutdown signal flips.
+///
+/// Backoff on transient failure is linear-capped at 30s — the same family as
+/// the Telegram long-poll loop. A tight failure loop here is usually a
+/// transient outage, not a coding error, so the loop is self-correcting.
+pub(crate) async fn sync_loop(args: SyncArgs) {
+    let SyncArgs {
+        http,
+        api_base,
+        access_token,
+        user_id,
+        inbox,
+        mut shutdown,
+    } = args;
+
+    // `None` until the first /sync completes — the first response only seeds
+    // the cursor and never emits timeline events (replay guard).
+    let mut since: Option<String> = None;
+    let mut consecutive_failures: u32 = 0;
+
+    loop {
+        if *shutdown.borrow() {
+            break;
+        }
+
+        // Race the next API call against a shutdown signal so we don't get
+        // stuck for ~SYNC_TIMEOUT_MS after stop() flips the flag.
+        let result = tokio::select! {
+            biased;
+            _ = shutdown.changed() => {
+                if *shutdown.borrow() { break; }
+                continue;
+            }
+            r = sync_once(&http, &api_base, &access_token, since.as_deref()) => r,
+        };
+
+        match result {
+            Ok(resp) => {
+                consecutive_failures = 0;
+                let is_initial = since.is_none();
+                let next_batch = resp.next_batch.clone();
+                // Only emit events once `since` is set (i.e. after the first
+                // sync). The initial full-state sync is consumed for its
+                // cursor only, never replayed into the inbox.
+                if !is_initial {
+                    let events = parse_sync_events(&resp, &user_id);
+                    if !events.is_empty() {
+                        let mut guard = inbox.lock().await;
+                        for e in events {
+                            guard.push_back(e);
+                        }
+                    }
+                }
+                since = Some(next_batch);
+            }
+            Err(e) => {
+                tracing::warn!(
+                    target: "wcore_channel_matrix::sync",
+                    error = %e,
+                    "/sync failed; backing off"
+                );
+                consecutive_failures = consecutive_failures.saturating_add(1);
+                let sleep_secs = (2_u64.saturating_mul(consecutive_failures as u64)).min(30);
+                tokio::select! {
+                    biased;
+                    _ = shutdown.changed() => {
+                        if *shutdown.borrow() { break; }
+                    }
+                    _ = tokio::time::sleep(Duration::from_secs(sleep_secs)) => {}
+                }
+            }
+        }
+    }
+}
+
+/// One `GET /_matrix/client/v3/sync` call. Returns the decoded response.
+/// 4xx/5xx and network failures surface as `Err`; callers back off and retry.
+async fn sync_once(
+    http: &wcore_egress::EgressClient,
+    api_base: &str,
+    access_token: &str,
+    since: Option<&str>,
+) -> Result<SyncResponse, MatrixError> {
+    let url = format!("{api_base}/_matrix/client/v3/sync");
+    let timeout_str = SYNC_TIMEOUT_MS.to_string();
+
+    let mut query: Vec<(&str, &str)> = vec![("timeout", timeout_str.as_str())];
+    if let Some(s) = since {
+        query.push(("since", s));
+    }
+
+    let resp = http
+        .get(&url)
+        .bearer_auth(access_token)
+        .query(&query)
+        // HTTP read timeout = long-poll wait + buffer so we don't hang
+        // forever on a misbehaving proxy.
+        .timeout(Duration::from_millis(SYNC_TIMEOUT_MS.saturating_add(10_000)))
+        .send()
+        .await
+        .map_err(|e| MatrixError::Network(e.to_string()))?;
+
+    let status = resp.status().as_u16();
+    if !resp.status().is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        return Err(MatrixError::Http { status, body });
+    }
+
+    resp.json::<SyncResponse>()
+        .await
+        .map_err(|e| MatrixError::Parse(e.to_string()))
+}
+
+/// Pure parse: a decoded `/sync` response + the bot's own user id → the
+/// `MessageReceived` events it should emit. Network-free so it can be unit
+/// tested directly.
+///
+/// - Only `m.room.message` timeline events become messages.
+/// - Events sent by `bot_user_id` are skipped to avoid self-loops.
+/// - `conversation_id` is the room id; `sender`/`author` is the sender mxid.
+/// - `chat_type` defaults to [`ChatType::Group`]: Matrix can't cheaply tell DM
+///   from group without reading `m.direct` account-data. A later refinement can
+///   read `m.direct` and set [`ChatType::Direct`] for 1:1 rooms.
+/// - `was_mentioned` is best-effort: set when `m.mentions.user_ids` includes
+///   the bot, or the message body literally contains the bot's mxid.
+fn parse_sync_events(resp: &SyncResponse, bot_user_id: &str) -> Vec<ChannelEvent> {
+    let mut events = Vec::new();
+    for (room_id, room) in &resp.rooms.join {
+        for ev in &room.timeline.events {
+            if ev.event_type != "m.room.message" {
+                continue;
+            }
+            // Skip the bot's own echoes — prevents self-loops.
+            if ev.sender == bot_user_id {
+                continue;
+            }
+
+            let ts_secs = ev.origin_server_ts / 1000;
+
+            // Best-effort mention detection.
+            let mentioned_via_block = ev
+                .content
+                .mentions
+                .as_ref()
+                .map(|m| m.user_ids.iter().any(|u| u == bot_user_id))
+                .unwrap_or(false);
+            let mentioned_in_body =
+                !bot_user_id.is_empty() && ev.content.body.contains(bot_user_id);
+            let was_mentioned = mentioned_via_block || mentioned_in_body;
+
+            let msg = IncomingMessage {
+                sender_id: ev.sender.clone(),
+                chat_type: ChatType::Group,
+                platform: Some("matrix".into()),
+                was_mentioned,
+                ..IncomingMessage::new(
+                    ev.event_id.clone(),
+                    room_id.clone(),
+                    ev.sender.clone(),
+                    ev.content.body.clone(),
+                    ts_secs,
+                )
+            };
+            events.push(ChannelEvent::MessageReceived { msg });
+        }
+    }
+    events
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const BOT: &str = "@bot:matrix.example.org";
+
+    fn parse(body: &str, bot: &str) -> Vec<ChannelEvent> {
+        let resp: SyncResponse = serde_json::from_str(body).expect("valid /sync body");
+        parse_sync_events(&resp, bot)
+    }
+
+    // 1. One joined room with one m.room.message → one enriched IncomingMessage.
+    #[test]
+    fn parses_single_room_message() {
+        let body = r#"{
+            "next_batch": "s2_batch",
+            "rooms": {
+                "join": {
+                    "!room123:matrix.example.org": {
+                        "timeline": {
+                            "events": [
+                                {
+                                    "type": "m.room.message",
+                                    "sender": "@alice:matrix.example.org",
+                                    "event_id": "$evt1",
+                                    "origin_server_ts": 1700000010000,
+                                    "content": { "msgtype": "m.text", "body": "hi there" }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        }"#;
+
+        let events = parse(body, BOT);
+        assert_eq!(events.len(), 1, "expected exactly one message event");
+        let ChannelEvent::MessageReceived { msg } = &events[0] else {
+            panic!("expected MessageReceived, got {:?}", events[0]);
+        };
+        assert_eq!(msg.id, "$evt1");
+        assert_eq!(msg.sender_id, "@alice:matrix.example.org");
+        assert_eq!(msg.author, "@alice:matrix.example.org");
+        assert_eq!(msg.conversation_id, "!room123:matrix.example.org");
+        assert_eq!(msg.text, "hi there");
+        // origin_server_ts is millis → seconds.
+        assert_eq!(msg.ts_secs, 1_700_000_010);
+        assert_eq!(msg.platform.as_deref(), Some("matrix"));
+        assert_eq!(msg.chat_type, ChatType::Group);
+        assert!(!msg.was_mentioned);
+    }
+
+    // 2. An event sent by the bot's own user id is skipped (no self-loop).
+    #[test]
+    fn skips_bot_own_message() {
+        let body = r#"{
+            "next_batch": "s3_batch",
+            "rooms": {
+                "join": {
+                    "!room123:matrix.example.org": {
+                        "timeline": {
+                            "events": [
+                                {
+                                    "type": "m.room.message",
+                                    "sender": "@bot:matrix.example.org",
+                                    "event_id": "$self",
+                                    "origin_server_ts": 1700000020000,
+                                    "content": { "msgtype": "m.text", "body": "my own reply" }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        }"#;
+
+        let events = parse(body, BOT);
+        assert!(
+            events.is_empty(),
+            "bot's own message must be skipped, got {events:?}"
+        );
+    }
+
+    // 3. Non-message timeline events (e.g. m.room.member) are ignored.
+    #[test]
+    fn ignores_non_message_events() {
+        let body = r#"{
+            "next_batch": "s4_batch",
+            "rooms": {
+                "join": {
+                    "!room123:matrix.example.org": {
+                        "timeline": {
+                            "events": [
+                                {
+                                    "type": "m.room.member",
+                                    "sender": "@alice:matrix.example.org",
+                                    "event_id": "$member",
+                                    "origin_server_ts": 1700000030000,
+                                    "content": { "membership": "join" }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        }"#;
+
+        let events = parse(body, BOT);
+        assert!(events.is_empty(), "non-message events must be ignored");
+    }
+
+    // 4. m.mentions.user_ids referencing the bot sets was_mentioned.
+    #[test]
+    fn detects_native_mention() {
+        let body = r#"{
+            "next_batch": "s5_batch",
+            "rooms": {
+                "join": {
+                    "!room123:matrix.example.org": {
+                        "timeline": {
+                            "events": [
+                                {
+                                    "type": "m.room.message",
+                                    "sender": "@alice:matrix.example.org",
+                                    "event_id": "$mention",
+                                    "origin_server_ts": 1700000040000,
+                                    "content": {
+                                        "msgtype": "m.text",
+                                        "body": "hey can you help",
+                                        "m.mentions": { "user_ids": ["@bot:matrix.example.org"] }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        }"#;
+
+        let events = parse(body, BOT);
+        assert_eq!(events.len(), 1);
+        let ChannelEvent::MessageReceived { msg } = &events[0] else {
+            panic!("expected MessageReceived");
+        };
+        assert!(msg.was_mentioned, "m.mentions of the bot must set was_mentioned");
+    }
+
+    // 5. Empty /sync (no joined rooms) yields no events.
+    #[test]
+    fn empty_sync_yields_nothing() {
+        let body = r#"{ "next_batch": "s6_batch" }"#;
+        let events = parse(body, BOT);
+        assert!(events.is_empty());
+    }
+}

--- a/crates/wcore-channel-matrix/src/sync.rs
+++ b/crates/wcore-channel-matrix/src/sync.rs
@@ -149,7 +149,15 @@ pub(crate) async fn sync_loop(args: SyncArgs) {
                         }
                     }
                 }
-                since = Some(next_batch);
+                // Advance the cursor only on a non-empty token. A spec-
+                // compliant homeserver always returns a non-empty next_batch,
+                // but a malformed/proxy response with `next_batch: ""` would,
+                // if stored, send `?since=` next tick — which some homeservers
+                // treat as an initial sync and could replay backlog. Keep the
+                // prior cursor in that case.
+                if !next_batch.is_empty() {
+                    since = Some(next_batch);
+                }
             }
             Err(e) => {
                 tracing::warn!(

--- a/crates/wcore-channel-msteams/src/inbound.rs
+++ b/crates/wcore-channel-msteams/src/inbound.rs
@@ -1,0 +1,285 @@
+//! Bot Framework inbound Activity parsing.
+//!
+//! A Teams bot receives inbound traffic as Bot Framework **Activity** JSON
+//! POSTed to its messaging endpoint by the Azure Bot Service. This module
+//! turns the slice of that payload we care about into the enriched
+//! [`IncomingMessage`] the inbound dispatch kernel consumes.
+//!
+//! Only `type == "message"` activities produce a message; lifecycle
+//! activities (`conversationUpdate`, `typing`, …) parse to `Ok(None)` so the
+//! webhook host can ACK them without enqueuing anything.
+//!
+//! **Round-trip with the send path**: `conversation_id` is encoded as
+//! `{serviceUrl}|{conversationId}` so the reply path's `parse_chat_id`
+//! recovers the tenant-specific `serviceUrl` the Connector API requires. The
+//! `serviceUrl` is taken from the activity itself (Teams stamps it per
+//! activity), falling back to the channel's configured service URL.
+//!
+//! **Attachments are NOT parsed in v1.** Teams delivers files as
+//! `attachments[]` entries with `contentType`/`contentUrl`, but fetching them
+//! requires a separate auth-gated download against the Graph/Connector API;
+//! deferred to a follow-up. `attachments` is left empty here.
+
+use serde::Deserialize;
+use wcore_channels::event::{ChatType, IncomingMessage};
+
+use crate::error::MsTeamsError;
+
+/// The slice of a Bot Framework Activity we consume. Every field is
+/// `#[serde(default)]` so partial / unfamiliar payloads deserialize rather
+/// than 400 — we validate the fields we actually require explicitly.
+#[derive(Debug, Deserialize, Default)]
+struct Activity {
+    #[serde(rename = "type", default)]
+    activity_type: String,
+    #[serde(default)]
+    id: String,
+    #[serde(default)]
+    text: String,
+    #[serde(default)]
+    from: ChannelAccount,
+    #[serde(default)]
+    recipient: ChannelAccount,
+    #[serde(default)]
+    conversation: ConversationAccount,
+    #[serde(rename = "serviceUrl", default)]
+    service_url: String,
+    /// RFC3339 timestamp string, e.g. `2026-06-10T12:34:56.789Z`.
+    #[serde(default)]
+    timestamp: String,
+}
+
+/// `from` / `recipient` — a Bot Framework channel account.
+#[derive(Debug, Deserialize, Default)]
+struct ChannelAccount {
+    #[serde(default)]
+    id: String,
+    #[serde(default)]
+    name: String,
+}
+
+/// `conversation` — the Bot Framework conversation reference.
+#[derive(Debug, Deserialize, Default)]
+struct ConversationAccount {
+    #[serde(default)]
+    id: String,
+    #[serde(rename = "conversationType", default)]
+    conversation_type: String,
+    #[serde(rename = "isGroup", default)]
+    is_group: bool,
+    #[serde(default)]
+    name: String,
+}
+
+/// Map a Teams conversation descriptor to a [`ChatType`].
+///
+/// Teams uses `conversationType` of `"personal"` (1:1 DM), `"groupChat"`
+/// (ad-hoc group), or `"channel"` (a channel within a team). `isGroup` is a
+/// secondary signal for older payloads that omit `conversationType`.
+fn chat_type_of(conv: &ConversationAccount) -> ChatType {
+    match conv.conversation_type.as_str() {
+        "personal" => ChatType::Direct,
+        "channel" => ChatType::Channel,
+        "groupChat" => ChatType::Group,
+        _ if conv.is_group => ChatType::Group,
+        _ => ChatType::Direct,
+    }
+}
+
+/// Parse a Bot Framework Activity JSON body into an [`IncomingMessage`].
+///
+/// Returns:
+/// * `Ok(Some(msg))` for a `type == "message"` activity.
+/// * `Ok(None)` for any other activity type (lifecycle events such as
+///   `conversationUpdate`, `typing`, message reactions, …).
+/// * `Err(MsTeamsError::Parse)` if the JSON is malformed or a `message`
+///   activity is missing the required `from.id` (the access-control / dedup
+///   key — we refuse to fabricate it).
+///
+/// `service_url_fallback` is used to build `conversation_id` when the
+/// activity omits its own `serviceUrl` (the channel's configured service URL).
+pub fn activity_to_incoming(
+    raw_body: &str,
+    service_url_fallback: &str,
+) -> Result<Option<IncomingMessage>, MsTeamsError> {
+    let activity: Activity =
+        serde_json::from_str(raw_body).map_err(|e| MsTeamsError::Parse(e.to_string()))?;
+
+    // Only message activities carry user text; everything else is a
+    // lifecycle/control event the host can ACK without enqueuing.
+    if activity.activity_type != "message" {
+        return Ok(None);
+    }
+
+    if activity.from.id.is_empty() {
+        return Err(MsTeamsError::Parse(
+            "message activity missing from.id".to_string(),
+        ));
+    }
+
+    // serviceUrl|conversationId so the reply path (parse_chat_id) recovers
+    // the tenant-specific serviceUrl. Strip a trailing slash on the
+    // serviceUrl so the encoding is stable regardless of how Teams stamps it.
+    let service_url = if activity.service_url.is_empty() {
+        service_url_fallback
+    } else {
+        activity.service_url.as_str()
+    };
+    let service_url = service_url.strip_suffix('/').unwrap_or(service_url);
+    let conversation_id = format!("{service_url}|{}", activity.conversation.id);
+
+    // RFC3339 timestamp → epoch seconds; fall back to now if absent/unparsable.
+    let ts_secs = chrono::DateTime::parse_from_rfc3339(&activity.timestamp)
+        .map(|dt| dt.timestamp())
+        .unwrap_or_else(|_| chrono::Utc::now().timestamp());
+
+    let chat_type = chat_type_of(&activity.conversation);
+    let chat_name = if activity.conversation.name.is_empty() {
+        None
+    } else {
+        Some(activity.conversation.name.clone())
+    };
+    let sender_display = if activity.from.name.is_empty() {
+        None
+    } else {
+        Some(activity.from.name.clone())
+    };
+    // recipient.id is the bot identity that received this activity.
+    let account_id = if activity.recipient.id.is_empty() {
+        None
+    } else {
+        Some(activity.recipient.id.clone())
+    };
+
+    // Author label: prefer the display name, fall back to the stable id.
+    let author = if activity.from.name.is_empty() {
+        activity.from.id.clone()
+    } else {
+        activity.from.name.clone()
+    };
+
+    let msg = IncomingMessage {
+        sender_id: activity.from.id.clone(),
+        sender_display,
+        chat_type,
+        chat_name,
+        account_id,
+        platform: Some("msteams".into()),
+        // Teams does not echo the bot's own outbound back to its endpoint,
+        // so there is no reliable self-loop to guard here; leave is_self
+        // false. Attachments are deferred to a follow-up (see module docs).
+        ..IncomingMessage::new(
+            activity.id,
+            conversation_id,
+            author,
+            activity.text,
+            ts_secs,
+        )
+    };
+
+    Ok(Some(msg))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SERVICE_FALLBACK: &str = "https://smba.trafficmanager.net/amer/";
+
+    #[test]
+    fn message_activity_parses_enriched_fields() {
+        let body = r#"{
+            "type": "message",
+            "id": "1622471234567",
+            "text": "hello bot",
+            "serviceUrl": "https://smba.trafficmanager.net/emea/",
+            "timestamp": "2026-06-10T12:34:56.789Z",
+            "from": { "id": "29:user-aad-id", "name": "Ada Lovelace" },
+            "recipient": { "id": "28:bot-app-id", "name": "Wayland" },
+            "conversation": {
+                "id": "19:abc@thread.v2",
+                "conversationType": "personal",
+                "isGroup": false,
+                "name": "Ada / Wayland"
+            }
+        }"#;
+
+        let msg = activity_to_incoming(body, SERVICE_FALLBACK)
+            .expect("parse ok")
+            .expect("message activity yields Some");
+
+        assert_eq!(msg.id, "1622471234567");
+        assert_eq!(msg.sender_id, "29:user-aad-id");
+        assert_eq!(msg.author, "Ada Lovelace");
+        assert_eq!(msg.sender_display.as_deref(), Some("Ada Lovelace"));
+        assert_eq!(msg.text, "hello bot");
+        assert_eq!(msg.account_id.as_deref(), Some("28:bot-app-id"));
+        assert_eq!(msg.platform.as_deref(), Some("msteams"));
+        assert_eq!(msg.chat_type, ChatType::Direct);
+        assert_eq!(msg.chat_name.as_deref(), Some("Ada / Wayland"));
+        // conversation_id uses the activity's own serviceUrl (trailing slash
+        // stripped) so parse_chat_id round-trips it on the reply path.
+        assert_eq!(
+            msg.conversation_id,
+            "https://smba.trafficmanager.net/emea|19:abc@thread.v2"
+        );
+        // 2026-06-10T12:34:56Z epoch seconds.
+        assert_eq!(msg.ts_secs, 1_781_094_896);
+        assert!(!msg.is_self);
+        assert!(msg.attachments.is_empty());
+    }
+
+    #[test]
+    fn group_chat_maps_to_group_chat_type() {
+        let body = r#"{
+            "type": "message",
+            "id": "id1",
+            "text": "hi all",
+            "from": { "id": "29:u", "name": "U" },
+            "recipient": { "id": "28:bot" },
+            "conversation": { "id": "19:room@thread.v2", "conversationType": "groupChat" }
+        }"#;
+        let msg = activity_to_incoming(body, SERVICE_FALLBACK)
+            .unwrap()
+            .unwrap();
+        assert_eq!(msg.chat_type, ChatType::Group);
+        // No serviceUrl on the activity → fallback is used (slash stripped).
+        assert_eq!(
+            msg.conversation_id,
+            "https://smba.trafficmanager.net/amer|19:room@thread.v2"
+        );
+    }
+
+    #[test]
+    fn conversation_update_yields_none() {
+        let body = r#"{
+            "type": "conversationUpdate",
+            "id": "id2",
+            "membersAdded": [{ "id": "29:u" }],
+            "recipient": { "id": "28:bot" },
+            "conversation": { "id": "19:abc@thread.v2" }
+        }"#;
+        let out = activity_to_incoming(body, SERVICE_FALLBACK).expect("parse ok");
+        assert!(out.is_none(), "non-message activity must yield None");
+    }
+
+    #[test]
+    fn message_missing_from_id_errors() {
+        let body = r#"{
+            "type": "message",
+            "id": "id3",
+            "text": "anon",
+            "from": { "name": "No Id" },
+            "recipient": { "id": "28:bot" },
+            "conversation": { "id": "19:abc@thread.v2", "conversationType": "personal" }
+        }"#;
+        let err = activity_to_incoming(body, SERVICE_FALLBACK).expect_err("missing from.id errors");
+        assert!(matches!(err, MsTeamsError::Parse(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn malformed_json_errors() {
+        let err = activity_to_incoming("{ not json", SERVICE_FALLBACK).expect_err("bad json errors");
+        assert!(matches!(err, MsTeamsError::Parse(_)), "got {err:?}");
+    }
+}

--- a/crates/wcore-channel-msteams/src/lib.rs
+++ b/crates/wcore-channel-msteams/src/lib.rs
@@ -17,6 +17,7 @@
 
 pub mod config;
 pub mod error;
+pub mod inbound;
 mod token;
 
 use std::collections::VecDeque;
@@ -99,6 +100,41 @@ impl MsTeamsChannel {
     pub fn state(&self) -> ConnectionState {
         self.state
     }
+
+    /// Webhook-router entrypoint for an inbound Bot Framework Activity.
+    ///
+    /// Parses `raw_body` (the JSON Activity the Azure Bot Service POSTed to
+    /// the bot's messaging endpoint) and, for a `type == "message"` activity,
+    /// enqueues a [`ChannelEvent::MessageReceived`] for the next
+    /// [`poll_events`](Channel::poll_events). Lifecycle activities
+    /// (`conversationUpdate`, `typing`, …) are silently ignored.
+    ///
+    /// The activity's `conversation_id` is encoded as
+    /// `{serviceUrl}|{conversationId}` (falling back to the channel's
+    /// configured `service_url`) so the reply path round-trips the
+    /// tenant-specific serviceUrl. See [`inbound::activity_to_incoming`].
+    ///
+    /// # Security — NOT authenticated
+    ///
+    /// This method performs **no** authentication of the inbound request. The
+    /// Bot Framework signs inbound activities with a JWT in the
+    /// `Authorization: Bearer <jwt>` header that must be validated (issuer +
+    /// audience + signature against Azure's OpenID JWKS metadata) before the
+    /// payload can be trusted. That validation is a separate, heavier
+    /// follow-up.
+    ///
+    // TODO(security): validate Bot Framework JWT (iss/aud + JWKS) before
+    // trusting inbound; the inbound webhook host must not call this until that
+    // lands or must gate on network trust.
+    pub async fn ingest_activity(&self, raw_body: &str) -> Result<(), MsTeamsError> {
+        if let Some(msg) = inbound::activity_to_incoming(raw_body, &self.config.service_url)? {
+            self.inbox
+                .lock()
+                .await
+                .push_back(ChannelEvent::MessageReceived { msg });
+        }
+        Ok(())
+    }
 }
 
 #[async_trait]
@@ -173,7 +209,8 @@ impl Channel for MsTeamsChannel {
         Ok(())
     }
 
-    /// Always empty — inbound webhook receive is deferred to v0.8.3.
+    /// Drain events enqueued by lifecycle transitions and inbound activities
+    /// (via [`ingest_activity`](MsTeamsChannel::ingest_activity)).
     async fn poll_events(&mut self) -> Result<Vec<ChannelEvent>, ChannelError> {
         Ok(self.inbox.lock().await.drain(..).collect())
     }
@@ -398,7 +435,43 @@ service_url = "https://smba.trafficmanager.net/emea/"
         assert_eq!(conv, "19:abc@thread.v2");
     }
 
-    // 6. start + send via mockito (token endpoint + connector).
+    // 6. ingest_activity enqueues a MessageReceived that poll_events drains.
+    #[tokio::test]
+    async fn ingest_activity_enqueues_message() {
+        let mut ch = MsTeamsChannel::new("test", cfg(), MemCreds::empty());
+        let body = r#"{
+            "type": "message",
+            "id": "act-1",
+            "text": "ping",
+            "from": { "id": "29:user", "name": "User" },
+            "recipient": { "id": "28:bot" },
+            "conversation": { "id": "19:abc@thread.v2", "conversationType": "personal" }
+        }"#;
+        ch.ingest_activity(body).await.unwrap();
+
+        let events = ch.poll_events().await.unwrap();
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            ChannelEvent::MessageReceived { msg } => {
+                assert_eq!(msg.id, "act-1");
+                assert_eq!(msg.sender_id, "29:user");
+                assert_eq!(msg.text, "ping");
+                assert_eq!(msg.platform.as_deref(), Some("msteams"));
+            }
+            other => panic!("expected MessageReceived, got {other:?}"),
+        }
+    }
+
+    // 7. ingest_activity ignores lifecycle (conversationUpdate) activities.
+    #[tokio::test]
+    async fn ingest_activity_ignores_conversation_update() {
+        let mut ch = MsTeamsChannel::new("test", cfg(), MemCreds::empty());
+        let body = r#"{ "type": "conversationUpdate", "id": "x", "conversation": { "id": "19:abc" } }"#;
+        ch.ingest_activity(body).await.unwrap();
+        assert!(ch.poll_events().await.unwrap().is_empty());
+    }
+
+    // 8. start + send via mockito (token endpoint + connector).
     #[tokio::test]
     async fn send_message_succeeds_on_200() {
         let mut server = mockito::Server::new_async().await;

--- a/crates/wcore-channel-msteams/src/lib.rs
+++ b/crates/wcore-channel-msteams/src/lib.rs
@@ -282,6 +282,11 @@ impl Channel for MsTeamsChannel {
     fn config_schema(&self) -> &str {
         include_str!("schemas/msteams.json")
     }
+
+    /// Microsoft Teams caps a single message at roughly 28000 characters.
+    fn max_message_len(&self) -> Option<usize> {
+        Some(28_000)
+    }
 }
 
 /// Parse `{serviceUrl}|{conversationId}` or return `(default_service_url, raw)`.
@@ -403,6 +408,12 @@ service_url = "https://smba.trafficmanager.net/emea/"
     fn platform_tag_is_msteams() {
         let ch = MsTeamsChannel::new("test", cfg(), MemCreds::empty());
         assert_eq!(ch.platform(), "msteams");
+    }
+
+    #[test]
+    fn max_message_len_is_msteams_cap() {
+        let ch = MsTeamsChannel::new("test", cfg(), MemCreds::empty());
+        assert_eq!(ch.max_message_len(), Some(28_000));
     }
 
     // 3. send_message before start surfaces NotStarted.

--- a/crates/wcore-channel-signal/src/jsonrpc.rs
+++ b/crates/wcore-channel-signal/src/jsonrpc.rs
@@ -208,12 +208,17 @@ pub fn build_send_params(conversation_id: &str, text: &str) -> Value {
     }
 }
 
-/// Discriminator between a direct recipient and a group id. Signal e164
-/// phone numbers (and signal-cli's accepted recipient addresses) start
-/// with `+`; group ids are base64 strings that never do. We treat a
-/// leading `+` as the sole signal for a direct recipient.
+/// Discriminator between a direct recipient and a group id. A direct
+/// recipient is an e164 phone number: a leading `+` followed by ALL digits.
+/// The leading `+` alone is NOT sufficient — Signal group ids are base64
+/// (the standard alphabet includes `+`), so an id like `+abc/123==` starts
+/// with `+` yet must route via `groupId`. Requiring digits after the `+`
+/// disambiguates the ~1.5% of group ids that happen to start with `+`.
 pub fn is_direct_recipient(conversation_id: &str) -> bool {
-    conversation_id.starts_with('+')
+    match conversation_id.strip_prefix('+') {
+        Some(rest) => !rest.is_empty() && rest.bytes().all(|b| b.is_ascii_digit()),
+        None => false,
+    }
 }
 
 #[cfg(test)]
@@ -245,6 +250,14 @@ mod tests {
         assert!(is_direct_recipient("+15551234567"));
         assert!(!is_direct_recipient("abcd1234EFGH=="));
         assert!(!is_direct_recipient(""));
+        // A base64 group id that happens to start with '+' is NOT a phone
+        // number and must route via groupId, not recipient.
+        assert!(!is_direct_recipient("+abc/123Qo=="));
+        assert!(!is_direct_recipient("+"));
+        // build_send_params must follow the same discrimination.
+        let p = build_send_params("+abc/123Qo==", "hi");
+        assert!(p.get("recipient").is_none());
+        assert_eq!(p["groupId"], "+abc/123Qo==");
     }
 
     #[test]

--- a/crates/wcore-channel-signal/src/jsonrpc.rs
+++ b/crates/wcore-channel-signal/src/jsonrpc.rs
@@ -7,7 +7,7 @@
 //! arrive with no `id` and a `method`.
 
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
+use serde_json::{Value, json};
 
 #[derive(Debug, Clone, Serialize)]
 pub struct Request<'a> {
@@ -119,5 +119,210 @@ pub struct SendResult {
     #[serde(default)]
     pub timestamp: Option<i64>,
     #[serde(default)]
-    pub results: Option<Vec<Value>>,
+    pub results: Option<Vec<SendResultEntry>>,
+}
+
+/// One per-recipient delivery outcome inside a `send` result. signal-cli
+/// reports a `type` per recipient: `"SUCCESS"` on delivery, or a failure
+/// discriminant (`"UNREGISTERED_FAILURE"`, `"NETWORK_FAILURE"`,
+/// `"IDENTITY_FAILURE"`, …) otherwise. Fields beyond `type` (recipient
+/// address, etc.) are intentionally not captured — they carry no
+/// content we surface, and parsing them would risk leaking PII into
+/// logs.
+#[derive(Debug, Clone, Deserialize)]
+pub struct SendResultEntry {
+    /// Delivery outcome discriminant. Treated case-insensitively; any
+    /// value other than `SUCCESS` is a per-recipient failure.
+    #[serde(default, rename = "type")]
+    pub result_type: Option<String>,
+}
+
+impl SendResultEntry {
+    /// `true` when this entry reports a successful delivery. A missing
+    /// `type` is treated as success: older signal-cli builds omit the
+    /// field entirely on the happy path, and we must not regress those
+    /// sends into spurious failures.
+    pub fn is_success(&self) -> bool {
+        match self.result_type.as_deref() {
+            None => true,
+            Some(t) => t.eq_ignore_ascii_case("SUCCESS"),
+        }
+    }
+}
+
+/// Aggregate delivery outcome computed from a `send` result's
+/// per-recipient `results` array.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeliveryOutcome {
+    /// Every recipient succeeded (or no per-recipient detail was
+    /// reported, which signal-cli does for trivially-accepted sends).
+    AllSucceeded,
+    /// Some — but not all — recipients failed. Carries the failed and
+    /// total counts (counts only, never recipient identities).
+    Partial { failed: usize, total: usize },
+    /// Every recipient failed.
+    AllFailed { total: usize },
+}
+
+/// Classify a `send` result's per-recipient `results` into a single
+/// [`DeliveryOutcome`]. An absent or empty `results` array is treated
+/// as `AllSucceeded`: signal-cli omits per-recipient detail for sends
+/// it accepts outright, and the round-trip already succeeded by the
+/// time we parse this.
+pub fn classify_delivery(results: Option<&[SendResultEntry]>) -> DeliveryOutcome {
+    let entries = match results {
+        Some(e) if !e.is_empty() => e,
+        _ => return DeliveryOutcome::AllSucceeded,
+    };
+    let total = entries.len();
+    let failed = entries.iter().filter(|e| !e.is_success()).count();
+    match failed {
+        0 => DeliveryOutcome::AllSucceeded,
+        f if f == total => DeliveryOutcome::AllFailed { total },
+        f => DeliveryOutcome::Partial { failed: f, total },
+    }
+}
+
+/// Build the `params` object for a `send` JSON-RPC call.
+///
+/// signal-cli's `send` method takes EITHER a `recipient` array (1:1 /
+/// direct addresses) OR a `groupId` (groups) — never both. We pick
+/// based on the conversation id's shape: a value that starts with `+`
+/// (an e164 phone number) is a direct recipient; anything else is
+/// treated as a base64 group id. This mirrors how inbound group
+/// messages are keyed — `build_incoming` sets `conversation_id` to the
+/// raw base64 `groupId` for group envelopes and to the `+`-prefixed
+/// source for direct ones, so the discriminator is symmetric across the
+/// inbound/outbound boundary.
+pub fn build_send_params(conversation_id: &str, text: &str) -> Value {
+    if is_direct_recipient(conversation_id) {
+        json!({
+            "recipient": [conversation_id],
+            "message": text,
+        })
+    } else {
+        json!({
+            "groupId": conversation_id,
+            "message": text,
+        })
+    }
+}
+
+/// Discriminator between a direct recipient and a group id. Signal e164
+/// phone numbers (and signal-cli's accepted recipient addresses) start
+/// with `+`; group ids are base64 strings that never do. We treat a
+/// leading `+` as the sole signal for a direct recipient.
+pub fn is_direct_recipient(conversation_id: &str) -> bool {
+    conversation_id.starts_with('+')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_send_params_uses_recipient_for_phone_number() {
+        let params = build_send_params("+15550001111", "hi");
+        assert_eq!(params["recipient"][0], "+15550001111");
+        assert_eq!(params["message"], "hi");
+        // A direct send must NOT carry a groupId — signal-cli rejects both.
+        assert!(params.get("groupId").is_none());
+    }
+
+    #[test]
+    fn build_send_params_uses_group_id_for_group_conversation() {
+        // Base64-ish group id (as keyed by inbound `groupInfo.groupId`).
+        let gid = "abcd1234EFGH==";
+        let params = build_send_params(gid, "hello group");
+        assert_eq!(params["groupId"], gid);
+        assert_eq!(params["message"], "hello group");
+        // A group send must NOT carry a recipient array.
+        assert!(params.get("recipient").is_none());
+    }
+
+    #[test]
+    fn is_direct_recipient_discriminates_on_leading_plus() {
+        assert!(is_direct_recipient("+15551234567"));
+        assert!(!is_direct_recipient("abcd1234EFGH=="));
+        assert!(!is_direct_recipient(""));
+    }
+
+    #[test]
+    fn classify_delivery_absent_or_empty_results_is_success() {
+        assert_eq!(classify_delivery(None), DeliveryOutcome::AllSucceeded);
+        assert_eq!(classify_delivery(Some(&[])), DeliveryOutcome::AllSucceeded);
+    }
+
+    fn entry(ty: Option<&str>) -> SendResultEntry {
+        SendResultEntry {
+            result_type: ty.map(|s| s.to_string()),
+        }
+    }
+
+    #[test]
+    fn classify_delivery_all_success_entries() {
+        let entries = [entry(Some("SUCCESS")), entry(None)];
+        assert_eq!(
+            classify_delivery(Some(&entries)),
+            DeliveryOutcome::AllSucceeded
+        );
+    }
+
+    #[test]
+    fn classify_delivery_all_failed_returns_all_failed() {
+        let entries = [
+            entry(Some("UNREGISTERED_FAILURE")),
+            entry(Some("NETWORK_FAILURE")),
+        ];
+        assert_eq!(
+            classify_delivery(Some(&entries)),
+            DeliveryOutcome::AllFailed { total: 2 }
+        );
+    }
+
+    #[test]
+    fn classify_delivery_some_failed_returns_partial_with_counts() {
+        let entries = [
+            entry(Some("SUCCESS")),
+            entry(Some("IDENTITY_FAILURE")),
+            entry(Some("SUCCESS")),
+        ];
+        assert_eq!(
+            classify_delivery(Some(&entries)),
+            DeliveryOutcome::Partial {
+                failed: 1,
+                total: 3
+            }
+        );
+    }
+
+    #[test]
+    fn send_result_entry_is_success_is_case_insensitive() {
+        assert!(entry(Some("success")).is_success());
+        assert!(entry(Some("SUCCESS")).is_success());
+        assert!(entry(None).is_success());
+        assert!(!entry(Some("network_failure")).is_success());
+    }
+
+    #[test]
+    fn send_result_parses_typed_per_recipient_entries() {
+        // Round-trip the real signal-cli `result` shape through serde so
+        // the typed `results` array stays compatible with the wire form.
+        let raw = serde_json::json!({
+            "timestamp": 1700000000000i64,
+            "results": [
+                {"recipientAddress": {"number": "+15550001111"}, "type": "SUCCESS"},
+                {"recipientAddress": {"number": "+15550002222"}, "type": "UNREGISTERED_FAILURE"}
+            ]
+        });
+        let parsed: SendResult = serde_json::from_value(raw).unwrap();
+        let outcome = classify_delivery(parsed.results.as_deref());
+        assert_eq!(
+            outcome,
+            DeliveryOutcome::Partial {
+                failed: 1,
+                total: 2
+            }
+        );
+    }
 }

--- a/crates/wcore-channel-signal/src/lib.rs
+++ b/crates/wcore-channel-signal/src/lib.rs
@@ -486,6 +486,12 @@ mod tests {
         assert_eq!(msg.conversation_id, "+15550002222");
         assert_eq!(msg.ts_secs, 1_700_000_999);
         assert_eq!(msg.id, "1700000999000");
+        // Enriched fields: no UUID in this payload, so the phone is the
+        // stable sender id; sourceName surfaces as the display label; a
+        // non-group envelope is a 1:1 Direct chat.
+        assert_eq!(msg.sender_id, "+15550002222");
+        assert_eq!(msg.sender_display.as_deref(), Some("Alice"));
+        assert_eq!(msg.chat_type, wcore_channels::ChatType::Direct);
         ch.stop().await.unwrap();
     }
 

--- a/crates/wcore-channel-signal/src/lib.rs
+++ b/crates/wcore-channel-signal/src/lib.rs
@@ -13,8 +13,14 @@
 //! - `send_message()` allocates a request id, registers a pending
 //!   oneshot, writes the request to stdin, then awaits the oneshot
 //!   with the configured `send_timeout_secs`.
-//! - `stop()` flips a watch::Sender to true (reader exits its select),
-//!   drops the writer, kills the child if still alive, and joins.
+//! - A supervisor task owns the launch → reader-loop cycle in a respawn
+//!   loop: when the child dies / stdout hits EOF / the reader errors for
+//!   a non-shutdown reason, it emits `ConnectionState::Reconnecting`,
+//!   backs off, and relaunches `signal-cli` — rebuilding the stdin
+//!   writer and pending map without losing channel identity.
+//! - `stop()` flips a watch::Sender to true (reader + supervisor exit),
+//!   drops the writer, kills the child if still alive, and joins. No
+//!   respawn happens after an intentional stop.
 
 use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
@@ -23,7 +29,7 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use serde_json::json;
-use tokio::io::{AsyncWrite, AsyncWriteExt};
+use tokio::io::AsyncWriteExt;
 use tokio::sync::{Mutex, oneshot, watch};
 use tokio::task::JoinHandle;
 
@@ -36,13 +42,15 @@ pub use crate::config::SignalConfig;
 pub use crate::error::SignalError;
 pub use crate::jsonrpc::SendResult;
 pub use crate::subprocess::{
-    PendingResponses, RealLauncher, SignalProcessHandle, SignalProcessLauncher,
+    PendingResponses, RealLauncher, SharedStdin, SignalProcessHandle, SignalProcessLauncher,
 };
+pub use crate::supervisor::Backoff;
 
 pub mod config;
 pub mod error;
 pub mod jsonrpc;
 pub mod subprocess;
+pub mod supervisor;
 
 /// Production Signal channel adapter.
 pub struct SignalChannel {
@@ -50,17 +58,20 @@ pub struct SignalChannel {
     config: SignalConfig,
     state: ConnectionState,
     launcher: Arc<dyn SignalProcessLauncher>,
-    /// The subprocess handle. Set inside `start()`, cleared by `stop()`.
-    child: Option<tokio::process::Child>,
-    /// Locked stdin writer — `send_message` serializes writes here.
-    stdin: Option<Arc<Mutex<Box<dyn AsyncWrite + Unpin + Send>>>>,
+    /// Swappable stdin writer — `send_message` serializes writes through
+    /// the current inner box. The supervisor swaps the inner writer on
+    /// each (re)spawn, and clears it (`None`) between process death and
+    /// the next respawn. Always `Some(Arc)` after construction.
+    stdin: SharedStdin,
     /// Monotonic id allocator for JSON-RPC requests.
     request_id: Arc<AtomicU64>,
     /// Inbox of inbound events (drained by `poll_events`).
     inbox: Arc<Mutex<VecDeque<ChannelEvent>>>,
     /// In-flight request id → response sender.
     pending: PendingResponses,
-    reader_handle: Option<JoinHandle<()>>,
+    /// The supervisor task — owns the launch → reader → respawn loop.
+    /// Set by `start()`, joined + cleared by `stop()`.
+    supervisor_handle: Option<JoinHandle<()>>,
     shutdown: Option<watch::Sender<bool>>,
 }
 
@@ -82,12 +93,11 @@ impl SignalChannel {
             config,
             state: ConnectionState::Disconnected,
             launcher,
-            child: None,
-            stdin: None,
+            stdin: Arc::new(Mutex::new(None)),
             request_id: Arc::new(AtomicU64::new(1)),
             inbox: Arc::new(Mutex::new(VecDeque::new())),
             pending: Arc::new(Mutex::new(HashMap::new())),
-            reader_handle: None,
+            supervisor_handle: None,
             shutdown: None,
         }
     }
@@ -109,13 +119,17 @@ impl Channel for SignalChannel {
     }
 
     async fn start(&mut self) -> Result<(), ChannelError> {
-        if self.reader_handle.is_some() {
+        if self.supervisor_handle.is_some() {
             // Already started — idempotent.
             return Ok(());
         }
         self.state = ConnectionState::Connecting;
 
-        let handle = self
+        // Perform the FIRST launch synchronously so a launcher failure
+        // surfaces as a `start()` error (rather than vanishing into the
+        // supervisor's retry loop). Subsequent respawns are owned by the
+        // supervisor task.
+        let seed = self
             .launcher
             .launch(&self.config.signal_cli_path, &self.config.account)
             .map_err(|e| {
@@ -123,14 +137,15 @@ impl Channel for SignalChannel {
                 ChannelError::from(e)
             })?;
 
+        // Install the seed's stdin writer into the shared, swappable
+        // slot. The supervisor swaps this on each respawn; `send_message`
+        // always reads the current writer.
         let SignalProcessHandle {
-            stdin,
-            stdout,
-            child,
-        } = handle;
-
-        self.child = child;
-        self.stdin = Some(Arc::new(Mutex::new(stdin)));
+            stdin: seed_stdin,
+            stdout: seed_stdout,
+            child: seed_child,
+        } = seed;
+        *self.stdin.lock().await = Some(seed_stdin);
 
         // Push a Connected state-change so consumers know we're up.
         self.inbox
@@ -141,34 +156,52 @@ impl Channel for SignalChannel {
             });
 
         let (tx, rx) = watch::channel(false);
-        let args = subprocess::ReaderArgs {
-            stdout,
+        let args = supervisor::SupervisorArgs {
+            config: self.config.clone(),
+            launcher: Arc::clone(&self.launcher),
+            stdin: Arc::clone(&self.stdin),
             inbox: Arc::clone(&self.inbox),
             pending: Arc::clone(&self.pending),
             shutdown: rx,
+            seed: supervisor::SeedHandle {
+                stdout: seed_stdout,
+                child: seed_child,
+            },
         };
-        let join = tokio::spawn(subprocess::reader_loop(args));
-        self.reader_handle = Some(join);
+        let join = tokio::spawn(supervisor::supervisor_loop(args));
+        self.supervisor_handle = Some(join);
         self.shutdown = Some(tx);
         self.state = ConnectionState::Connected;
         Ok(())
     }
 
     async fn stop(&mut self) -> Result<(), ChannelError> {
-        if self.reader_handle.is_none() {
+        if self.supervisor_handle.is_none() {
             return Ok(());
         }
+        // Flip the shutdown watch: both the active reader loop AND the
+        // supervisor observe it and exit without respawning.
         if let Some(tx) = self.shutdown.take() {
             let _ = tx.send(true);
         }
-        // Drop the writer — closing stdin signals signal-cli to exit.
-        self.stdin = None;
-        // Kill child if still running.
-        if let Some(mut child) = self.child.take() {
-            let _ = child.start_kill();
-        }
-        if let Some(handle) = self.reader_handle.take() {
-            let _ = tokio::time::timeout(Duration::from_secs(5), handle).await;
+        // Drop the live writer — closing stdin signals signal-cli to
+        // exit. The supervisor owns + kills the child it launched.
+        *self.stdin.lock().await = None;
+        // Join the supervisor task so it fully unwinds (kills its child,
+        // clears stdin) before we return — no task leak. If it doesn't
+        // exit in time, abort it explicitly so it can't linger and
+        // respawn behind our back (a dropped JoinHandle detaches, it does
+        // NOT cancel).
+        if let Some(mut handle) = self.supervisor_handle.take()
+            && tokio::time::timeout(Duration::from_secs(5), &mut handle)
+                .await
+                .is_err()
+        {
+            tracing::warn!(
+                target: "wcore_channel_signal",
+                "stop: supervisor did not exit within 5s; aborting task"
+            );
+            handle.abort();
         }
         // Drain any pending oneshots (they'll get SubprocessClosed from
         // the reader's EOF branch, but in case the reader exited via
@@ -194,7 +227,7 @@ impl Channel for SignalChannel {
     }
 
     async fn send_message(&mut self, msg: OutgoingMessage) -> Result<MessageReceipt, ChannelError> {
-        let stdin = self.stdin.as_ref().ok_or(ChannelError::NotStarted)?.clone();
+        let stdin = Arc::clone(&self.stdin);
         let id = self.request_id.fetch_add(1, Ordering::Relaxed);
 
         // Register pending oneshot BEFORE writing — avoids a race where
@@ -211,18 +244,28 @@ impl Channel for SignalChannel {
             .map_err(|e| ChannelError::from(SignalError::Decode(format!("encode request: {e}"))))?;
 
         // Write line + newline atomically — JSON-RPC over stdio is
-        // line-delimited.
+        // line-delimited. The stdin slot is swapped by the supervisor on
+        // respawn and is `None` between a process death and the next
+        // (re)launch; treat an absent writer as NotStarted so callers
+        // can retry once the supervisor reconnects.
         {
             let mut guard = stdin.lock().await;
-            if let Err(e) = guard.write_all(line.as_bytes()).await {
+            let writer = match guard.as_mut() {
+                Some(w) => w,
+                None => {
+                    self.pending.lock().await.remove(&id);
+                    return Err(ChannelError::NotStarted);
+                }
+            };
+            if let Err(e) = writer.write_all(line.as_bytes()).await {
                 self.pending.lock().await.remove(&id);
                 return Err(SignalError::Io(format!("write request: {e}")).into());
             }
-            if let Err(e) = guard.write_all(b"\n").await {
+            if let Err(e) = writer.write_all(b"\n").await {
                 self.pending.lock().await.remove(&id);
                 return Err(SignalError::Io(format!("write newline: {e}")).into());
             }
-            if let Err(e) = guard.flush().await {
+            if let Err(e) = writer.flush().await {
                 self.pending.lock().await.remove(&id);
                 return Err(SignalError::Io(format!("flush: {e}")).into());
             }
@@ -538,12 +581,12 @@ mod tests {
         let (launcher, _io) = build_test_pair();
         let mut ch = SignalChannel::with_launcher("test", cfg(), launcher);
         ch.start().await.unwrap();
-        assert!(ch.reader_handle.is_some());
+        assert!(ch.supervisor_handle.is_some());
 
         ch.stop().await.unwrap();
-        assert!(ch.reader_handle.is_none());
+        assert!(ch.supervisor_handle.is_none());
         assert!(ch.shutdown.is_none());
-        assert!(ch.stdin.is_none());
+        assert!(ch.stdin.lock().await.is_none());
         assert_eq!(ch.state(), ConnectionState::Disconnected);
 
         // Idempotent.
@@ -650,7 +693,7 @@ send_timeout_secs = 20
             other => panic!("expected Transport, got {other:?}"),
         }
         assert_eq!(ch.state(), ConnectionState::Disconnected);
-        assert!(ch.reader_handle.is_none());
+        assert!(ch.supervisor_handle.is_none());
     }
 
     // -----------------------------------------------------------------
@@ -697,5 +740,132 @@ send_timeout_secs = 20
             }
             other => panic!("expected Rejected, got {other:?}"),
         }
+    }
+
+    // -----------------------------------------------------------------
+    // 11. SUPERVISED RESPAWN (CRITICAL-4). A launcher that serves a
+    //     queue of duplex handles + counts launches. The first child's
+    //     stdout is closed (EOF), which must drive the supervisor to:
+    //       (a) emit ConnectionState::Reconnecting,
+    //       (b) call the launcher a SECOND time (respawn),
+    //     and then `stop()` must tear down WITHOUT a third launch.
+    // -----------------------------------------------------------------
+
+    /// One queued handle the respawn launcher will hand out, in order.
+    struct QueuedHandle {
+        stdin: DuplexStream,
+        stdout: DuplexStream,
+    }
+
+    /// Launcher that serves handles from a queue and records launch
+    /// count. Returns an error if asked to launch past the queue end.
+    struct RespawnLauncher {
+        queue: StdMutex<VecDeque<QueuedHandle>>,
+        launches: Arc<std::sync::atomic::AtomicUsize>,
+    }
+
+    impl SignalProcessLauncher for RespawnLauncher {
+        fn launch(
+            &self,
+            _cli_path: &Path,
+            _account: &str,
+        ) -> Result<SignalProcessHandle, SignalError> {
+            self.launches
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            let h = self
+                .queue
+                .lock()
+                .unwrap()
+                .pop_front()
+                .ok_or_else(|| SignalError::Spawn("respawn launcher: queue exhausted".into()))?;
+            Ok(SignalProcessHandle {
+                stdin: Box::new(h.stdin),
+                stdout: Box::new(BufReader::new(h.stdout)),
+                child: None,
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn supervisor_respawns_on_eof_and_stops_without_respawn() {
+        // First handle: keep the write-half of its stdout so we can drop
+        // it to force EOF. Second handle: the respawn target.
+        let (ch_stdin_1, _harness_reads_1) = tokio::io::duplex(64 * 1024);
+        let (harness_writes_1, ch_stdout_1) = tokio::io::duplex(64 * 1024);
+        let (ch_stdin_2, _harness_reads_2) = tokio::io::duplex(64 * 1024);
+        let (_harness_writes_2, ch_stdout_2) = tokio::io::duplex(64 * 1024);
+
+        let mut queue = VecDeque::new();
+        queue.push_back(QueuedHandle {
+            stdin: ch_stdin_1,
+            stdout: ch_stdout_1,
+        });
+        queue.push_back(QueuedHandle {
+            stdin: ch_stdin_2,
+            stdout: ch_stdout_2,
+        });
+
+        let launches = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let launcher = Arc::new(RespawnLauncher {
+            queue: StdMutex::new(queue),
+            launches: Arc::clone(&launches),
+        });
+
+        let mut ch = SignalChannel::with_launcher("test", cfg(), launcher);
+        ch.start().await.unwrap();
+        assert_eq!(
+            launches.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "start() should launch exactly once"
+        );
+
+        // Force EOF on the first child's stdout: drop the harness's
+        // write-half. The reader sees Ok(0) → the supervisor respawns.
+        drop(harness_writes_1);
+
+        // Wait for the second launch (respawn). Backoff base is 1s, so
+        // give it a generous window.
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        while launches.load(std::sync::atomic::Ordering::SeqCst) < 2 {
+            if std::time::Instant::now() >= deadline {
+                panic!("supervisor did not respawn within 5s");
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+        assert_eq!(
+            launches.load(std::sync::atomic::Ordering::SeqCst),
+            2,
+            "supervisor must relaunch exactly once after EOF"
+        );
+
+        // A Reconnecting event must have been emitted onto the inbox.
+        let mut saw_reconnecting = false;
+        for ev in ch.poll_events().await.unwrap() {
+            if let ChannelEvent::ConnectionStateChanged {
+                state: ConnectionState::Reconnecting,
+            } = ev
+            {
+                saw_reconnecting = true;
+            }
+        }
+        assert!(
+            saw_reconnecting,
+            "supervisor must emit a Reconnecting state-change on respawn"
+        );
+
+        // Now stop. The supervisor must observe shutdown and exit; with
+        // the queue exhausted, any erroneous third launch attempt would
+        // bump the counter — assert it does NOT.
+        ch.stop().await.unwrap();
+        let after_stop = launches.load(std::sync::atomic::Ordering::SeqCst);
+        // Give any stray respawn a moment to (incorrectly) fire.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert_eq!(
+            launches.load(std::sync::atomic::Ordering::SeqCst),
+            after_stop,
+            "no respawn may occur after stop()"
+        );
+        assert_eq!(after_stop, 2, "exactly two launches total");
+        assert!(ch.supervisor_handle.is_none());
     }
 }

--- a/crates/wcore-channel-signal/src/lib.rs
+++ b/crates/wcore-channel-signal/src/lib.rs
@@ -28,7 +28,6 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 use async_trait::async_trait;
-use serde_json::json;
 use tokio::io::AsyncWriteExt;
 use tokio::sync::{Mutex, oneshot, watch};
 use tokio::task::JoinHandle;
@@ -40,7 +39,10 @@ use wcore_channels::outgoing::OutgoingMessage;
 
 pub use crate::config::SignalConfig;
 pub use crate::error::SignalError;
-pub use crate::jsonrpc::SendResult;
+pub use crate::jsonrpc::{
+    DeliveryOutcome, SendResult, SendResultEntry, build_send_params, classify_delivery,
+    is_direct_recipient,
+};
 pub use crate::subprocess::{
     PendingResponses, RealLauncher, SharedStdin, SignalProcessHandle, SignalProcessLauncher,
 };
@@ -235,10 +237,10 @@ impl Channel for SignalChannel {
         let (tx, rx) = oneshot::channel();
         self.pending.lock().await.insert(id, tx);
 
-        let params = json!({
-            "recipient": [msg.conversation_id.clone()],
-            "message": msg.text,
-        });
+        // Route to `recipient` (direct) or `groupId` (group) based on the
+        // conversation id's shape — signal-cli's `send` accepts one XOR
+        // the other. See `jsonrpc::build_send_params`.
+        let params = jsonrpc::build_send_params(&msg.conversation_id, &msg.text);
         let request = jsonrpc::Request::new(id, "send", params);
         let line = serde_json::to_string(&request)
             .map_err(|e| ChannelError::from(SignalError::Decode(format!("encode request: {e}"))))?;
@@ -290,6 +292,28 @@ impl Channel for SignalChannel {
         let parsed: SendResult = serde_json::from_value(raw).map_err(|e| {
             ChannelError::from(SignalError::Decode(format!("parse send result: {e}")))
         })?;
+
+        // Inspect per-recipient delivery. signal-cli answers the
+        // round-trip even when some/all recipients are undelivered, so a
+        // bare response is NOT proof of delivery — classify the results
+        // array. Logging is content-free: counts only, never message
+        // text or recipient identities.
+        match jsonrpc::classify_delivery(parsed.results.as_deref()) {
+            jsonrpc::DeliveryOutcome::AllSucceeded => {}
+            jsonrpc::DeliveryOutcome::Partial { failed, total } => {
+                tracing::warn!(
+                    target: "wcore_channel_signal",
+                    failed,
+                    total,
+                    "send: partial delivery — some recipients undelivered"
+                );
+            }
+            jsonrpc::DeliveryOutcome::AllFailed { total } => {
+                return Err(ChannelError::Rejected(format!(
+                    "all {total} recipient(s) undelivered"
+                )));
+            }
+        }
 
         let ts_ms = parsed.timestamp.unwrap_or_else(now_ms);
         let ts_secs = ts_ms / 1000;
@@ -740,6 +764,100 @@ send_timeout_secs = 20
             }
             other => panic!("expected Rejected, got {other:?}"),
         }
+    }
+
+    // -----------------------------------------------------------------
+    // 11a. Group send routes through `groupId` (not `recipient`) when the
+    //      conversation id is a base64 group id rather than a +phone.
+    // -----------------------------------------------------------------
+    #[tokio::test]
+    async fn group_send_uses_group_id_param() {
+        let (launcher, mut io) = build_test_pair();
+        let mut ch = SignalChannel::with_launcher("test", cfg(), launcher);
+        ch.start().await.unwrap();
+
+        let send_fut = tokio::spawn(async move {
+            ch.send_message(OutgoingMessage::text("abcd1234EFGH==", "hi group"))
+                .await
+        });
+
+        let line = io.read_line().await;
+        let req: serde_json::Value = serde_json::from_str(line.trim()).unwrap();
+        assert_eq!(req["method"], "send");
+        assert_eq!(req["params"]["groupId"], "abcd1234EFGH==");
+        assert_eq!(req["params"]["message"], "hi group");
+        // recipient must be absent for a group send.
+        assert!(req["params"].get("recipient").is_none());
+        let id = req["id"].as_u64().unwrap();
+
+        let resp =
+            format!(r#"{{"jsonrpc":"2.0","id":{id},"result":{{"timestamp":1700000123456}}}}"#);
+        io.write_line(&resp).await;
+
+        let receipt = send_fut.await.unwrap().unwrap();
+        assert_eq!(receipt.conversation_id, "abcd1234EFGH==");
+    }
+
+    // -----------------------------------------------------------------
+    // 11b. A send whose per-recipient results are ALL failures surfaces
+    //      as ChannelError::Rejected even though signal-cli answered the
+    //      round-trip.
+    // -----------------------------------------------------------------
+    #[tokio::test]
+    async fn all_failed_recipients_surface_as_rejected() {
+        let (launcher, mut io) = build_test_pair();
+        let mut ch = SignalChannel::with_launcher("test", cfg(), launcher);
+        ch.start().await.unwrap();
+
+        let send_fut = tokio::spawn(async move {
+            ch.send_message(OutgoingMessage::text("groupIdBase64==", "undelivered"))
+                .await
+        });
+
+        let line = io.read_line().await;
+        let req: serde_json::Value = serde_json::from_str(line.trim()).unwrap();
+        let id = req["id"].as_u64().unwrap();
+
+        let resp = format!(
+            r#"{{"jsonrpc":"2.0","id":{id},"result":{{"timestamp":1700000123456,"results":[{{"type":"NETWORK_FAILURE"}},{{"type":"UNREGISTERED_FAILURE"}}]}}}}"#
+        );
+        io.write_line(&resp).await;
+
+        let err = send_fut.await.unwrap().expect_err("expected rejection");
+        match err {
+            ChannelError::Rejected(msg) => {
+                assert!(msg.contains('2'), "should name the recipient count: {msg}");
+            }
+            other => panic!("expected Rejected, got {other:?}"),
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // 11c. A send with SOME failed recipients still returns a receipt
+    //      (partial → warn-and-succeed).
+    // -----------------------------------------------------------------
+    #[tokio::test]
+    async fn partial_failure_still_returns_receipt() {
+        let (launcher, mut io) = build_test_pair();
+        let mut ch = SignalChannel::with_launcher("test", cfg(), launcher);
+        ch.start().await.unwrap();
+
+        let send_fut = tokio::spawn(async move {
+            ch.send_message(OutgoingMessage::text("groupIdBase64==", "partial"))
+                .await
+        });
+
+        let line = io.read_line().await;
+        let req: serde_json::Value = serde_json::from_str(line.trim()).unwrap();
+        let id = req["id"].as_u64().unwrap();
+
+        let resp = format!(
+            r#"{{"jsonrpc":"2.0","id":{id},"result":{{"timestamp":1700000123456,"results":[{{"type":"SUCCESS"}},{{"type":"NETWORK_FAILURE"}}]}}}}"#
+        );
+        io.write_line(&resp).await;
+
+        let receipt = send_fut.await.unwrap().expect("partial should still succeed");
+        assert_eq!(receipt.id, "1700000123456");
     }
 
     // -----------------------------------------------------------------

--- a/crates/wcore-channel-signal/src/subprocess.rs
+++ b/crates/wcore-channel-signal/src/subprocess.rs
@@ -25,6 +25,12 @@ use crate::jsonrpc::{Frame, ReceiveParams};
 pub type PendingResponses =
     Arc<Mutex<HashMap<u64, oneshot::Sender<Result<serde_json::Value, SignalError>>>>>;
 
+/// Shared, swappable stdin writer. `send_message` reads the current
+/// writer from this slot; the supervisor swaps the inner writer on each
+/// (re)spawn so sends always target the live `signal-cli` process. The
+/// `Option` is `None` between a process death and the next respawn.
+pub type SharedStdin = Arc<Mutex<Option<Box<dyn AsyncWrite + Unpin + Send>>>>;
+
 /// Handle returned by a [`SignalProcessLauncher`]. Carries the
 /// half-duplex stdio + (optional) a child handle to kill on `stop()`.
 pub struct SignalProcessHandle {

--- a/crates/wcore-channel-signal/src/subprocess.rs
+++ b/crates/wcore-channel-signal/src/subprocess.rs
@@ -15,7 +15,7 @@ use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncWrite, BufReader};
 use tokio::process::Command;
 use tokio::sync::{Mutex, oneshot, watch};
 
-use wcore_channels::event::{ChannelEvent, IncomingMessage};
+use wcore_channels::event::{ChannelEvent, ChatType, IncomingMessage};
 
 use crate::error::SignalError;
 use crate::jsonrpc::{Frame, ReceiveParams};
@@ -245,6 +245,18 @@ fn build_incoming(parsed: &ReceiveParams) -> Option<IncomingMessage> {
         .or_else(|| envelope.source_uuid.clone())
         .unwrap_or_default();
 
+    // sender_id: ACI/UUID is the stable Signal identity. Fall back to
+    // phone number if no UUID is present (older clients / linked devices
+    // may omit it), then to source_name as last resort.
+    let sender_id = envelope
+        .source_uuid
+        .clone()
+        .or_else(|| envelope.source.clone())
+        .or_else(|| envelope.source_name.clone())
+        .unwrap_or_default();
+
+    // author: stable address label — phone, then UUID, then display name
+    // as a last resort. The display name lives in `sender_display`.
     let author = envelope
         .source
         .clone()
@@ -252,12 +264,72 @@ fn build_incoming(parsed: &ReceiveParams) -> Option<IncomingMessage> {
         .or_else(|| envelope.source_name.clone())
         .unwrap_or_default();
 
+    // sender_display: source_name when present.
+    let sender_display = envelope.source_name.clone();
+
+    // sender_handle: e164 phone number.
+    let sender_handle = envelope.source.clone();
+
+    // sender_alt_id: the OTHER half of the UUID/number union. When UUID
+    // is the primary id (sender_id), put the phone number here; when UUID
+    // is absent and phone is primary, there is no alt.
+    let sender_alt_id = if envelope.source_uuid.is_some() {
+        envelope.source.clone()
+    } else {
+        None
+    };
+
+    // chat_type: presence of groupInfo in the data message is the
+    // definitive Signal indicator for a group context. Signal does not
+    // have broadcast channels in the daemon JSON-RPC surface, so all
+    // non-group messages are 1:1 Direct.
+    let chat_type = if data.group_info.is_some() {
+        ChatType::Group
+    } else {
+        ChatType::Direct
+    };
+
+    // account_id: the receiving Signal account number, if signal-cli
+    // reported it in the outer params envelope.
+    let account_id = parsed.account.clone();
+
     Some(IncomingMessage {
         id,
         conversation_id,
         author,
         text,
         ts_secs,
+        // attachments: signal-cli's JSON-RPC `receive` notification does
+        // not surface attachment references in the current ReceiveParams
+        // schema; leave empty until the struct gains an attachments field.
         attachments: Vec::new(),
+        sender_id,
+        sender_display,
+        sender_handle,
+        sender_alt_id,
+        // is_bot / is_self: signal-cli gives no bot flag and no self-send
+        // indicator in the receive notification path.
+        is_bot: false,
+        is_self: false,
+        chat_type,
+        // chat_name: GroupInfo only carries a base64 group id, not a
+        // human-readable name; leave None until a name-resolution layer
+        // is added.
+        chat_name: None,
+        // space_id / thread_id / parent_chat_id: Signal has no workspace
+        // or thread nesting concept exposed via JSON-RPC.
+        space_id: None,
+        thread_id: None,
+        parent_chat_id: None,
+        account_id,
+        platform: Some("signal".into()),
+        // was_mentioned / mention_kind: ReceiveParams carries no mentions
+        // array; mention detection is deferred to a higher layer.
+        was_mentioned: false,
+        mention_kind: None,
+        // reply_to_message_id / reply_to_text: DataMessage carries no
+        // quote field in the current schema.
+        reply_to_message_id: None,
+        reply_to_text: None,
     })
 }

--- a/crates/wcore-channel-signal/src/supervisor.rs
+++ b/crates/wcore-channel-signal/src/supervisor.rs
@@ -1,0 +1,325 @@
+//! Supervised lifecycle for the `signal-cli` subprocess.
+//!
+//! CRITICAL-4 fix: previously the child process + its reader task died
+//! permanently on EOF / IO error / process death, so the channel went
+//! silent forever after any disconnect. The supervisor wraps the
+//! launch → reader-loop cycle in a respawn loop:
+//!
+//! 1. Launch `signal-cli`, wire stdin/stdout, start the reader loop.
+//! 2. Wait for the reader loop to end OR for shutdown.
+//! 3. If the reader ended for a NON-shutdown reason (EOF, IO error,
+//!    process death), emit `ConnectionState::Reconnecting`, wait a
+//!    backoff interval, and respawn — rebuilding the stdin writer and
+//!    starting a fresh pending map / reader.
+//! 4. If shutdown was signalled, exit without respawning.
+//!
+//! The supervisor observes the same `watch::Receiver<bool>` shutdown
+//! channel the reader does, so `stop()` tears the whole thing down with
+//! no respawn and no task leak.
+
+use std::collections::VecDeque;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::io::AsyncBufRead;
+use tokio::sync::{Mutex, watch};
+
+use wcore_channels::event::{ChannelEvent, ConnectionState};
+
+use crate::config::SignalConfig;
+use crate::subprocess::{
+    PendingResponses, ReaderArgs, SharedStdin, SignalProcessHandle, SignalProcessLauncher,
+    reader_loop,
+};
+
+/// The stdout half + owned child for an already-launched process —
+/// handed to the supervisor as its first iteration's seed so `start()`
+/// can validate the launch synchronously while the supervisor owns the
+/// reader + every respawn thereafter.
+pub struct SeedHandle {
+    pub stdout: Box<dyn AsyncBufRead + Unpin + Send>,
+    pub child: Option<tokio::process::Child>,
+}
+
+/// Exponential backoff schedule for respawn attempts.
+///
+/// Deterministic (no jitter) so it is unit-testable: the delay doubles
+/// from `base` each failed attempt, capped at `cap`. A successful
+/// reconnect that stays up past [`Backoff::STABLE_AFTER`] resets the
+/// schedule back to `base`.
+#[derive(Debug, Clone)]
+pub struct Backoff {
+    base: Duration,
+    cap: Duration,
+    current: Duration,
+}
+
+impl Backoff {
+    /// A reconnect that stays up at least this long is considered
+    /// "stable" and resets the backoff schedule to the base.
+    pub const STABLE_AFTER: Duration = Duration::from_secs(30);
+
+    /// Default schedule: 1s base, doubling, capped at 30s.
+    pub fn new() -> Self {
+        Self::with_params(Duration::from_secs(1), Duration::from_secs(30))
+    }
+
+    /// Construct with explicit base / cap — used by tests to keep the
+    /// schedule small and assertable.
+    pub fn with_params(base: Duration, cap: Duration) -> Self {
+        Self {
+            base,
+            cap,
+            current: base,
+        }
+    }
+
+    /// Return the delay to wait before the next respawn attempt, then
+    /// advance the schedule (double, capped at `cap`). The first call
+    /// after construction (or after [`Backoff::reset`]) returns `base`.
+    pub fn next_delay(&mut self) -> Duration {
+        let delay = self.current;
+        // Double for the next call, saturating at the cap.
+        self.current = (self.current * 2).min(self.cap);
+        delay
+    }
+
+    /// Reset the schedule back to the base delay. Called after a
+    /// reconnect that stayed up past [`Backoff::STABLE_AFTER`].
+    pub fn reset(&mut self) {
+        self.current = self.base;
+    }
+}
+
+impl Default for Backoff {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Everything the supervisor task needs to own the respawn loop.
+pub struct SupervisorArgs {
+    pub config: SignalConfig,
+    pub launcher: Arc<dyn SignalProcessLauncher>,
+    /// Shared stdin slot — the supervisor swaps the inner writer on each
+    /// (re)spawn so `send_message` always sees the current process.
+    pub stdin: SharedStdin,
+    pub inbox: Arc<Mutex<VecDeque<ChannelEvent>>>,
+    pub pending: PendingResponses,
+    /// Shutdown watch shared with each reader loop. The supervisor
+    /// exits (without respawning) when this flips to `true`.
+    pub shutdown: watch::Receiver<bool>,
+    /// The first, already-launched process's stdout + child. `start()`
+    /// performs the initial launch synchronously so launcher errors
+    /// surface as a `start()` failure; it then hands the live stdout +
+    /// child here so the supervisor runs its reader before entering the
+    /// respawn loop. The stdin writer for this seed is already installed
+    /// in `stdin`.
+    pub seed: SeedHandle,
+}
+
+/// The supervisor task body. Runs until shutdown is signalled.
+///
+/// Returns once shutdown is observed. Each respawn rebuilds the stdin
+/// writer and starts a fresh reader loop; stale pending requests are
+/// already failed by the reader on exit (EOF → `SubprocessClosed`, IO
+/// error → `Io`), and we clear the pending map before each respawn so
+/// the new process starts clean.
+pub async fn supervisor_loop(args: SupervisorArgs) {
+    let SupervisorArgs {
+        config,
+        launcher,
+        stdin,
+        inbox,
+        pending,
+        shutdown,
+        seed,
+    } = args;
+
+    let mut backoff = Backoff::new();
+    // The first iteration consumes the seed handle that `start()`
+    // already launched + whose stdin is already installed. Later
+    // iterations launch fresh inside the loop.
+    let mut seed = Some(seed);
+
+    loop {
+        // Bail before launching if shutdown is already set.
+        if *shutdown.borrow() {
+            tracing::debug!(target: "wcore_channel_signal", "supervisor: shutdown before launch");
+            break;
+        }
+
+        // Acquire the handle for this iteration: the seed on the first
+        // pass, or a fresh launch (after Reconnecting + backoff) on a
+        // respawn. Either way we end up with the process's stdout +
+        // owned child, and the live stdin writer installed in `stdin`.
+        let (stdout, child) = match seed.take() {
+            // First pass: reuse the handle `start()` launched. Its stdin
+            // is already installed and Connected already announced.
+            Some(SeedHandle { stdout, child }) => (stdout, child),
+
+            // Respawn pass: announce Reconnecting, back off, relaunch.
+            None => {
+                inbox
+                    .lock()
+                    .await
+                    .push_back(ChannelEvent::ConnectionStateChanged {
+                        state: ConnectionState::Reconnecting,
+                    });
+
+                let delay = backoff.next_delay();
+                tracing::warn!(
+                    target: "wcore_channel_signal",
+                    delay_ms = delay.as_millis() as u64,
+                    "supervisor: signal-cli connection lost; backing off before respawn"
+                );
+
+                // Sleep, but wake early if shutdown fires during the wait.
+                let mut sd = shutdown.clone();
+                tokio::select! {
+                    biased;
+                    _ = sd.changed() => {
+                        if *shutdown.borrow() {
+                            tracing::debug!(target: "wcore_channel_signal", "supervisor: shutdown during backoff");
+                            break;
+                        }
+                    }
+                    _ = tokio::time::sleep(delay) => {}
+                }
+                if *shutdown.borrow() {
+                    break;
+                }
+
+                // Clear any residual pending requests so the new process
+                // starts with a clean map. The reader already failed them
+                // on exit; this is belt-and-suspenders for the respawn.
+                clear_pending(&pending).await;
+
+                match launcher.launch(&config.signal_cli_path, &config.account) {
+                    Ok(SignalProcessHandle {
+                        stdin: new_stdin,
+                        stdout,
+                        child,
+                    }) => {
+                        // Swap the live stdin writer in so `send_message`
+                        // targets the new process. Previous writer dropped.
+                        *stdin.lock().await = Some(new_stdin);
+                        // Announce Connected on a successful respawn.
+                        inbox
+                            .lock()
+                            .await
+                            .push_back(ChannelEvent::ConnectionStateChanged {
+                                state: ConnectionState::Connected,
+                            });
+                        (stdout, child)
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            target: "wcore_channel_signal",
+                            error = %e,
+                            "supervisor: relaunch failed; will retry after backoff"
+                        );
+                        // Treat a failed launch like a lost connection:
+                        // loop back so the backoff branch fires again.
+                        continue;
+                    }
+                }
+            }
+        };
+
+        let reader_args = ReaderArgs {
+            stdout,
+            inbox: Arc::clone(&inbox),
+            pending: Arc::clone(&pending),
+            shutdown: shutdown.clone(),
+        };
+
+        // Run the reader loop inline (this task IS the supervisor; the
+        // reader returning means the connection ended one way or
+        // another). Time how long it stayed up to decide on backoff
+        // reset.
+        let started = std::time::Instant::now();
+        reader_loop(reader_args).await;
+        let uptime = started.elapsed();
+
+        // Kill the child we own so a dead-stdout process doesn't linger.
+        if let Some(mut child) = child {
+            let _ = child.start_kill();
+        }
+        // Drop the stale writer; the next launch installs a fresh one.
+        *stdin.lock().await = None;
+
+        // If shutdown drove the reader's exit, stop cleanly — no respawn.
+        if *shutdown.borrow() {
+            tracing::debug!(target: "wcore_channel_signal", "supervisor: reader exited on shutdown; stopping");
+            break;
+        }
+
+        // Non-shutdown exit (EOF / IO / process death). If the
+        // connection had stayed up long enough, reset the backoff so a
+        // healthy-then-flaky process doesn't inherit a huge delay.
+        if uptime >= Backoff::STABLE_AFTER {
+            backoff.reset();
+        }
+        // Loop back around: the top of the loop emits Reconnecting and
+        // backs off before relaunching.
+    }
+}
+
+/// Fail + clear every in-flight request so a respawn starts clean and no
+/// caller hangs on a oneshot whose process is gone.
+async fn clear_pending(pending: &PendingResponses) {
+    let mut guard = pending.lock().await;
+    for (_, tx) in guard.drain() {
+        let _ = tx.send(Err(crate::error::SignalError::SubprocessClosed));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn backoff_sequence_doubles_from_base() {
+        let mut b = Backoff::with_params(Duration::from_secs(1), Duration::from_secs(30));
+        assert_eq!(b.next_delay(), Duration::from_secs(1));
+        assert_eq!(b.next_delay(), Duration::from_secs(2));
+        assert_eq!(b.next_delay(), Duration::from_secs(4));
+        assert_eq!(b.next_delay(), Duration::from_secs(8));
+        assert_eq!(b.next_delay(), Duration::from_secs(16));
+    }
+
+    #[test]
+    fn backoff_caps_at_ceiling() {
+        let mut b = Backoff::with_params(Duration::from_secs(1), Duration::from_secs(30));
+        // 1, 2, 4, 8, 16 → next would be 32 but caps at 30, and stays.
+        for _ in 0..5 {
+            b.next_delay();
+        }
+        assert_eq!(b.next_delay(), Duration::from_secs(30));
+        assert_eq!(b.next_delay(), Duration::from_secs(30));
+        assert_eq!(b.next_delay(), Duration::from_secs(30));
+    }
+
+    #[test]
+    fn backoff_reset_returns_to_base() {
+        let mut b = Backoff::with_params(Duration::from_secs(1), Duration::from_secs(30));
+        b.next_delay(); // 1
+        b.next_delay(); // 2
+        b.next_delay(); // 4
+        b.reset();
+        assert_eq!(b.next_delay(), Duration::from_secs(1));
+        assert_eq!(b.next_delay(), Duration::from_secs(2));
+    }
+
+    #[test]
+    fn backoff_default_matches_one_second_base_thirty_cap() {
+        let mut b = Backoff::new();
+        assert_eq!(b.next_delay(), Duration::from_secs(1));
+        // Walk to the ceiling and confirm it's 30s.
+        for _ in 0..10 {
+            b.next_delay();
+        }
+        assert_eq!(b.next_delay(), Duration::from_secs(30));
+    }
+}

--- a/crates/wcore-channel-slack/src/inbound.rs
+++ b/crates/wcore-channel-slack/src/inbound.rs
@@ -10,7 +10,7 @@
 //!   surface as errors.
 
 use serde::Deserialize;
-use wcore_channels::event::{ChannelEvent, IncomingMessage};
+use wcore_channels::event::{Attachment, ChannelEvent, ChatType, IncomingMessage, MediaKind};
 
 use crate::error::SlackError;
 
@@ -28,7 +28,12 @@ enum Envelope {
 }
 
 /// Outcome of parsing one webhook body.
+///
+/// `Event` wraps the enriched `ChannelEvent`, which is intentionally
+/// large (the dominant `MessageReceived` variant); boxing it here would
+/// only complicate the nested match arms for no real gain.
 #[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
 pub enum Parsed {
     /// The webhook is the app-config challenge handshake. The HTTP host
     /// should respond `200 OK` with `challenge` as the body.
@@ -87,20 +92,84 @@ fn parse_inner_event(ev: &serde_json::Value) -> Result<Parsed, SlackError> {
         .and_then(|s| s.parse().ok())
         .unwrap_or(0);
 
-    let files = ev
+    // --- Attachments ---
+    // Map Slack `mimetype` to a coarse `MediaKind`; fall back to Other.
+    let attachments: Vec<Attachment> = ev
         .get("files")
         .and_then(|v| v.as_array())
         .map(|arr| {
             arr.iter()
                 .filter_map(|f| {
-                    f.get("url_private")
+                    let url = f
+                        .get("url_private")
                         .or_else(|| f.get("permalink"))
-                        .and_then(|v| v.as_str())
-                        .map(str::to_owned)
+                        .and_then(|v| v.as_str())?;
+                    let mime = f.get("mimetype").and_then(|v| v.as_str()).unwrap_or("");
+                    let kind = if mime.starts_with("image/") {
+                        MediaKind::Image
+                    } else if mime.starts_with("video/") {
+                        MediaKind::Video
+                    } else if mime.starts_with("audio/") {
+                        MediaKind::Audio
+                    } else if mime.starts_with("application/")
+                        || mime.starts_with("text/")
+                    {
+                        MediaKind::Document
+                    } else {
+                        MediaKind::Other
+                    };
+                    let content_type = if mime.is_empty() {
+                        None
+                    } else {
+                        Some(mime.to_owned())
+                    };
+                    Some(Attachment {
+                        url: url.to_owned(),
+                        content_type,
+                        kind,
+                        ..Default::default()
+                    })
                 })
                 .collect()
         })
         .unwrap_or_default();
+
+    // --- chat_type ---
+    // Prefer explicit `channel_type` field; fall back to channel-id prefix.
+    // Slack channel_type values: "im" (1:1 DM), "mpim" (multi-person DM),
+    // "channel" (public), "group" (private channel).
+    // Channel id prefixes: D = im, G = group/mpim, C = public channel.
+    let chat_type = match ev
+        .get("channel_type")
+        .and_then(|v| v.as_str())
+    {
+        Some("im") => ChatType::Direct,
+        Some("mpim") => ChatType::Group,
+        Some("channel" | "group") => ChatType::Channel,
+        // No channel_type field — infer from channel id prefix.
+        _ => match channel.chars().next() {
+            Some('D') => ChatType::Direct,
+            Some('G') => ChatType::Group,
+            _ => ChatType::Channel,
+        },
+    };
+
+    // --- Thread / reply ---
+    // `thread_ts` is the id of the thread root. If it equals `ts` this
+    // message IS the root; otherwise it's a reply within that thread.
+    let thread_ts = ev.get("thread_ts").and_then(|v| v.as_str());
+    let thread_id = thread_ts.map(str::to_owned);
+    let reply_to_message_id = thread_ts
+        .filter(|&tts| tts != ts_str)
+        .map(str::to_owned);
+
+    // --- Bot flag ---
+    // `bot_message` subtype is already filtered above (returns Ignored).
+    // A `thread_broadcast` can still arrive here and may carry `bot_id`.
+    let is_bot = ev.get("bot_id").is_some();
+
+    // --- Workspace id ---
+    let space_id = ev.get("team").and_then(|v| v.as_str()).map(str::to_owned);
 
     let msg = IncomingMessage {
         id: ts_str.to_string(),
@@ -108,7 +177,27 @@ fn parse_inner_event(ev: &serde_json::Value) -> Result<Parsed, SlackError> {
         author: user.to_string(),
         text: text.to_string(),
         ts_secs: secs,
-        attachments: files,
+        attachments,
+        // `user` is the stable Slack user id (e.g. U012ABC) — correct
+        // access-control key. Falls back to "unknown" only when the event
+        // truly has no `user` field (should not happen for human messages).
+        sender_id: user.to_string(),
+        is_bot,
+        chat_type,
+        space_id,
+        thread_id,
+        reply_to_message_id,
+        platform: Some("slack".into()),
+        // Fields we cannot populate from the inner event alone:
+        //   sender_display / sender_handle — require a users.info API call.
+        //   sender_alt_id — Slack exposes no secondary stable id in events.
+        //   is_self — requires knowing our own bot user id (not in scope).
+        //   chat_name — not present in the event payload.
+        //   parent_chat_id — not applicable to Slack's flat channel model.
+        //   account_id — multi-account routing not tracked at this layer.
+        //   was_mentioned / mention_kind — requires our bot user id.
+        //   reply_to_text — Slack does not inline quoted text in events.
+        ..Default::default()
     };
     Ok(Parsed::Event(ChannelEvent::MessageReceived { msg }))
 }
@@ -194,18 +283,124 @@ mod tests {
                 "text":"see attached",
                 "ts":"1700000000.000200",
                 "files":[
-                    {"url_private":"https://files.slack.com/a.png"},
-                    {"permalink":"https://files.slack.com/b.jpg"}
+                    {"url_private":"https://files.slack.com/a.png","mimetype":"image/png"},
+                    {"permalink":"https://files.slack.com/b.jpg","mimetype":"image/jpeg"}
                 ]
             }
         }"#;
         match parse_webhook(body).unwrap() {
             Parsed::Event(ChannelEvent::MessageReceived { msg }) => {
                 assert_eq!(msg.attachments.len(), 2);
-                assert_eq!(msg.attachments[0], "https://files.slack.com/a.png");
-                assert_eq!(msg.attachments[1], "https://files.slack.com/b.jpg");
+                assert_eq!(msg.attachments[0].url, "https://files.slack.com/a.png");
+                assert_eq!(msg.attachments[0].kind, MediaKind::Image);
+                assert_eq!(
+                    msg.attachments[0].content_type.as_deref(),
+                    Some("image/png")
+                );
+                assert_eq!(msg.attachments[1].url, "https://files.slack.com/b.jpg");
+                assert_eq!(msg.attachments[1].kind, MediaKind::Image);
             }
             other => panic!("expected MessageReceived with files, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn message_round_trips_structured_fields() {
+        let body = r#"{
+            "type":"event_callback",
+            "event": {
+                "type":"message",
+                "channel":"D012ABC",
+                "user":"U456",
+                "text":"hello",
+                "ts":"1700000001.000100",
+                "team":"T789",
+                "channel_type":"im"
+            }
+        }"#;
+        match parse_webhook(body).unwrap() {
+            Parsed::Event(ChannelEvent::MessageReceived { msg }) => {
+                assert_eq!(msg.sender_id, "U456");
+                assert_eq!(msg.chat_type, ChatType::Direct);
+                assert_eq!(msg.space_id.as_deref(), Some("T789"));
+                assert_eq!(msg.platform.as_deref(), Some("slack"));
+                assert!(!msg.is_bot);
+                assert!(msg.thread_id.is_none());
+                assert!(msg.reply_to_message_id.is_none());
+            }
+            other => panic!("expected MessageReceived, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn channel_id_prefix_drives_chat_type_fallback() {
+        // No channel_type field — inferred from prefix.
+        for (channel, expected) in [
+            ("D001", ChatType::Direct),
+            ("G001", ChatType::Group),
+            ("C001", ChatType::Channel),
+        ] {
+            let body = format!(
+                r#"{{"type":"event_callback","event":{{"type":"message","channel":"{channel}","user":"U1","text":"x","ts":"1700000000.000100"}}}}"#
+            );
+            match parse_webhook(&body).unwrap() {
+                Parsed::Event(ChannelEvent::MessageReceived { msg }) => {
+                    assert_eq!(
+                        msg.chat_type, expected,
+                        "channel {channel} should map to {expected:?}"
+                    );
+                }
+                other => panic!("expected MessageReceived, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn threaded_reply_sets_thread_and_reply_ids() {
+        // thread_ts != ts  →  reply within an existing thread.
+        let body = r#"{
+            "type":"event_callback",
+            "event": {
+                "type":"message",
+                "channel":"C1",
+                "user":"U1",
+                "text":"reply",
+                "ts":"1700000002.000100",
+                "thread_ts":"1700000001.000100"
+            }
+        }"#;
+        match parse_webhook(body).unwrap() {
+            Parsed::Event(ChannelEvent::MessageReceived { msg }) => {
+                assert_eq!(msg.thread_id.as_deref(), Some("1700000001.000100"));
+                assert_eq!(
+                    msg.reply_to_message_id.as_deref(),
+                    Some("1700000001.000100")
+                );
+            }
+            other => panic!("expected MessageReceived, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn thread_root_has_thread_id_but_no_reply_to() {
+        // thread_ts == ts  →  this message is the thread root itself.
+        let body = r#"{
+            "type":"event_callback",
+            "event": {
+                "type":"message",
+                "channel":"C1",
+                "user":"U1",
+                "text":"root",
+                "ts":"1700000001.000100",
+                "thread_ts":"1700000001.000100"
+            }
+        }"#;
+        match parse_webhook(body).unwrap() {
+            Parsed::Event(ChannelEvent::MessageReceived { msg }) => {
+                assert_eq!(msg.thread_id.as_deref(), Some("1700000001.000100"));
+                assert!(msg.reply_to_message_id.is_none());
+            }
+            other => panic!("expected MessageReceived, got {other:?}"),
         }
     }
 }

--- a/crates/wcore-channel-slack/src/lib.rs
+++ b/crates/wcore-channel-slack/src/lib.rs
@@ -29,7 +29,7 @@ use async_trait::async_trait;
 use chrono::Utc;
 use tokio::sync::Mutex;
 use wcore_channels::{
-    Channel, ChannelError,
+    Channel, ChannelError, WebhookRequest, WebhookResponse,
     event::{ChannelEvent, ConnectionState, MessageReceipt},
     outgoing::OutgoingMessage,
 };
@@ -264,6 +264,35 @@ impl Channel for SlackChannel {
 
     fn config_schema(&self) -> &str {
         include_str!("../schemas/slack.json")
+    }
+
+    /// Verify a Slack Events API POST and enqueue any resulting event.
+    ///
+    /// Pulls the `X-Slack-Signature` + `X-Slack-Request-Timestamp` headers
+    /// the platform sends, then delegates to [`Self::ingest_event`] (which
+    /// runs the signing-secret HMAC + timestamp window). A
+    /// `url_verification` challenge surfaces as a `200` echoing the
+    /// challenge string; everything else is an empty `200`.
+    async fn ingest_webhook(
+        &self,
+        req: &WebhookRequest,
+    ) -> Result<WebhookResponse, ChannelError> {
+        let (sig, ts) = match (
+            req.header("x-slack-signature"),
+            req.header("x-slack-request-timestamp"),
+        ) {
+            (Some(sig), Some(ts)) => (sig, ts),
+            _ => {
+                return Err(ChannelError::Auth(
+                    "missing slack signature headers".into(),
+                ));
+            }
+        };
+        match self.ingest_event(&req.body, sig, ts).await {
+            Ok(Some(challenge)) => Ok(WebhookResponse::challenge(challenge)),
+            Ok(None) => Ok(WebhookResponse::ok()),
+            Err(e) => Err(ChannelError::Rejected(e.to_string())),
+        }
     }
 }
 

--- a/crates/wcore-channel-slack/src/lib.rs
+++ b/crates/wcore-channel-slack/src/lib.rs
@@ -266,6 +266,11 @@ impl Channel for SlackChannel {
         include_str!("../schemas/slack.json")
     }
 
+    /// Slack caps a single message around 40k characters; 39k is conservative.
+    fn max_message_len(&self) -> Option<usize> {
+        Some(39_000)
+    }
+
     /// Verify a Slack Events API POST and enqueue any resulting event.
     ///
     /// Pulls the `X-Slack-Signature` + `X-Slack-Request-Timestamp` headers
@@ -569,6 +574,12 @@ mod tests {
         let parsed: serde_json::Value =
             serde_json::from_str(ch.config_schema()).expect("schema parses");
         assert_eq!(parsed["title"].as_str(), Some("SlackChannelConfig"));
+    }
+
+    #[tokio::test]
+    async fn max_message_len_is_slack_cap() {
+        let ch = SlackChannel::new("test", cfg_for("https://unused.example"), store_for_test());
+        assert_eq!(ch.max_message_len(), Some(39_000));
     }
 
     #[tokio::test]

--- a/crates/wcore-channel-sms/src/inbound.rs
+++ b/crates/wcore-channel-sms/src/inbound.rs
@@ -17,7 +17,7 @@
 use base64::Engine;
 use hmac::{Hmac, Mac};
 use sha1::Sha1;
-use wcore_channels::event::IncomingMessage;
+use wcore_channels::event::{Attachment, ChatType, IncomingMessage, MediaKind};
 
 use crate::error::SmsError;
 
@@ -139,19 +139,32 @@ pub fn pairs_to_incoming(pairs: &[(String, String)]) -> Result<IncomingMessage, 
     let num_media: usize = get("NumMedia").and_then(|s| s.parse().ok()).unwrap_or(0);
     let mut attachments = Vec::with_capacity(num_media);
     for i in 0..num_media {
-        let key = format!("MediaUrl{i}");
-        if let Some(url) = get(&key) {
-            attachments.push(url.to_string());
+        let url_key = format!("MediaUrl{i}");
+        if let Some(url) = get(&url_key) {
+            let ct_key = format!("MediaContentType{i}");
+            let content_type = get(&ct_key).map(|s| s.to_string());
+            let kind = match content_type.as_deref() {
+                Some(ct) if ct.starts_with("image/") => MediaKind::Image,
+                Some(ct) if ct.starts_with("video/") => MediaKind::Video,
+                Some(ct) if ct.starts_with("audio/") => MediaKind::Audio,
+                _ => MediaKind::Other,
+            };
+            attachments.push(Attachment {
+                url: url.to_string(),
+                content_type,
+                kind,
+                ..Default::default()
+            });
         }
     }
 
     Ok(IncomingMessage {
-        id: sid,
-        conversation_id: to,
-        author: from,
-        text: body,
-        ts_secs: chrono::Utc::now().timestamp(),
+        sender_id: from.clone(),
+        chat_type: ChatType::Direct,
+        account_id: Some(to.clone()),
+        platform: Some("sms".into()),
         attachments,
+        ..IncomingMessage::new(sid, to, from, body, chrono::Utc::now().timestamp())
     })
 }
 
@@ -252,7 +265,13 @@ mod tests {
         let msg = pairs_to_incoming(&pairs).unwrap();
         assert_eq!(msg.id, "SM123");
         assert_eq!(msg.author, "+15551234567");
+        assert_eq!(msg.sender_id, "+15551234567");
         assert_eq!(msg.conversation_id, "+15559876543");
+        assert_eq!(msg.account_id.as_deref(), Some("+15559876543"));
+        assert_eq!(msg.platform.as_deref(), Some("sms"));
+        assert_eq!(msg.chat_type, ChatType::Direct);
+        assert!(!msg.is_bot);
+        assert!(!msg.is_self);
         assert_eq!(msg.text, "hello");
         assert!(msg.attachments.is_empty());
     }
@@ -262,12 +281,17 @@ mod tests {
         let pairs = parse_form(
             "MessageSid=SM1&From=%2B1&To=%2B2&Body=see&NumMedia=2\
              &MediaUrl0=https%3A%2F%2Fapi.twilio.com%2Fa.jpg\
+             &MediaContentType0=image%2Fjpeg\
              &MediaUrl1=https%3A%2F%2Fapi.twilio.com%2Fb.jpg",
         );
         let msg = pairs_to_incoming(&pairs).unwrap();
         assert_eq!(msg.attachments.len(), 2);
-        assert_eq!(msg.attachments[0], "https://api.twilio.com/a.jpg");
-        assert_eq!(msg.attachments[1], "https://api.twilio.com/b.jpg");
+        assert_eq!(msg.attachments[0].url, "https://api.twilio.com/a.jpg");
+        assert_eq!(msg.attachments[0].content_type.as_deref(), Some("image/jpeg"));
+        assert_eq!(msg.attachments[0].kind, MediaKind::Image);
+        assert_eq!(msg.attachments[1].url, "https://api.twilio.com/b.jpg");
+        assert_eq!(msg.attachments[1].content_type, None);
+        assert_eq!(msg.attachments[1].kind, MediaKind::Other);
     }
 
     #[test]

--- a/crates/wcore-channel-sms/src/lib.rs
+++ b/crates/wcore-channel-sms/src/lib.rs
@@ -8,8 +8,9 @@
 //!
 //! Inbound: Twilio sends `application/x-www-form-urlencoded` POSTs to a
 //! configured webhook URL on every incoming SMS. The engine's webhook
-//! router invokes `SmsChannel::ingest_webhook(full_url, raw_body, signature)`
-//! when a POST hits the channel's URL. The adapter verifies the
+//! router invokes the [`Channel::ingest_webhook`] trait method, which
+//! delegates to `SmsChannel::ingest_twilio_webhook(full_url, raw_body,
+//! signature)` when a POST hits the channel's URL. The adapter verifies the
 //! HMAC-SHA1 signature, parses the form body, and enqueues an
 //! `IncomingMessage` for the next `poll_events()`.
 //!
@@ -29,7 +30,7 @@ use async_trait::async_trait;
 use chrono::Utc;
 use tokio::sync::Mutex;
 use wcore_channels::{
-    Channel, ChannelError,
+    Channel, ChannelError, WebhookRequest, WebhookResponse,
     event::{ChannelEvent, ConnectionState, MessageReceipt},
     outgoing::OutgoingMessage,
 };
@@ -118,7 +119,11 @@ impl SmsChannel {
     ///
     /// Returns `Err(SmsError::SignatureMismatch)` if the signature is
     /// invalid; the engine should respond HTTP 403 in that case.
-    pub async fn ingest_webhook(
+    ///
+    /// Named distinctly from the [`Channel::ingest_webhook`] trait method
+    /// (which takes a `&WebhookRequest`) to avoid inherent-vs-trait method
+    /// resolution ambiguity; the trait override delegates here.
+    pub async fn ingest_twilio_webhook(
         &self,
         full_url: &str,
         raw_body: &str,
@@ -255,6 +260,29 @@ impl Channel for SmsChannel {
 
     fn config_schema(&self) -> &str {
         include_str!("schemas/sms.json")
+    }
+
+    /// Verify a Twilio webhook POST and enqueue the inbound SMS.
+    ///
+    /// Twilio signs the full request URL plus the sorted form body, so the
+    /// host must supply [`WebhookRequest::full_url`] matching the exact
+    /// public URL Twilio called (see the host's `public_base_url`). Pulls
+    /// the `X-Twilio-Signature` header and delegates to
+    /// [`Self::ingest_twilio_webhook`].
+    async fn ingest_webhook(
+        &self,
+        req: &WebhookRequest,
+    ) -> Result<WebhookResponse, ChannelError> {
+        let sig = req.header("x-twilio-signature").ok_or_else(|| {
+            ChannelError::Auth("missing twilio signature header".into())
+        })?;
+        match self
+            .ingest_twilio_webhook(&req.full_url, &req.body, sig)
+            .await
+        {
+            Ok(()) => Ok(WebhookResponse::ok()),
+            Err(e) => Err(ChannelError::Rejected(e.to_string())),
+        }
     }
 }
 
@@ -491,7 +519,7 @@ mod tests {
         let pairs = inbound::parse_form(body);
         let sig = inbound::expected_signature(TEST_TOKEN, url, &pairs);
 
-        ch.ingest_webhook(url, body, &sig).await.unwrap();
+        ch.ingest_twilio_webhook(url, body, &sig).await.unwrap();
 
         let evs = ch.poll_events().await.unwrap();
         assert_eq!(evs.len(), 1);
@@ -519,7 +547,10 @@ mod tests {
         let body = "MessageSid=SM1&From=%2B1&To=%2B2&Body=hi&NumMedia=0";
         // Wrong signature (well-formed base64, 28 chars, but not a valid HMAC).
         let bogus = "AAAAAAAAAAAAAAAAAAAAAAAAAAAA";
-        let err = ch.ingest_webhook(url, body, bogus).await.unwrap_err();
+        let err = ch
+            .ingest_twilio_webhook(url, body, bogus)
+            .await
+            .unwrap_err();
         assert!(matches!(err, SmsError::SignatureMismatch));
     }
 
@@ -566,7 +597,7 @@ mod tests {
     async fn ingest_webhook_before_start_errors() {
         let ch = SmsChannel::new("test", cfg_for("https://unused.example"), store_for_test());
         let err = ch
-            .ingest_webhook(
+            .ingest_twilio_webhook(
                 "https://x",
                 "MessageSid=SM1&From=%2B1&To=%2B2&Body=hi",
                 "sig",

--- a/crates/wcore-channel-sms/src/lib.rs
+++ b/crates/wcore-channel-sms/src/lib.rs
@@ -262,6 +262,11 @@ impl Channel for SmsChannel {
         include_str!("schemas/sms.json")
     }
 
+    /// Twilio concatenated SMS caps a single message at 1600 characters.
+    fn max_message_len(&self) -> Option<usize> {
+        Some(1600)
+    }
+
     /// Verify a Twilio webhook POST and enqueue the inbound SMS.
     ///
     /// Twilio signs the full request URL plus the sorted form body, so the
@@ -338,6 +343,12 @@ mod tests {
             ("sms.test.account_sid", TEST_SID),
             ("sms.test.auth_token", TEST_TOKEN),
         ])
+    }
+
+    #[test]
+    fn max_message_len_is_sms_cap() {
+        let ch = SmsChannel::new("test", cfg_for("https://unused.example"), store_for_test());
+        assert_eq!(ch.max_message_len(), Some(1600));
     }
 
     // -----------------------------------------------------------------

--- a/crates/wcore-channel-telegram/src/api.rs
+++ b/crates/wcore-channel-telegram/src/api.rs
@@ -183,6 +183,33 @@ pub struct SendDocumentBody<'a> {
     pub reply_to_message_id: Option<i64>,
 }
 
+/// `sendChatAction` request body. We always send `action: "typing"` — the
+/// only chat action this adapter emits. Telegram auto-expires the typing
+/// indicator after ~5s, so the subscriber refreshes it periodically.
+#[derive(Debug, Clone, Serialize)]
+pub struct SendChatActionBody<'a> {
+    pub chat_id: &'a str,
+    pub action: &'a str,
+}
+
+/// One reaction in a `setMessageReaction` request. Telegram models a
+/// reaction as a tagged object; we only ever send `type: "emoji"`.
+#[derive(Debug, Clone, Serialize)]
+pub struct ReactionType<'a> {
+    #[serde(rename = "type")]
+    pub kind: &'a str,
+    pub emoji: &'a str,
+}
+
+/// `setMessageReaction` request body. `reaction` is an array — an empty
+/// array would clear reactions, but we always send exactly one emoji.
+#[derive(Debug, Clone, Serialize)]
+pub struct SetReactionBody<'a> {
+    pub chat_id: &'a str,
+    pub message_id: i64,
+    pub reaction: Vec<ReactionType<'a>>,
+}
+
 /// Send one message with the retry policy described in the crate docs:
 /// up to `SEND_MAX_ATTEMPTS` total tries, exponential backoff on 5xx /
 /// network failure, Telegram-style 429 (honors `parameters.retry_after`),
@@ -464,6 +491,99 @@ pub(crate) async fn send_document(
     post_with_retry(http, &url, body).await
 }
 
+/// Build the `sendChatAction` body for a typing indicator. Factored out so
+/// the request shape is testable without a network round-trip.
+pub(crate) fn build_send_chat_action(chat_id: &str) -> SendChatActionBody<'_> {
+    SendChatActionBody {
+        chat_id,
+        action: "typing",
+    }
+}
+
+/// Build the `setMessageReaction` body for a single emoji reaction.
+/// Factored out so the nested `reaction` array shape is testable without a
+/// network round-trip.
+pub(crate) fn build_set_reaction<'a>(
+    chat_id: &'a str,
+    message_id: i64,
+    emoji: &'a str,
+) -> SetReactionBody<'a> {
+    SetReactionBody {
+        chat_id,
+        message_id,
+        reaction: vec![ReactionType {
+            kind: "emoji",
+            emoji,
+        }],
+    }
+}
+
+/// POST a serializable body to a Telegram endpoint that returns a bare
+/// `result: true` envelope (not a `Message`), with NO retry. Used by the
+/// best-effort ack signals (`sendChatAction`, `setMessageReaction`) where
+/// a single attempt is sufficient and the caller treats failures as
+/// non-fatal. Non-2xx maps to a clean error so the caller can log + ignore.
+async fn post_once<B: Serialize>(
+    http: &wcore_egress::EgressClient,
+    url: &str,
+    body: &B,
+) -> Result<(), TelegramError> {
+    let resp = http
+        .post(url)
+        .json(body)
+        .send()
+        .await
+        .map_err(|e| TelegramError::Http(format!("network: {e}")))?;
+
+    let status = resp.status();
+    if status.is_success() {
+        return Ok(());
+    }
+
+    // Non-2xx — surface a clean error. Auth on 401/403, otherwise Rejected
+    // with whatever description Telegram returned (e.g. an invalid reaction
+    // emoji yields a 400 here).
+    let bytes = resp.bytes().await.unwrap_or_default();
+    let api = serde_json::from_slice::<ApiResponse<serde_json::Value>>(&bytes).ok();
+    let desc = api
+        .as_ref()
+        .and_then(|a| a.description.clone())
+        .unwrap_or_else(|| format!("status {status}"));
+    let code = api
+        .as_ref()
+        .and_then(|a| a.error_code)
+        .unwrap_or(status.as_u16() as i64);
+    if matches!(status.as_u16(), 401 | 403) {
+        return Err(TelegramError::Auth(desc));
+    }
+    Err(TelegramError::Rejected {
+        code,
+        description: desc,
+    })
+}
+
+/// Send a `typing` chat action. Best-effort, single attempt.
+pub(crate) async fn send_chat_action(
+    http: &wcore_egress::EgressClient,
+    api_base: &str,
+    bot_token: &str,
+    body: &SendChatActionBody<'_>,
+) -> Result<(), TelegramError> {
+    let url = format!("{api_base}/bot{bot_token}/sendChatAction");
+    post_once(http, &url, body).await
+}
+
+/// Set a single emoji reaction on a message. Best-effort, single attempt.
+pub(crate) async fn set_message_reaction(
+    http: &wcore_egress::EgressClient,
+    api_base: &str,
+    bot_token: &str,
+    body: &SetReactionBody<'_>,
+) -> Result<(), TelegramError> {
+    let url = format!("{api_base}/bot{bot_token}/setMessageReaction");
+    post_once(http, &url, body).await
+}
+
 fn exp_backoff_ms(attempt: u32) -> u64 {
     // attempt=1 -> 200ms, attempt=2 -> 400ms, attempt=3 -> 800ms, ...
     let shift = attempt.saturating_sub(1).min(10);
@@ -530,5 +650,26 @@ mod tests {
         // caption + reply_to_message_id skip-serialize when None.
         assert!(json.get("caption").is_none());
         assert!(json.get("reply_to_message_id").is_none());
+    }
+
+    #[test]
+    fn send_chat_action_body_serializes_typing() {
+        let body = build_send_chat_action("42");
+        let json = serde_json::to_value(&body).unwrap();
+        assert_eq!(json["chat_id"], "42");
+        assert_eq!(json["action"], "typing");
+    }
+
+    #[test]
+    fn set_reaction_body_serializes_nested_emoji_array() {
+        let body = build_set_reaction("42", 7, "👀");
+        let json = serde_json::to_value(&body).unwrap();
+        assert_eq!(json["chat_id"], "42");
+        // message_id is sent as a JSON number, not a string.
+        assert_eq!(json["message_id"], 7);
+        let reaction = json["reaction"].as_array().expect("reaction is an array");
+        assert_eq!(reaction.len(), 1);
+        assert_eq!(reaction[0]["type"], "emoji");
+        assert_eq!(reaction[0]["emoji"], "👀");
     }
 }

--- a/crates/wcore-channel-telegram/src/api.rs
+++ b/crates/wcore-channel-telegram/src/api.rs
@@ -162,6 +162,27 @@ pub struct SendMessageBody<'a> {
     pub reply_to_message_id: Option<i64>,
 }
 
+/// `getFile` result — we only need `file_path`, the relative path under
+/// `{api_base}/file/bot{token}/` from which the media bytes download.
+#[derive(Debug, Clone, Deserialize)]
+pub struct File {
+    #[serde(default)]
+    pub file_path: Option<String>,
+}
+
+/// sendDocument request body. Telegram fetches `document` itself when it
+/// is a URL, so we never upload bytes from our side (no SSRF surface).
+/// `caption` carries the message text when there is one to attach.
+#[derive(Debug, Clone, Serialize)]
+pub struct SendDocumentBody<'a> {
+    pub chat_id: &'a str,
+    pub document: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub caption: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reply_to_message_id: Option<i64>,
+}
+
 /// Send one message with the retry policy described in the crate docs:
 /// up to `SEND_MAX_ATTEMPTS` total tries, exponential backoff on 5xx /
 /// network failure, Telegram-style 429 (honors `parameters.retry_after`),
@@ -173,6 +194,19 @@ pub(crate) async fn send_message(
     body: &SendMessageBody<'_>,
 ) -> Result<Message, TelegramError> {
     let url = format!("{api_base}/bot{bot_token}/sendMessage");
+    post_with_retry(http, &url, body).await
+}
+
+/// POST a serializable body to a Telegram send endpoint and decode a
+/// `Message` from the envelope, applying the shared retry policy
+/// (exponential backoff on 5xx / network, 429 `retry_after` honoured and
+/// capped, permanent short-circuit on other 4xx). Shared by `sendMessage`
+/// and `sendDocument` so the policy lives in exactly one place.
+async fn post_with_retry<B: Serialize>(
+    http: &wcore_egress::EgressClient,
+    url: &str,
+    body: &B,
+) -> Result<Message, TelegramError> {
     let mut last_err = TelegramError::Http("no attempts made".to_string());
     let mut last_retry_after: u64 = 0;
 
@@ -182,7 +216,7 @@ pub(crate) async fn send_message(
             tokio::time::sleep(Duration::from_millis(sleep_ms)).await;
         }
 
-        let resp = match http.post(&url).json(body).send().await {
+        let resp = match http.post(url).json(body).send().await {
             Ok(r) => r,
             Err(e) => {
                 last_err = TelegramError::Http(format!("network: {e}"));
@@ -342,10 +376,159 @@ pub(crate) async fn get_updates(
     Ok(api.result.unwrap_or_default())
 }
 
+/// Build the media download URL for a resolved `file_path`.
+///
+/// Telegram serves uploaded file bytes from a *different* path than the
+/// bot method endpoints: `{api_base}/file/bot{token}/{file_path}` rather
+/// than `{api_base}/bot{token}/{method}`. Pure + testable so the URL
+/// shape is pinned independently of any network call.
+pub(crate) fn file_download_url(api_base: &str, bot_token: &str, file_path: &str) -> String {
+    let base = api_base.trim_end_matches('/');
+    let path = file_path.trim_start_matches('/');
+    format!("{base}/file/bot{bot_token}/{path}")
+}
+
+/// Resolve a `file_id` to its downloadable URL via `getFile`.
+///
+/// Returns the full `{api_base}/file/bot{token}/{file_path}` URL on
+/// success. The HTTP read is bounded by a short timeout so a hung
+/// `getFile` can't stall the long-poll loop. Any failure (network, non-2xx,
+/// `ok=false`, or a missing `file_path`) surfaces as `Err`; the caller
+/// decides whether to fall back to the raw `file_id`.
+pub(crate) async fn get_file(
+    http: &wcore_egress::EgressClient,
+    api_base: &str,
+    bot_token: &str,
+    file_id: &str,
+) -> Result<String, TelegramError> {
+    let url = format!("{api_base}/bot{bot_token}/getFile");
+    let resp = http
+        .get(&url)
+        .query(&[("file_id", file_id)])
+        // Bound the resolve so a hung getFile doesn't stall the poll loop.
+        .timeout(Duration::from_secs(10))
+        .send()
+        .await
+        .map_err(|e| TelegramError::Http(format!("network: {e}")))?;
+
+    let status = resp.status();
+    if !status.is_success() {
+        return Err(TelegramError::Http(format!("getFile status {status}")));
+    }
+
+    let bytes = resp
+        .bytes()
+        .await
+        .map_err(|e| TelegramError::Http(format!("body read: {e}")))?;
+    let api: ApiResponse<File> =
+        serde_json::from_slice(&bytes).map_err(|e| TelegramError::Decode(e.to_string()))?;
+    if !api.ok {
+        return Err(TelegramError::ApiNotOk(
+            api.description.unwrap_or_else(|| "ok=false".to_string()),
+        ));
+    }
+    match api.result.and_then(|f| f.file_path) {
+        Some(path) => Ok(file_download_url(api_base, bot_token, &path)),
+        None => Err(TelegramError::ApiNotOk(
+            "getFile ok=true but no file_path".to_string(),
+        )),
+    }
+}
+
+/// Build the `sendDocument` JSON body for a single attachment. Factored
+/// out so the request shape is testable without a network round-trip.
+/// `caption` is `None` when no text accompanies the document.
+pub(crate) fn build_send_document<'a>(
+    chat_id: &'a str,
+    document: &'a str,
+    caption: Option<&'a str>,
+    reply_to_message_id: Option<i64>,
+) -> SendDocumentBody<'a> {
+    SendDocumentBody {
+        chat_id,
+        document,
+        caption,
+        reply_to_message_id,
+    }
+}
+
+/// Send one attachment via `sendDocument`, reusing the same retry policy
+/// as [`send_message`]. Telegram fetches the `document` URL itself.
+pub(crate) async fn send_document(
+    http: &wcore_egress::EgressClient,
+    api_base: &str,
+    bot_token: &str,
+    body: &SendDocumentBody<'_>,
+) -> Result<Message, TelegramError> {
+    let url = format!("{api_base}/bot{bot_token}/sendDocument");
+    post_with_retry(http, &url, body).await
+}
+
 fn exp_backoff_ms(attempt: u32) -> u64 {
     // attempt=1 -> 200ms, attempt=2 -> 400ms, attempt=3 -> 800ms, ...
     let shift = attempt.saturating_sub(1).min(10);
     SEND_BASE_BACKOFF_MS
         .saturating_mul(1u64 << shift)
         .min(SEND_MAX_BACKOFF_MS)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn file_download_url_builds_file_path_endpoint() {
+        let url = file_download_url("https://api.telegram.org", "111:AAA", "photos/file_0.jpg");
+        assert_eq!(
+            url,
+            "https://api.telegram.org/file/bot111:AAA/photos/file_0.jpg"
+        );
+    }
+
+    #[test]
+    fn file_download_url_normalizes_slashes() {
+        // Trailing slash on base + leading slash on path must not double up.
+        let url = file_download_url("https://api.telegram.org/", "T", "/voice/a.ogg");
+        assert_eq!(url, "https://api.telegram.org/file/botT/voice/a.ogg");
+    }
+
+    #[test]
+    fn getfile_response_parses_file_path() {
+        let raw = r#"{"ok":true,"result":{"file_id":"x","file_unique_id":"u","file_size":123,"file_path":"documents/file_3.pdf"}}"#;
+        let api: ApiResponse<File> = serde_json::from_slice(raw.as_bytes()).unwrap();
+        assert!(api.ok);
+        assert_eq!(
+            api.result.and_then(|f| f.file_path).as_deref(),
+            Some("documents/file_3.pdf")
+        );
+    }
+
+    #[test]
+    fn getfile_response_tolerates_missing_file_path() {
+        // Some results omit file_path; we must not fail to deserialize.
+        let raw = r#"{"ok":true,"result":{"file_id":"x"}}"#;
+        let api: ApiResponse<File> = serde_json::from_slice(raw.as_bytes()).unwrap();
+        assert!(api.result.and_then(|f| f.file_path).is_none());
+    }
+
+    #[test]
+    fn send_document_body_serializes_with_caption() {
+        let body = build_send_document("42", "https://x/a.jpg", Some("hello"), Some(7));
+        let json = serde_json::to_value(&body).unwrap();
+        assert_eq!(json["chat_id"], "42");
+        assert_eq!(json["document"], "https://x/a.jpg");
+        assert_eq!(json["caption"], "hello");
+        assert_eq!(json["reply_to_message_id"], 7);
+    }
+
+    #[test]
+    fn send_document_body_omits_absent_optionals() {
+        let body = build_send_document("42", "https://x/a.jpg", None, None);
+        let json = serde_json::to_value(&body).unwrap();
+        assert_eq!(json["chat_id"], "42");
+        assert_eq!(json["document"], "https://x/a.jpg");
+        // caption + reply_to_message_id skip-serialize when None.
+        assert!(json.get("caption").is_none());
+        assert!(json.get("reply_to_message_id").is_none());
+    }
 }

--- a/crates/wcore-channel-telegram/src/api.rs
+++ b/crates/wcore-channel-telegram/src/api.rs
@@ -40,21 +40,90 @@ pub struct Message {
     pub from: Option<User>,
     #[serde(default)]
     pub text: Option<String>,
+    /// Forum topic / thread id (supergroups with topics enabled).
+    #[serde(default)]
+    pub message_thread_id: Option<i64>,
+    /// The message this one replies to, if any.
+    #[serde(default)]
+    pub reply_to_message: Option<Box<Message>>,
+    /// Photo sizes — present when the message contains a photo.
+    #[serde(default)]
+    pub photo: Option<Vec<PhotoSize>>,
+    /// Voice note — present when the message contains a voice recording.
+    #[serde(default)]
+    pub voice: Option<Voice>,
+    /// Generic document attachment.
+    #[serde(default)]
+    pub document: Option<Document>,
+    /// Video attachment.
+    #[serde(default)]
+    pub video: Option<Video>,
+    /// Text entities (mentions, bot_commands, …).
+    #[serde(default)]
+    pub entities: Option<Vec<MessageEntity>>,
+}
+
+/// Telegram `PhotoSize` — we only need the `file_id` as a reference URL.
+#[derive(Debug, Clone, Deserialize)]
+pub struct PhotoSize {
+    pub file_id: String,
+}
+
+/// Telegram `Voice` note.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Voice {
+    pub file_id: String,
+    #[serde(default)]
+    pub mime_type: Option<String>,
+}
+
+/// Telegram `Document`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Document {
+    pub file_id: String,
+    #[serde(default)]
+    pub mime_type: Option<String>,
+}
+
+/// Telegram `Video`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Video {
+    pub file_id: String,
+    #[serde(default)]
+    pub mime_type: Option<String>,
+}
+
+/// Telegram `MessageEntity` — text annotations (mentions, commands, …).
+#[derive(Debug, Clone, Deserialize)]
+pub struct MessageEntity {
+    /// Entity type string, e.g. `"mention"`, `"bot_command"`, …
+    #[serde(rename = "type")]
+    pub kind: String,
 }
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct Chat {
     /// Telegram chat ids are i64 (can be negative for groups/channels).
     pub id: i64,
+    /// Chat type: `"private"`, `"group"`, `"supergroup"`, `"channel"`.
+    #[serde(rename = "type", default)]
+    pub chat_type: String,
+    /// Human-facing title (groups/channels); absent for private chats.
+    #[serde(default)]
+    pub title: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct User {
     pub id: i64,
     #[serde(default)]
+    pub is_bot: bool,
+    #[serde(default)]
     pub username: Option<String>,
     #[serde(default)]
     pub first_name: Option<String>,
+    #[serde(default)]
+    pub last_name: Option<String>,
 }
 
 /// Envelope wrapping every Telegram Bot API response.

--- a/crates/wcore-channel-telegram/src/config.rs
+++ b/crates/wcore-channel-telegram/src/config.rs
@@ -59,6 +59,41 @@ impl ParseMode {
     }
 }
 
+/// Escape every character Telegram reserves under MarkdownV2 by prefixing
+/// it with a backslash.
+///
+/// Telegram's MarkdownV2 spec requires these characters be escaped in ALL
+/// text (not just inside entities):
+/// `_ * [ ] ( ) ~ ` > # + - = | { } . !`
+///
+/// v1 semantics: we escape the FULL message text, so the body is always
+/// delivered as valid literal text and Telegram never returns
+/// `400 Bad Request: can't parse entities`. The tradeoff is that any
+/// model-emitted Markdown formatting (`*bold*`, `[label](url)`) is rendered
+/// literally rather than interpreted. That is the correct, safe default for
+/// v1 — never 400. Formatting fidelity via selective escaping (escaping only
+/// the reserved characters that are NOT part of intended markup) is a future
+/// enhancement.
+///
+/// This is MarkdownV2-specific. It must NOT be applied to `HTML` parse mode
+/// (HTML has its own escaping rules — `< > &` — out of scope here) nor to the
+/// legacy `Markdown` parse mode (which has a different, smaller reserved set:
+/// `_ * ` [`). Callers gate on `parse_mode == MarkdownV2`.
+pub fn escape_markdown_v2(s: &str) -> String {
+    // Reserved set per https://core.telegram.org/bots/api#markdownv2-style
+    const RESERVED: &[char] = &[
+        '_', '*', '[', ']', '(', ')', '~', '`', '>', '#', '+', '-', '=', '|', '{', '}', '.', '!',
+    ];
+    let mut out = String::with_capacity(s.len());
+    for ch in s.chars() {
+        if RESERVED.contains(&ch) {
+            out.push('\\');
+        }
+        out.push(ch);
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -102,6 +137,46 @@ unknown = "boom"
             err.to_string().contains("unknown"),
             "error should mention unknown field, got: {err}"
         );
+    }
+
+    #[test]
+    fn escape_markdown_v2_escapes_every_reserved_char() {
+        for ch in [
+            '_', '*', '[', ']', '(', ')', '~', '`', '>', '#', '+', '-', '=', '|', '{', '}', '.',
+            '!',
+        ] {
+            let input = ch.to_string();
+            let escaped = escape_markdown_v2(&input);
+            assert_eq!(
+                escaped,
+                format!("\\{ch}"),
+                "reserved char {ch:?} should be backslash-escaped"
+            );
+        }
+    }
+
+    #[test]
+    fn escape_markdown_v2_realistic_reply() {
+        // `Hello! I'm here. (ready)` -> `!`, `.`, `(`, `)` get escaped.
+        // The apostrophe is NOT reserved and stays as-is.
+        let input = "Hello! I'm here. (ready)";
+        let escaped = escape_markdown_v2(input);
+        assert_eq!(escaped, "Hello\\! I'm here\\. \\(ready\\)");
+    }
+
+    #[test]
+    fn escape_markdown_v2_plain_alphanumeric_unchanged() {
+        let input = "abc 123 XYZ";
+        assert_eq!(escape_markdown_v2(input), input);
+    }
+
+    #[test]
+    fn escape_markdown_v2_backslash_prefix_is_correct() {
+        // A literal backslash is itself NOT in the reserved set, so it is
+        // left untouched; the reserved char following it still gets its own
+        // backslash. Verifies we only prepend `\` to reserved chars.
+        let escaped = escape_markdown_v2("a\\b.c");
+        assert_eq!(escaped, "a\\b\\.c");
     }
 
     #[test]

--- a/crates/wcore-channel-telegram/src/lib.rs
+++ b/crates/wcore-channel-telegram/src/lib.rs
@@ -210,9 +210,22 @@ impl Channel for TelegramChannel {
 
     async fn send_message(&mut self, msg: OutgoingMessage) -> Result<MessageReceipt, ChannelError> {
         let token = self.bot_token.as_deref().ok_or(ChannelError::NotStarted)?;
+        // Under MarkdownV2 every reserved character must be backslash-escaped
+        // or Telegram rejects the send with `400 ... can't parse entities`.
+        // We escape the full text (see `escape_markdown_v2` docs for v1
+        // semantics). HTML / legacy Markdown have different escaping rules and
+        // are left untouched here. `escaped` outlives `body`'s borrow.
+        let escaped;
+        let text: &str = match self.config.parse_mode {
+            ParseMode::MarkdownV2 => {
+                escaped = config::escape_markdown_v2(&msg.text);
+                &escaped
+            }
+            ParseMode::Html | ParseMode::Markdown => &msg.text,
+        };
         let body = api::SendMessageBody {
             chat_id: &msg.conversation_id,
-            text: &msg.text,
+            text,
             parse_mode: Some(self.config.parse_mode.as_api_str()),
             reply_to_message_id: msg.reply_to.as_deref().and_then(|s| s.parse::<i64>().ok()),
         };
@@ -319,6 +332,67 @@ mod tests {
         assert_eq!(receipt.id, "42");
         assert_eq!(receipt.conversation_id, "42");
         assert_eq!(receipt.ts_secs, 1_700_000_000);
+        mock.assert_async().await;
+        ch.stop().await.unwrap();
+    }
+
+    // -----------------------------------------------------------------
+    // 1b. MarkdownV2 channel escapes reserved chars in the send payload;
+    //     HTML channel sends the raw text (no MarkdownV2 escaping). This
+    //     is the HIGH-9 regression guard: a reply like `Hi! (ok).` must
+    //     reach Telegram as `Hi\! \(ok\)\.` under MarkdownV2.
+    // -----------------------------------------------------------------
+    #[tokio::test]
+    async fn markdown_v2_escapes_payload_text() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("POST", format!("/bot{TEST_TOKEN}/sendMessage").as_str())
+            .match_body(mockito::Matcher::PartialJsonString(
+                // JSON-encoded form of `Hi\! \(ok\)\.` — each backslash is
+                // doubled because it is itself escaped in the JSON string.
+                r#"{"text":"Hi\\! \\(ok\\)\\.","parse_mode":"MarkdownV2"}"#.to_string(),
+            ))
+            .with_status(200)
+            .with_body(r#"{"ok":true,"result":{"message_id":1,"date":1,"chat":{"id":1}}}"#)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let creds = InMemoryCreds::with_token("telegram.test.bot_token", TEST_TOKEN);
+        let mut ch = TelegramChannel::with_api_base("test", cfg(), creds, server.url());
+        ch.start().await.unwrap();
+        ch.send_message(OutgoingMessage::text("1", "Hi! (ok)."))
+            .await
+            .unwrap();
+        mock.assert_async().await;
+        ch.stop().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn html_mode_does_not_apply_markdown_v2_escaping() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("POST", format!("/bot{TEST_TOKEN}/sendMessage").as_str())
+            .match_body(mockito::Matcher::PartialJsonString(
+                // Raw text, unescaped, under HTML parse mode.
+                r#"{"text":"Hi! (ok).","parse_mode":"HTML"}"#.to_string(),
+            ))
+            .with_status(200)
+            .with_body(r#"{"ok":true,"result":{"message_id":1,"date":1,"chat":{"id":1}}}"#)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let html_cfg = TelegramConfig {
+            parse_mode: ParseMode::Html,
+            ..cfg()
+        };
+        let creds = InMemoryCreds::with_token("telegram.test.bot_token", TEST_TOKEN);
+        let mut ch = TelegramChannel::with_api_base("test", html_cfg, creds, server.url());
+        ch.start().await.unwrap();
+        ch.send_message(OutgoingMessage::text("1", "Hi! (ok)."))
+            .await
+            .unwrap();
         mock.assert_async().await;
         ch.stop().await.unwrap();
     }

--- a/crates/wcore-channel-telegram/src/lib.rs
+++ b/crates/wcore-channel-telegram/src/lib.rs
@@ -272,6 +272,40 @@ impl Channel for TelegramChannel {
         })
     }
 
+    /// POST `sendChatAction` with `action: "typing"`. Best-effort: the
+    /// typing indicator auto-expires after ~5s, which is why the inbound
+    /// subscriber refreshes it. A single attempt is sufficient — transport
+    /// failures map to [`ChannelError::Transport`] and are logged + ignored
+    /// by the caller, never fatal to the turn.
+    async fn send_typing(&self, conversation_id: &str) -> Result<(), ChannelError> {
+        let token = self.bot_token.as_deref().ok_or(ChannelError::NotStarted)?;
+        let body = api::build_send_chat_action(conversation_id);
+        api::send_chat_action(&self.http, &self.api_base, token, &body)
+            .await
+            .map_err(ChannelError::from)
+    }
+
+    /// POST `setMessageReaction` with a single emoji. `message_id` arrives
+    /// as a string and must parse to an `i64`; a parse failure is a caller
+    /// bug and surfaces as [`ChannelError::Rejected`]. We do not validate
+    /// the emoji against Telegram's fixed reaction set — an unknown emoji is
+    /// rejected by Telegram with a 400, which maps to `Rejected`.
+    async fn react(
+        &self,
+        conversation_id: &str,
+        message_id: &str,
+        emoji: &str,
+    ) -> Result<(), ChannelError> {
+        let token = self.bot_token.as_deref().ok_or(ChannelError::NotStarted)?;
+        let message_id: i64 = message_id
+            .parse()
+            .map_err(|_| ChannelError::Rejected("invalid message_id".to_string()))?;
+        let body = api::build_set_reaction(conversation_id, message_id, emoji);
+        api::set_message_reaction(&self.http, &self.api_base, token, &body)
+            .await
+            .map_err(ChannelError::from)
+    }
+
     fn config_schema(&self) -> &str {
         include_str!("schemas/telegram.json")
     }
@@ -859,6 +893,147 @@ parse_mode = "MarkdownV2"
         assert_eq!(receipt.id, "9");
         m_text.assert_async().await;
         m_doc.assert_async().await;
+        ch.stop().await.unwrap();
+    }
+
+    // -----------------------------------------------------------------
+    // 12. send_typing POSTs sendChatAction with action=typing and succeeds
+    //     on 200.
+    // -----------------------------------------------------------------
+    #[tokio::test]
+    async fn send_typing_posts_chat_action_on_200() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("POST", format!("/bot{TEST_TOKEN}/sendChatAction").as_str())
+            .match_header("content-type", "application/json")
+            .match_body(mockito::Matcher::PartialJsonString(
+                r#"{"chat_id":"42","action":"typing"}"#.to_string(),
+            ))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"ok":true,"result":true}"#)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let creds = InMemoryCreds::with_token("telegram.test.bot_token", TEST_TOKEN);
+        let mut ch = TelegramChannel::with_api_base("test", cfg(), creds, server.url());
+        ch.start().await.unwrap();
+        ch.send_typing("42").await.unwrap();
+        mock.assert_async().await;
+        ch.stop().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn send_typing_before_start_errors_not_started() {
+        let creds = InMemoryCreds::with_token("telegram.test.bot_token", TEST_TOKEN);
+        let ch = TelegramChannel::with_api_base("test", cfg(), creds, "http://unused".to_string());
+        let err = ch
+            .send_typing("42")
+            .await
+            .expect_err("expected NotStarted");
+        assert!(matches!(err, ChannelError::NotStarted), "got {err:?}");
+    }
+
+    // -----------------------------------------------------------------
+    // 13. react POSTs setMessageReaction with the nested reaction array
+    //     and succeeds on 200.
+    // -----------------------------------------------------------------
+    #[tokio::test]
+    async fn react_posts_set_message_reaction_on_200() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock(
+                "POST",
+                format!("/bot{TEST_TOKEN}/setMessageReaction").as_str(),
+            )
+            .match_header("content-type", "application/json")
+            .match_body(mockito::Matcher::PartialJsonString(
+                r#"{"chat_id":"42","message_id":7,"reaction":[{"type":"emoji","emoji":"👀"}]}"#
+                    .to_string(),
+            ))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"ok":true,"result":true}"#)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let creds = InMemoryCreds::with_token("telegram.test.bot_token", TEST_TOKEN);
+        let mut ch = TelegramChannel::with_api_base("test", cfg(), creds, server.url());
+        ch.start().await.unwrap();
+        ch.react("42", "7", "👀").await.unwrap();
+        mock.assert_async().await;
+        ch.stop().await.unwrap();
+    }
+
+    // -----------------------------------------------------------------
+    // 14. react with a non-numeric message_id is Rejected without ever
+    //     hitting the network.
+    // -----------------------------------------------------------------
+    #[tokio::test]
+    async fn react_with_non_numeric_message_id_is_rejected() {
+        let creds = InMemoryCreds::with_token("telegram.test.bot_token", TEST_TOKEN);
+        // Start so bot_token is populated and we exercise the parse path,
+        // not the NotStarted path. api_base is unused (no request is made).
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("GET", format!("/bot{TEST_TOKEN}/getUpdates").as_str())
+            .with_status(200)
+            .with_body(r#"{"ok":true,"result":[]}"#)
+            .expect_at_least(0)
+            .create_async()
+            .await;
+        let mut ch = TelegramChannel::with_api_base("test", cfg(), creds, server.url());
+        ch.start().await.unwrap();
+
+        let err = ch
+            .react("42", "not-a-number", "👀")
+            .await
+            .expect_err("expected Rejected for bad message_id");
+        match err {
+            ChannelError::Rejected(msg) => assert!(msg.contains("invalid message_id"), "msg = {msg}"),
+            other => panic!("expected Rejected, got {other:?}"),
+        }
+        ch.stop().await.unwrap();
+    }
+
+    // -----------------------------------------------------------------
+    // 15. react maps a Telegram 400 (e.g. unknown emoji) to a clean
+    //     Rejected error.
+    // -----------------------------------------------------------------
+    #[tokio::test]
+    async fn react_maps_400_to_rejected() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock(
+                "POST",
+                format!("/bot{TEST_TOKEN}/setMessageReaction").as_str(),
+            )
+            .with_status(400)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"ok":false,"error_code":400,"description":"Bad Request: REACTION_INVALID"}"#,
+            )
+            .expect(1)
+            .create_async()
+            .await;
+
+        let creds = InMemoryCreds::with_token("telegram.test.bot_token", TEST_TOKEN);
+        let mut ch = TelegramChannel::with_api_base("test", cfg(), creds, server.url());
+        ch.start().await.unwrap();
+        let err = ch
+            .react("42", "7", "🦄")
+            .await
+            .expect_err("expected Rejected for invalid reaction");
+        match err {
+            ChannelError::Rejected(msg) => {
+                assert!(msg.contains("400"), "msg = {msg}");
+                assert!(msg.contains("REACTION_INVALID"), "msg = {msg}");
+            }
+            other => panic!("expected Rejected, got {other:?}"),
+        }
+        mock.assert_async().await;
         ch.stop().await.unwrap();
     }
 

--- a/crates/wcore-channel-telegram/src/lib.rs
+++ b/crates/wcore-channel-telegram/src/lib.rs
@@ -210,28 +210,61 @@ impl Channel for TelegramChannel {
 
     async fn send_message(&mut self, msg: OutgoingMessage) -> Result<MessageReceipt, ChannelError> {
         let token = self.bot_token.as_deref().ok_or(ChannelError::NotStarted)?;
-        // Under MarkdownV2 every reserved character must be backslash-escaped
-        // or Telegram rejects the send with `400 ... can't parse entities`.
-        // We escape the full text (see `escape_markdown_v2` docs for v1
-        // semantics). HTML / legacy Markdown have different escaping rules and
-        // are left untouched here. `escaped` outlives `body`'s borrow.
-        let escaped;
-        let text: &str = match self.config.parse_mode {
-            ParseMode::MarkdownV2 => {
-                escaped = config::escape_markdown_v2(&msg.text);
-                &escaped
-            }
-            ParseMode::Html | ParseMode::Markdown => &msg.text,
-        };
-        let body = api::SendMessageBody {
-            chat_id: &msg.conversation_id,
-            text,
-            parse_mode: Some(self.config.parse_mode.as_api_str()),
-            reply_to_message_id: msg.reply_to.as_deref().and_then(|s| s.parse::<i64>().ok()),
-        };
-        let result = api::send_message(&self.http, &self.api_base, token, &body)
-            .await
-            .map_err(ChannelError::from)?;
+        let reply_to = msg.reply_to.as_deref().and_then(|s| s.parse::<i64>().ok());
+
+        // Track the most recent successful send so the receipt reflects
+        // the last thing Telegram accepted (text first, then each
+        // attachment). At least one of text/attachments is always sent.
+        let mut last_result: Option<api::Message> = None;
+
+        // ---- Text -------------------------------------------------------
+        // Skip the text send entirely when the body is empty but there are
+        // attachments — Telegram rejects empty-body sendMessage, and the
+        // documents carry the payload in that case.
+        let has_attachments = !msg.attachments.is_empty();
+        if !msg.text.is_empty() || !has_attachments {
+            // Under MarkdownV2 every reserved character must be backslash-escaped
+            // or Telegram rejects the send with `400 ... can't parse entities`.
+            // We escape the full text (see `escape_markdown_v2` docs for v1
+            // semantics). HTML / legacy Markdown have different escaping rules and
+            // are left untouched here. `escaped` outlives `body`'s borrow.
+            let escaped;
+            let text: &str = match self.config.parse_mode {
+                ParseMode::MarkdownV2 => {
+                    escaped = config::escape_markdown_v2(&msg.text);
+                    &escaped
+                }
+                ParseMode::Html | ParseMode::Markdown => &msg.text,
+            };
+            let body = api::SendMessageBody {
+                chat_id: &msg.conversation_id,
+                text,
+                parse_mode: Some(self.config.parse_mode.as_api_str()),
+                reply_to_message_id: reply_to,
+            };
+            let result = api::send_message(&self.http, &self.api_base, token, &body)
+                .await
+                .map_err(ChannelError::from)?;
+            last_result = Some(result);
+        }
+
+        // ---- Attachments ------------------------------------------------
+        // Each attachment URL is fetched by Telegram itself via sendDocument
+        // (no local upload, no SSRF surface on our side). sendDocument works
+        // for arbitrary file URLs — images included — which keeps v1 simple.
+        for url in &msg.attachments {
+            let body = api::build_send_document(&msg.conversation_id, url, None, reply_to);
+            let result = api::send_document(&self.http, &self.api_base, token, &body)
+                .await
+                .map_err(ChannelError::from)?;
+            last_result = Some(result);
+        }
+
+        // `last_result` is always Some: we send text unless there are
+        // attachments, and we send at least one attachment otherwise.
+        let result = last_result.ok_or_else(|| {
+            ChannelError::Other("send_message produced no outbound request".to_string())
+        })?;
         Ok(MessageReceipt {
             id: result.message_id.to_string(),
             conversation_id: msg.conversation_id,
@@ -678,6 +711,155 @@ parse_mode = "MarkdownV2"
             .await
             .expect_err("expected NotStarted");
         assert!(matches!(err, ChannelError::NotStarted), "got {err:?}");
+    }
+
+    // -----------------------------------------------------------------
+    // 9. Inbound media: file_id is resolved to a real download URL via
+    //    getFile, and the typed Attachment carries it.
+    // -----------------------------------------------------------------
+    #[tokio::test]
+    async fn inbound_photo_resolves_download_url_via_get_file() {
+        let mut server = mockito::Server::new_async().await;
+        // getUpdates returns one message with a photo (two sizes).
+        let _m_upd = server
+            .mock("GET", format!("/bot{TEST_TOKEN}/getUpdates").as_str())
+            .match_query(mockito::Matcher::UrlEncoded("offset".into(), "0".into()))
+            .with_status(200)
+            .with_body(
+                r#"{"ok":true,"result":[{"update_id":1,"message":{"message_id":5,"date":1,"chat":{"id":7},"from":{"id":1,"username":"u"},"photo":[{"file_id":"small_id"},{"file_id":"big_id"}]}}]}"#,
+            )
+            .expect(1)
+            .create_async()
+            .await;
+        let _m_empty = server
+            .mock("GET", format!("/bot{TEST_TOKEN}/getUpdates").as_str())
+            .with_status(200)
+            .with_body(r#"{"ok":true,"result":[]}"#)
+            .expect_at_least(0)
+            .create_async()
+            .await;
+        // getFile for the largest photo resolves to a file_path.
+        let _m_file = server
+            .mock("GET", format!("/bot{TEST_TOKEN}/getFile").as_str())
+            .match_query(mockito::Matcher::UrlEncoded(
+                "file_id".into(),
+                "big_id".into(),
+            ))
+            .with_status(200)
+            .with_body(r#"{"ok":true,"result":{"file_id":"big_id","file_path":"photos/file_0.jpg"}}"#)
+            .expect_at_least(1)
+            .create_async()
+            .await;
+
+        let creds = InMemoryCreds::with_token("telegram.test.bot_token", TEST_TOKEN);
+        let mut ch = TelegramChannel::with_api_base("test", cfg(), creds, server.url());
+        ch.start().await.unwrap();
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
+        let mut got = None;
+        while std::time::Instant::now() < deadline {
+            for e in ch.poll_events().await.unwrap() {
+                if let ChannelEvent::MessageReceived { msg } = e
+                    && !msg.attachments.is_empty()
+                {
+                    got = Some(msg);
+                    break;
+                }
+            }
+            if got.is_some() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+        let msg = got.expect("expected a MessageReceived event with an attachment");
+        let att = &msg.attachments[0];
+        assert_eq!(
+            att.url,
+            format!("{}/file/bot{TEST_TOKEN}/photos/file_0.jpg", server.url())
+        );
+        assert_eq!(att.content_type.as_deref(), Some("image/jpeg"));
+        // The raw file_id is preserved for re-resolution.
+        assert_eq!(att.path.as_deref(), Some("big_id"));
+        ch.stop().await.unwrap();
+    }
+
+    // -----------------------------------------------------------------
+    // 10. Outbound attachments: each URL goes out via sendDocument with
+    //     chat_id + document=<url>, after the text send.
+    // -----------------------------------------------------------------
+    #[tokio::test]
+    async fn outbound_attachment_sends_via_send_document() {
+        let mut server = mockito::Server::new_async().await;
+        let _m_text = server
+            .mock("POST", format!("/bot{TEST_TOKEN}/sendMessage").as_str())
+            .with_status(200)
+            .with_body(r#"{"ok":true,"result":{"message_id":1,"date":1,"chat":{"id":1}}}"#)
+            .expect(1)
+            .create_async()
+            .await;
+        let m_doc = server
+            .mock("POST", format!("/bot{TEST_TOKEN}/sendDocument").as_str())
+            .match_body(mockito::Matcher::PartialJsonString(
+                r#"{"chat_id":"1","document":"https://example.com/a.pdf"}"#.to_string(),
+            ))
+            .with_status(200)
+            .with_body(r#"{"ok":true,"result":{"message_id":2,"date":2,"chat":{"id":1}}}"#)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let creds = InMemoryCreds::with_token("telegram.test.bot_token", TEST_TOKEN);
+        let mut ch = TelegramChannel::with_api_base("test", cfg(), creds, server.url());
+        ch.start().await.unwrap();
+        let msg = OutgoingMessage {
+            conversation_id: "1".to_string(),
+            text: "see attached".to_string(),
+            reply_to: None,
+            attachments: vec!["https://example.com/a.pdf".to_string()],
+        };
+        // Receipt reflects the last send (the document).
+        let receipt = ch.send_message(msg).await.unwrap();
+        assert_eq!(receipt.id, "2");
+        m_doc.assert_async().await;
+        ch.stop().await.unwrap();
+    }
+
+    // -----------------------------------------------------------------
+    // 11. Outbound: empty text + attachments skips sendMessage entirely
+    //     and only sends the document.
+    // -----------------------------------------------------------------
+    #[tokio::test]
+    async fn outbound_empty_text_with_attachment_skips_send_message() {
+        let mut server = mockito::Server::new_async().await;
+        let m_text = server
+            .mock("POST", format!("/bot{TEST_TOKEN}/sendMessage").as_str())
+            .with_status(200)
+            .with_body(r#"{"ok":true,"result":{"message_id":1,"date":1,"chat":{"id":1}}}"#)
+            .expect(0) // <- must NOT be called
+            .create_async()
+            .await;
+        let m_doc = server
+            .mock("POST", format!("/bot{TEST_TOKEN}/sendDocument").as_str())
+            .with_status(200)
+            .with_body(r#"{"ok":true,"result":{"message_id":9,"date":9,"chat":{"id":1}}}"#)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let creds = InMemoryCreds::with_token("telegram.test.bot_token", TEST_TOKEN);
+        let mut ch = TelegramChannel::with_api_base("test", cfg(), creds, server.url());
+        ch.start().await.unwrap();
+        let msg = OutgoingMessage {
+            conversation_id: "1".to_string(),
+            text: String::new(),
+            reply_to: None,
+            attachments: vec!["https://example.com/b.png".to_string()],
+        };
+        let receipt = ch.send_message(msg).await.unwrap();
+        assert_eq!(receipt.id, "9");
+        m_text.assert_async().await;
+        m_doc.assert_async().await;
+        ch.stop().await.unwrap();
     }
 
     // -----------------------------------------------------------------

--- a/crates/wcore-channel-telegram/src/lib.rs
+++ b/crates/wcore-channel-telegram/src/lib.rs
@@ -242,6 +242,11 @@ impl Channel for TelegramChannel {
     fn config_schema(&self) -> &str {
         include_str!("schemas/telegram.json")
     }
+
+    /// Telegram caps a single message at 4096 characters.
+    fn max_message_len(&self) -> Option<usize> {
+        Some(4096)
+    }
 }
 
 // ===========================================================================
@@ -301,6 +306,13 @@ mod tests {
     }
 
     const TEST_TOKEN: &str = "111:AAAA-test-bot-token";
+
+    #[test]
+    fn max_message_len_is_telegram_cap() {
+        let creds = InMemoryCreds::with_token("telegram.test.bot_token", TEST_TOKEN);
+        let ch = TelegramChannel::new("test", cfg(), creds);
+        assert_eq!(ch.max_message_len(), Some(4096));
+    }
 
     // -----------------------------------------------------------------
     // 1. send_message hits sendMessage with token + JSON body.

--- a/crates/wcore-channel-telegram/src/longpoll.rs
+++ b/crates/wcore-channel-telegram/src/longpoll.rs
@@ -10,7 +10,7 @@ use wcore_channels::event::{
     Attachment, ChannelEvent, ChatType, IncomingMessage, MediaKind, MentionKind,
 };
 
-use crate::api::{Update, get_updates};
+use crate::api::{Update, get_file, get_updates};
 
 /// Constructor arguments — flatter than a struct, easier to spawn.
 pub(crate) struct LongPollArgs {
@@ -60,7 +60,16 @@ pub(crate) async fn longpoll_loop(args: LongPollArgs) {
         match updates {
             Ok(updates) => {
                 consecutive_failures = 0;
-                ingest_updates(updates, &allowed_chat_ids, &inbox, &mut offset).await;
+                ingest_updates(
+                    updates,
+                    &http,
+                    &api_base,
+                    &bot_token,
+                    &allowed_chat_ids,
+                    &inbox,
+                    &mut offset,
+                )
+                .await;
             }
             Err(e) => {
                 tracing::warn!(
@@ -86,8 +95,104 @@ pub(crate) async fn longpoll_loop(args: LongPollArgs) {
     }
 }
 
+/// A media reference pulled off a Telegram message, pre-resolution. The
+/// `file_id` still needs a `getFile` round-trip before it points at
+/// downloadable bytes; `kind` / `content_type` are known from the field
+/// the media arrived in.
+struct PendingMedia {
+    file_id: String,
+    kind: MediaKind,
+    content_type: Option<String>,
+}
+
+/// Map a `(content_type, MediaKind)` for each media-bearing field on a
+/// Telegram message into the pre-resolution `PendingMedia` list. Pure so
+/// the field→kind/mime mapping is testable without a network call.
+fn pending_media(msg: &crate::api::Message) -> Vec<PendingMedia> {
+    let mut out: Vec<PendingMedia> = Vec::new();
+    // Photos: take the last (largest) PhotoSize only.
+    if let Some(ref sizes) = msg.photo
+        && let Some(largest) = sizes.last()
+    {
+        out.push(PendingMedia {
+            file_id: largest.file_id.clone(),
+            kind: MediaKind::Image,
+            content_type: Some("image/jpeg".to_string()),
+        });
+    }
+    if let Some(ref v) = msg.voice {
+        out.push(PendingMedia {
+            file_id: v.file_id.clone(),
+            kind: MediaKind::Audio,
+            // Voice notes are always OGG/Opus; fall back if absent.
+            content_type: v
+                .mime_type
+                .clone()
+                .or_else(|| Some("audio/ogg".to_string())),
+        });
+    }
+    if let Some(ref d) = msg.document {
+        out.push(PendingMedia {
+            file_id: d.file_id.clone(),
+            kind: MediaKind::Document,
+            content_type: d.mime_type.clone(),
+        });
+    }
+    if let Some(ref vid) = msg.video {
+        out.push(PendingMedia {
+            file_id: vid.file_id.clone(),
+            kind: MediaKind::Video,
+            content_type: vid
+                .mime_type
+                .clone()
+                .or_else(|| Some("video/mp4".to_string())),
+        });
+    }
+    out
+}
+
+/// Resolve each `PendingMedia` into a typed [`Attachment`]. The download
+/// URL comes from a bounded `getFile` call; on failure we log and fall
+/// back to leaving the raw `file_id` as the URL so the message is never
+/// dropped. The resolved `file_id` is preserved in `path` so downstream
+/// consumers can re-resolve if the URL expires.
+async fn resolve_attachments(
+    pending: Vec<PendingMedia>,
+    http: &wcore_egress::EgressClient,
+    api_base: &str,
+    bot_token: &str,
+) -> Vec<Attachment> {
+    let mut attachments = Vec::with_capacity(pending.len());
+    for m in pending {
+        let url = match get_file(http, api_base, bot_token, &m.file_id).await {
+            Ok(download_url) => download_url,
+            Err(e) => {
+                tracing::warn!(
+                    target: "wcore_channel_telegram::longpoll",
+                    error = %e,
+                    file_id = %m.file_id,
+                    "getFile failed; falling back to raw file_id as url"
+                );
+                m.file_id.clone()
+            }
+        };
+        attachments.push(Attachment {
+            url,
+            path: Some(m.file_id),
+            content_type: m.content_type,
+            kind: m.kind,
+            ..Default::default()
+        });
+    }
+    attachments
+}
+
+#[allow(clippy::too_many_arguments)]
 async fn ingest_updates(
     updates: Vec<Update>,
+    http: &wcore_egress::EgressClient,
+    api_base: &str,
+    bot_token: &str,
     allowed_chat_ids: &HashSet<String>,
     inbox: &Arc<Mutex<VecDeque<ChannelEvent>>>,
     offset: &mut i64,
@@ -137,41 +242,12 @@ async fn ingest_updates(
         };
 
         // ---- Attachments --------------------------------------------
-        let mut attachments: Vec<Attachment> = Vec::new();
-        // Photos: take the last (largest) PhotoSize only
-        if let Some(ref sizes) = msg.photo
-            && let Some(largest) = sizes.last()
-        {
-            attachments.push(Attachment {
-                url: largest.file_id.clone(),
-                kind: MediaKind::Image,
-                ..Default::default()
-            });
-        }
-        if let Some(ref v) = msg.voice {
-            attachments.push(Attachment {
-                url: v.file_id.clone(),
-                content_type: v.mime_type.clone(),
-                kind: MediaKind::Audio,
-                ..Default::default()
-            });
-        }
-        if let Some(ref d) = msg.document {
-            attachments.push(Attachment {
-                url: d.file_id.clone(),
-                content_type: d.mime_type.clone(),
-                kind: MediaKind::Document,
-                ..Default::default()
-            });
-        }
-        if let Some(ref vid) = msg.video {
-            attachments.push(Attachment {
-                url: vid.file_id.clone(),
-                content_type: vid.mime_type.clone(),
-                kind: MediaKind::Video,
-                ..Default::default()
-            });
-        }
+        // Collect the raw media references, then resolve each file_id to
+        // a real download URL via getFile. Only messages that actually
+        // carry media make these extra calls; each is bounded by the http
+        // client's timeout so a hung getFile can't stall the poll loop.
+        let pending = pending_media(&msg);
+        let attachments = resolve_attachments(pending, http, api_base, bot_token).await;
 
         // ---- Mention detection --------------------------------------
         // A `mention` entity in the text signals an @-mention; the bot
@@ -236,5 +312,59 @@ async fn ingest_updates(
         for e in events {
             guard.push_back(e);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::Message;
+
+    fn message_from_json(raw: &str) -> Message {
+        serde_json::from_str(raw).expect("valid Message JSON")
+    }
+
+    #[test]
+    fn pending_media_maps_photo_to_image_jpeg() {
+        // Photos carry no mime; we synthesize image/jpeg and pick the
+        // largest (last) PhotoSize.
+        let msg = message_from_json(
+            r#"{"message_id":1,"chat":{"id":1},"photo":[{"file_id":"small"},{"file_id":"large"}]}"#,
+        );
+        let pending = pending_media(&msg);
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].file_id, "large");
+        assert_eq!(pending[0].kind, MediaKind::Image);
+        assert_eq!(pending[0].content_type.as_deref(), Some("image/jpeg"));
+    }
+
+    #[test]
+    fn pending_media_maps_voice_to_audio_ogg_fallback() {
+        let msg = message_from_json(r#"{"message_id":1,"chat":{"id":1},"voice":{"file_id":"v"}}"#);
+        let pending = pending_media(&msg);
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].kind, MediaKind::Audio);
+        assert_eq!(pending[0].content_type.as_deref(), Some("audio/ogg"));
+    }
+
+    #[test]
+    fn pending_media_prefers_reported_mime() {
+        // A document with an explicit mime keeps it; a video without one
+        // falls back to video/mp4.
+        let msg = message_from_json(
+            r#"{"message_id":1,"chat":{"id":1},"document":{"file_id":"d","mime_type":"application/pdf"},"video":{"file_id":"vid"}}"#,
+        );
+        let pending = pending_media(&msg);
+        assert_eq!(pending.len(), 2);
+        assert_eq!(pending[0].kind, MediaKind::Document);
+        assert_eq!(pending[0].content_type.as_deref(), Some("application/pdf"));
+        assert_eq!(pending[1].kind, MediaKind::Video);
+        assert_eq!(pending[1].content_type.as_deref(), Some("video/mp4"));
+    }
+
+    #[test]
+    fn pending_media_empty_for_text_only_message() {
+        let msg = message_from_json(r#"{"message_id":1,"chat":{"id":1},"text":"hello"}"#);
+        assert!(pending_media(&msg).is_empty());
     }
 }

--- a/crates/wcore-channel-telegram/src/longpoll.rs
+++ b/crates/wcore-channel-telegram/src/longpoll.rs
@@ -6,7 +6,9 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use tokio::sync::{Mutex, watch};
-use wcore_channels::event::{ChannelEvent, IncomingMessage};
+use wcore_channels::event::{
+    Attachment, ChannelEvent, ChatType, IncomingMessage, MediaKind, MentionKind,
+};
 
 use crate::api::{Update, get_updates};
 
@@ -104,17 +106,98 @@ async fn ingest_updates(
         if !allowed_chat_ids.is_empty() && !allowed_chat_ids.contains(&chat_id_str) {
             continue;
         }
-        let author = msg
-            .from
-            .as_ref()
-            .and_then(|f| {
-                f.username
+
+        // ---- Sender identity ----------------------------------------
+        let (sender_id, author, sender_display, sender_handle, is_bot) =
+            if let Some(ref f) = msg.from {
+                let sid = f.id.to_string();
+                // author: prefer @username, fall back to first_name, then id
+                let display_name = match (f.first_name.as_deref(), f.last_name.as_deref()) {
+                    (Some(first), Some(last)) => Some(format!("{first} {last}")),
+                    (Some(first), None) => Some(first.to_string()),
+                    _ => None,
+                };
+                let author = f
+                    .username
                     .clone()
-                    .or_else(|| f.first_name.clone())
-                    .or_else(|| Some(f.id.to_string()))
-            })
-            .unwrap_or_else(|| "unknown".to_string());
+                    .or_else(|| display_name.clone())
+                    .unwrap_or_else(|| sid.clone());
+                (sid, author, display_name, f.username.clone(), f.is_bot)
+            } else {
+                ("unknown".to_string(), "unknown".to_string(), None, None, false)
+            };
+
+        // ---- Chat type ----------------------------------------------
+        let chat_type = match msg.chat.chat_type.as_str() {
+            "private" => ChatType::Direct,
+            "group" | "supergroup" => ChatType::Group,
+            "channel" => ChatType::Channel,
+            // Unrecognised future type — treat as Group (multi-party)
+            _ => ChatType::Group,
+        };
+
+        // ---- Attachments --------------------------------------------
+        let mut attachments: Vec<Attachment> = Vec::new();
+        // Photos: take the last (largest) PhotoSize only
+        if let Some(ref sizes) = msg.photo
+            && let Some(largest) = sizes.last()
+        {
+            attachments.push(Attachment {
+                url: largest.file_id.clone(),
+                kind: MediaKind::Image,
+                ..Default::default()
+            });
+        }
+        if let Some(ref v) = msg.voice {
+            attachments.push(Attachment {
+                url: v.file_id.clone(),
+                content_type: v.mime_type.clone(),
+                kind: MediaKind::Audio,
+                ..Default::default()
+            });
+        }
+        if let Some(ref d) = msg.document {
+            attachments.push(Attachment {
+                url: d.file_id.clone(),
+                content_type: d.mime_type.clone(),
+                kind: MediaKind::Document,
+                ..Default::default()
+            });
+        }
+        if let Some(ref vid) = msg.video {
+            attachments.push(Attachment {
+                url: vid.file_id.clone(),
+                content_type: vid.mime_type.clone(),
+                kind: MediaKind::Video,
+                ..Default::default()
+            });
+        }
+
+        // ---- Mention detection --------------------------------------
+        // A `mention` entity in the text signals an @-mention; the bot
+        // has no self-identity here so we can only detect the presence of
+        // any mention and surface it as Native.
+        let has_mention = msg
+            .entities
+            .as_deref()
+            .unwrap_or_default()
+            .iter()
+            .any(|e| e.kind == "mention");
+        let was_mentioned = has_mention;
+        let mention_kind = was_mentioned.then_some(MentionKind::Native);
+
+        // ---- Reply context ------------------------------------------
+        let reply_to_message_id = msg
+            .reply_to_message
+            .as_deref()
+            .map(|r| r.message_id.to_string());
+        let reply_to_text = msg
+            .reply_to_message
+            .as_deref()
+            .and_then(|r| r.text.clone());
+
         let text = msg.text.unwrap_or_default();
+
         events.push(ChannelEvent::MessageReceived {
             msg: IncomingMessage {
                 id: msg.message_id.to_string(),
@@ -122,7 +205,29 @@ async fn ingest_updates(
                 author,
                 text,
                 ts_secs: msg.date,
-                attachments: Vec::new(),
+                attachments,
+                // Sender identity
+                sender_id,
+                sender_display,
+                sender_handle,
+                sender_alt_id: None,
+                is_bot,
+                is_self: false,
+                // Chat context
+                chat_type,
+                chat_name: msg.chat.title.clone(),
+                space_id: None,
+                thread_id: msg.message_thread_id.map(|id| id.to_string()),
+                parent_chat_id: None,
+                // Account / platform routing
+                account_id: None,
+                platform: Some("telegram".into()),
+                // Mention
+                was_mentioned,
+                mention_kind,
+                // Reply
+                reply_to_message_id,
+                reply_to_text,
             },
         });
     }

--- a/crates/wcore-channel-whatsapp/schemas/whatsapp.json
+++ b/crates/wcore-channel-whatsapp/schemas/whatsapp.json
@@ -32,6 +32,10 @@
       "type": "string",
       "description": "Key used to look up the Meta App Secret in the CredentialsStore — used for X-Hub-Signature-256 verification."
     },
+    "verify_token": {
+      "type": "string",
+      "description": "Operator-chosen verify token for Meta's GET hub.challenge subscription handshake (must match the value set in the Meta App dashboard). Not a platform secret; when unset the GET verification handshake is rejected."
+    },
     "api_base_url": {
       "type": "string",
       "description": "Override for the Graph API base URL. Defaults to https://graph.facebook.com — tests inject a mockito URL here.",

--- a/crates/wcore-channel-whatsapp/src/config.rs
+++ b/crates/wcore-channel-whatsapp/src/config.rs
@@ -37,6 +37,14 @@ pub struct WhatsappConfig {
     /// signature verification via `X-Hub-Signature-256`).
     pub credential_handle_app_secret: String,
 
+    /// Verify token for Meta's GET `hub.challenge` subscription handshake.
+    /// This is an operator-chosen string (set identically in the Meta App
+    /// dashboard), not a platform-issued secret, so it lives in config
+    /// rather than the CredentialsStore. When unset, the GET verification
+    /// handshake is rejected.
+    #[serde(default)]
+    pub verify_token: Option<String>,
+
     /// Override the Graph API base URL — tests point this at mockito.
     #[serde(default = "default_api_base")]
     pub api_base_url: String,
@@ -72,6 +80,7 @@ impl WhatsappConfig {
             default_recipient: String::new(),
             credential_handle_access_token: "whatsapp.test.access_token".to_string(),
             credential_handle_app_secret: "whatsapp.test.app_secret".to_string(),
+            verify_token: None,
             api_base_url: api_base.into(),
             graph_version: DEFAULT_GRAPH_VERSION.to_string(),
             max_retry_attempts: 3,

--- a/crates/wcore-channel-whatsapp/src/inbound.rs
+++ b/crates/wcore-channel-whatsapp/src/inbound.rs
@@ -35,7 +35,7 @@
 use hmac::{Hmac, Mac};
 use serde::Deserialize;
 use sha2::Sha256;
-use wcore_channels::event::{ChannelEvent, IncomingMessage};
+use wcore_channels::event::{Attachment, ChannelEvent, ChatType, IncomingMessage, MediaKind};
 
 use crate::error::WhatsappError;
 
@@ -94,7 +94,33 @@ struct Change {
 #[derive(Debug, Deserialize)]
 struct ChangeValue {
     #[serde(default)]
+    metadata: Option<RawMetadata>,
+    #[serde(default)]
+    contacts: Vec<RawContact>,
+    #[serde(default)]
     messages: Vec<RawMessage>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawMetadata {
+    /// Receiving phone number id — stable account routing key.
+    #[serde(default)]
+    phone_number_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawContact {
+    /// Stable WhatsApp user id (same value as `messages[].from`).
+    #[serde(default)]
+    wa_id: Option<String>,
+    #[serde(default)]
+    profile: Option<RawProfile>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawProfile {
+    #[serde(default)]
+    name: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -109,12 +135,42 @@ struct RawMessage {
     text: Option<RawText>,
     #[serde(default, rename = "type")]
     kind: Option<String>,
+    /// Present when this message is a reply — carries the quoted message id
+    /// (and optionally its body if the platform inlines it).
+    #[serde(default)]
+    context: Option<RawContext>,
+    // Media message objects — present when kind != "text".
+    #[serde(default)]
+    image: Option<RawMedia>,
+    #[serde(default)]
+    audio: Option<RawMedia>,
+    #[serde(default)]
+    video: Option<RawMedia>,
+    #[serde(default)]
+    document: Option<RawMedia>,
 }
 
 #[derive(Debug, Deserialize)]
 struct RawText {
     #[serde(default)]
     body: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawContext {
+    /// Message id of the message being replied to.
+    #[serde(default)]
+    id: Option<String>,
+}
+
+/// Shared shape for image / audio / video / document objects.
+/// WhatsApp Cloud API returns a media `id` (to be fetched via the Media
+/// API), not a direct URL, so we store the media id as the `url` field
+/// until a later fetch resolves it to a download URL.
+#[derive(Debug, Deserialize)]
+struct RawMedia {
+    #[serde(default)]
+    id: Option<String>,
 }
 
 /// Parse one webhook body. Caller is responsible for first verifying
@@ -128,24 +184,90 @@ pub fn parse_webhook(raw_body: &str) -> Result<Vec<ChannelEvent>, WhatsappError>
     for entry in env.entry {
         for change in entry.changes {
             let Some(value) = change.value else { continue };
-            for raw in value.messages {
-                // We currently translate only `text` messages — status
-                // events / media / interactive replies surface as
-                // PlatformWarning so they don't fail the whole envelope
-                // and so the engine sees they arrived.
+
+            // Receiving account id (phone_number_id from metadata).
+            let account_id = value
+                .metadata
+                .as_ref()
+                .and_then(|m| m.phone_number_id.clone());
+            // Destructure before the consuming loop so both fields are
+            // accessible inside it without a partial-move error.
+            let ChangeValue { contacts, messages, .. } = value;
+
+            for raw in messages {
                 let kind = raw.kind.as_deref().unwrap_or("text");
-                if kind != "text" {
-                    out.push(ChannelEvent::PlatformWarning {
-                        message: format!("ignored non-text whatsapp message kind={kind}"),
-                    });
-                    continue;
-                }
-                let body = raw
-                    .text
-                    .as_ref()
-                    .and_then(|t| t.body.clone())
-                    .unwrap_or_default();
-                let from = raw.from.unwrap_or_else(|| "unknown".to_string());
+
+                // Build an attachment list for media message types.
+                // WhatsApp Cloud API returns a media id rather than a direct
+                // URL; we store it as the `url` field (prefixed with the
+                // media id) for the fetching layer to resolve.
+                let (body, attachments): (String, Vec<Attachment>) = match kind {
+                    "text" => {
+                        let text = raw
+                            .text
+                            .as_ref()
+                            .and_then(|t| t.body.clone())
+                            .unwrap_or_default();
+                        (text, Vec::new())
+                    }
+                    "image" => {
+                        let att = raw.image.as_ref().and_then(|m| m.id.as_deref()).map(|id| {
+                            Attachment {
+                                url: id.to_string(),
+                                kind: MediaKind::Image,
+                                ..Default::default()
+                            }
+                        });
+                        (String::new(), att.into_iter().collect())
+                    }
+                    "audio" => {
+                        let att =
+                            raw.audio.as_ref().and_then(|m| m.id.as_deref()).map(|id| {
+                                Attachment {
+                                    url: id.to_string(),
+                                    kind: MediaKind::Audio,
+                                    ..Default::default()
+                                }
+                            });
+                        (String::new(), att.into_iter().collect())
+                    }
+                    "video" => {
+                        let att =
+                            raw.video.as_ref().and_then(|m| m.id.as_deref()).map(|id| {
+                                Attachment {
+                                    url: id.to_string(),
+                                    kind: MediaKind::Video,
+                                    ..Default::default()
+                                }
+                            });
+                        (String::new(), att.into_iter().collect())
+                    }
+                    "document" => {
+                        let att =
+                            raw.document
+                                .as_ref()
+                                .and_then(|m| m.id.as_deref())
+                                .map(|id| Attachment {
+                                    url: id.to_string(),
+                                    kind: MediaKind::Document,
+                                    ..Default::default()
+                                });
+                        (String::new(), att.into_iter().collect())
+                    }
+                    _ => {
+                        // Status events / interactive replies / stickers etc. —
+                        // surface as PlatformWarning so the engine sees they
+                        // arrived without failing the whole envelope.
+                        out.push(ChannelEvent::PlatformWarning {
+                            message: format!(
+                                "ignored non-text whatsapp message kind={kind}"
+                            ),
+                        });
+                        continue;
+                    }
+                };
+
+                let from = raw.from.clone().unwrap_or_else(|| "unknown".to_string());
                 let id = raw.id.unwrap_or_default();
                 let ts_secs: i64 = raw
                     .timestamp
@@ -153,13 +275,71 @@ pub fn parse_webhook(raw_body: &str) -> Result<Vec<ChannelEvent>, WhatsappError>
                     .and_then(|s| s.parse().ok())
                     .unwrap_or(0);
 
+                // Look up the contact entry whose wa_id matches this message's
+                // `from` field to resolve the display name.
+                let sender_display: Option<String> = contacts
+                    .iter()
+                    .find(|c| c.wa_id.as_deref() == Some(from.as_str()))
+                    .and_then(|c| c.profile.as_ref())
+                    .and_then(|p| p.name.clone());
+
+                // WhatsApp Cloud API is strictly 1:1 DMs in the standard
+                // messages webhook; group-chat webhooks carry a group id in
+                // `from` that starts with a numeric prefix but is distinct from
+                // individual phone numbers. The Meta Cloud API does not expose a
+                // reliable "is this a group" flag in the messages object itself,
+                // so we default to Direct — the correct value for every standard
+                // Business API integration. Group-aware connectors should
+                // override this after construction if they can detect group ids.
+                let chat_type = ChatType::Direct;
+
+                // Reply context: messages[].context.id is the id of the message
+                // being replied to.
+                let reply_to_message_id: Option<String> =
+                    raw.context.as_ref().and_then(|c| c.id.clone());
+
                 let msg = IncomingMessage {
-                    id: id.clone(),
+                    id,
+                    // conversation_id: for 1:1 DMs on WhatsApp Cloud API the
+                    // natural conversation key is the sender's wa_id (= `from`).
                     conversation_id: from.clone(),
-                    author: from,
+                    // author: human-facing label; same as sender_id here because
+                    // WhatsApp Cloud API does not provide a separate display-name
+                    // in the message object (only in contacts[].profile.name).
+                    author: from.clone(),
                     text: body,
                     ts_secs,
-                    attachments: Vec::new(),
+                    attachments,
+                    // sender_id: the `from` field is the stable wa_id / phone
+                    // number id assigned by the platform — the correct
+                    // access-control and dedup key.
+                    sender_id: from,
+                    sender_display,
+                    // sender_handle / sender_alt_id: not exposed by WhatsApp
+                    // Cloud API in the standard webhook payload.
+                    sender_handle: None,
+                    sender_alt_id: None,
+                    is_bot: false,
+                    is_self: false,
+                    chat_type,
+                    // chat_name / space_id / thread_id / parent_chat_id: not
+                    // present in the WhatsApp Cloud API webhook payload.
+                    chat_name: None,
+                    space_id: None,
+                    thread_id: None,
+                    parent_chat_id: None,
+                    account_id: account_id.clone(),
+                    platform: Some("whatsapp".into()),
+                    // was_mentioned / mention_kind: bots in 1:1 DMs are always
+                    // directly addressed — but WhatsApp has no explicit mention
+                    // syntax, so we leave this false; the dispatch kernel can
+                    // infer addressing from chat_type == Direct.
+                    was_mentioned: false,
+                    mention_kind: None,
+                    reply_to_message_id,
+                    // reply_to_text: WhatsApp Cloud API does not inline the
+                    // quoted body in the context object.
+                    reply_to_text: None,
                 };
                 out.push(ChannelEvent::MessageReceived { msg });
             }
@@ -241,23 +421,90 @@ mod tests {
             ChannelEvent::MessageReceived { msg } => {
                 assert_eq!(msg.text, "hello there");
                 assert_eq!(msg.author, "15555550100");
+                assert_eq!(msg.sender_id, "15555550100");
                 assert_eq!(msg.conversation_id, "15555550100");
                 assert_eq!(msg.id, "wamid.HBgL...");
                 assert_eq!(msg.ts_secs, 1700000000);
+                assert_eq!(msg.sender_display.as_deref(), Some("Alice"));
+                assert_eq!(msg.account_id.as_deref(), Some("PNID"));
+                assert_eq!(msg.platform.as_deref(), Some("whatsapp"));
+                assert_eq!(msg.chat_type, ChatType::Direct);
+                assert!(!msg.is_bot);
+                assert!(!msg.is_self);
+                assert!(msg.attachments.is_empty());
+                assert!(msg.reply_to_message_id.is_none());
             }
             other => panic!("expected MessageReceived, got {other:?}"),
         }
     }
 
     #[test]
-    fn parse_webhook_non_text_kind_surfaces_warning() {
+    fn parse_webhook_image_message_produces_attachment() {
+        let body = r#"{
+            "entry":[{"changes":[{"value":{
+                "metadata":{"phone_number_id":"PNID"},
+                "contacts":[],
+                "messages":[{
+                    "from":"15555550100",
+                    "id":"wamid.IMG",
+                    "timestamp":"1700000001",
+                    "type":"image",
+                    "image":{"id":"media-abc123"}
+                }]
+            }}]}]
+        }"#;
+        let evs = parse_webhook(body).unwrap();
+        assert_eq!(evs.len(), 1);
+        match &evs[0] {
+            ChannelEvent::MessageReceived { msg } => {
+                assert_eq!(msg.attachments.len(), 1);
+                assert_eq!(msg.attachments[0].url, "media-abc123");
+                assert_eq!(msg.attachments[0].kind, MediaKind::Image);
+                assert!(msg.text.is_empty());
+            }
+            other => panic!("expected MessageReceived, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_webhook_reply_context_sets_reply_to_message_id() {
+        let body = r#"{
+            "entry":[{"changes":[{"value":{
+                "metadata":{"phone_number_id":"PNID"},
+                "contacts":[],
+                "messages":[{
+                    "from":"15555550100",
+                    "id":"wamid.REPLY",
+                    "timestamp":"1700000002",
+                    "type":"text",
+                    "text":{"body":"that's great"},
+                    "context":{"id":"wamid.ORIGINAL"}
+                }]
+            }}]}]
+        }"#;
+        let evs = parse_webhook(body).unwrap();
+        assert_eq!(evs.len(), 1);
+        match &evs[0] {
+            ChannelEvent::MessageReceived { msg } => {
+                assert_eq!(
+                    msg.reply_to_message_id.as_deref(),
+                    Some("wamid.ORIGINAL")
+                );
+                assert!(msg.reply_to_text.is_none());
+            }
+            other => panic!("expected MessageReceived, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_webhook_unhandled_kind_surfaces_warning() {
+        // Stickers, interactive replies, reactions — not yet translated.
         let body = r#"{
             "entry":[{"changes":[{"value":{"messages":[{
                 "from":"15555550100",
                 "id":"wamid.X",
                 "timestamp":"1700000000",
-                "type":"image",
-                "image":{"id":"media-id"}
+                "type":"sticker"
             }]}}]}]
         }"#;
         let evs = parse_webhook(body).unwrap();

--- a/crates/wcore-channel-whatsapp/src/lib.rs
+++ b/crates/wcore-channel-whatsapp/src/lib.rs
@@ -30,7 +30,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use tokio::sync::Mutex;
 use wcore_channels::{
-    Channel, ChannelError,
+    Channel, ChannelError, WebhookRequest, WebhookResponse,
     event::{ChannelEvent, ConnectionState, MessageReceipt},
     outgoing::OutgoingMessage,
 };
@@ -258,6 +258,46 @@ impl Channel for WhatsappChannel {
 
     fn config_schema(&self) -> &str {
         include_str!("../schemas/whatsapp.json")
+    }
+
+    /// Handle a Meta WhatsApp Cloud API webhook request.
+    ///
+    /// Meta drives two distinct flows over the same URL:
+    ///   * **GET** — the one-time subscription handshake. Meta calls with
+    ///     `hub.mode=subscribe`, `hub.verify_token=<operator token>`, and
+    ///     `hub.challenge=<nonce>`. When the mode is `subscribe` and the
+    ///     token matches the connector's configured `verify_token`, the
+    ///     challenge is echoed back verbatim; otherwise it is rejected.
+    ///   * **POST** — runtime delivery. The `X-Hub-Signature-256` header
+    ///     is verified against the app secret (in [`Self::ingest_event`]).
+    async fn ingest_webhook(
+        &self,
+        req: &WebhookRequest,
+    ) -> Result<WebhookResponse, ChannelError> {
+        if req.method == "GET" {
+            let configured = self.config.verify_token.as_deref();
+            let mode = req.query_get("hub.mode");
+            let token = req.query_get("hub.verify_token");
+            let challenge = req.query_get("hub.challenge");
+            match (mode, token, challenge, configured) {
+                (Some("subscribe"), Some(token), Some(challenge), Some(configured))
+                    if token == configured =>
+                {
+                    Ok(WebhookResponse::challenge(challenge))
+                }
+                _ => Err(ChannelError::Auth(
+                    "whatsapp webhook verification failed".into(),
+                )),
+            }
+        } else {
+            let sig = req.header("x-hub-signature-256").ok_or_else(|| {
+                ChannelError::Auth("missing whatsapp signature header".into())
+            })?;
+            match self.ingest_event(&req.body, sig).await {
+                Ok(()) => Ok(WebhookResponse::ok()),
+                Err(e) => Err(ChannelError::Rejected(e.to_string())),
+            }
+        }
     }
 }
 

--- a/crates/wcore-channel-whatsapp/src/lib.rs
+++ b/crates/wcore-channel-whatsapp/src/lib.rs
@@ -260,6 +260,11 @@ impl Channel for WhatsappChannel {
         include_str!("../schemas/whatsapp.json")
     }
 
+    /// WhatsApp caps a single text message body at 4096 characters.
+    fn max_message_len(&self) -> Option<usize> {
+        Some(4096)
+    }
+
     /// Handle a Meta WhatsApp Cloud API webhook request.
     ///
     /// Meta drives two distinct flows over the same URL:
@@ -549,6 +554,12 @@ mod tests {
         let parsed: serde_json::Value =
             serde_json::from_str(ch.config_schema()).expect("schema parses");
         assert_eq!(parsed["title"].as_str(), Some("WhatsappChannelConfig"));
+    }
+
+    #[tokio::test]
+    async fn max_message_len_is_whatsapp_cap() {
+        let ch = WhatsappChannel::new("test", cfg_for("https://unused.example"), store_for_test());
+        assert_eq!(ch.max_message_len(), Some(4096));
     }
 
     #[tokio::test]

--- a/crates/wcore-channels/src/chunk.rs
+++ b/crates/wcore-channels/src/chunk.rs
@@ -1,0 +1,132 @@
+//! Outbound message chunking.
+//!
+//! Every chat platform caps a single message's length (Discord 2000,
+//! Telegram/WhatsApp 4096, Slack ~40k, MS Teams ~28k, SMS 1600 …). An agent
+//! reply that exceeds the cap was previously **rejected by the platform and
+//! silently dropped** (HIGH-6). [`chunk_message`] splits an over-long body
+//! into platform-sized pieces the sender delivers in order.
+//!
+//! Length is measured in **Unicode scalar values** (`char`s). This is exact
+//! for the ASCII/BMP text that dominates chat and never splits a codepoint.
+//! Platforms that count UTF-16 code units (Telegram, Discord) could see a
+//! message composed almost entirely of astral-plane characters (e.g. many
+//! emoji) measure higher on their side than our scalar count; the
+//! per-connector caps are set at the documented limits, so keep that astral
+//! caveat in mind if a connector ever reports truncation. Splitting always
+//! happens on a `char` boundary regardless.
+
+/// Split `text` into chunks of at most `max_len` `char`s each, preferring to
+/// break at the last newline (then the last ASCII space) inside the window
+/// so words/lines stay intact; falls back to a hard `char`-boundary split
+/// for a single unbroken run longer than `max_len`.
+///
+/// Returns the text unchanged (as a single chunk) when it already fits or
+/// when `max_len == 0` (cap unknown/disabled). Never returns an empty
+/// `Vec` for non-empty input, and never an empty chunk. Empty input returns
+/// a single empty chunk so callers preserve their existing "send this body"
+/// semantics rather than silently sending nothing.
+pub fn chunk_message(text: &str, max_len: usize) -> Vec<String> {
+    let total = text.chars().count();
+    if max_len == 0 || total <= max_len {
+        return vec![text.to_string()];
+    }
+
+    let mut chunks = Vec::new();
+    // Work over char indices so every split lands on a codepoint boundary.
+    let chars: Vec<char> = text.chars().collect();
+    let mut start = 0usize;
+    while start < chars.len() {
+        let hard_end = (start + max_len).min(chars.len());
+        // If this is the final piece, take it all.
+        if hard_end == chars.len() {
+            chunks.push(chars[start..hard_end].iter().collect());
+            break;
+        }
+        // Otherwise prefer a soft break (newline, then space) within
+        // [start, hard_end). Search from the window end backwards.
+        let window = &chars[start..hard_end];
+        let split_at = window
+            .iter()
+            .rposition(|&c| c == '\n')
+            .or_else(|| window.iter().rposition(|&c| c == ' '))
+            // Keep at least one char of progress: a break at index 0 would
+            // loop forever, so reject it and hard-split instead.
+            .filter(|&idx| idx > 0)
+            .map(|idx| start + idx + 1) // include the break char in this chunk
+            .unwrap_or(hard_end);
+
+        chunks.push(chars[start..split_at].iter().collect::<String>());
+        start = split_at;
+    }
+    chunks
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn short_text_is_single_chunk() {
+        assert_eq!(chunk_message("hello", 100), vec!["hello"]);
+    }
+
+    #[test]
+    fn empty_text_is_single_empty_chunk() {
+        assert_eq!(chunk_message("", 100), vec![""]);
+    }
+
+    #[test]
+    fn zero_max_disables_chunking() {
+        let long = "x".repeat(10_000);
+        assert_eq!(chunk_message(&long, 0), vec![long]);
+    }
+
+    #[test]
+    fn hard_split_for_unbroken_run() {
+        let s = "abcdefghij"; // 10 chars, no break points
+        let out = chunk_message(s, 4);
+        assert_eq!(out, vec!["abcd", "efgh", "ij"]);
+        // Every chunk is within the cap.
+        assert!(out.iter().all(|c| c.chars().count() <= 4));
+        // Lossless reassembly.
+        assert_eq!(out.concat(), s);
+    }
+
+    #[test]
+    fn prefers_newline_break() {
+        let s = "line one\nline two\nline three";
+        let out = chunk_message(s, 12);
+        // First chunk ends at the first newline (kept), not mid-word.
+        assert_eq!(out[0], "line one\n");
+        assert_eq!(out.concat(), s);
+        assert!(out.iter().all(|c| c.chars().count() <= 12));
+    }
+
+    #[test]
+    fn prefers_space_break_when_no_newline() {
+        let s = "the quick brown fox";
+        let out = chunk_message(s, 10);
+        assert_eq!(out[0], "the quick "); // breaks after the space within window
+        assert_eq!(out.concat(), s);
+        assert!(out.iter().all(|c| c.chars().count() <= 10));
+    }
+
+    #[test]
+    fn never_splits_a_codepoint() {
+        // 8 multi-byte chars; cap 3 → chunks of 3,3,2 chars, all valid UTF-8.
+        let s = "αβγδεζηθ";
+        let out = chunk_message(s, 3);
+        assert_eq!(out.iter().map(|c| c.chars().count()).collect::<Vec<_>>(), vec![3, 3, 2]);
+        assert_eq!(out.concat(), s);
+    }
+
+    #[test]
+    fn leading_break_char_does_not_loop() {
+        // A space at index 0 of the window must NOT be chosen (would not make
+        // progress); the run hard-splits instead.
+        let s = " aaaaaaaa"; // leading space then 8 a's
+        let out = chunk_message(s, 4);
+        assert_eq!(out.concat(), s);
+        assert!(out.iter().all(|c| !c.is_empty() && c.chars().count() <= 4));
+    }
+}

--- a/crates/wcore-channels/src/config.rs
+++ b/crates/wcore-channels/src/config.rs
@@ -35,6 +35,12 @@ pub struct ChannelConfig {
     /// (preferred) or plain strings (unsafe; logged as warning).
     #[serde(default)]
     pub secrets: toml::Table,
+    /// Inbound access + session-shaping policy for this channel. Absent
+    /// `[inbound]` table -> the fail-closed default (denies all inbound
+    /// until the operator adds allowlist entries). See
+    /// [`crate::dispatch::access::InboundPolicy`].
+    #[serde(default)]
+    pub inbound: crate::dispatch::access::InboundPolicy,
 }
 
 fn default_enabled() -> bool {
@@ -163,6 +169,56 @@ platform = "slack"
         let loader = ChannelConfigLoader::new(tmp.path());
         let err = loader.load_all().expect_err("expected mismatch");
         assert!(matches!(err, ChannelError::Config(_)));
+    }
+
+    #[test]
+    fn inbound_table_round_trips_into_policy() {
+        use crate::dispatch::access::{DmPolicy, GroupPolicy};
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(
+            tmp.path().join("acme.toml"),
+            r#"
+name = "acme"
+platform = "slack"
+
+[inbound]
+dm = "allowlist"
+group = "open"
+require_mention = false
+dm_allowlist = ["*"]
+"#,
+        )
+        .unwrap();
+        let loader = ChannelConfigLoader::new(tmp.path());
+        let v = loader.load_all().unwrap();
+        assert_eq!(v.len(), 1);
+        assert_eq!(v[0].inbound.dm, DmPolicy::Allowlist);
+        assert_eq!(v[0].inbound.group, GroupPolicy::Open);
+        assert!(!v[0].inbound.require_mention);
+        assert_eq!(v[0].inbound.dm_allowlist, vec!["*".to_string()]);
+    }
+
+    #[test]
+    fn missing_inbound_table_defaults_fail_closed() {
+        use crate::dispatch::access::{DmPolicy, GroupPolicy, InboundPolicy};
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(
+            tmp.path().join("acme.toml"),
+            r#"
+name = "acme"
+platform = "slack"
+"#,
+        )
+        .unwrap();
+        let loader = ChannelConfigLoader::new(tmp.path());
+        let v = loader.load_all().unwrap();
+        assert_eq!(v.len(), 1);
+        // No [inbound] table -> the fail-closed default.
+        assert_eq!(v[0].inbound, InboundPolicy::default());
+        assert_eq!(v[0].inbound.dm, DmPolicy::Allowlist);
+        assert_eq!(v[0].inbound.group, GroupPolicy::Disabled);
+        assert!(v[0].inbound.require_mention);
+        assert!(v[0].inbound.dm_allowlist.is_empty());
     }
 
     #[test]

--- a/crates/wcore-channels/src/dispatch/access.rs
+++ b/crates/wcore-channels/src/dispatch/access.rs
@@ -59,6 +59,38 @@ pub enum ChannelToolPosture {
     Full,
 }
 
+/// How the bot acknowledges an inbound message it's working on.
+///
+/// A human who messages a bot wants to know it heard them. This selects
+/// the ack signal the inbound subscriber emits around a turn: emoji
+/// reactions on the triggering message (👀 received → ✅ done / ❌ failed)
+/// and/or a periodic "typing…" indicator while the turn runs. Both are
+/// best-effort — a connector that lacks the platform API no-ops.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum AckMode {
+    /// No acknowledgement (default).
+    #[default]
+    Off,
+    /// React 👀 on receipt, ✅/❌ on completion.
+    Reactions,
+    /// Send a typing indicator, refreshed while the turn runs.
+    Typing,
+    /// Both reactions and typing.
+    Both,
+}
+
+impl AckMode {
+    /// Whether this mode emits emoji reactions.
+    pub fn reactions(self) -> bool {
+        matches!(self, AckMode::Reactions | AckMode::Both)
+    }
+    /// Whether this mode emits a typing indicator.
+    pub fn typing(self) -> bool {
+        matches!(self, AckMode::Typing | AckMode::Both)
+    }
+}
+
 /// Policy governing whether group/channel messages are accepted.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -123,6 +155,10 @@ pub struct InboundPolicy {
     /// working directory is used as the jail root.
     #[serde(default)]
     pub tool_workspace_root: Option<String>,
+    /// How the bot acknowledges inbound messages it's working on
+    /// (reactions / typing). Defaults to [`AckMode::Off`].
+    #[serde(default)]
+    pub ack: AckMode,
 }
 
 fn default_dm_policy() -> DmPolicy {
@@ -152,6 +188,7 @@ impl Default for InboundPolicy {
             thread_sessions_per_user: false,
             tools: ChannelToolPosture::Conversational,
             tool_workspace_root: None,
+            ack: AckMode::Off,
         }
     }
 }
@@ -427,6 +464,18 @@ mod tests {
         assert_eq!(w.tool_workspace_root.as_deref(), Some("/srv/agent"));
         let f: InboundPolicy = toml::from_str("dm = \"open\"\ntools = \"full\"").unwrap();
         assert_eq!(f.tools, ChannelToolPosture::Full);
+    }
+
+    #[test]
+    fn ack_mode_parses_and_defaults() {
+        let p: InboundPolicy = toml::from_str("dm = \"open\"").unwrap();
+        assert_eq!(p.ack, AckMode::Off);
+        assert!(!p.ack.reactions() && !p.ack.typing());
+        let b: InboundPolicy = toml::from_str("dm = \"open\"\nack = \"both\"").unwrap();
+        assert_eq!(b.ack, AckMode::Both);
+        assert!(b.ack.reactions() && b.ack.typing());
+        let r: InboundPolicy = toml::from_str("dm = \"open\"\nack = \"reactions\"").unwrap();
+        assert!(r.ack.reactions() && !r.ack.typing());
     }
 
     #[test]

--- a/crates/wcore-channels/src/dispatch/access.rs
+++ b/crates/wcore-channels/src/dispatch/access.rs
@@ -29,6 +29,36 @@ pub enum DmPolicy {
     Disabled,
 }
 
+/// Filesystem/shell posture for a channel-originated agent turn.
+///
+/// A channel sender is REMOTE and (depending on the access policy) may be
+/// untrusted, so the per-conversation agent engine must not inherit the
+/// local CLI's full host access. This enum selects which built-in tools
+/// the channel engine is built with — enforced at tool-registration time
+/// in `wcore-agent` (the `wcore-channels` crate only carries the config).
+///
+/// **Default is [`Conversational`](ChannelToolPosture::Conversational)** —
+/// the safe floor: no host filesystem, no shell. Operators opt UP to
+/// `Workspace` (jailed filesystem) or `Full` (host-wide) per channel.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum ChannelToolPosture {
+    /// No filesystem and no shell. Only conversational/network tools
+    /// (and operator-wired MCP servers) are exposed. The safe default
+    /// for remote chat senders — closes host-secret exfiltration.
+    #[default]
+    Conversational,
+    /// Filesystem tools (Read/Write/Edit/Grep/Glob) are available but
+    /// JAILED to a workspace root via `SandboxedFs`; shell/exec tools
+    /// (Bash, git, kubectl, …) remain unavailable because they bypass the
+    /// jail. Lets a channel agent do real, confined filesystem work.
+    Workspace,
+    /// Full host access — every tool, no jail. Identical to a local CLI
+    /// session. Dangerous for publicly-reachable channels; explicit
+    /// opt-in only.
+    Full,
+}
+
 /// Policy governing whether group/channel messages are accepted.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -83,6 +113,16 @@ pub struct InboundPolicy {
     /// [`crate::dispatch::build_session_key`].
     #[serde(default)]
     pub thread_sessions_per_user: bool,
+    /// Filesystem/shell posture for this channel's agent turns. Defaults
+    /// to [`ChannelToolPosture::Conversational`] (no host fs/shell) so a
+    /// remote sender cannot read host secrets. See [`ChannelToolPosture`].
+    #[serde(default)]
+    pub tools: ChannelToolPosture,
+    /// Root the `Workspace` posture jails filesystem tools to. Ignored
+    /// for `Conversational`/`Full`. When `None`, the agent engine's
+    /// working directory is used as the jail root.
+    #[serde(default)]
+    pub tool_workspace_root: Option<String>,
 }
 
 fn default_dm_policy() -> DmPolicy {
@@ -110,6 +150,8 @@ impl Default for InboundPolicy {
             sender_allowlist: Vec::new(),
             group_sessions_per_user: true,
             thread_sessions_per_user: false,
+            tools: ChannelToolPosture::Conversational,
+            tool_workspace_root: None,
         }
     }
 }
@@ -204,6 +246,9 @@ mod tests {
         assert!(p.sender_allowlist.is_empty());
         assert!(p.group_sessions_per_user);
         assert!(!p.thread_sessions_per_user);
+        // Tool posture defaults to the safe, no-host-access floor.
+        assert_eq!(p.tools, ChannelToolPosture::Conversational);
+        assert!(p.tool_workspace_root.is_none());
         // A DM under the default policy is denied (empty allowlist).
         assert!(matches!(
             decide_access(&dm_from("u1"), &p),
@@ -366,6 +411,22 @@ mod tests {
         let mut m = group_from("c1", "u1");
         m.chat_type = ChatType::Channel;
         assert_eq!(decide_access(&m, &p), AccessDecision::Allow);
+    }
+
+    #[test]
+    fn tool_posture_parses_and_defaults() {
+        // Absent `tools` key -> Conversational (the fail-closed default),
+        // even though `deny_unknown_fields` is set.
+        let p: InboundPolicy = toml::from_str("dm = \"open\"").unwrap();
+        assert_eq!(p.tools, ChannelToolPosture::Conversational);
+        // Each posture string round-trips.
+        let w: InboundPolicy =
+            toml::from_str("dm = \"open\"\ntools = \"workspace\"\ntool_workspace_root = \"/srv/agent\"")
+                .unwrap();
+        assert_eq!(w.tools, ChannelToolPosture::Workspace);
+        assert_eq!(w.tool_workspace_root.as_deref(), Some("/srv/agent"));
+        let f: InboundPolicy = toml::from_str("dm = \"open\"\ntools = \"full\"").unwrap();
+        assert_eq!(f.tools, ChannelToolPosture::Full);
     }
 
     #[test]

--- a/crates/wcore-channels/src/dispatch/access.rs
+++ b/crates/wcore-channels/src/dispatch/access.rs
@@ -1,0 +1,378 @@
+//! Fail-closed inbound access policy — THE security gate.
+//!
+//! `decide_access` is the single chokepoint that decides whether an
+//! inbound message is permitted to reach the agent. Its posture is
+//! deliberately fail-closed: an unconfigured channel denies everything
+//! until the operator adds explicit allowlist entries (see
+//! [`InboundPolicy`]'s `Default`).
+//!
+//! This module is pure config + logic — no I/O, no async. The
+//! orchestrator in [`crate::dispatch`] combines it with classification,
+//! dedup, and session-key derivation.
+
+use serde::{Deserialize, Serialize};
+
+use crate::event::{ChatType, IncomingMessage};
+
+/// Policy governing who may DM the bot.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DmPolicy {
+    /// Anyone may DM the bot.
+    Open,
+    /// Only `sender_id`s in `dm_allowlist` may DM the bot.
+    Allowlist,
+    /// Pairing handshake required (deferred to a later phase — currently
+    /// fail-closed: every pairing DM is denied).
+    Pairing,
+    /// DMs are rejected entirely.
+    Disabled,
+}
+
+/// Policy governing whether group/channel messages are accepted.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GroupPolicy {
+    /// Any group/channel message is accepted (still subject to
+    /// mention-gating, which is enforced in admission, not here).
+    Open,
+    /// Only allowlisted group chats AND allowlisted senders are accepted.
+    Allowlist,
+    /// Group/channel messages are rejected entirely.
+    Disabled,
+}
+
+/// Inbound access + session-shaping policy for one channel.
+///
+/// **Fail-closed by default.** The [`Default`] impl denies all inbound
+/// until the operator opts in: `dm: Allowlist` with an EMPTY allowlist
+/// (so no one is permitted), `group: Disabled`, and `require_mention:
+/// true`. An unconfigured channel therefore rejects every message. To
+/// open DMs to everyone, set `dm_allowlist = ["*"]`; to allow a specific
+/// person, add their stable `sender_id`.
+///
+/// Allowlist semantics: a list permits an id iff it contains the literal
+/// `"*"` (wildcard) OR the exact id. An EMPTY list permits NOTHING.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", deny_unknown_fields)]
+pub struct InboundPolicy {
+    /// Who may DM the bot.
+    #[serde(default = "default_dm_policy")]
+    pub dm: DmPolicy,
+    /// Whether group/channel messages are accepted.
+    #[serde(default = "default_group_policy")]
+    pub group: GroupPolicy,
+    /// In groups, only act when the bot is addressed (mention/reply/
+    /// quote/thread). Enforced in admission classification.
+    #[serde(default = "default_require_mention")]
+    pub require_mention: bool,
+    /// Permitted `sender_id`s for DMs. `"*"` = any. Empty = none.
+    #[serde(default)]
+    pub dm_allowlist: Vec<String>,
+    /// Permitted group `conversation_id`s. `"*"` = any. Empty = none.
+    #[serde(default)]
+    pub group_allowlist: Vec<String>,
+    /// Permitted `sender_id`s within groups. `"*"` = any. Empty = none.
+    #[serde(default)]
+    pub sender_allowlist: Vec<String>,
+    /// Give each user their own isolated session within a group. See
+    /// [`crate::dispatch::build_session_key`].
+    #[serde(default = "default_true")]
+    pub group_sessions_per_user: bool,
+    /// Split sessions per thread within a group. See
+    /// [`crate::dispatch::build_session_key`].
+    #[serde(default)]
+    pub thread_sessions_per_user: bool,
+}
+
+fn default_dm_policy() -> DmPolicy {
+    DmPolicy::Allowlist
+}
+fn default_group_policy() -> GroupPolicy {
+    GroupPolicy::Disabled
+}
+fn default_require_mention() -> bool {
+    true
+}
+fn default_true() -> bool {
+    true
+}
+
+impl Default for InboundPolicy {
+    /// Fail-closed posture — denies all inbound until configured.
+    fn default() -> Self {
+        Self {
+            dm: DmPolicy::Allowlist,
+            group: GroupPolicy::Disabled,
+            require_mention: true,
+            dm_allowlist: Vec::new(),
+            group_allowlist: Vec::new(),
+            sender_allowlist: Vec::new(),
+            group_sessions_per_user: true,
+            thread_sessions_per_user: false,
+        }
+    }
+}
+
+/// Outcome of the access gate.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AccessDecision {
+    /// Message is permitted to proceed.
+    Allow,
+    /// Message is rejected. `reason` is a short, non-PII-leaking tag for
+    /// logging — it never embeds sender ids or message content.
+    Deny { reason: String },
+}
+
+/// True iff `list` permits `id`: contains the `"*"` wildcard, or contains
+/// `id` exactly. An empty list permits nothing (fail-closed).
+fn permits(list: &[String], id: &str) -> bool {
+    list.iter().any(|e| e == "*" || e == id)
+}
+
+/// The fail-closed access gate. Decides whether `msg` is permitted under
+/// `policy`, without considering mention-gating (that lives in
+/// admission). Reasons are short, content-free tags.
+pub fn decide_access(msg: &IncomingMessage, policy: &InboundPolicy) -> AccessDecision {
+    match msg.chat_type {
+        ChatType::Direct => match policy.dm {
+            DmPolicy::Disabled => AccessDecision::Deny {
+                reason: "dms disabled".into(),
+            },
+            DmPolicy::Open => AccessDecision::Allow,
+            DmPolicy::Allowlist => {
+                if permits(&policy.dm_allowlist, &msg.sender_id) {
+                    AccessDecision::Allow
+                } else {
+                    AccessDecision::Deny {
+                        reason: "sender not in dm allowlist".into(),
+                    }
+                }
+            }
+            DmPolicy::Pairing => AccessDecision::Deny {
+                reason: "pairing not yet implemented".into(),
+            },
+        },
+        ChatType::Group | ChatType::Channel => match policy.group {
+            GroupPolicy::Disabled => AccessDecision::Deny {
+                reason: "groups disabled".into(),
+            },
+            GroupPolicy::Open => AccessDecision::Allow,
+            GroupPolicy::Allowlist => {
+                if !permits(&policy.group_allowlist, &msg.conversation_id) {
+                    AccessDecision::Deny {
+                        reason: "group not allowlisted".into(),
+                    }
+                } else if !permits(&policy.sender_allowlist, &msg.sender_id) {
+                    AccessDecision::Deny {
+                        reason: "sender not in group allowlist".into(),
+                    }
+                } else {
+                    AccessDecision::Allow
+                }
+            }
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dm_from(sender: &str) -> IncomingMessage {
+        let mut m = IncomingMessage::new("id1", "conv1", "Alice", "hi", 0);
+        m.sender_id = sender.into();
+        m.chat_type = ChatType::Direct;
+        m
+    }
+
+    fn group_from(conv: &str, sender: &str) -> IncomingMessage {
+        let mut m = IncomingMessage::new("id1", conv, "Alice", "hi", 0);
+        m.sender_id = sender.into();
+        m.chat_type = ChatType::Group;
+        m
+    }
+
+    #[test]
+    fn default_policy_is_fail_closed() {
+        let p = InboundPolicy::default();
+        assert_eq!(p.dm, DmPolicy::Allowlist);
+        assert_eq!(p.group, GroupPolicy::Disabled);
+        assert!(p.require_mention);
+        assert!(p.dm_allowlist.is_empty());
+        assert!(p.group_allowlist.is_empty());
+        assert!(p.sender_allowlist.is_empty());
+        assert!(p.group_sessions_per_user);
+        assert!(!p.thread_sessions_per_user);
+        // A DM under the default policy is denied (empty allowlist).
+        assert!(matches!(
+            decide_access(&dm_from("u1"), &p),
+            AccessDecision::Deny { .. }
+        ));
+        // A group message under the default policy is denied (disabled).
+        assert!(matches!(
+            decide_access(&group_from("g1", "u1"), &p),
+            AccessDecision::Deny { .. }
+        ));
+    }
+
+    // ---- DM ----
+
+    #[test]
+    fn dm_empty_allowlist_denies() {
+        let p = InboundPolicy {
+            dm: DmPolicy::Allowlist,
+            dm_allowlist: vec![],
+            ..Default::default()
+        };
+        assert!(matches!(
+            decide_access(&dm_from("u1"), &p),
+            AccessDecision::Deny { .. }
+        ));
+    }
+
+    #[test]
+    fn dm_wildcard_allows_anyone() {
+        let p = InboundPolicy {
+            dm: DmPolicy::Allowlist,
+            dm_allowlist: vec!["*".into()],
+            ..Default::default()
+        };
+        assert_eq!(decide_access(&dm_from("anyone"), &p), AccessDecision::Allow);
+    }
+
+    #[test]
+    fn dm_exact_id_allows_only_that_id() {
+        let p = InboundPolicy {
+            dm: DmPolicy::Allowlist,
+            dm_allowlist: vec!["u1".into()],
+            ..Default::default()
+        };
+        assert_eq!(decide_access(&dm_from("u1"), &p), AccessDecision::Allow);
+        assert!(matches!(
+            decide_access(&dm_from("u2"), &p),
+            AccessDecision::Deny { .. }
+        ));
+    }
+
+    #[test]
+    fn dm_open_allows_all() {
+        let p = InboundPolicy {
+            dm: DmPolicy::Open,
+            ..Default::default()
+        };
+        assert_eq!(decide_access(&dm_from("u1"), &p), AccessDecision::Allow);
+    }
+
+    #[test]
+    fn dm_disabled_denies_even_with_wildcard() {
+        let p = InboundPolicy {
+            dm: DmPolicy::Disabled,
+            dm_allowlist: vec!["*".into()],
+            ..Default::default()
+        };
+        assert!(matches!(
+            decide_access(&dm_from("u1"), &p),
+            AccessDecision::Deny { .. }
+        ));
+    }
+
+    #[test]
+    fn dm_pairing_denies_with_specific_reason() {
+        let p = InboundPolicy {
+            dm: DmPolicy::Pairing,
+            dm_allowlist: vec!["*".into()],
+            ..Default::default()
+        };
+        match decide_access(&dm_from("u1"), &p) {
+            AccessDecision::Deny { reason } => assert!(reason.contains("pairing")),
+            AccessDecision::Allow => panic!("pairing must deny until implemented"),
+        }
+    }
+
+    // ---- Group ----
+
+    #[test]
+    fn group_disabled_denies_even_with_wildcards() {
+        let p = InboundPolicy {
+            group: GroupPolicy::Disabled,
+            group_allowlist: vec!["*".into()],
+            sender_allowlist: vec!["*".into()],
+            ..Default::default()
+        };
+        assert!(matches!(
+            decide_access(&group_from("g1", "u1"), &p),
+            AccessDecision::Deny { .. }
+        ));
+    }
+
+    #[test]
+    fn group_open_allows() {
+        let p = InboundPolicy {
+            group: GroupPolicy::Open,
+            ..Default::default()
+        };
+        assert_eq!(
+            decide_access(&group_from("g1", "u1"), &p),
+            AccessDecision::Allow
+        );
+    }
+
+    #[test]
+    fn group_allowlist_requires_both_group_and_sender() {
+        let p = InboundPolicy {
+            group: GroupPolicy::Allowlist,
+            group_allowlist: vec!["g1".into()],
+            sender_allowlist: vec!["u1".into()],
+            ..Default::default()
+        };
+        // Both match -> allow.
+        assert_eq!(
+            decide_access(&group_from("g1", "u1"), &p),
+            AccessDecision::Allow
+        );
+        // Group not allowlisted -> deny.
+        match decide_access(&group_from("g2", "u1"), &p) {
+            AccessDecision::Deny { reason } => assert!(reason.contains("group")),
+            AccessDecision::Allow => panic!("non-allowlisted group must deny"),
+        }
+        // Sender not allowlisted -> deny.
+        match decide_access(&group_from("g1", "u2"), &p) {
+            AccessDecision::Deny { reason } => assert!(reason.contains("sender")),
+            AccessDecision::Allow => panic!("non-allowlisted sender must deny"),
+        }
+    }
+
+    #[test]
+    fn group_allowlist_empty_lists_deny() {
+        let p = InboundPolicy {
+            group: GroupPolicy::Allowlist,
+            group_allowlist: vec![],
+            sender_allowlist: vec![],
+            ..Default::default()
+        };
+        assert!(matches!(
+            decide_access(&group_from("g1", "u1"), &p),
+            AccessDecision::Deny { .. }
+        ));
+    }
+
+    #[test]
+    fn channel_chat_type_uses_group_policy() {
+        let p = InboundPolicy {
+            group: GroupPolicy::Open,
+            ..Default::default()
+        };
+        let mut m = group_from("c1", "u1");
+        m.chat_type = ChatType::Channel;
+        assert_eq!(decide_access(&m, &p), AccessDecision::Allow);
+    }
+
+    #[test]
+    fn permits_helper_semantics() {
+        assert!(!permits(&[], "x"), "empty list permits nothing");
+        assert!(permits(&["*".into()], "x"), "wildcard permits any");
+        assert!(permits(&["x".into()], "x"), "exact match permits");
+        assert!(!permits(&["y".into()], "x"), "non-match denies");
+    }
+}

--- a/crates/wcore-channels/src/dispatch/admission.rs
+++ b/crates/wcore-channels/src/dispatch/admission.rs
@@ -1,0 +1,163 @@
+//! Turn admission — classifies whether an inbound message is
+//! turn-worthy, observe-only, or should be dropped.
+//!
+//! Classification is independent of access control: `classify` decides
+//! *worthiness* (loop guard, mention-gating), while
+//! [`crate::dispatch::access::decide_access`] decides *permission*. The
+//! orchestrator combines the two.
+
+use crate::event::{ChatType, IncomingMessage};
+
+use super::access::InboundPolicy;
+
+/// What the dispatch kernel should do with an inbound message after
+/// classification.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TurnAdmission {
+    /// A candidate turn — the access gate still decides whether it runs.
+    Dispatch,
+    /// Record to history but don't start an agent turn (e.g. an
+    /// un-addressed group message under `require_mention`).
+    ObserveOnly,
+    /// Already handled by an earlier stage; take no further action.
+    Handled,
+    /// Drop the message. `record_history` distinguishes a silent loop-guard
+    /// drop (`false`) from a drop that should still be journaled (`true`).
+    Drop { record_history: bool },
+}
+
+/// Classify a message for turn-worthiness.
+///
+/// Order:
+/// 1. Self/bot authored -> `Drop { record_history: false }` (loop guard).
+/// 2. Group/channel + `require_mention` + not addressed -> `ObserveOnly`.
+/// 3. Otherwise -> `Dispatch` (a candidate; access decided separately).
+///
+/// This does NOT enforce access control.
+pub fn classify(msg: &IncomingMessage, policy: &InboundPolicy) -> TurnAdmission {
+    // Loop guard: never react to our own / other bots' messages.
+    if msg.is_self || msg.is_bot {
+        return TurnAdmission::Drop {
+            record_history: false,
+        };
+    }
+
+    // Group/channel mention gating.
+    let is_group = msg.chat_type != ChatType::Direct;
+    if is_group && policy.require_mention && !msg.was_mentioned {
+        return TurnAdmission::ObserveOnly;
+    }
+
+    TurnAdmission::Dispatch
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn msg() -> IncomingMessage {
+        IncomingMessage::new("id1", "conv1", "Alice", "hi", 0)
+    }
+
+    #[test]
+    fn self_message_dropped_without_history() {
+        let mut m = msg();
+        m.is_self = true;
+        assert_eq!(
+            classify(&m, &InboundPolicy::default()),
+            TurnAdmission::Drop {
+                record_history: false
+            }
+        );
+    }
+
+    #[test]
+    fn bot_message_dropped_without_history() {
+        let mut m = msg();
+        m.is_bot = true;
+        assert_eq!(
+            classify(&m, &InboundPolicy::default()),
+            TurnAdmission::Drop {
+                record_history: false
+            }
+        );
+    }
+
+    #[test]
+    fn unmentioned_group_is_observe_only() {
+        let p = InboundPolicy {
+            require_mention: true,
+            ..Default::default()
+        };
+        let mut m = msg();
+        m.chat_type = ChatType::Group;
+        m.was_mentioned = false;
+        assert_eq!(classify(&m, &p), TurnAdmission::ObserveOnly);
+    }
+
+    #[test]
+    fn mentioned_group_dispatches() {
+        let p = InboundPolicy {
+            require_mention: true,
+            ..Default::default()
+        };
+        let mut m = msg();
+        m.chat_type = ChatType::Group;
+        m.was_mentioned = true;
+        assert_eq!(classify(&m, &p), TurnAdmission::Dispatch);
+    }
+
+    #[test]
+    fn group_without_require_mention_dispatches() {
+        let p = InboundPolicy {
+            require_mention: false,
+            ..Default::default()
+        };
+        let mut m = msg();
+        m.chat_type = ChatType::Group;
+        m.was_mentioned = false;
+        assert_eq!(classify(&m, &p), TurnAdmission::Dispatch);
+    }
+
+    #[test]
+    fn channel_unmentioned_is_observe_only() {
+        let p = InboundPolicy {
+            require_mention: true,
+            ..Default::default()
+        };
+        let mut m = msg();
+        m.chat_type = ChatType::Channel;
+        m.was_mentioned = false;
+        assert_eq!(classify(&m, &p), TurnAdmission::ObserveOnly);
+    }
+
+    #[test]
+    fn dm_dispatches_regardless_of_mention() {
+        let p = InboundPolicy {
+            require_mention: true,
+            ..Default::default()
+        };
+        let mut m = msg();
+        m.chat_type = ChatType::Direct;
+        m.was_mentioned = false;
+        assert_eq!(classify(&m, &p), TurnAdmission::Dispatch);
+    }
+
+    #[test]
+    fn self_flag_beats_mention_gating() {
+        // A self message in a group is dropped, not observed.
+        let p = InboundPolicy {
+            require_mention: true,
+            ..Default::default()
+        };
+        let mut m = msg();
+        m.chat_type = ChatType::Group;
+        m.is_self = true;
+        assert_eq!(
+            classify(&m, &p),
+            TurnAdmission::Drop {
+                record_history: false
+            }
+        );
+    }
+}

--- a/crates/wcore-channels/src/dispatch/dedupe.rs
+++ b/crates/wcore-channels/src/dispatch/dedupe.rs
@@ -1,0 +1,291 @@
+//! `DedupeCache` — bounded TTL + LRU duplicate-suppression cache.
+//!
+//! Platforms re-deliver the same inbound message on retries, reconnects,
+//! and at-least-once gateway semantics. This cache suppresses
+//! reprocessing by remembering message ids that were already admitted,
+//! keyed by `(platform, account, message_id)`.
+//!
+//! Time is caller-supplied (`now_ms`, monotonic millis) so the cache is
+//! fully deterministic under test — it never reads the wall clock.
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+/// Identity of a single inbound message for dedup purposes.
+///
+/// Equality is on all three fields: two messages collide only when they
+/// share the same platform, receiving account, and platform message id.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct DedupeKey {
+    /// Platform tag (`"slack"`, `"telegram"`, …).
+    pub platform: String,
+    /// Receiving bot/account identity (empty when single-account).
+    pub account_id: String,
+    /// Platform-assigned message id.
+    pub message_id: String,
+}
+
+impl DedupeKey {
+    /// Convenience constructor.
+    pub fn new(
+        platform: impl Into<String>,
+        account_id: impl Into<String>,
+        message_id: impl Into<String>,
+    ) -> Self {
+        Self {
+            platform: platform.into(),
+            account_id: account_id.into(),
+            message_id: message_id.into(),
+        }
+    }
+}
+
+/// Bounded duplicate-suppression cache with TTL expiry and LRU eviction.
+///
+/// Two independent bounds:
+///
+/// - `ttl_ms`: entries older than this (by `now_ms - first_seen`) are
+///   treated as expired and removed lazily on the next call. Duplicates do
+///   NOT slide this window — suppression is measured from first sight.
+///   `ttl_ms == 0` disables time expiry — entries never expire by age.
+/// - `max_size`: when recording a new entry would exceed this count, the
+///   least-recently-used entry is evicted first. `max_size == 0` disables
+///   size-capping.
+///
+/// With both `ttl_ms == 0` and `max_size == 0` the cache is effectively
+/// unbounded (grows with the number of distinct keys ever seen) — only
+/// suitable for short-lived or test scenarios.
+#[derive(Debug, Clone)]
+pub struct DedupeCache {
+    ttl_ms: u64,
+    max_size: usize,
+    /// key -> entry. TTL expiry is measured from `first_seen` (fixed at
+    /// insert), while LRU eviction picks the entry with the smallest
+    /// `last_seen` (refreshed on every hit, including duplicates).
+    entries: HashMap<DedupeKey, Entry>,
+}
+
+/// A tracked key's timestamps. `first_seen` anchors TTL expiry (so a
+/// duplicate never slides the suppression window); `last_seen` tracks
+/// recency for LRU eviction.
+#[derive(Debug, Clone, Copy)]
+struct Entry {
+    first_seen: u64,
+    last_seen: u64,
+}
+
+impl DedupeCache {
+    /// Construct a cache. See the type docs for the `ttl_ms == 0` /
+    /// `max_size == 0` "disabled" semantics.
+    pub fn new(ttl_ms: u64, max_size: usize) -> Self {
+        Self {
+            ttl_ms,
+            max_size,
+            entries: HashMap::new(),
+        }
+    }
+
+    /// Drop every entry whose age (`now_ms - last_seen`) exceeds `ttl_ms`.
+    /// No-op when `ttl_ms == 0`. Uses saturating arithmetic so a `now_ms`
+    /// that runs backwards (clock skew) never underflows into a false
+    /// "expired" sweep.
+    fn evict_expired(&mut self, now_ms: u64) {
+        if self.ttl_ms == 0 {
+            return;
+        }
+        let ttl = self.ttl_ms;
+        self.entries
+            .retain(|_, e| now_ms.saturating_sub(e.first_seen) < ttl);
+    }
+
+    /// True if a live (non-expired) entry exists for `key`. With
+    /// `ttl_ms == 0` any present entry is considered live.
+    fn is_live(&self, key: &DedupeKey, now_ms: u64) -> bool {
+        match self.entries.get(key) {
+            None => false,
+            Some(e) => self.ttl_ms == 0 || now_ms.saturating_sub(e.first_seen) < self.ttl_ms,
+        }
+    }
+
+    /// Check-and-record. Returns `true` if `key` is NEW (never seen, or
+    /// its prior entry has expired) and records it at `now_ms`. Returns
+    /// `false` if `key` is a live duplicate — in which case the entry's
+    /// recency is refreshed to `now_ms` (a re-seen key counts as recently
+    /// used for LRU purposes).
+    ///
+    /// On every call: expired entries are swept first, then if recording a
+    /// brand-new key would exceed `max_size` the least-recently-used entry
+    /// is evicted before insertion.
+    pub fn check(&mut self, key: DedupeKey, now_ms: u64) -> bool {
+        self.evict_expired(now_ms);
+
+        if self.is_live(&key, now_ms) {
+            // Live duplicate: refresh LRU recency only (NOT the TTL anchor),
+            // report not-new.
+            if let Some(e) = self.entries.get_mut(&key) {
+                e.last_seen = now_ms;
+            }
+            return false;
+        }
+
+        // New (or expired) key: make room under the size cap, then record.
+        if self.max_size > 0 {
+            // The key isn't currently a live entry; if a stale copy lingers
+            // it will be overwritten by the insert below, so only evict when
+            // adding a genuinely new key would push us over the cap.
+            let adding_new = !self.entries.contains_key(&key);
+            while adding_new && self.entries.len() >= self.max_size {
+                if let Some(lru) = self.lru_key() {
+                    self.entries.remove(&lru);
+                } else {
+                    break;
+                }
+            }
+        }
+
+        self.entries.insert(
+            key,
+            Entry {
+                first_seen: now_ms,
+                last_seen: now_ms,
+            },
+        );
+        true
+    }
+
+    /// Non-mutating liveness probe. True if a live (non-expired) entry
+    /// exists for `key` at `now_ms`. Does not record or refresh anything.
+    pub fn peek(&self, key: &DedupeKey, now_ms: u64) -> bool {
+        self.is_live(key, now_ms)
+    }
+
+    /// Find the least-recently-used key (smallest `last_seen`).
+    fn lru_key(&self) -> Option<DedupeKey> {
+        self.entries
+            .iter()
+            .min_by_key(|(_, e)| e.last_seen)
+            .map(|(k, _)| k.clone())
+    }
+
+    /// Current number of tracked entries (post any lazy eviction from the
+    /// last mutating call). Primarily for tests / introspection.
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// True when no entries are tracked.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key(id: &str) -> DedupeKey {
+        DedupeKey::new("slack", "acct", id)
+    }
+
+    #[test]
+    fn new_key_is_new_and_recorded() {
+        let mut c = DedupeCache::new(1000, 100);
+        assert!(c.check(key("m1"), 0), "first sight of a key is new");
+        assert_eq!(c.len(), 1);
+    }
+
+    #[test]
+    fn immediate_duplicate_is_not_new() {
+        let mut c = DedupeCache::new(1000, 100);
+        assert!(c.check(key("m1"), 0));
+        assert!(!c.check(key("m1"), 10), "live duplicate must be suppressed");
+        assert_eq!(c.len(), 1);
+    }
+
+    #[test]
+    fn key_equality_is_on_all_three_fields() {
+        let mut c = DedupeCache::new(1000, 100);
+        assert!(c.check(DedupeKey::new("slack", "a", "m1"), 0));
+        // Different platform -> distinct key -> new.
+        assert!(c.check(DedupeKey::new("discord", "a", "m1"), 0));
+        // Different account -> distinct key -> new.
+        assert!(c.check(DedupeKey::new("slack", "b", "m1"), 0));
+        // Different message id -> distinct key -> new.
+        assert!(c.check(DedupeKey::new("slack", "a", "m2"), 0));
+        assert_eq!(c.len(), 4);
+    }
+
+    #[test]
+    fn reappears_as_new_after_ttl_elapses() {
+        let mut c = DedupeCache::new(1000, 100);
+        assert!(c.check(key("m1"), 0));
+        assert!(!c.check(key("m1"), 999), "still live just under ttl");
+        // At exactly ttl the age == ttl, which is NOT < ttl -> expired.
+        assert!(c.check(key("m1"), 1000), "expired at the ttl boundary -> new again");
+    }
+
+    #[test]
+    fn ttl_zero_disables_expiry() {
+        let mut c = DedupeCache::new(0, 100);
+        assert!(c.check(key("m1"), 0));
+        // Arbitrarily far in the future, still a duplicate.
+        assert!(!c.check(key("m1"), u64::MAX), "ttl=0 means entries never age out");
+    }
+
+    #[test]
+    fn lru_evicts_oldest_keeps_recently_touched() {
+        let mut c = DedupeCache::new(0, 2);
+        assert!(c.check(key("m1"), 1));
+        assert!(c.check(key("m2"), 2));
+        // Touch m1 so it becomes the most-recently-used.
+        assert!(!c.check(key("m1"), 3));
+        // Inserting m3 overflows cap (2); LRU is m2, which gets evicted.
+        assert!(c.check(key("m3"), 4));
+        assert_eq!(c.len(), 2);
+        assert!(c.peek(&key("m1"), 5), "recently-touched m1 retained");
+        assert!(c.peek(&key("m3"), 5), "newest m3 present");
+        assert!(!c.peek(&key("m2"), 5), "LRU m2 evicted");
+        // m2 now reads as new again (it was evicted).
+        assert!(c.check(key("m2"), 6));
+    }
+
+    #[test]
+    fn max_size_zero_disables_capping() {
+        let mut c = DedupeCache::new(0, 0);
+        for i in 0..1000 {
+            assert!(c.check(key(&format!("m{i}")), i as u64));
+        }
+        assert_eq!(c.len(), 1000, "no cap -> all distinct keys retained");
+    }
+
+    #[test]
+    fn peek_does_not_record() {
+        let mut c = DedupeCache::new(1000, 100);
+        assert!(!c.peek(&key("m1"), 0), "absent key is not live");
+        assert_eq!(c.len(), 0, "peek must not insert");
+        // Confirm a subsequent check still treats it as new.
+        assert!(c.check(key("m1"), 0));
+    }
+
+    #[test]
+    fn peek_respects_ttl() {
+        let mut c = DedupeCache::new(1000, 100);
+        c.check(key("m1"), 0);
+        assert!(c.peek(&key("m1"), 500), "live within ttl");
+        assert!(!c.peek(&key("m1"), 1000), "expired at ttl boundary");
+    }
+
+    #[test]
+    fn duplicate_refreshes_recency_for_lru() {
+        let mut c = DedupeCache::new(0, 2);
+        c.check(key("a"), 1);
+        c.check(key("b"), 2);
+        // Re-seeing "a" refreshes it to now=3 (newer than b@2).
+        assert!(!c.check(key("a"), 3));
+        // Adding "c" evicts the true LRU, which is now "b".
+        assert!(c.check(key("c"), 4));
+        assert!(c.peek(&key("a"), 5));
+        assert!(!c.peek(&key("b"), 5), "b was LRU after a's refresh");
+    }
+}

--- a/crates/wcore-channels/src/dispatch/mod.rs
+++ b/crates/wcore-channels/src/dispatch/mod.rs
@@ -23,7 +23,9 @@ pub mod admission;
 pub mod dedupe;
 pub mod session_key;
 
-pub use access::{decide_access, AccessDecision, DmPolicy, GroupPolicy, InboundPolicy};
+pub use access::{
+    decide_access, AccessDecision, ChannelToolPosture, DmPolicy, GroupPolicy, InboundPolicy,
+};
 pub use admission::{classify, TurnAdmission};
 pub use dedupe::{DedupeCache, DedupeKey};
 pub use session_key::build_session_key;

--- a/crates/wcore-channels/src/dispatch/mod.rs
+++ b/crates/wcore-channels/src/dispatch/mod.rs
@@ -24,7 +24,8 @@ pub mod dedupe;
 pub mod session_key;
 
 pub use access::{
-    decide_access, AccessDecision, ChannelToolPosture, DmPolicy, GroupPolicy, InboundPolicy,
+    decide_access, AccessDecision, AckMode, ChannelToolPosture, DmPolicy, GroupPolicy,
+    InboundPolicy,
 };
 pub use admission::{classify, TurnAdmission};
 pub use dedupe::{DedupeCache, DedupeKey};

--- a/crates/wcore-channels/src/dispatch/mod.rs
+++ b/crates/wcore-channels/src/dispatch/mod.rs
@@ -1,0 +1,253 @@
+//! Inbound dispatch kernel — pure, fail-closed admission for channel
+//! traffic.
+//!
+//! Given an [`IncomingMessage`], an [`InboundPolicy`], and a
+//! [`DedupeCache`], [`evaluate`] decides whether the message becomes an
+//! agent turn, is observed only, or is dropped — and if it dispatches,
+//! which session key it routes to.
+//!
+//! The kernel is deliberately free of async, I/O, and any engine/agent
+//! dependency: it is the security gate's logic core, unit-testable in
+//! isolation. The orchestrating channel runtime supplies `now_ms` and the
+//! cache.
+//!
+//! Pipeline (each step may short-circuit):
+//! 1. **classify** — loop guard (self/bot) and mention gating. A `Drop`
+//!    or `ObserveOnly` here returns immediately (no dedup needed).
+//! 2. **dedup** — suppress platform re-deliveries of the same message id.
+//! 3. **access** — the fail-closed allowlist gate.
+//! 4. **route** — derive the session key for the admitted turn.
+
+pub mod access;
+pub mod admission;
+pub mod dedupe;
+pub mod session_key;
+
+pub use access::{decide_access, AccessDecision, DmPolicy, GroupPolicy, InboundPolicy};
+pub use admission::{classify, TurnAdmission};
+pub use dedupe::{DedupeCache, DedupeKey};
+pub use session_key::build_session_key;
+
+use crate::event::IncomingMessage;
+
+/// Result of evaluating one inbound message through the dispatch kernel.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DispatchOutcome {
+    /// Final admission decision.
+    pub admission: TurnAdmission,
+    /// The routed session key — `Some` only when `admission` is
+    /// [`TurnAdmission::Dispatch`].
+    pub session_key: Option<String>,
+    /// Short, content-free deny reason — `Some` only when the access gate
+    /// rejected the message.
+    pub deny_reason: Option<String>,
+}
+
+/// Evaluate one inbound message: classify, dedup, gate, and route.
+///
+/// See the module docs for the pipeline. `now_ms` is caller-supplied
+/// monotonic millis (for deterministic dedup); `dedupe` is the shared
+/// per-channel cache and is mutated on every non-short-circuited call.
+pub fn evaluate(
+    channel_name: &str,
+    msg: &IncomingMessage,
+    policy: &InboundPolicy,
+    dedupe: &mut DedupeCache,
+    now_ms: u64,
+) -> DispatchOutcome {
+    // 1. Classification — loop guard + mention gating.
+    match classify(msg, policy) {
+        TurnAdmission::Dispatch => {}
+        other => {
+            // Drop (self/bot) or ObserveOnly — return as-is, no dedup.
+            return DispatchOutcome {
+                admission: other,
+                session_key: None,
+                deny_reason: None,
+            };
+        }
+    }
+
+    // 2. Dedup — suppress platform re-deliveries of the same message.
+    let key = DedupeKey {
+        platform: msg
+            .platform
+            .clone()
+            .unwrap_or_else(|| channel_name.to_string()),
+        account_id: msg.account_id.clone().unwrap_or_default(),
+        message_id: msg.id.clone(),
+    };
+    if !dedupe.check(key, now_ms) {
+        // Live duplicate — silently drop.
+        return DispatchOutcome {
+            admission: TurnAdmission::Drop {
+                record_history: false,
+            },
+            session_key: None,
+            deny_reason: None,
+        };
+    }
+
+    // 3. Access gate — fail-closed allowlist enforcement.
+    if let AccessDecision::Deny { reason } = decide_access(msg, policy) {
+        return DispatchOutcome {
+            admission: TurnAdmission::Drop {
+                record_history: true,
+            },
+            session_key: None,
+            deny_reason: Some(reason),
+        };
+    }
+
+    // 4. Route — derive the session key for the admitted turn.
+    let session_key = build_session_key(channel_name, msg, policy);
+    DispatchOutcome {
+        admission: TurnAdmission::Dispatch,
+        session_key: Some(session_key),
+        deny_reason: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::event::ChatType;
+
+    fn cache() -> DedupeCache {
+        DedupeCache::new(60_000, 1024)
+    }
+
+    fn dm(sender: &str, id: &str) -> IncomingMessage {
+        let mut m = IncomingMessage::new(id, "conv1", "Alice", "hi", 0);
+        m.sender_id = sender.into();
+        m.chat_type = ChatType::Direct;
+        m
+    }
+
+    #[test]
+    fn disallowed_dm_drops_with_deny_reason() {
+        // Default policy: dm Allowlist with EMPTY allowlist -> fail-closed.
+        let policy = InboundPolicy::default();
+        let mut c = cache();
+        let out = evaluate("slack", &dm("u1", "m1"), &policy, &mut c, 0);
+        assert_eq!(
+            out.admission,
+            TurnAdmission::Drop {
+                record_history: true
+            }
+        );
+        assert!(out.session_key.is_none());
+        assert!(out.deny_reason.is_some(), "fail-closed deny carries a reason");
+    }
+
+    #[test]
+    fn allowed_dm_dispatches_with_session_key() {
+        let policy = InboundPolicy {
+            dm: DmPolicy::Open,
+            ..Default::default()
+        };
+        let mut c = cache();
+        let out = evaluate("slack", &dm("u1", "m1"), &policy, &mut c, 0);
+        assert_eq!(out.admission, TurnAdmission::Dispatch);
+        assert_eq!(out.session_key.as_deref(), Some("agent:main:slack:dm:conv1"));
+        assert!(out.deny_reason.is_none());
+    }
+
+    #[test]
+    fn duplicate_message_drops_after_first_dispatch() {
+        let policy = InboundPolicy {
+            dm: DmPolicy::Open,
+            ..Default::default()
+        };
+        let mut c = cache();
+        // First sight dispatches.
+        let first = evaluate("slack", &dm("u1", "m1"), &policy, &mut c, 0);
+        assert_eq!(first.admission, TurnAdmission::Dispatch);
+        // Re-delivery of the same id within ttl drops silently.
+        let dup = evaluate("slack", &dm("u1", "m1"), &policy, &mut c, 10);
+        assert_eq!(
+            dup.admission,
+            TurnAdmission::Drop {
+                record_history: false
+            }
+        );
+        assert!(dup.session_key.is_none());
+        assert!(dup.deny_reason.is_none());
+    }
+
+    #[test]
+    fn unmentioned_group_is_observe_only_and_skips_dedup() {
+        let policy = InboundPolicy {
+            group: GroupPolicy::Open,
+            require_mention: true,
+            ..Default::default()
+        };
+        let mut c = cache();
+        let mut m = IncomingMessage::new("m1", "g1", "Bob", "hi", 0);
+        m.sender_id = "u1".into();
+        m.chat_type = ChatType::Group;
+        m.was_mentioned = false;
+        let out = evaluate("slack", &m, &policy, &mut c, 0);
+        assert_eq!(out.admission, TurnAdmission::ObserveOnly);
+        assert!(out.session_key.is_none());
+        // ObserveOnly short-circuits before dedup, so the cache stays empty.
+        assert!(c.is_empty(), "observe-only must not consume a dedup slot");
+    }
+
+    #[test]
+    fn self_message_drops_without_history() {
+        let policy = InboundPolicy {
+            dm: DmPolicy::Open,
+            ..Default::default()
+        };
+        let mut c = cache();
+        let mut m = dm("u1", "m1");
+        m.is_self = true;
+        let out = evaluate("slack", &m, &policy, &mut c, 0);
+        assert_eq!(
+            out.admission,
+            TurnAdmission::Drop {
+                record_history: false
+            }
+        );
+        assert!(out.deny_reason.is_none());
+        // Loop-guard drop short-circuits before dedup too.
+        assert!(c.is_empty());
+    }
+
+    #[test]
+    fn dedup_key_uses_platform_field_over_channel_name() {
+        let policy = InboundPolicy {
+            dm: DmPolicy::Open,
+            ..Default::default()
+        };
+        let mut c = cache();
+        let mut m = dm("u1", "m1");
+        m.platform = Some("telegram".into());
+        m.account_id = Some("bot7".into());
+        let out = evaluate("chan-a", &m, &policy, &mut c, 0);
+        assert_eq!(out.admission, TurnAdmission::Dispatch);
+        // The recorded key should be (telegram, bot7, m1), not the channel.
+        assert!(c.peek(&DedupeKey::new("telegram", "bot7", "m1"), 1));
+        assert!(!c.peek(&DedupeKey::new("chan-a", "", "m1"), 1));
+    }
+
+    #[test]
+    fn allowed_group_dispatches_with_per_user_key() {
+        let policy = InboundPolicy {
+            group: GroupPolicy::Allowlist,
+            group_allowlist: vec!["g1".into()],
+            sender_allowlist: vec!["u1".into()],
+            require_mention: false,
+            group_sessions_per_user: true,
+            ..Default::default()
+        };
+        let mut c = cache();
+        let mut m = IncomingMessage::new("m1", "g1", "Bob", "hi", 0);
+        m.sender_id = "u1".into();
+        m.chat_type = ChatType::Group;
+        let out = evaluate("slack", &m, &policy, &mut c, 0);
+        assert_eq!(out.admission, TurnAdmission::Dispatch);
+        assert_eq!(out.session_key.as_deref(), Some("agent:main:slack:g1:u1"));
+    }
+}

--- a/crates/wcore-channels/src/dispatch/session_key.rs
+++ b/crates/wcore-channels/src/dispatch/session_key.rs
@@ -1,0 +1,163 @@
+//! Pure session-key derivation.
+//!
+//! The session key determines which agent session an inbound message
+//! routes to. Key composition is policy-driven so operators can choose
+//! between shared and isolated sessions per user / per thread.
+//!
+//! Defaults: groups get **isolated per-user** sessions
+//! (`group_sessions_per_user = true`), and threads are **shared** with
+//! their parent chat (`thread_sessions_per_user = false`) — a thread only
+//! splits into its own session when `thread_sessions_per_user` is set.
+
+use crate::event::{ChatType, IncomingMessage};
+
+use super::access::InboundPolicy;
+
+/// Derive the session key for `msg` within `channel_name` under `policy`.
+///
+/// DM (`Direct`):
+/// `agent:main:<channel>:dm:<conversation_id>`, plus `:<thread_id>` when
+/// the message carries a thread id (DMs always split per thread).
+///
+/// Group/Channel:
+/// `agent:main:<channel>:<conversation_id>`, plus `:<sender_id>` when
+/// `group_sessions_per_user`, plus `:<thread_id>` when the message has a
+/// thread id AND `thread_sessions_per_user`.
+pub fn build_session_key(
+    channel_name: &str,
+    msg: &IncomingMessage,
+    policy: &InboundPolicy,
+) -> String {
+    match msg.chat_type {
+        ChatType::Direct => {
+            let mut key = format!("agent:main:{channel_name}:dm:{}", msg.conversation_id);
+            if let Some(thread) = &msg.thread_id {
+                key.push(':');
+                key.push_str(thread);
+            }
+            key
+        }
+        ChatType::Group | ChatType::Channel => {
+            let mut key = format!("agent:main:{channel_name}:{}", msg.conversation_id);
+            if policy.group_sessions_per_user {
+                key.push(':');
+                key.push_str(&msg.sender_id);
+            }
+            if policy.thread_sessions_per_user
+                && let Some(thread) = &msg.thread_id
+            {
+                key.push(':');
+                key.push_str(thread);
+            }
+            key
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base() -> IncomingMessage {
+        let mut m = IncomingMessage::new("id1", "conv1", "Alice", "hi", 0);
+        m.sender_id = "u1".into();
+        m
+    }
+
+    #[test]
+    fn dm_key_without_thread() {
+        let mut m = base();
+        m.chat_type = ChatType::Direct;
+        let key = build_session_key("slack", &m, &InboundPolicy::default());
+        assert_eq!(key, "agent:main:slack:dm:conv1");
+    }
+
+    #[test]
+    fn dm_key_with_thread() {
+        let mut m = base();
+        m.chat_type = ChatType::Direct;
+        m.thread_id = Some("t9".into());
+        let key = build_session_key("slack", &m, &InboundPolicy::default());
+        assert_eq!(key, "agent:main:slack:dm:conv1:t9");
+    }
+
+    #[test]
+    fn group_isolated_per_user() {
+        let p = InboundPolicy {
+            group_sessions_per_user: true,
+            ..Default::default()
+        };
+        let mut m = base();
+        m.chat_type = ChatType::Group;
+        let key = build_session_key("slack", &m, &p);
+        assert_eq!(key, "agent:main:slack:conv1:u1");
+    }
+
+    #[test]
+    fn group_shared_when_per_user_off() {
+        let p = InboundPolicy {
+            group_sessions_per_user: false,
+            ..Default::default()
+        };
+        let mut m = base();
+        m.chat_type = ChatType::Group;
+        let key = build_session_key("slack", &m, &p);
+        assert_eq!(key, "agent:main:slack:conv1");
+    }
+
+    #[test]
+    fn group_thread_split_when_enabled() {
+        let p = InboundPolicy {
+            group_sessions_per_user: true,
+            thread_sessions_per_user: true,
+            ..Default::default()
+        };
+        let mut m = base();
+        m.chat_type = ChatType::Group;
+        m.thread_id = Some("t9".into());
+        let key = build_session_key("slack", &m, &p);
+        assert_eq!(key, "agent:main:slack:conv1:u1:t9");
+    }
+
+    #[test]
+    fn group_thread_shared_when_disabled() {
+        let p = InboundPolicy {
+            group_sessions_per_user: true,
+            thread_sessions_per_user: false,
+            ..Default::default()
+        };
+        let mut m = base();
+        m.chat_type = ChatType::Group;
+        m.thread_id = Some("t9".into());
+        let key = build_session_key("slack", &m, &p);
+        // Thread id ignored -> shared with the parent chat session.
+        assert_eq!(key, "agent:main:slack:conv1:u1");
+    }
+
+    #[test]
+    fn group_thread_split_ignored_without_thread_id() {
+        // thread_sessions_per_user on, but no thread id present.
+        let p = InboundPolicy {
+            group_sessions_per_user: false,
+            thread_sessions_per_user: true,
+            ..Default::default()
+        };
+        let mut m = base();
+        m.chat_type = ChatType::Group;
+        m.thread_id = None;
+        let key = build_session_key("slack", &m, &p);
+        assert_eq!(key, "agent:main:slack:conv1");
+    }
+
+    #[test]
+    fn channel_uses_group_composition() {
+        let p = InboundPolicy {
+            group_sessions_per_user: true,
+            ..Default::default()
+        };
+        let mut m = base();
+        m.chat_type = ChatType::Channel;
+        let key = build_session_key("disc", &m, &p);
+        assert_eq!(key, "agent:main:disc:conv1:u1");
+    }
+}

--- a/crates/wcore-channels/src/event.rs
+++ b/crates/wcore-channels/src/event.rs
@@ -16,26 +16,204 @@ pub enum ConnectionState {
     AuthError,
 }
 
+/// Shape of the conversation an inbound message arrived in. Drives the
+/// access gate (DM vs group policy) and the session-key composition in
+/// the inbound dispatch kernel. `Direct` = 1:1 DM, `Group` = multi-user
+/// room / group chat, `Channel` = broadcast / announcement surface.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum ChatType {
+    #[default]
+    Direct,
+    Group,
+    Channel,
+}
+
+/// Coarse media class for a typed inbound attachment.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum MediaKind {
+    Image,
+    Video,
+    Audio,
+    Document,
+    #[default]
+    Other,
+}
+
+/// How the bot came to be addressed in a group context. `None` (on the
+/// owning message) means the bot was not addressed at all.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum MentionKind {
+    /// Explicit platform mention (`@bot`).
+    Native,
+    /// The message is a reply to one of the bot's messages.
+    ReplyToBot,
+    /// The message quotes one of the bot's messages.
+    QuotedBot,
+    /// The bot is a participant in this thread.
+    ThreadParticipant,
+}
+
+/// One typed inbound attachment. `url` / `path` resolve to bytes lazily;
+/// channels fetch on demand (auth-gated, SSRF-guarded — see Phase 5).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(deny_unknown_fields)]
+pub struct Attachment {
+    /// Platform URL / reference for the media.
+    pub url: String,
+    /// Local filesystem path once downloaded (None until fetched).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    /// MIME type if the platform reported one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub content_type: Option<String>,
+    /// Coarse media class.
+    #[serde(default)]
+    pub kind: MediaKind,
+    /// Transcribed text (audio/voice notes) once produced.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub transcribed: Option<String>,
+}
+
+impl Attachment {
+    /// Construct a bare URL attachment with unknown type/kind.
+    pub fn url(url: impl Into<String>) -> Self {
+        Self {
+            url: url.into(),
+            ..Default::default()
+        }
+    }
+}
+
 /// One inbound message from a channel.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+///
+/// Carries the structured facts the inbound dispatch kernel needs to
+/// dedup, gate (access control), and route (session key). Connectors
+/// populate every field they can resolve from the platform payload and
+/// leave the rest at their defaults.
+///
+/// Field-trust note: `reply_to_text` and any quoted body are UNTRUSTED
+/// remote content and must never be folded into the system prompt.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(deny_unknown_fields)]
 pub struct IncomingMessage {
-    /// Platform-assigned message ID.
+    /// Platform-assigned message ID. The dedup key (with platform +
+    /// account).
     pub id: String,
-    /// Channel / room / thread / DM identifier — platform specific.
+    /// Chat / room / thread / DM identifier — the conversation this
+    /// message belongs to (platform specific). This is the chat id.
     pub conversation_id: String,
-    /// Author identifier (platform user id or display name —
-    /// per-platform).
+    /// Human-facing author label. May be a display name; for stable
+    /// identity use `sender_id`.
     pub author: String,
     /// Message text. Always present; rich content travels in
     /// `attachments`.
     pub text: String,
     /// Unix epoch seconds.
     pub ts_secs: i64,
-    /// Optional file / media attachments. Each is a URL or platform
-    /// reference; channels resolve to bytes on demand.
+    /// Typed file / media attachments. Channels resolve to bytes on
+    /// demand.
     #[serde(default)]
-    pub attachments: Vec<String>,
+    pub attachments: Vec<Attachment>,
+
+    // ---- Sender identity ----
+    /// Stable platform user id of the sender — the access-control /
+    /// dedup key. Connectors MUST set this to the immutable id, not a
+    /// display name. Defaults to `author` via [`IncomingMessage::new`].
+    #[serde(default)]
+    pub sender_id: String,
+    /// Display name of the sender, if distinct from `sender_id`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sender_display: Option<String>,
+    /// Platform handle (`@username`) of the sender, if any.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sender_handle: Option<String>,
+    /// Secondary stable id where a platform exposes a union (Signal
+    /// UUID, Feishu `union_id`, …).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sender_alt_id: Option<String>,
+    /// Sender is a bot account.
+    #[serde(default)]
+    pub is_bot: bool,
+    /// Message was authored by this bot's own identity (loop guard).
+    #[serde(default)]
+    pub is_self: bool,
+
+    // ---- Chat context ----
+    /// DM / group / channel.
+    #[serde(default)]
+    pub chat_type: ChatType,
+    /// Human-facing chat / room name, if any.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub chat_name: Option<String>,
+    /// Enclosing space — guild / workspace / team id, if any.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub space_id: Option<String>,
+    /// Thread id within the chat, if this message is in a thread.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thread_id: Option<String>,
+    /// Parent chat id when this chat is nested (sub-channel/thread root).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_chat_id: Option<String>,
+
+    // ---- Account / platform routing ----
+    /// Receiving bot identity for multi-account routing (which bot/token
+    /// received this), if the connector tracks more than one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub account_id: Option<String>,
+    /// Platform tag (`"slack"`, `"telegram"`, …). Usually redundant with
+    /// the owning channel's platform; carried for normalized handling.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub platform: Option<String>,
+
+    // ---- Mention / addressing ----
+    /// The bot was addressed by this message (native mention, reply,
+    /// quote, or thread participation).
+    #[serde(default)]
+    pub was_mentioned: bool,
+    /// How the bot was addressed, if `was_mentioned`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mention_kind: Option<MentionKind>,
+
+    // ---- Reply / quote (UNTRUSTED remote content) ----
+    /// The message id this message replies to, if any.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reply_to_message_id: Option<String>,
+    /// The body of the replied-to message, if the platform inlines it.
+    /// UNTRUSTED — never folded into the system prompt.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reply_to_text: Option<String>,
+}
+
+impl IncomingMessage {
+    /// Minimal constructor for the core fields. Enriched fields take
+    /// their defaults; `sender_id` is seeded from `author` and SHOULD be
+    /// overridden with the stable platform user id. Set the structured
+    /// fields (`chat_type`, mention/reply/account, typed attachments)
+    /// via struct-update after construction.
+    pub fn new(
+        id: impl Into<String>,
+        conversation_id: impl Into<String>,
+        author: impl Into<String>,
+        text: impl Into<String>,
+        ts_secs: i64,
+    ) -> Self {
+        let author = author.into();
+        Self {
+            id: id.into(),
+            conversation_id: conversation_id.into(),
+            sender_id: author.clone(),
+            author,
+            text: text.into(),
+            ts_secs,
+            ..Default::default()
+        }
+    }
 }
 
 /// Receipt returned by `Channel::send_message` after the platform
@@ -51,8 +229,15 @@ pub struct MessageReceipt {
 
 /// Events surface from a `Channel` via `poll_events()`. Non-exhaustive
 /// so new variants don't break consumers.
+///
+/// `MessageReceived` carries the full enriched `IncomingMessage` and is
+/// by far the dominant variant in real channel traffic; the lifecycle
+/// variants are rare. Boxing the message to satisfy `large_enum_variant`
+/// would add a heap allocation on the hot path to shrink a fixed buffer
+/// by a negligible amount, so the lint is suppressed here deliberately.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "kind", rename_all = "snake_case")]
+#[allow(clippy::large_enum_variant)]
 #[non_exhaustive]
 pub enum ChannelEvent {
     MessageReceived { msg: IncomingMessage },

--- a/crates/wcore-channels/src/lib.rs
+++ b/crates/wcore-channels/src/lib.rs
@@ -24,8 +24,8 @@ pub mod outgoing;
 
 pub use config::{ChannelConfig, ChannelConfigLoader};
 pub use dispatch::{
-    build_session_key, classify, decide_access, evaluate, AccessDecision, DedupeCache, DedupeKey,
-    DispatchOutcome, DmPolicy, GroupPolicy, InboundPolicy, TurnAdmission,
+    build_session_key, classify, decide_access, evaluate, AccessDecision, ChannelToolPosture,
+    DedupeCache, DedupeKey, DispatchOutcome, DmPolicy, GroupPolicy, InboundPolicy, TurnAdmission,
 };
 pub use error::ChannelError;
 pub use event::{

--- a/crates/wcore-channels/src/lib.rs
+++ b/crates/wcore-channels/src/lib.rs
@@ -21,6 +21,7 @@ pub mod event;
 pub mod manager;
 pub mod mock;
 pub mod outgoing;
+pub mod webhook;
 
 pub use config::{ChannelConfig, ChannelConfigLoader};
 pub use dispatch::{
@@ -35,6 +36,7 @@ pub use event::{
 pub use manager::{ChannelManager, TaggedEvent};
 pub use mock::MockChannel;
 pub use outgoing::OutgoingMessage;
+pub use webhook::{WebhookRequest, WebhookResponse};
 
 use async_trait::async_trait;
 
@@ -79,4 +81,27 @@ pub trait Channel: Send + Sync {
     /// config TOML. UI uses this to render a setup form; tests use
     /// it to validate config files.
     fn config_schema(&self) -> &str;
+
+    /// Handle an inbound webhook HTTP request routed to this channel by
+    /// the inbound webhook host.
+    ///
+    /// Default: **unsupported** — poll-based connectors (telegram,
+    /// matrix, signal, …) and any connector whose inbound path is not yet
+    /// signature-verified return `Rejected`, so the host never exposes an
+    /// unauthenticated parse to the network. Webhook connectors that
+    /// verify the platform signature (Slack, WhatsApp, Twilio SMS)
+    /// override this to verify → parse → enqueue (mirroring their existing
+    /// `ingest_*` methods) and return a [`WebhookResponse`].
+    ///
+    /// Takes `&self` (not `&mut self`): connectors enqueue through their
+    /// interior-mutable inbox, so the host can ingest concurrently with
+    /// the poll loop without an exclusive borrow.
+    async fn ingest_webhook(
+        &self,
+        _req: &WebhookRequest,
+    ) -> Result<WebhookResponse, ChannelError> {
+        Err(ChannelError::Rejected(
+            "channel does not accept inbound webhooks".to_string(),
+        ))
+    }
 }

--- a/crates/wcore-channels/src/lib.rs
+++ b/crates/wcore-channels/src/lib.rs
@@ -27,8 +27,9 @@ pub mod webhook;
 pub use chunk::chunk_message;
 pub use config::{ChannelConfig, ChannelConfigLoader};
 pub use dispatch::{
-    build_session_key, classify, decide_access, evaluate, AccessDecision, ChannelToolPosture,
-    DedupeCache, DedupeKey, DispatchOutcome, DmPolicy, GroupPolicy, InboundPolicy, TurnAdmission,
+    build_session_key, classify, decide_access, evaluate, AccessDecision, AckMode,
+    ChannelToolPosture, DedupeCache, DedupeKey, DispatchOutcome, DmPolicy, GroupPolicy,
+    InboundPolicy, TurnAdmission,
 };
 pub use error::ChannelError;
 pub use event::{
@@ -95,6 +96,33 @@ pub trait Channel: Send + Sync {
     /// limit.
     fn max_message_len(&self) -> Option<usize> {
         None
+    }
+
+    /// Send a transient "typing…" indicator to `conversation_id`.
+    ///
+    /// Default: no-op `Ok(())` — platforms without a typing API simply do
+    /// nothing. The inbound subscriber calls this periodically while a turn
+    /// is running (when the channel's ack mode enables typing) so a human
+    /// sees the bot is working. Must be cheap and best-effort; a failure is
+    /// logged and ignored, never fatal to the turn.
+    async fn send_typing(&self, _conversation_id: &str) -> Result<(), ChannelError> {
+        Ok(())
+    }
+
+    /// React to a message with a single unicode emoji — the ack/status
+    /// signal used by the subscriber's ack state machine (👀 received →
+    /// ✅ done / ❌ failed).
+    ///
+    /// Default: `Rejected` (the platform has no reaction API, or it isn't
+    /// implemented for this connector). The subscriber treats a reaction
+    /// failure as non-fatal.
+    async fn react(
+        &self,
+        _conversation_id: &str,
+        _message_id: &str,
+        _emoji: &str,
+    ) -> Result<(), ChannelError> {
+        Err(ChannelError::Rejected("reactions unsupported".to_string()))
     }
 
     /// Handle an inbound webhook HTTP request routed to this channel by

--- a/crates/wcore-channels/src/lib.rs
+++ b/crates/wcore-channels/src/lib.rs
@@ -23,7 +23,10 @@ pub mod outgoing;
 
 pub use config::{ChannelConfig, ChannelConfigLoader};
 pub use error::ChannelError;
-pub use event::{ChannelEvent, ConnectionState, IncomingMessage, MessageReceipt};
+pub use event::{
+    Attachment, ChannelEvent, ChatType, ConnectionState, IncomingMessage, MediaKind, MentionKind,
+    MessageReceipt,
+};
 pub use manager::{ChannelManager, TaggedEvent};
 pub use mock::MockChannel;
 pub use outgoing::OutgoingMessage;

--- a/crates/wcore-channels/src/lib.rs
+++ b/crates/wcore-channels/src/lib.rs
@@ -15,6 +15,7 @@
 
 pub mod auto_register;
 pub mod config;
+pub mod dispatch;
 pub mod error;
 pub mod event;
 pub mod manager;
@@ -22,6 +23,10 @@ pub mod mock;
 pub mod outgoing;
 
 pub use config::{ChannelConfig, ChannelConfigLoader};
+pub use dispatch::{
+    build_session_key, classify, decide_access, evaluate, AccessDecision, DedupeCache, DedupeKey,
+    DispatchOutcome, DmPolicy, GroupPolicy, InboundPolicy, TurnAdmission,
+};
 pub use error::ChannelError;
 pub use event::{
     Attachment, ChannelEvent, ChatType, ConnectionState, IncomingMessage, MediaKind, MentionKind,

--- a/crates/wcore-channels/src/lib.rs
+++ b/crates/wcore-channels/src/lib.rs
@@ -14,6 +14,7 @@
 //! came from.
 
 pub mod auto_register;
+pub mod chunk;
 pub mod config;
 pub mod dispatch;
 pub mod error;
@@ -23,6 +24,7 @@ pub mod mock;
 pub mod outgoing;
 pub mod webhook;
 
+pub use chunk::chunk_message;
 pub use config::{ChannelConfig, ChannelConfigLoader};
 pub use dispatch::{
     build_session_key, classify, decide_access, evaluate, AccessDecision, ChannelToolPosture,
@@ -81,6 +83,19 @@ pub trait Channel: Send + Sync {
     /// config TOML. UI uses this to render a setup form; tests use
     /// it to validate config files.
     fn config_schema(&self) -> &str;
+
+    /// Maximum length (in Unicode scalar values) of a single outbound
+    /// message this platform accepts, or `None` when effectively
+    /// unbounded / unknown. [`ChannelManager::send_to`] splits longer
+    /// bodies into in-order chunks via
+    /// [`chunk_message`](crate::chunk::chunk_message) before sending, so
+    /// an over-long agent reply is delivered in pieces instead of being
+    /// rejected and dropped by the platform. Each connector declares its
+    /// own cap here — the shared layer never hardcodes a per-platform
+    /// limit.
+    fn max_message_len(&self) -> Option<usize> {
+        None
+    }
 
     /// Handle an inbound webhook HTTP request routed to this channel by
     /// the inbound webhook host.

--- a/crates/wcore-channels/src/manager.rs
+++ b/crates/wcore-channels/src/manager.rs
@@ -230,6 +230,27 @@ impl ChannelManager {
         names.sort();
         names
     }
+
+    /// Route an inbound webhook request to channel `name`'s
+    /// [`Channel::ingest_webhook`](crate::Channel::ingest_webhook). The
+    /// connector verifies the platform signature, parses the body, and
+    /// enqueues any resulting event(s) for the next `poll_events()` (which
+    /// the inbound subscriber drains). The returned
+    /// [`WebhookResponse`](crate::webhook::WebhookResponse) is what the host
+    /// writes back to the platform. Unknown channel → `Config` error (the
+    /// host maps it to a 404). Mirrors [`Self::send_to`] for inbound.
+    pub async fn ingest_webhook(
+        &self,
+        name: &str,
+        req: &crate::webhook::WebhookRequest,
+    ) -> Result<crate::webhook::WebhookResponse, ChannelError> {
+        let slot = self
+            .channels
+            .get(name)
+            .ok_or_else(|| ChannelError::Config(format!("unknown channel: {name}")))?;
+        let guard = slot.lock().await;
+        guard.ingest_webhook(req).await
+    }
 }
 
 impl Default for ChannelManager {

--- a/crates/wcore-channels/src/manager.rs
+++ b/crates/wcore-channels/src/manager.rs
@@ -256,6 +256,40 @@ impl ChannelManager {
         receipt.ok_or_else(|| ChannelError::Other("chunked send produced no receipt".into()))
     }
 
+    /// Send a transient typing indicator to `conversation_id` on channel
+    /// `name`. Best-effort: unknown channel → `Config` error; platforms
+    /// without a typing API no-op via the trait default.
+    pub async fn send_typing_to(
+        &self,
+        name: &str,
+        conversation_id: &str,
+    ) -> Result<(), ChannelError> {
+        let slot = self
+            .channels
+            .get(name)
+            .ok_or_else(|| ChannelError::Config(format!("unknown channel: {name}")))?;
+        let guard = slot.lock().await;
+        guard.send_typing(conversation_id).await
+    }
+
+    /// React to `message_id` in `conversation_id` on channel `name` with a
+    /// unicode emoji (ack state machine). Unknown channel → `Config` error;
+    /// platforms without reactions → `Rejected` via the trait default.
+    pub async fn react_on(
+        &self,
+        name: &str,
+        conversation_id: &str,
+        message_id: &str,
+        emoji: &str,
+    ) -> Result<(), ChannelError> {
+        let slot = self
+            .channels
+            .get(name)
+            .ok_or_else(|| ChannelError::Config(format!("unknown channel: {name}")))?;
+        let guard = slot.lock().await;
+        guard.react(conversation_id, message_id, emoji).await
+    }
+
     /// List names of registered channels, sorted alphabetically.
     pub fn list_names(&self) -> Vec<String> {
         let mut names: Vec<String> = self.channels.keys().cloned().collect();

--- a/crates/wcore-channels/src/manager.rs
+++ b/crates/wcore-channels/src/manager.rs
@@ -19,11 +19,23 @@ use tokio::task::JoinHandle;
 
 use crate::Channel;
 use crate::error::ChannelError;
-use crate::event::{ChannelEvent, MessageReceipt};
+use crate::event::{ChannelEvent, ConnectionState, MessageReceipt};
 use crate::outgoing::OutgoingMessage;
 
 const DEFAULT_POLL_INTERVAL_MS: u64 = 250;
 const EVENT_CHANNEL_CAP: usize = 256;
+
+/// Consecutive non-`NotStarted` poll errors tolerated before the poll
+/// task treats the channel as disconnected and enters supervised
+/// reconnect. Below this, errors back off one tick and retry (the
+/// historical behavior) to absorb transient blips without churn.
+const RECONNECT_ERROR_THRESHOLD: u32 = 5;
+/// First reconnect-attempt backoff. Doubles each failed `start()` up to
+/// `RECONNECT_BACKOFF_CAP`.
+const RECONNECT_BACKOFF_BASE: Duration = Duration::from_secs(1);
+/// Upper bound on reconnect backoff so a permanently broken channel
+/// retries at a steady, low rate rather than escalating unbounded.
+const RECONNECT_BACKOFF_CAP: Duration = Duration::from_secs(30);
 
 /// Driver for a set of `Channel` instances. Build with `new`, register
 /// channels with `register`, then call `start_all` to spawn the poll
@@ -94,20 +106,78 @@ impl ChannelManager {
             let handle = tokio::spawn(async move {
                 let mut ticker = tokio::time::interval(interval);
                 ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+                // Consecutive non-`NotStarted` poll errors. Reset to 0 on
+                // any successful poll. Crossing `RECONNECT_ERROR_THRESHOLD`
+                // promotes the channel to supervised reconnect.
+                let mut consecutive_errors: u32 = 0;
                 loop {
                     ticker.tick().await;
                     let evs = {
                         let mut guard = task_slot.lock().await;
                         match guard.poll_events().await {
-                            Ok(v) => v,
+                            Ok(v) => {
+                                consecutive_errors = 0;
+                                v
+                            }
                             Err(ChannelError::NotStarted) => break,
                             Err(e) => {
+                                consecutive_errors += 1;
                                 tracing::warn!(
                                     target: "wcore_channels::manager",
                                     channel = %task_name,
                                     error = %e,
+                                    consecutive_errors,
                                     "poll_events errored; backing off one tick"
                                 );
+                                if consecutive_errors < RECONNECT_ERROR_THRESHOLD {
+                                    continue;
+                                }
+                                // Drop the guard before the reconnect loop so we
+                                // don't hold the slot lock across backoff sleeps
+                                // (send_to / stop_all must still acquire it).
+                                drop(guard);
+                                // Supervised reconnect: announce Reconnecting and
+                                // retry start() with exponential backoff until it
+                                // succeeds. The task is stopped via handle.abort()
+                                // (stop_all / register replace), so the sleeps
+                                // below double as the abort points.
+                                let _ = task_tx.send(TaggedEvent {
+                                    channel_name: task_name.clone(),
+                                    event: ChannelEvent::ConnectionStateChanged {
+                                        state: ConnectionState::Reconnecting,
+                                    },
+                                });
+                                let mut backoff = RECONNECT_BACKOFF_BASE;
+                                loop {
+                                    tokio::time::sleep(backoff).await;
+                                    let start_result = {
+                                        let mut guard = task_slot.lock().await;
+                                        guard.start().await
+                                    };
+                                    match start_result {
+                                        Ok(()) => {
+                                            tracing::info!(
+                                                target: "wcore_channels::manager",
+                                                channel = %task_name,
+                                                "channel reconnected; resuming polling"
+                                            );
+                                            consecutive_errors = 0;
+                                            break;
+                                        }
+                                        Err(re) => {
+                                            backoff = (backoff * 2).min(RECONNECT_BACKOFF_CAP);
+                                            tracing::warn!(
+                                                target: "wcore_channels::manager",
+                                                channel = %task_name,
+                                                error = %re,
+                                                next_backoff_ms = backoff.as_millis() as u64,
+                                                "reconnect start() failed; will retry"
+                                            );
+                                        }
+                                    }
+                                }
+                                // Reconnected — skip this tick's broadcast and
+                                // resume the normal polling cadence.
                                 continue;
                             }
                         }
@@ -171,8 +241,89 @@ impl Default for ChannelManager {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::event::IncomingMessage;
     use crate::mock::MockChannel;
+    use async_trait::async_trait;
     use std::time::Duration;
+
+    /// Test-only channel whose `poll_events` errors until the manager
+    /// re-`start()`s it (the reconnect primitive), after which it recovers
+    /// and delivers a single injected message. Models a channel whose
+    /// polling breaks until supervised reconnect heals it.
+    struct FlakyChannel {
+        name: String,
+        /// True once the channel has been started at least once.
+        started_once: bool,
+        /// True after a second `start()` (the manager's reconnect).
+        recovered: bool,
+        /// True once the recovery message has been delivered.
+        delivered: bool,
+    }
+
+    impl FlakyChannel {
+        fn new(name: impl Into<String>) -> Self {
+            Self {
+                name: name.into(),
+                started_once: false,
+                recovered: false,
+                delivered: false,
+            }
+        }
+    }
+
+    #[async_trait]
+    impl Channel for FlakyChannel {
+        fn name(&self) -> &str {
+            &self.name
+        }
+
+        fn platform(&self) -> &str {
+            "flaky"
+        }
+
+        async fn start(&mut self) -> Result<(), ChannelError> {
+            // First start() = initial connect. Any later start() is the
+            // manager's reconnect attempt, which heals the channel.
+            if self.started_once {
+                self.recovered = true;
+            }
+            self.started_once = true;
+            Ok(())
+        }
+
+        async fn stop(&mut self) -> Result<(), ChannelError> {
+            Ok(())
+        }
+
+        async fn poll_events(&mut self) -> Result<Vec<ChannelEvent>, ChannelError> {
+            if self.recovered {
+                if !self.delivered {
+                    self.delivered = true;
+                    return Ok(vec![ChannelEvent::MessageReceived {
+                        msg: IncomingMessage::new("flaky-1", "c1", "alice", "back online", 0),
+                    }]);
+                }
+                return Ok(Vec::new());
+            }
+            // Still in the failing window: error until reconnect heals us.
+            Err(ChannelError::Transport("simulated poll failure".into()))
+        }
+
+        async fn send_message(
+            &mut self,
+            msg: OutgoingMessage,
+        ) -> Result<MessageReceipt, ChannelError> {
+            Ok(MessageReceipt {
+                id: "flaky-out".into(),
+                conversation_id: msg.conversation_id,
+                ts_secs: 0,
+            })
+        }
+
+        fn config_schema(&self) -> &str {
+            r#"{"name": "string", "platform": "flaky"}"#
+        }
+    }
 
     #[tokio::test]
     async fn register_and_list() {
@@ -229,6 +380,50 @@ mod tests {
             .unwrap();
         assert!(!receipt.id.is_empty());
         let _ = rx; // suppress unused
+        mgr.stop_all().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn persistent_poll_failure_triggers_supervised_reconnect() {
+        // Fail enough polls to cross the threshold, then recover on the
+        // manager's reconnect start(). Assert a Reconnecting state is
+        // broadcast and the channel resumes delivering messages.
+        let mut mgr = ChannelManager::new().with_poll_interval(Duration::from_millis(5));
+        let mut rx = mgr.subscribe();
+        mgr.register(Box::new(FlakyChannel::new("flaky"))).await;
+        mgr.start_all().await.unwrap();
+
+        // Reconnect backoff base is 1s; allow margin for ticks + delivery.
+        let deadline = std::time::Instant::now() + Duration::from_secs(4);
+        let mut saw_reconnecting = false;
+        let mut saw_recovery_msg = false;
+        while std::time::Instant::now() < deadline && !(saw_reconnecting && saw_recovery_msg) {
+            match tokio::time::timeout(Duration::from_millis(200), rx.recv()).await {
+                Ok(Ok(tagged)) => {
+                    assert_eq!(tagged.channel_name, "flaky");
+                    match tagged.event {
+                        ChannelEvent::ConnectionStateChanged {
+                            state: ConnectionState::Reconnecting,
+                        } => saw_reconnecting = true,
+                        ChannelEvent::MessageReceived { ref msg }
+                            if msg.text == "back online" =>
+                        {
+                            saw_recovery_msg = true;
+                        }
+                        _ => {}
+                    }
+                }
+                _ => continue,
+            }
+        }
+        assert!(
+            saw_reconnecting,
+            "expected a Reconnecting ConnectionStateChanged broadcast"
+        );
+        assert!(
+            saw_recovery_msg,
+            "expected the channel to resume delivering messages after reconnect"
+        );
         mgr.stop_all().await.unwrap();
     }
 

--- a/crates/wcore-channels/src/manager.rs
+++ b/crates/wcore-channels/src/manager.rs
@@ -221,7 +221,39 @@ impl ChannelManager {
             .get(name)
             .ok_or_else(|| ChannelError::Config(format!("unknown channel: {name}")))?;
         let mut guard = slot.lock().await;
-        guard.send_message(msg).await
+
+        // Split over-long bodies to the platform cap so a long reply is
+        // delivered in pieces rather than rejected+dropped (HIGH-6). When the
+        // connector declares no cap (or the body already fits) this is a
+        // single send, byte-identical to the pre-chunking path.
+        let chunks = match guard.max_message_len() {
+            Some(max) if max > 0 => crate::chunk::chunk_message(&msg.text, max),
+            _ => vec![msg.text.clone()],
+        };
+        if chunks.len() <= 1 {
+            return guard.send_message(msg).await;
+        }
+
+        // Multi-chunk: each piece keeps the conversation + reply target;
+        // attachments ride the LAST chunk (so the text precedes the media).
+        // Returns the final chunk's receipt.
+        let last = chunks.len() - 1;
+        let mut receipt: Option<MessageReceipt> = None;
+        for (i, chunk) in chunks.into_iter().enumerate() {
+            let part = OutgoingMessage {
+                conversation_id: msg.conversation_id.clone(),
+                text: chunk,
+                reply_to: msg.reply_to.clone(),
+                attachments: if i == last {
+                    msg.attachments.clone()
+                } else {
+                    Vec::new()
+                },
+            };
+            receipt = Some(guard.send_message(part).await?);
+        }
+        // INVARIANT: chunks.len() > 1 here, so the loop ran and set `receipt`.
+        receipt.ok_or_else(|| ChannelError::Other("chunked send produced no receipt".into()))
     }
 
     /// List names of registered channels, sorted alphabetically.
@@ -344,6 +376,132 @@ mod tests {
         fn config_schema(&self) -> &str {
             r#"{"name": "string", "platform": "flaky"}"#
         }
+    }
+
+    /// Test-only channel with a small `max_message_len` that records every
+    /// `send_message` into a shared log, so a test can assert how `send_to`
+    /// chunked an over-long body.
+    struct CappedChannel {
+        name: String,
+        cap: usize,
+        sent: std::sync::Arc<tokio::sync::Mutex<Vec<OutgoingMessage>>>,
+    }
+
+    impl CappedChannel {
+        fn new(
+            name: &str,
+            cap: usize,
+        ) -> (Self, std::sync::Arc<tokio::sync::Mutex<Vec<OutgoingMessage>>>) {
+            let sent = std::sync::Arc::new(tokio::sync::Mutex::new(Vec::new()));
+            (
+                Self {
+                    name: name.into(),
+                    cap,
+                    sent: std::sync::Arc::clone(&sent),
+                },
+                sent,
+            )
+        }
+    }
+
+    #[async_trait]
+    impl Channel for CappedChannel {
+        fn name(&self) -> &str {
+            &self.name
+        }
+        fn platform(&self) -> &str {
+            "capped"
+        }
+        async fn start(&mut self) -> Result<(), ChannelError> {
+            Ok(())
+        }
+        async fn stop(&mut self) -> Result<(), ChannelError> {
+            Ok(())
+        }
+        async fn poll_events(&mut self) -> Result<Vec<ChannelEvent>, ChannelError> {
+            Ok(Vec::new())
+        }
+        async fn send_message(
+            &mut self,
+            msg: OutgoingMessage,
+        ) -> Result<MessageReceipt, ChannelError> {
+            let idx = {
+                let mut log = self.sent.lock().await;
+                log.push(msg.clone());
+                log.len() - 1
+            };
+            Ok(MessageReceipt {
+                id: format!("capped-out-{idx}"),
+                conversation_id: msg.conversation_id,
+                ts_secs: 0,
+            })
+        }
+        fn config_schema(&self) -> &str {
+            r#"{"name":"string","platform":"capped"}"#
+        }
+        fn max_message_len(&self) -> Option<usize> {
+            Some(self.cap)
+        }
+    }
+
+    #[tokio::test]
+    async fn send_to_chunks_overlong_body_to_the_cap() {
+        let (ch, sent) = CappedChannel::new("capped", 10);
+        let mut mgr = ChannelManager::new();
+        mgr.register(Box::new(ch)).await;
+
+        // 25 chars, no break points → hard-split into 10/10/5.
+        let body = "abcdefghijklmnopqrstuvwxy".to_string();
+        let receipt = mgr
+            .send_to(
+                "capped",
+                OutgoingMessage {
+                    conversation_id: "c1".into(),
+                    text: body.clone(),
+                    reply_to: Some("t1".into()),
+                    attachments: vec!["file://a".into()],
+                },
+            )
+            .await
+            .expect("send_to");
+
+        let log = sent.lock().await;
+        assert_eq!(log.len(), 3, "25 chars at cap 10 → 3 sends");
+        assert!(
+            log.iter().all(|m| m.text.chars().count() <= 10),
+            "every chunk within the cap"
+        );
+        assert_eq!(
+            log.iter().map(|m| m.text.clone()).collect::<String>(),
+            body,
+            "lossless reassembly across chunks"
+        );
+        // reply_to carried on every chunk; attachments only on the last.
+        assert!(log.iter().all(|m| m.reply_to.as_deref() == Some("t1")));
+        assert!(log[0].attachments.is_empty());
+        assert!(log[1].attachments.is_empty());
+        assert_eq!(log[2].attachments, vec!["file://a".to_string()]);
+        // Receipt is the final chunk's.
+        assert_eq!(receipt.id, "capped-out-2");
+    }
+
+    #[tokio::test]
+    async fn send_to_does_not_chunk_when_within_cap() {
+        let (ch, sent) = CappedChannel::new("capped", 100);
+        let mut mgr = ChannelManager::new();
+        mgr.register(Box::new(ch)).await;
+        mgr.send_to(
+            "capped",
+            OutgoingMessage {
+                conversation_id: "c1".into(),
+                text: "short".into(),
+                reply_to: None,
+                attachments: Vec::new(),
+            },
+        )
+        .await
+        .expect("send_to");
+        assert_eq!(sent.lock().await.len(), 1, "a fitting body is one send");
     }
 
     #[tokio::test]

--- a/crates/wcore-channels/src/mock.rs
+++ b/crates/wcore-channels/src/mock.rs
@@ -47,14 +47,13 @@ impl MockChannel {
         text: impl Into<String>,
     ) {
         self.inject(ChannelEvent::MessageReceived {
-            msg: IncomingMessage {
-                id: format!("mock-in-{}", self.next_id),
-                conversation_id: conversation_id.into(),
-                author: author.into(),
-                text: text.into(),
-                ts_secs: 0,
-                attachments: Vec::new(),
-            },
+            msg: IncomingMessage::new(
+                format!("mock-in-{}", self.next_id),
+                conversation_id,
+                author,
+                text,
+                0,
+            ),
         });
         self.next_id += 1;
     }

--- a/crates/wcore-channels/src/webhook.rs
+++ b/crates/wcore-channels/src/webhook.rs
@@ -1,0 +1,133 @@
+//! Inbound webhook request/response types — the platform-neutral seam
+//! between the inbound webhook HTTP host (in `wcore-agent`) and each
+//! webhook-based connector's signature-verifying ingest path.
+//!
+//! Webhook connectors (Slack, WhatsApp, Twilio SMS) receive inbound
+//! traffic as HTTP POSTs from the platform, not by polling. The host
+//! owns the listener; it normalizes each request into a
+//! [`WebhookRequest`] and routes it to the destination channel's
+//! [`Channel::ingest_webhook`](crate::Channel::ingest_webhook), which
+//! verifies the platform signature, parses the body, and enqueues the
+//! resulting event(s) for the next `poll_events()`. The connector returns
+//! a [`WebhookResponse`] the host writes back (e.g. Slack's
+//! `url_verification` challenge, or a Meta `hub.challenge` echo).
+//!
+//! This module is dependency-free (no `http`/`axum` types) so the pure
+//! `wcore-channels` crate stays decoupled from whatever server the host
+//! uses.
+
+/// One inbound webhook HTTP request, normalized for a connector to verify
+/// and parse. The host fills this from the live request.
+#[derive(Debug, Clone, Default)]
+pub struct WebhookRequest {
+    /// HTTP method, uppercased (`"POST"`, `"GET"`). Most platforms POST;
+    /// Meta (WhatsApp) does a one-time `GET` verification handshake.
+    pub method: String,
+    /// The full URL the platform called — `scheme://host/path?query`.
+    /// Signature schemes that sign the URL (Twilio) require this to match
+    /// byte-for-byte what the platform signed, so the host reconstructs it
+    /// from a configured public base URL when set (behind a proxy the local
+    /// `Host` differs from the public URL).
+    pub full_url: String,
+    /// Request headers with **lowercased** names (HTTP header names are
+    /// case-insensitive; lowercasing once here lets [`Self::header`] do a
+    /// simple compare).
+    pub headers: Vec<(String, String)>,
+    /// Parsed query parameters (for Meta's `hub.*` GET verification).
+    pub query: Vec<(String, String)>,
+    /// Raw request body as received (UTF-8). Signature verification MUST
+    /// run over these exact bytes — never a re-serialized form.
+    pub body: String,
+}
+
+impl WebhookRequest {
+    /// Case-insensitive header lookup. `name` is compared lowercased
+    /// against the (already-lowercased) stored header names.
+    pub fn header(&self, name: &str) -> Option<&str> {
+        let want = name.to_ascii_lowercase();
+        self.headers
+            .iter()
+            .find(|(k, _)| *k == want)
+            .map(|(_, v)| v.as_str())
+    }
+
+    /// First query value for `key`, if present.
+    pub fn query_get(&self, key: &str) -> Option<&str> {
+        self.query
+            .iter()
+            .find(|(k, _)| k == key)
+            .map(|(_, v)| v.as_str())
+    }
+}
+
+/// What the host should write back to the platform after a connector
+/// handled (or rejected) a webhook.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WebhookResponse {
+    /// HTTP status to return.
+    pub status: u16,
+    /// Optional response body. Slack's `url_verification` returns the
+    /// `challenge` string; Meta's GET verify echoes `hub.challenge`. Most
+    /// runtime deliveries return `None` (empty 200).
+    pub body: Option<String>,
+}
+
+impl WebhookResponse {
+    /// Empty `200 OK` — the normal "received, enqueued" reply.
+    pub fn ok() -> Self {
+        Self {
+            status: 200,
+            body: None,
+        }
+    }
+
+    /// `200 OK` echoing a verification challenge (Slack `url_verification`,
+    /// Meta `hub.challenge`).
+    pub fn challenge(body: impl Into<String>) -> Self {
+        Self {
+            status: 200,
+            body: Some(body.into()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn header_lookup_is_case_insensitive() {
+        let req = WebhookRequest {
+            headers: vec![("x-slack-signature".into(), "v0=abc".into())],
+            ..Default::default()
+        };
+        assert_eq!(req.header("X-Slack-Signature"), Some("v0=abc"));
+        assert_eq!(req.header("x-slack-signature"), Some("v0=abc"));
+        assert_eq!(req.header("missing"), None);
+    }
+
+    #[test]
+    fn query_lookup() {
+        let req = WebhookRequest {
+            query: vec![
+                ("hub.mode".into(), "subscribe".into()),
+                ("hub.challenge".into(), "1234".into()),
+            ],
+            ..Default::default()
+        };
+        assert_eq!(req.query_get("hub.challenge"), Some("1234"));
+        assert_eq!(req.query_get("nope"), None);
+    }
+
+    #[test]
+    fn response_constructors() {
+        assert_eq!(WebhookResponse::ok().body, None);
+        assert_eq!(
+            WebhookResponse::challenge("x"),
+            WebhookResponse {
+                status: 200,
+                body: Some("x".into())
+            }
+        );
+    }
+}

--- a/crates/wcore-cli/src/main.rs
+++ b/crates/wcore-cli/src/main.rs
@@ -1241,9 +1241,14 @@ async fn run() -> anyhow::Result<ExitCode> {
 
     let provider_name = config.provider_label.clone();
 
-    // Bootstrap engine with full feature initialization
+    // Bootstrap engine with full feature initialization. Phase 1B-2 — this
+    // build backs both the long-running interactive line-REPL and the
+    // headless one-shot `-p` path; opt into inbound channel dispatch so the
+    // primary interactive session listens to configured channels (the
+    // short-lived one-shot simply aborts the subscriber on exit).
     let mut bootstrap = AgentBootstrap::new(config, &cwd, output.clone())
-        .plugin_provider_router(make_plugin_provider_router());
+        .plugin_provider_router(make_plugin_provider_router())
+        .enable_inbound_dispatch(true);
 
     if let Some(resume_id) = &resume {
         let cfg = bootstrap.config();
@@ -1532,8 +1537,12 @@ async fn run_tui_mode(
         approval_manager.set_mode(wcore_protocol::commands::SessionMode::Force);
     }
 
+    // Phase 1B-2 — the interactive TUI is a primary long-running session, so
+    // opt into inbound channel dispatch (the InboundSubscriber turns admitted
+    // channel messages into agent turns for the lifetime of this session).
     let mut bootstrap = AgentBootstrap::new(config, cwd, output.clone())
-        .plugin_provider_router(make_plugin_provider_router());
+        .plugin_provider_router(make_plugin_provider_router())
+        .enable_inbound_dispatch(true);
 
     if let Some(resume_id) = &resume {
         let cfg = bootstrap.config();
@@ -2217,9 +2226,12 @@ async fn run_json_stream_mode(
 
     let provider_name = config.provider_label.clone();
 
-    // Bootstrap engine with full feature initialization
+    // Bootstrap engine with full feature initialization. Phase 1B-2 —
+    // json-stream is a primary long-running host session (e.g. AionUI), so
+    // opt into inbound channel dispatch.
     let mut bootstrap = AgentBootstrap::new(config, cwd, output.clone())
-        .plugin_provider_router(make_plugin_provider_router());
+        .plugin_provider_router(make_plugin_provider_router())
+        .enable_inbound_dispatch(true);
 
     if let Some(resume_id) = &resume {
         let cfg = bootstrap.config();

--- a/crates/wcore-config/src/config.rs
+++ b/crates/wcore-config/src/config.rs
@@ -166,6 +166,11 @@ pub struct ConfigFile {
     #[serde(default)]
     pub session: SessionConfig,
 
+    /// `[inbound_webhook]` — HTTP host for inbound platform webhooks
+    /// (Slack / WhatsApp / Twilio SMS). Off by default.
+    #[serde(default)]
+    pub inbound_webhook: InboundWebhookConfig,
+
     #[serde(default)]
     pub compact: CompactConfig,
 
@@ -638,6 +643,40 @@ impl Default for SessionConfig {
     }
 }
 
+/// Inbound webhook host (`[inbound_webhook]`).
+///
+/// When `enabled`, the agent stands up an HTTP listener that routes
+/// `POST`/`GET /webhooks/<channel>` requests to the matching channel's
+/// signature-verifying [`Channel::ingest_webhook`] path. Off by default —
+/// no listener is bound unless the operator opts in.
+///
+/// `public_base_url` must be set to the exact public URL (scheme + host)
+/// the platform calls when the host sits behind a reverse proxy: Twilio
+/// signs the full request URL, so a mismatch fails signature verification.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct InboundWebhookConfig {
+    /// Whether to bind the inbound webhook listener. Default `false`.
+    pub enabled: bool,
+    /// Socket address to bind. Default `"127.0.0.1:8787"` (loopback only;
+    /// front it with a TLS-terminating proxy for public exposure).
+    pub bind: String,
+    /// Public base URL the platform calls (scheme + host, no trailing
+    /// path). Required for Twilio signature verification behind a proxy;
+    /// `None` reconstructs the URL from the request `Host` header.
+    pub public_base_url: Option<String>,
+}
+
+impl Default for InboundWebhookConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            bind: "127.0.0.1:8787".to_string(),
+            public_base_url: None,
+        }
+    }
+}
+
 // --- Default value functions ---
 
 fn default_provider() -> String {
@@ -714,6 +753,10 @@ pub struct Config {
     /// registration is a no-op.
     pub advertised_capabilities: crate::tools::AdvertisedCapabilitiesConfig,
     pub session: SessionConfig,
+    /// Resolved copy of the on-disk `[inbound_webhook]` block. Bootstrap
+    /// consults `enabled` to decide whether to spawn the inbound webhook
+    /// host (see `wcore_agent::inbound_webhook`).
+    pub inbound_webhook: InboundWebhookConfig,
     pub compact: CompactConfig,
     pub plan: PlanConfig,
     pub file_cache: FileCacheConfig,
@@ -794,6 +837,7 @@ impl Default for Config {
             builtin_tools: crate::tools::BuiltinToolsConfig::default(),
             advertised_capabilities: crate::tools::AdvertisedCapabilitiesConfig::default(),
             session: SessionConfig::default(),
+            inbound_webhook: InboundWebhookConfig::default(),
             compact: crate::compact::CompactConfig::default(),
             plan: crate::plan::PlanConfig::default(),
             file_cache: crate::file_cache::FileCacheConfig::default(),
@@ -1267,6 +1311,7 @@ impl Config {
             builtin_tools: crate::tools::BuiltinToolsConfig::default(),
             advertised_capabilities: crate::tools::AdvertisedCapabilitiesConfig::default(),
             session: merged.session,
+            inbound_webhook: merged.inbound_webhook,
             compact: merged.compact,
             plan: merged.plan,
             file_cache: merged.file_cache,
@@ -2339,6 +2384,15 @@ fn merge_config_files(global: ConfigFile, project: ConfigFile) -> ConfigFile {
     // bootstrap skips tracker installation.
     let session_cap = project.session_cap.or(global.session_cap);
 
+    // Inbound webhook host — a present project block (anything differing from
+    // the off-by-default) wins outright; otherwise inherit global. Mirrors the
+    // presence-over-default strategy used for memory/browser above.
+    let inbound_webhook = if project.inbound_webhook != InboundWebhookConfig::default() {
+        project.inbound_webhook
+    } else {
+        global.inbound_webhook
+    };
+
     // FleetDispatcher-class fix (audit 2026-05-24 §3) — browser section:
     // project overrides global if any policy field differs from
     // `BrowserPolicyConfig::default()`. Mirrors the memory/budget strategy
@@ -2360,6 +2414,7 @@ fn merge_config_files(global: ConfigFile, project: ConfigFile) -> ConfigFile {
         profiles,
         tools,
         session,
+        inbound_webhook,
         compact,
         plan,
         file_cache,

--- a/crates/wcore-tools/src/registry.rs
+++ b/crates/wcore-tools/src/registry.rs
@@ -23,6 +23,16 @@ pub struct ToolRegistry {
     /// so the registry can be shared across async call sites without
     /// requiring `&mut self` at dispatch time.
     breakers: Arc<RwLock<HashMap<String, CircuitBreaker>>>,
+    /// Optional filesystem the orchestration dispatcher routes every
+    /// tool's `ToolContext` through. `None` (the default) means the
+    /// dispatcher uses an unconfined `RealFs` — the local-CLI behaviour.
+    /// A channel-originated engine in `Workspace` posture sets this to a
+    /// `SandboxedFs` rooted at its workspace so `Read`/`Grep`/`Glob`
+    /// (which honour `ctx.vfs`) cannot escape the jail. Carried on the
+    /// registry — which is already threaded into every orchestration
+    /// `execute_*` call — to avoid plumbing a new parameter through the
+    /// whole dispatch stack.
+    tool_vfs: Option<Arc<dyn crate::vfs::VirtualFs>>,
 }
 
 impl Default for ToolRegistry {
@@ -35,7 +45,45 @@ impl ToolRegistry {
         Self {
             tools: Vec::new(),
             breakers: Arc::new(RwLock::new(HashMap::new())),
+            tool_vfs: None,
         }
+    }
+
+    /// Set the filesystem every dispatched tool's `ToolContext` is built
+    /// with. See the [`tool_vfs`](Self::tool_vfs) field. Used by the
+    /// channel `Workspace` posture to install a `SandboxedFs` jail.
+    pub fn set_tool_vfs(&mut self, vfs: Arc<dyn crate::vfs::VirtualFs>) {
+        self.tool_vfs = Some(vfs);
+    }
+
+    /// The filesystem the dispatcher should build tool contexts with, if
+    /// one was installed. `None` means use the default `RealFs`.
+    pub fn tool_vfs(&self) -> Option<Arc<dyn crate::vfs::VirtualFs>> {
+        self.tool_vfs.clone()
+    }
+
+    /// Drop every registered tool for which `keep` returns `false`.
+    ///
+    /// Applied once, AFTER the full tool set is registered, to enforce a
+    /// reduced toolset on a restricted engine (e.g. a channel-originated
+    /// engine that must not expose host filesystem/shell tools to a remote
+    /// sender). Filtering at the registry — rather than only omitting tools
+    /// from the LLM schema — means a dropped tool is also un-dispatchable:
+    /// `get()` returns `None`, so even a hallucinated call cannot reach it.
+    /// The matching circuit-breaker entries are pruned too.
+    pub fn retain<F>(&mut self, keep: F)
+    where
+        F: Fn(&dyn Tool) -> bool,
+    {
+        let mut kept_names: Vec<String> = Vec::with_capacity(self.tools.len());
+        self.tools.retain(|t| {
+            let keep_it = keep(t.as_ref());
+            if keep_it {
+                kept_names.push(t.name().to_string());
+            }
+            keep_it
+        });
+        self.breakers.write().retain(|name, _| kept_names.contains(name));
     }
 
     pub fn register(&mut self, tool: Box<dyn Tool>) {
@@ -374,6 +422,39 @@ mod tests {
         for def in &defs {
             assert_eq!(def.input_schema, expected_schema);
         }
+    }
+
+    // --- retain / tool_vfs tests ---
+
+    #[test]
+    fn retain_drops_unmatched_tools_and_prunes_breakers() {
+        let mut registry = ToolRegistry::new();
+        registry.register(make_tool_with_category("Read", "fs read", ToolCategory::Info));
+        registry.register(make_tool_with_category("Bash", "shell", ToolCategory::Exec));
+        registry.register(make_tool_with_category("web", "net", ToolCategory::Info));
+
+        // Keep only "web".
+        registry.retain(|t| t.name() == "web");
+
+        let mut names = registry.tool_names();
+        names.sort();
+        assert_eq!(names, vec!["web"], "only the kept tool survives");
+        // Dropped tools are un-dispatchable, not merely hidden from the schema.
+        assert!(registry.get("Read").is_none());
+        assert!(registry.get("Bash").is_none());
+        // Breaker entries for dropped tools are pruned; the survivor keeps one.
+        assert!(!registry.breaker_is_open("web"), "survivor breaker intact");
+        assert!(registry.breakers.read().contains_key("web"));
+        assert!(!registry.breakers.read().contains_key("Read"));
+        assert!(!registry.breakers.read().contains_key("Bash"));
+    }
+
+    #[test]
+    fn tool_vfs_defaults_none_and_round_trips() {
+        let mut registry = ToolRegistry::new();
+        assert!(registry.tool_vfs().is_none(), "default is unconfined RealFs");
+        registry.set_tool_vfs(Arc::new(crate::vfs::RealFs));
+        assert!(registry.tool_vfs().is_some(), "installed vfs is observable");
     }
 
     // --- to_tool_defs_filtered tests ---

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -1,0 +1,103 @@
+# Channels — inbound security model
+
+wayland-core can receive messages from chat platforms (Telegram, Discord,
+Slack, Signal, …) and answer them with an agent turn. Because a channel
+sender is **remote** — and, depending on your access policy, possibly
+untrusted — inbound traffic passes through two independent security gates
+before and around the agent turn:
+
+1. **Access policy** — *who* may drive the agent (fail-closed allowlists).
+2. **Tool posture** — *what the agent may touch* on the host (no filesystem
+   or shell by default).
+
+Both are configured per channel in that channel's config file under
+`~/.wayland/channels/<name>.toml`, in the `[inbound]` table.
+
+> If `[inbound]` is absent, the channel is **fail-closed**: every inbound
+> message is denied. Inbound dispatch does nothing until you opt in.
+
+---
+
+## Access policy — who may drive the agent
+
+```toml
+# ~/.wayland/channels/tg.toml
+platform = "telegram"
+
+[inbound]
+dm = "allowlist"                 # open | allowlist | pairing | disabled
+dm_allowlist = ["123456789"]     # stable platform sender ids; "*" = anyone
+group = "disabled"               # open | allowlist | disabled
+require_mention = true           # in groups, only act when addressed
+```
+
+Defaults (used for any unset field) are the fail-closed posture:
+`dm = "allowlist"` with an **empty** `dm_allowlist` (so no one is
+permitted), `group = "disabled"`, `require_mention = true`.
+
+**Lock `dm_allowlist` to specific sender ids.** `dm_allowlist = ["*"]`
+opens DMs to *anyone who can find the bot* — only use it for a throwaway
+test bot, never a deployment. To allow a specific person, add their stable
+platform `sender_id` (e.g. their Telegram numeric user id):
+
+```toml
+dm = "allowlist"
+dm_allowlist = ["123456789"]     # only this user may DM the bot
+```
+
+Allowlist semantics: a list permits an id **iff** it contains the literal
+`"*"` (wildcard) **or** the exact id. An empty list permits nothing. Group
+acceptance under `group = "allowlist"` requires BOTH the group
+(`group_allowlist`) AND the sender (`sender_allowlist`) to be listed.
+
+---
+
+## Tool posture — what the agent may touch
+
+A channel turn runs a real agent engine on your host. Without scoping, the
+built-in `Read`/`Grep`/`Glob` tools (which are auto-approved) would let a
+remote sender read host secrets and have the reply ship them back. The
+`tools` posture controls which tools a channel-originated engine is built
+with:
+
+```toml
+[inbound]
+tools = "conversational"         # conversational (default) | workspace | full
+tool_workspace_root = "/srv/agent-workspace"   # only used by "workspace"
+```
+
+| Posture | Filesystem / shell | Use when |
+|---|---|---|
+| **`conversational`** (default) | **None.** Only conversational/network tools (and operator-wired MCP servers) are exposed. | A chat bot that answers questions, calls APIs, and uses your MCP tools — but must never touch the host filesystem. |
+| **`workspace`** | `Read`/`Write`/`Edit`/`Grep`/`Glob` are available but **jailed** to `tool_workspace_root` (a remote sender cannot read or write outside it). Shell/exec tools (`Bash`, `Git`, `kubectl`, …) stay **unavailable** — they bypass the jail. | A confined "do real work in this directory" agent reachable over chat. |
+| **`full`** | **Everything**, host-wide — identical to a local CLI session. | Trusted, locked-down deployments only. Dangerous for any publicly-reachable channel. |
+
+Notes:
+
+- The posture is enforced at the tool registry, so a dropped tool is
+  **un-dispatchable** — not merely hidden from the model. Even a
+  hallucinated call cannot reach it.
+- `tool_workspace_root` defaults to the agent's working directory when
+  unset under `workspace`.
+- The posture applies **only** to channel-originated engines. Your local
+  CLI / TUI / `--json-stream` sessions always keep the full toolset.
+- **MCP caveat:** operator-wired MCP servers are kept under
+  `conversational` and `workspace` (they are deliberate, named
+  extensions). If an MCP server itself exposes host filesystem access,
+  threat-model that channel as `full`-equivalent.
+
+---
+
+## Recommended deployment baseline
+
+```toml
+[inbound]
+dm = "allowlist"
+dm_allowlist = ["<your-platform-user-id>"]
+group = "disabled"
+require_mention = true
+tools = "conversational"
+```
+
+This admits only you, in DMs, with no host filesystem or shell exposure.
+Widen deliberately from there.

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -88,6 +88,59 @@ Notes:
 
 ---
 
+## Acknowledgements — reactions & typing
+
+So a sender knows the bot heard them, set the per-channel `ack` mode:
+
+```toml
+[inbound]
+ack = "both"   # off (default) | reactions | typing | both
+```
+
+- `reactions` — the bot reacts 👀 when it receives your message, then ✅ on
+  success or ❌ on failure.
+- `typing` — the bot shows a "typing…" indicator, refreshed every 5s while
+  it works.
+- `both` — reactions + typing.
+
+Best-effort: a connector without the platform API simply does nothing
+(Telegram implements both today; other connectors fall back to no-op until
+implemented). Ack failures never affect the reply itself.
+
+## Inbound webhook host (Slack / WhatsApp / Twilio SMS)
+
+Slack, WhatsApp, and Twilio SMS receive inbound messages as HTTP webhooks
+rather than by polling. Enable the receiver:
+
+```toml
+# main config (not the per-channel file)
+[inbound_webhook]
+enabled = true
+bind = "127.0.0.1:8787"
+# REQUIRED for Twilio signature verification (it signs the public URL);
+# set to the exact public https URL the platform calls:
+public_base_url = "https://bot.example.com"
+```
+
+Point each platform's webhook at `https://bot.example.com/webhooks/<channel-name>`
+(the `<channel-name>` is the config file stem). Each connector verifies its
+platform signature before accepting a message. (MS Teams inbound is parsed
+but **not** exposed over the host yet — its Bot Framework JWT validation is
+a pending follow-up.)
+
+## Not yet built (channel parity follow-ups)
+
+- Message **edit / delete** surfaces on the `Channel` trait.
+- **Multi-agent conversation-binding**: each conversation already gets its
+  own isolated session/engine; binding *distinct agent configs* per
+  conversation/peer is not built.
+- A **setup doctor / token-probe** CLI to validate channel config and
+  credentials interactively.
+- Outbound **idempotency nonces** (the inbound dedup already prevents
+  double-processing of platform replays).
+- MS Teams inbound webhook **JWT/JWKS** validation (parse exists; host
+  exposure gated until then).
+
 ## Recommended deployment baseline
 
 ```toml


### PR DESCRIPTION
Completes the channel two-way story: connectors were outbound-only (inbound polled, broadcast, then dropped — you couldn't hold a conversation over any channel). Phases 0–2 (prior) built the inbound kernel; **this branch adds the production-gate hardening, phases 3–7, and a full cross-audit.**

## Production gate
- **Channel tool posture** (`[inbound].tools`): `conversational` (default — no host fs/shell) / `workspace` (Read/Write/Edit jailed to a root via the audited `SandboxedFs`) / `full`. Enforced at the `ToolRegistry` so dropped tools are un-dispatchable. Closes remote-sender host-secret exfiltration; only applies to channel-originated engines (local CLI unchanged).

## Phases 3–7
- **P3** — matrix `/sync` inbound + msteams Activity parse + an **axum inbound webhook host** un-muting slack/whatsapp/sms (their signature-verifying `ingest_*` methods had no receiver). Off by default; msteams stays gated pending Bot Framework JWT validation.
- **P4** — outbound chunking + per-platform caps (discord 2000 / telegram·whatsapp 4096 / slack 39k / msteams 28k / sms 1600). HIGH-6.
- **P5** — telegram media both directions (getFile resolve + sendDocument) + agent attachment surfacing.
- **P6** — email threading/MIME-walk/attachments; signal group-send + partial-failure; imessage real GUID receipts.
- **P7** — ack reactions (👀/✅/❌) + typing keepalive state machine (telegram impl; trait defaults elsewhere).

## Cross-audit (3 adversarial reviewers over the 5.6k-line diff)
7 findings, all fixed: posture jail escape (Grep/Glob shell out → removed from workspace), typing-task leak on cancellation (abort-on-drop), matrix stop-detach + empty-next_batch replay, signal `+`-group misroute, email MIME-recursion DoS, imessage GUID missing recipient filter.

## Gate
Box gate green on Linux: `clippy --workspace --all-targets` clean, `nextest` **8145 passed**. **imessage is `cfg(macos)`** — compiled only by the macOS CI lane here, not the Linux build box.

Docs: `docs/channels.md` (access policy, tool posture, webhook host, ack modes, parity follow-ups). Parity audit (vs Hermes/OpenClaw) in `.planning/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)