### PR TITLE
msteams: Bot Framework JWT validation (un-mutes the last inbound channel)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -449,7 +449,7 @@ dependencies = [
  "hmac 0.13.0",
  "http 0.2.12",
  "http 1.4.1",
- "p256",
+ "p256 0.11.1",
  "percent-encoding",
  "ring",
  "sha2 0.11.0",
@@ -733,6 +733,12 @@ name = "base16ct"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
+
+[[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
@@ -1974,8 +1980,10 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
+ "generic-array",
  "rand_core 0.6.4",
  "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -2196,6 +2204,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid 0.9.6",
+ "pem-rfc7468",
  "zeroize",
 ]
 
@@ -2280,6 +2289,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
+ "const-oid 0.9.6",
  "crypto-common 0.1.7",
  "subtle",
 ]
@@ -2403,9 +2413,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
 dependencies = [
  "der 0.6.1",
- "elliptic-curve",
- "rfc6979",
+ "elliptic-curve 0.12.3",
+ "rfc6979 0.3.1",
  "signature 1.6.4",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der 0.7.10",
+ "digest 0.10.7",
+ "elliptic-curve 0.13.8",
+ "rfc6979 0.4.0",
+ "signature 2.2.0",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -2445,16 +2469,37 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
 dependencies = [
- "base16ct",
+ "base16ct 0.1.1",
  "crypto-bigint 0.4.9",
  "der 0.6.1",
  "digest 0.10.7",
- "ff",
+ "ff 0.12.1",
  "generic-array",
- "group",
+ "group 0.12.1",
  "pkcs8 0.9.0",
  "rand_core 0.6.4",
- "sec1",
+ "sec1 0.3.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct 0.2.0",
+ "crypto-bigint 0.5.5",
+ "digest 0.10.7",
+ "ff 0.13.1",
+ "generic-array",
+ "group 0.13.0",
+ "hkdf",
+ "pem-rfc7468",
+ "pkcs8 0.10.2",
+ "rand_core 0.6.4",
+ "sec1 0.7.3",
  "subtle",
  "zeroize",
 ]
@@ -2661,6 +2706,16 @@ name = "ff"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
  "rand_core 0.6.4",
  "subtle",
@@ -3058,6 +3113,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -3166,7 +3222,18 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
 dependencies = [
- "ff",
+ "ff 0.12.1",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff 0.13.1",
  "rand_core 0.6.4",
  "subtle",
 ]
@@ -3318,6 +3385,15 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -4009,11 +4085,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
 dependencies = [
  "base64 0.22.1",
+ "ed25519-dalek",
  "getrandom 0.2.17",
+ "hmac 0.12.1",
  "js-sys",
+ "p256 0.13.2",
+ "p384",
  "pem",
+ "rand 0.8.6",
+ "rsa",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
  "signature 2.2.0",
  "simple_asn1",
 ]
@@ -4095,6 +4178,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "lazycell"
@@ -4796,6 +4882,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.6",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4828,6 +4930,17 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
  "num-traits",
 ]
 
@@ -5316,8 +5429,32 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
 dependencies = [
- "ecdsa",
- "elliptic-curve",
+ "ecdsa 0.14.8",
+ "elliptic-curve 0.12.3",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
+ "primeorder",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
+ "primeorder",
  "sha2 0.10.9",
 ]
 
@@ -5398,6 +5535,15 @@ checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
  "base64 0.22.1",
  "serde_core",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -5551,6 +5697,17 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der 0.7.10",
+ "pkcs8 0.10.2",
+ "spki 0.7.3",
+]
 
 [[package]]
 name = "pkcs8"
@@ -5782,6 +5939,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve 0.13.8",
 ]
 
 [[package]]
@@ -6408,6 +6574,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac 0.12.1",
+ "subtle",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6442,6 +6618,26 @@ dependencies = [
  "libc",
  "rtoolbox",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid 0.9.6",
+ "digest 0.10.7",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8 0.10.2",
+ "rand_core 0.6.4",
+ "signature 2.2.0",
+ "spki 0.7.3",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -6739,10 +6935,24 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
 dependencies = [
- "base16ct",
+ "base16ct 0.1.1",
  "der 0.6.1",
  "generic-array",
  "pkcs8 0.9.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct 0.2.0",
+ "der 0.7.10",
+ "generic-array",
+ "pkcs8 0.10.2",
  "subtle",
  "zeroize",
 ]
@@ -7107,6 +7317,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -7170,6 +7381,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "spki"
@@ -8993,6 +9210,7 @@ version = "0.10.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "axum",
  "base64 0.22.1",
  "chrono",
  "cpal",
@@ -9208,7 +9426,9 @@ name = "wcore-channel-msteams"
 version = "0.10.0"
 dependencies = [
  "async-trait",
+ "base64 0.22.1",
  "chrono",
+ "jsonwebtoken",
  "mockito",
  "reqwest",
  "serde",

--- a/crates/wcore-channel-msteams/Cargo.toml
+++ b/crates/wcore-channel-msteams/Cargo.toml
@@ -8,6 +8,10 @@ description = "Microsoft Teams channel adapter for Wayland-Core — Bot Framewor
 [dependencies]
 async-trait = { workspace = true }
 chrono = { workspace = true, features = ["serde"] }
+# `rust_crypto`: jsonwebtoken 10.x requires an explicit CryptoProvider feature
+# (no default). Pure-Rust provider — no C toolchain, so the Windows CI lane
+# builds cleanly. Needed because this crate actually verifies RS256 JWTs.
+jsonwebtoken = { workspace = true, features = ["rust_crypto"] }
 reqwest = { workspace = true, features = ["json"] }
 wcore-egress = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
@@ -21,5 +25,6 @@ wcore-channels = { workspace = true }
 wcore-config = { workspace = true }
 
 [dev-dependencies]
+base64 = { workspace = true }
 mockito = "1"
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }

--- a/crates/wcore-channel-msteams/src/auth.rs
+++ b/crates/wcore-channel-msteams/src/auth.rs
@@ -1,0 +1,615 @@
+//! Bot Framework inbound JWT validation.
+//!
+//! Every inbound Bot Framework Activity arrives with an
+//! `Authorization: Bearer <jwt>` header. That JWT is signed by Microsoft's
+//! Bot Framework token service. Before the webhook host can trust (parse +
+//! enqueue) the Activity body, the token MUST be validated:
+//!
+//! 1. **Signature** — verified against the RSA public key Azure publishes in
+//!    its OpenID JWKS metadata, selected by the token's `kid` header.
+//! 2. **Audience** — must equal this bot's Microsoft App ID (`self.app_id`).
+//! 3. **Issuer** — must equal `https://api.botframework.com`.
+//! 4. **Expiry / not-before** — enforced by `jsonwebtoken` (`validate_exp`
+//!    defaults to true; we also validate `nbf`).
+//!
+//! ## Algorithm-confusion / `alg: none` defense
+//!
+//! The verifier hardcodes `Algorithm::RS256` and NEVER reads the algorithm
+//! from the token header. This blocks the classic JWT attacks where an
+//! attacker swaps the `alg` to `none` (no signature) or to a symmetric
+//! algorithm (`HS256`) and signs with the *public* key as if it were an HMAC
+//! secret. `jsonwebtoken` only accepts tokens whose `alg` is in
+//! [`Validation::algorithms`], which we pin to `[RS256]`.
+//!
+//! ## JWKS caching
+//!
+//! The JWKS is fetched once and cached for 24h. On a `kid` we don't have
+//! (key rotation), we force a single refetch before failing — Azure rotates
+//! signing keys roughly daily, so a missing `kid` is the expected rotation
+//! signal, not necessarily an attack.
+
+use std::time::{Duration, Instant};
+
+use jsonwebtoken::{Algorithm, DecodingKey, Validation, decode, decode_header};
+use serde::Deserialize;
+use tokio::sync::Mutex;
+
+use crate::error::MsTeamsError;
+
+/// Canonical Bot Framework token issuer.
+pub const BF_ISSUER: &str = "https://api.botframework.com";
+/// OpenID Connect metadata document — its `jwks_uri` points at the live JWKS.
+pub const BF_OPENID_METADATA_URL: &str =
+    "https://login.botframework.com/v1/.well-known/openidconfiguration";
+
+/// How long a fetched JWKS is trusted before a refetch.
+const JWKS_TTL: Duration = Duration::from_secs(24 * 60 * 60);
+
+/// Validated JWT claims we care about.
+///
+/// `jsonwebtoken` already validates `aud`, `iss`, `exp`, and `nbf` against the
+/// [`Validation`] config, so we do NOT re-check them here. We only surface the
+/// `serviceurl` claim (Bot Framework lowercases it) for the defense-in-depth
+/// cross-check against the Activity body's `serviceUrl`.
+#[derive(Debug, Deserialize)]
+pub struct Claims {
+    /// Bot Framework stamps the originating `serviceUrl` into the token,
+    /// lowercased as `serviceurl`. Absent on some token shapes, so optional.
+    #[serde(default)]
+    pub serviceurl: Option<String>,
+}
+
+/// One RSA signing key extracted from the JWKS.
+#[derive(Debug, Clone)]
+struct Jwk {
+    kid: String,
+    /// Base64url RSA modulus.
+    n: String,
+    /// Base64url RSA exponent.
+    e: String,
+}
+
+/// Cached JWKS plus the instant it was fetched (for TTL expiry).
+#[derive(Debug)]
+struct CachedJwks {
+    fetched: Instant,
+    keys: Vec<Jwk>,
+}
+
+/// OpenID metadata document — we only need the `jwks_uri`.
+#[derive(Debug, Deserialize, Default)]
+struct OpenIdMeta {
+    #[serde(default)]
+    jwks_uri: String,
+}
+
+/// A JWKS document: `{ "keys": [ ... ] }`.
+#[derive(Debug, Deserialize, Default)]
+struct JwkSet {
+    #[serde(default)]
+    keys: Vec<JwkJson>,
+}
+
+/// One raw JWK entry. Only RSA (`kty == "RSA"`) keys are retained.
+#[derive(Debug, Deserialize, Default)]
+struct JwkJson {
+    #[serde(default)]
+    kty: String,
+    #[serde(default)]
+    kid: String,
+    #[serde(default)]
+    n: String,
+    #[serde(default)]
+    e: String,
+}
+
+/// Bot Framework inbound JWT validator.
+///
+/// Holds the egress client (for JWKS fetches), the expected audience
+/// (`app_id`), the OpenID metadata URL + issuer (overrideable for tests), and
+/// a TTL-bounded JWKS cache.
+pub struct BotFrameworkAuth {
+    http: wcore_egress::EgressClient,
+    /// Microsoft App ID — the JWT audience.
+    app_id: String,
+    /// OpenID metadata URL (defaults to [`BF_OPENID_METADATA_URL`]).
+    metadata_url: String,
+    /// Expected token issuer (defaults to [`BF_ISSUER`]).
+    issuer: String,
+    jwks: Mutex<Option<CachedJwks>>,
+}
+
+impl BotFrameworkAuth {
+    /// Construct with production defaults (live Azure metadata + issuer).
+    pub fn new(http: wcore_egress::EgressClient, app_id: String) -> Self {
+        Self::with_endpoints(
+            http,
+            app_id,
+            BF_OPENID_METADATA_URL.to_string(),
+            BF_ISSUER.to_string(),
+        )
+    }
+
+    /// Construct with explicit metadata URL + issuer — used by tests to point
+    /// at a mock OpenID/JWKS server.
+    #[doc(hidden)]
+    pub fn with_endpoints(
+        http: wcore_egress::EgressClient,
+        app_id: String,
+        metadata_url: String,
+        issuer: String,
+    ) -> Self {
+        Self {
+            http,
+            app_id,
+            metadata_url,
+            issuer,
+            jwks: Mutex::new(None),
+        }
+    }
+
+    /// Validate an `Authorization` header value, returning the token claims.
+    ///
+    /// Steps:
+    /// 1. Strip a case-insensitive `Bearer ` prefix (missing → [`MsTeamsError::Auth`]).
+    /// 2. Decode the header and require a `kid` (absent → `Auth`).
+    /// 3. Resolve the RSA signing key for that `kid` from the (cached) JWKS.
+    /// 4. Verify signature + audience + issuer + expiry via RS256-only
+    ///    [`validate_with_key`].
+    pub async fn validate(&self, auth_header: &str) -> Result<Claims, MsTeamsError> {
+        let token = strip_bearer(auth_header)
+            .ok_or_else(|| MsTeamsError::Auth("missing or malformed Bearer token".to_string()))?;
+
+        let header = decode_header(token)
+            .map_err(|e| MsTeamsError::Auth(format!("malformed JWT header: {e}")))?;
+        let kid = header
+            .kid
+            .ok_or_else(|| MsTeamsError::Auth("JWT header missing kid".to_string()))?;
+
+        let jwk = self.key_for_kid(&kid).await?;
+        let key = DecodingKey::from_rsa_components(&jwk.n, &jwk.e)
+            .map_err(|e| MsTeamsError::Auth(format!("invalid RSA JWK for kid {kid}: {e}")))?;
+
+        validate_with_key(token, &key, &self.app_id, &self.issuer)
+    }
+
+    /// Resolve the RSA signing key for `kid`.
+    ///
+    /// Cache hit (fresh AND contains the kid) returns immediately. Otherwise
+    /// the JWKS is refetched and the cache replaced. As a key-rotation
+    /// accommodation, a *fresh* cache that is merely **missing** the kid still
+    /// forces ONE refetch before giving up — Azure rotates signing keys
+    /// roughly daily and a brand-new kid is the expected signal.
+    async fn key_for_kid(&self, kid: &str) -> Result<Jwk, MsTeamsError> {
+        {
+            let guard = self.jwks.lock().await;
+            if let Some(cached) = guard.as_ref()
+                && cached.fetched.elapsed() < JWKS_TTL
+                && let Some(jwk) = cached.keys.iter().find(|k| k.kid == kid)
+            {
+                return Ok(jwk.clone());
+            }
+        }
+
+        // Either no cache, an expired cache, or a fresh cache missing this kid
+        // (rotation): refetch once, replace the cache, then look up the kid.
+        let keys = self.fetch_jwks().await?;
+        let found = keys.iter().find(|k| k.kid == kid).cloned();
+        {
+            let mut guard = self.jwks.lock().await;
+            *guard = Some(CachedJwks {
+                fetched: Instant::now(),
+                keys,
+            });
+        }
+
+        found.ok_or_else(|| MsTeamsError::Auth(format!("no signing key for kid {kid}")))
+    }
+
+    /// Fetch + parse the live JWKS: GET metadata → `jwks_uri` → GET JWKS →
+    /// retain RSA keys.
+    async fn fetch_jwks(&self) -> Result<Vec<Jwk>, MsTeamsError> {
+        let meta_resp = self
+            .http
+            .get(&self.metadata_url)
+            .send()
+            .await
+            .map_err(|e| MsTeamsError::Network(format!("openid metadata: {e}")))?;
+        if !meta_resp.status().is_success() {
+            return Err(MsTeamsError::Network(format!(
+                "openid metadata HTTP {}",
+                meta_resp.status().as_u16()
+            )));
+        }
+        let meta: OpenIdMeta = meta_resp
+            .json()
+            .await
+            .map_err(|e| MsTeamsError::Parse(format!("openid metadata: {e}")))?;
+        if meta.jwks_uri.is_empty() {
+            return Err(MsTeamsError::Parse(
+                "openid metadata missing jwks_uri".to_string(),
+            ));
+        }
+
+        let jwks_resp = self
+            .http
+            .get(&meta.jwks_uri)
+            .send()
+            .await
+            .map_err(|e| MsTeamsError::Network(format!("jwks: {e}")))?;
+        if !jwks_resp.status().is_success() {
+            return Err(MsTeamsError::Network(format!(
+                "jwks HTTP {}",
+                jwks_resp.status().as_u16()
+            )));
+        }
+        let set: JwkSet = jwks_resp
+            .json()
+            .await
+            .map_err(|e| MsTeamsError::Parse(format!("jwks: {e}")))?;
+
+        let keys = set
+            .keys
+            .into_iter()
+            .filter(|k| k.kty == "RSA" && !k.kid.is_empty() && !k.n.is_empty() && !k.e.is_empty())
+            .map(|k| Jwk {
+                kid: k.kid,
+                n: k.n,
+                e: k.e,
+            })
+            .collect();
+        Ok(keys)
+    }
+}
+
+/// Strip a case-insensitive `Bearer ` prefix, returning the bare token.
+///
+/// Returns `None` if the prefix is absent or the remaining token is empty.
+fn strip_bearer(header: &str) -> Option<&str> {
+    let header = header.trim();
+    // `Bearer ` is 7 ASCII bytes, so `..7` is always a char boundary here.
+    header
+        .get(..7)
+        .filter(|prefix| prefix.eq_ignore_ascii_case("Bearer "))?;
+    let token = header[7..].trim();
+    if token.is_empty() { None } else { Some(token) }
+}
+
+/// Verify a token against an already-resolved decoding key.
+///
+/// Pins the algorithm to **RS256 only** — the token's `alg` header is never
+/// trusted, which blocks `alg: none` and HS256-confusion attacks.
+/// `jsonwebtoken` enforces signature + `aud` + `iss` + `exp` + `nbf`; we do
+/// not re-implement those checks.
+fn validate_with_key(
+    token: &str,
+    key: &DecodingKey,
+    app_id: &str,
+    issuer: &str,
+) -> Result<Claims, MsTeamsError> {
+    // RS256-only: do NOT derive the algorithm from the (attacker-controlled)
+    // token header. `Validation::new` sets `algorithms` to exactly [RS256].
+    let mut v = Validation::new(Algorithm::RS256);
+    v.set_audience(&[app_id]);
+    v.set_issuer(&[issuer]);
+    // Defaults: validate_exp = true. Enforce nbf too.
+    v.validate_nbf = true;
+
+    decode::<Claims>(token, key, &v)
+        .map(|data| data.claims)
+        .map_err(|e| MsTeamsError::Auth(format!("JWT validation failed: {e}")))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jsonwebtoken::{EncodingKey, Header, encode};
+    use serde::Serialize;
+
+    // 2048-bit RSA test keypair (TEST ONLY — never used in production).
+    const TEST_PRIV_PEM: &str = "-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCxK7iZ13vevXvm
+p5s5s0R9epARhp6UlVe3gc2JJ0Gg/5pCrcNPmeprwkIPAsmrsyXb/8SiFNBMV/i9
+TdywmkSSgaGIHdFw2H1Dt9xq7FP3QWl7sTZxqd0Rq8JoPCiPlY/Mm4qJOS0Vwiiy
+odqorI2BDFJOtz4cZ1+Fyc1zqYt0rT5gLM/9OyqmvJtPc8rZ3af31yJSm/ComIHY
+4P7m3Q94Q9Ep5Es1+wAECguGxs6bQSnCUBtHOcCCAo581z1ZJnobnq269OmyzhBL
+oz9fNgwtMVcjHje3rOMRbSe36nR85Ahc/zaqngxnt0jdkuFBiiVbEdw2+gG2Qhub
+sbbEH4xXAgMBAAECggEAAlPdt/+xu+pnX09iZa6qPq/GhsRq/u67WUjWR3ABl7jj
+8O5Re5E9GC9UKNhTh/Lxk2NX1P1LA0XAmdQVCyjrr7UORziFEON3OdWHiswSClSM
+qzhXy8R8iAfmpPHtYn2HhxugBU9//SIw4K/prH+f2EsuJaSYp0zgX2SYU2Wt1FmQ
+tGxLKWPKF1q51wBsTMKC7XiC+wUZ213vvMAGVFKbFxC9Ldy1Z38QaDtWIIbbA7JB
+Wv5GqBEzkcy8wqhn31IPuoeZRHA+VvvoiNFpX6cjmrtri9aO+S5zgE2HZ0IuYo1+
+bzixKfhGdfuvomnOpa/V5edLQFiSkYQTISZsrBVu4QKBgQDmBM/8JbdNOK9S7Xdb
+p8oD8tO/tFOC8oBZcWDoh5MlMtGuaUXxJ80Or5XayC+o/6IzUraEYTvlqO0p9X1C
+4fOvqFg3GwMr3O8jlEKErRaikPfF6R1wtG3sNbjtcLc5JSXNl4RyVJKu1mLqV3dA
+fOATBQe/K9Aqd+Rzg4bL9DGC5wKBgQDFLsOHhcOlyWLbC/rbqo0LMqvWHwCC+ta2
+6v2JVcshX/V7eZci/Rer9t8fPiZMZNUPoo2Ay0Y2uOF9ryTlb8jtW/x9J6vva/Kx
+CNyoiiDSmwc8aT9FwISiMVNixyzL7HGFyGpMnPmx7qWnVv+pPmzyAT5lsujAUrC3
+fRg9BWrtEQKBgGNruxZKmxMmqClY+NlGCfxw7fOTlvEnrjB64B9B0mkmsRkI6bFV
+ub1aSZR6KJeMfuheHQPVH1WiEXisYksRbQoE4rRW2aUQ5tBjGelNA1abAG2r2AzK
+ACU0B02iBaAOnWtizV25jnlBsxmFWscl8phl+TY5Us24aqc/N3lagDgLAoGAR8nC
+vjBhDpbHOuCdsCPjvdPw47/du9H/IhFjxQBLOBdrlEysTby/RYhXq1RBNUbwmwSf
+Z+iZ44pj7hI56J5OFLyMrDQpUL2IWhPT4jiHwqVWeRQISSjSIQq8RRYmpQesPPy+
+Vq4/6hvsi4QNCF0F5QW25efA/WQdmnAcxvqV90ECgYEA4idGNvUuLmxrS64aZBgo
+H2favbG0pwxbCPvFEoX3Tviz1dwTTnQ1oA09E5TGqYASOtIrCZepPwJNg44cLpQK
+iAqbJ0OTSSXcdHU8aEUGrIomxRhmIXBRGG3CgNgc4oRME1Cqc82WQvUsXkctMsB/
+XBeQlzcfRANpSwysQGfZET8=
+-----END PRIVATE KEY-----";
+
+    const TEST_PUB_PEM: &str = "-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsSu4mdd73r175qebObNE
+fXqQEYaelJVXt4HNiSdBoP+aQq3DT5nqa8JCDwLJq7Ml2//EohTQTFf4vU3csJpE
+koGhiB3RcNh9Q7fcauxT90Fpe7E2candEavCaDwoj5WPzJuKiTktFcIosqHaqKyN
+gQxSTrc+HGdfhcnNc6mLdK0+YCzP/TsqprybT3PK2d2n99ciUpvwqJiB2OD+5t0P
+eEPRKeRLNfsABAoLhsbOm0EpwlAbRznAggKOfNc9WSZ6G56tuvTpss4QS6M/XzYM
+LTFXIx43t6zjEW0nt+p0fOQIXP82qp4MZ7dI3ZLhQYolWxHcNvoBtkIbm7G2xB+M
+VwIDAQAB
+-----END PUBLIC KEY-----";
+
+    // A DIFFERENT 2048-bit key — used to forge a token the real key rejects.
+    const OTHER_PRIV_PEM: &str = "-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDKHRFoQ5q3jRFS
+ecQlH5y+BFT15s7tEkQ/uknX//NED0rq4h8oHMwF8B500kVn3aFkrtfokcWMxNIK
++IMmYmTOnZkR0LUWtD8gxojYP1ntT+lbBxNX3GuPwoK+SrTbWyQds6GrwhWwiWsM
+7/tJNay01BqesvP7rOkXUbp6no5hf3+1xk0GzEPHPzWKXjr1WJ5jDWuezbV57gBG
+2Q3htDuRYsQYRU1BPTRKSRMQqB6kF2m6X6ckaXLj+AA0ISG9Hq/AnOoVFSYazWBN
+N873HquGYviX7Bw7gmFGmxc0bjiHqotC25PZcSShVex1UPuqn5A6UB/WaDWyl1l7
+g06yDNflAgMBAAECggEAQsmtPWeNolb+4OK1AtF58b6rtqCBQ4z0OZzdFwAQyq5F
+Au4a/p3Ze6LX5aGwZryxvvwaA9Pb1IMbp51sdUwxZKdmdCEkHi8M509D3DW/CTEN
+e1OQvEltz9EmdCxqrEvnWNtJsuDNWwtl8R4CSzRt8ElgzI11G3cNhXOv7CImCahK
+I5R0Z4Dntj3qsMvOOuowsH9mv/j+AZCXkLf0E6DW/RCGTBPL30OZ6GewCLvzqCI/
+/r+NlIrc+g6r+/+teKDwNe9JPcBGUoXGe2N60MZ99Zwa2CSReM3nQz/D9B/CsoxL
+yb1zgoyKckSzfrUbwo/unmV3SWJ24pMRWhUvtZgctwKBgQDwTAlmJQtgUJMWsKMB
+ulYaLRAfm+mKJAu5j4wFnNOqB/+Oaagz5JsKfoCT20WsZxogsAD30xOnnUn5M+kx
+k0LcfzSmar9iiSpstDinQS+hxXl9dpC0MyJpV7Kl5mMyDv3vS8yYPaKp1Y6FK1er
+iNM2bUtxcTdJ4W2t2F0zKa1XxwKBgQDXUkEnlxIyPg91YJEcdi+05irjJ7v48rYF
+5e8rrXzPbqR8jB//rh8RLcoWaTauN3VTSg33tsDkNpoAj/WIzzqK1ggp+mFY+2En
+/G9QzBakL9nIh+SRtv7CHdxCPDbuKfVwn4oYSseF6nVZ7S2oD1x5sJmKQSnxkUVt
+R7UkrcVK8wKBgQDm5Vk+sifNQ38ilVX8ag0kF9rfVJRCbcJqall0Zy4nuonAURwT
+yP2FRurLqC25rFQ5xoUXnNXNAGE9OLlBLqxXbU+s/POrffuq+j1Z0VQwkKzddpky
+3dOZ/2+k48y7JBay4lXUj50GrjLFGVGjfNTe/oQ4nD4xGpCmNDnR2KE8rwKBgGMU
+oZCjLqdZ8WkUt5F+PPOkGkYOyauDnAjYxpa1rUISarQ5EpxntjoEdQKdBaFjOaTK
+5eR//wDEs1bg5549pXWviXAvm84DVrC8s0hdsWl572AcUCxRJaeTcAA2jxxGyH87
+mqMU/fz8Z2WrAyBbeTUx82UwGSnkrCreHVe0cp3LAoGAYmR5NxEcG/4h7MBSrtTc
+wzUVBiX7ke9GUU50Xj6JFXx7uOlelL9sKD7EoHHofnYoJDQsFDsqIH8OXglMLLmb
+3o+w6ii/Qht+XNxVaAQDJDnM0gJCP+Q5zqjXZkND1irezbnytiDi6jU6qAbrtGn2
+ifbvjeUK+8dlmkIBgohnGFo=
+-----END PRIVATE KEY-----";
+
+    const TEST_APP_ID: &str = "11111111-2222-3333-4444-555555555555";
+
+    #[derive(Serialize)]
+    struct TestClaims {
+        aud: String,
+        iss: String,
+        exp: i64,
+        nbf: i64,
+        serviceurl: String,
+    }
+
+    fn now() -> i64 {
+        chrono::Utc::now().timestamp()
+    }
+
+    /// Sign a token with the given PEM private key + claims.
+    fn sign(priv_pem: &str, claims: &TestClaims) -> String {
+        let key = EncodingKey::from_rsa_pem(priv_pem.as_bytes()).expect("encode key");
+        encode(&Header::new(Algorithm::RS256), claims, &key).expect("encode token")
+    }
+
+    fn valid_claims() -> TestClaims {
+        TestClaims {
+            aud: TEST_APP_ID.to_string(),
+            iss: BF_ISSUER.to_string(),
+            exp: now() + 3600,
+            nbf: now() - 60,
+            serviceurl: "https://smba.trafficmanager.net/amer/".to_string(),
+        }
+    }
+
+    fn pub_key() -> DecodingKey {
+        DecodingKey::from_rsa_pem(TEST_PUB_PEM.as_bytes()).expect("decode pub key")
+    }
+
+    #[test]
+    fn validate_with_key_accepts_valid_token() {
+        let token = sign(TEST_PRIV_PEM, &valid_claims());
+        let claims =
+            validate_with_key(&token, &pub_key(), TEST_APP_ID, BF_ISSUER).expect("valid token");
+        assert_eq!(
+            claims.serviceurl.as_deref(),
+            Some("https://smba.trafficmanager.net/amer/")
+        );
+    }
+
+    #[test]
+    fn validate_with_key_rejects_wrong_audience() {
+        let mut c = valid_claims();
+        c.aud = "00000000-0000-0000-0000-000000000000".to_string();
+        let token = sign(TEST_PRIV_PEM, &c);
+        let err = validate_with_key(&token, &pub_key(), TEST_APP_ID, BF_ISSUER)
+            .expect_err("wrong aud must fail");
+        assert!(matches!(err, MsTeamsError::Auth(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn validate_with_key_rejects_wrong_issuer() {
+        let mut c = valid_claims();
+        c.iss = "https://evil.example.com".to_string();
+        let token = sign(TEST_PRIV_PEM, &c);
+        let err = validate_with_key(&token, &pub_key(), TEST_APP_ID, BF_ISSUER)
+            .expect_err("wrong iss must fail");
+        assert!(matches!(err, MsTeamsError::Auth(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn validate_with_key_rejects_expired_token() {
+        let mut c = valid_claims();
+        c.exp = now() - 3600;
+        c.nbf = now() - 7200;
+        let token = sign(TEST_PRIV_PEM, &c);
+        let err = validate_with_key(&token, &pub_key(), TEST_APP_ID, BF_ISSUER)
+            .expect_err("expired must fail");
+        assert!(matches!(err, MsTeamsError::Auth(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn validate_with_key_rejects_wrong_signature() {
+        // Signed by a DIFFERENT key → signature check against TEST_PUB fails.
+        let token = sign(OTHER_PRIV_PEM, &valid_claims());
+        let err = validate_with_key(&token, &pub_key(), TEST_APP_ID, BF_ISSUER)
+            .expect_err("bad signature must fail");
+        assert!(matches!(err, MsTeamsError::Auth(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn validate_with_key_rejects_alg_none() {
+        // An `alg: none` token (no signature). The RS256-only validator must
+        // refuse it regardless of the claims.
+        let claims = valid_claims();
+        // Hand-build header.payload. with empty signature.
+        let header = serde_json::json!({ "alg": "none", "typ": "JWT" });
+        let b64 = |v: &serde_json::Value| {
+            use base64::Engine;
+            base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(v.to_string().as_bytes())
+        };
+        let claims_json = serde_json::to_value(&claims).unwrap();
+        let token = format!("{}.{}.", b64(&header), b64(&claims_json));
+        let err = validate_with_key(&token, &pub_key(), TEST_APP_ID, BF_ISSUER)
+            .expect_err("alg none must fail");
+        assert!(matches!(err, MsTeamsError::Auth(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn validate_with_key_rejects_hs256_confusion() {
+        // Forge an HS256 token using the PUBLIC key bytes as the HMAC secret —
+        // the classic algorithm-confusion attack. RS256-only must reject it.
+        let key = EncodingKey::from_secret(TEST_PUB_PEM.as_bytes());
+        let token =
+            encode(&Header::new(Algorithm::HS256), &valid_claims(), &key).expect("hs256 encode");
+        let err = validate_with_key(&token, &pub_key(), TEST_APP_ID, BF_ISSUER)
+            .expect_err("hs256 confusion must fail");
+        assert!(matches!(err, MsTeamsError::Auth(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn strip_bearer_is_case_insensitive() {
+        assert_eq!(strip_bearer("Bearer abc.def.ghi"), Some("abc.def.ghi"));
+        assert_eq!(strip_bearer("bearer abc.def.ghi"), Some("abc.def.ghi"));
+        assert_eq!(strip_bearer("BEARER abc.def.ghi"), Some("abc.def.ghi"));
+        assert_eq!(strip_bearer("  Bearer  tok  "), Some("tok"));
+        assert_eq!(strip_bearer("Basic abc"), None);
+        assert_eq!(strip_bearer("Bearer "), None);
+        assert_eq!(strip_bearer("abc.def.ghi"), None);
+    }
+
+    // --- JWKS path (mockito) -------------------------------------------------
+
+    fn auth_for(metadata_url: String) -> BotFrameworkAuth {
+        let http = wcore_egress::EgressClient::builder()
+            .build()
+            .unwrap_or_default();
+        BotFrameworkAuth::with_endpoints(
+            http,
+            TEST_APP_ID.to_string(),
+            metadata_url,
+            BF_ISSUER.to_string(),
+        )
+    }
+
+    fn jwks_body(kids: &[&str]) -> String {
+        let keys: Vec<_> = kids
+            .iter()
+            .map(|kid| {
+                serde_json::json!({
+                    "kty": "RSA",
+                    "use": "sig",
+                    "kid": kid,
+                    "n": "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM",
+                    "e": "AQAB"
+                })
+            })
+            .collect();
+        serde_json::json!({ "keys": keys }).to_string()
+    }
+
+    #[tokio::test]
+    async fn key_for_kid_selects_matching_kid_and_caches() {
+        let mut server = mockito::Server::new_async().await;
+        let keys_url = format!("{}/keys", server.url());
+
+        let meta = server
+            .mock("GET", "/openid")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(format!(r#"{{"jwks_uri":"{keys_url}"}}"#))
+            .expect(1) // exactly one metadata fetch — second lookup hits cache
+            .create_async()
+            .await;
+        let keys = server
+            .mock("GET", "/keys")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(jwks_body(&["kid-A", "kid-B"]))
+            .expect(1)
+            .create_async()
+            .await;
+
+        let auth = auth_for(format!("{}/openid", server.url()));
+
+        let jwk = auth.key_for_kid("kid-B").await.expect("kid-B resolves");
+        assert_eq!(jwk.kid, "kid-B");
+        assert_eq!(jwk.e, "AQAB");
+
+        // Second lookup of a cached kid must NOT refetch (mocks .expect(1)).
+        let jwk_a = auth.key_for_kid("kid-A").await.expect("kid-A cached");
+        assert_eq!(jwk_a.kid, "kid-A");
+
+        meta.assert_async().await;
+        keys.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn key_for_kid_unknown_triggers_single_refetch_then_errors() {
+        let mut server = mockito::Server::new_async().await;
+        let keys_url = format!("{}/keys", server.url());
+
+        // First call populates the (fresh) cache with kid-A only. The unknown
+        // kid then forces exactly ONE more metadata+keys fetch before failing.
+        let meta = server
+            .mock("GET", "/openid")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(format!(r#"{{"jwks_uri":"{keys_url}"}}"#))
+            .expect(2)
+            .create_async()
+            .await;
+        let keys = server
+            .mock("GET", "/keys")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(jwks_body(&["kid-A"]))
+            .expect(2)
+            .create_async()
+            .await;
+
+        let auth = auth_for(format!("{}/openid", server.url()));
+
+        // Prime the cache (fresh, contains kid-A).
+        auth.key_for_kid("kid-A").await.expect("kid-A resolves");
+
+        // Unknown kid → fresh cache missing it → one refetch → still missing → err.
+        let err = auth
+            .key_for_kid("kid-ZZZ")
+            .await
+            .expect_err("unknown kid errors");
+        assert!(matches!(err, MsTeamsError::Auth(_)), "got {err:?}");
+
+        meta.assert_async().await;
+        keys.assert_async().await;
+    }
+}

--- a/crates/wcore-channel-msteams/src/error.rs
+++ b/crates/wcore-channel-msteams/src/error.rs
@@ -14,4 +14,9 @@ pub enum MsTeamsError {
     Parse(String),
     #[error("invalid chat_id format (expected serviceUrl|conversationId)")]
     InvalidChatId,
+    /// Inbound JWT validation failed — missing/invalid `Authorization`
+    /// header, unknown signing key, or a token that failed signature /
+    /// audience / issuer / expiry checks.
+    #[error("auth: {0}")]
+    Auth(String),
 }

--- a/crates/wcore-channel-msteams/src/inbound.rs
+++ b/crates/wcore-channel-msteams/src/inbound.rs
@@ -174,6 +174,28 @@ pub fn activity_to_incoming(
     Ok(Some(msg))
 }
 
+/// Extract just the `serviceUrl` from a Bot Framework Activity body, without
+/// the full enrichment parse.
+///
+/// Used by the webhook auth gate to cross-check the JWT's `serviceurl` claim
+/// against the Activity body (defense-in-depth against a token replayed
+/// alongside a swapped `serviceUrl`). Returns `Ok(None)` when the activity
+/// omits `serviceUrl`; `Err(Parse)` only on malformed JSON.
+pub fn service_url_of(raw_body: &str) -> Result<Option<String>, MsTeamsError> {
+    #[derive(Deserialize, Default)]
+    struct ServiceUrlOnly {
+        #[serde(rename = "serviceUrl", default)]
+        service_url: String,
+    }
+    let parsed: ServiceUrlOnly =
+        serde_json::from_str(raw_body).map_err(|e| MsTeamsError::Parse(e.to_string()))?;
+    if parsed.service_url.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(parsed.service_url))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/wcore-channel-msteams/src/lib.rs
+++ b/crates/wcore-channel-msteams/src/lib.rs
@@ -15,6 +15,7 @@
 //! Ported from the desktop app's TypeScript `MsTeamsPlugin` (OpenClaw MIT + Apache-2.0).
 //! See F-045 in the wcore audit triage.
 
+pub mod auth;
 pub mod config;
 pub mod error;
 pub mod inbound;
@@ -31,8 +32,10 @@ use wcore_channels::Channel;
 use wcore_channels::error::ChannelError;
 use wcore_channels::event::{ChannelEvent, ConnectionState, MessageReceipt};
 use wcore_channels::outgoing::OutgoingMessage;
+use wcore_channels::webhook::{WebhookRequest, WebhookResponse};
 use wcore_config::credentials::CredentialsStore;
 
+use auth::BotFrameworkAuth;
 pub use config::MsTeamsConfig;
 pub use error::MsTeamsError;
 use token::TokenCache;
@@ -60,6 +63,10 @@ pub struct MsTeamsChannel {
     creds: Arc<dyn CredentialsStore>,
     /// Token endpoint base — overrideable for tests.
     token_url: String,
+    /// Inbound Bot Framework JWT validator. `None` until `start()` resolves
+    /// the `app_id` (the JWT audience); inbound webhooks are refused until
+    /// then.
+    auth: Option<BotFrameworkAuth>,
 }
 
 impl MsTeamsChannel {
@@ -94,6 +101,7 @@ impl MsTeamsChannel {
             inbox: Arc::new(Mutex::new(VecDeque::new())),
             creds,
             token_url,
+            auth: None,
         }
     }
 
@@ -114,18 +122,15 @@ impl MsTeamsChannel {
     /// configured `service_url`) so the reply path round-trips the
     /// tenant-specific serviceUrl. See [`inbound::activity_to_incoming`].
     ///
-    /// # Security — NOT authenticated
+    /// # Security — authenticate before calling
     ///
-    /// This method performs **no** authentication of the inbound request. The
-    /// Bot Framework signs inbound activities with a JWT in the
-    /// `Authorization: Bearer <jwt>` header that must be validated (issuer +
-    /// audience + signature against Azure's OpenID JWKS metadata) before the
-    /// payload can be trusted. That validation is a separate, heavier
-    /// follow-up.
-    ///
-    // TODO(security): validate Bot Framework JWT (iss/aud + JWKS) before
-    // trusting inbound; the inbound webhook host must not call this until that
-    // lands or must gate on network trust.
+    /// This method performs **no** authentication itself — it trusts its
+    /// `raw_body`. The webhook entrypoint
+    /// [`ingest_webhook`](Channel::ingest_webhook) validates the Bot
+    /// Framework JWT (signature + audience + issuer + expiry, via
+    /// [`auth::BotFrameworkAuth`]) before calling this. Callers other than
+    /// `ingest_webhook` (e.g. tests) must guarantee the body's authenticity
+    /// some other way.
     pub async fn ingest_activity(&self, raw_body: &str) -> Result<(), MsTeamsError> {
         if let Some(msg) = inbound::activity_to_incoming(raw_body, &self.config.service_url)? {
             self.inbox
@@ -181,6 +186,10 @@ impl Channel for MsTeamsChannel {
             .await
             .map_err(|e| ChannelError::Auth(format!("Bot Framework token: {e}")))?;
 
+        // Bind the inbound JWT validator now that the audience (app_id) is
+        // known. Until this is set, `ingest_webhook` refuses inbound traffic.
+        self.auth = Some(BotFrameworkAuth::new(self.http.clone(), app_id.clone()));
+
         self.app_id = Some(app_id);
         self.app_password = Some(app_password);
         self.state = ConnectionState::Connected;
@@ -199,6 +208,7 @@ impl Channel for MsTeamsChannel {
         }
         self.app_id = None;
         self.app_password = None;
+        self.auth = None;
         self.state = ConnectionState::Disconnected;
         self.inbox
             .lock()
@@ -213,6 +223,60 @@ impl Channel for MsTeamsChannel {
     /// (via [`ingest_activity`](MsTeamsChannel::ingest_activity)).
     async fn poll_events(&mut self) -> Result<Vec<ChannelEvent>, ChannelError> {
         Ok(self.inbox.lock().await.drain(..).collect())
+    }
+
+    /// Authenticate and ingest an inbound Bot Framework Activity webhook.
+    ///
+    /// This is the security gate that makes inbound MS Teams safe to route:
+    ///
+    /// 1. Require the channel to be started (the JWT validator is bound in
+    ///    `start()` once the audience `app_id` is known).
+    /// 2. Require an `Authorization` header and validate its Bearer JWT against
+    ///    Azure's JWKS — signature (RS256-only), audience (`app_id`), issuer
+    ///    (`https://api.botframework.com`), and expiry. See
+    ///    [`auth::BotFrameworkAuth::validate`].
+    /// 3. **Defense-in-depth**: when both the JWT's `serviceurl` claim and the
+    ///    Activity body's `serviceUrl` are present, they must match. This
+    ///    blocks replaying a valid token alongside a swapped `serviceUrl` (the
+    ///    reply path trusts that `serviceUrl`, so a mismatch could redirect
+    ///    bot replies to an attacker endpoint). The JWT `aud == app_id`
+    ///    binding remains the primary control; this is a secondary check.
+    /// 4. Parse + enqueue via [`ingest_activity`](Self::ingest_activity).
+    ///
+    /// Returns an empty `200 OK` once enqueued (lifecycle activities are
+    /// ACKed without enqueuing). Any auth failure is surfaced as
+    /// [`ChannelError::Auth`] so the host returns `401` and never parses the
+    /// body of an unauthenticated request.
+    async fn ingest_webhook(&self, req: &WebhookRequest) -> Result<WebhookResponse, ChannelError> {
+        let auth = self.auth.as_ref().ok_or(ChannelError::NotStarted)?;
+        let hdr = req
+            .header("authorization")
+            .ok_or_else(|| ChannelError::Auth("missing authorization header".into()))?;
+        let claims = auth
+            .validate(hdr)
+            .await
+            .map_err(|e| ChannelError::Auth(e.to_string()))?;
+
+        // Defense-in-depth: the JWT's serviceurl claim must match the
+        // Activity's serviceUrl when both are present (blocks replay with a
+        // swapped serviceUrl). Compare with a stripped trailing slash so a
+        // cosmetic difference doesn't cause a false reject.
+        if let Some(claim_url) = claims.serviceurl.as_deref() {
+            let body_url = inbound::service_url_of(&req.body)
+                .map_err(|e| ChannelError::Rejected(e.to_string()))?;
+            if let Some(body_url) = body_url.as_deref()
+                && !service_urls_match(claim_url, body_url)
+            {
+                return Err(ChannelError::Auth(format!(
+                    "serviceUrl claim mismatch: token={claim_url} activity={body_url}"
+                )));
+            }
+        }
+
+        self.ingest_activity(&req.body)
+            .await
+            .map_err(|e| ChannelError::Rejected(e.to_string()))?;
+        Ok(WebhookResponse::ok())
     }
 
     /// Send a message via the Bot Framework Connector REST API.
@@ -287,6 +351,14 @@ impl Channel for MsTeamsChannel {
     fn max_message_len(&self) -> Option<usize> {
         Some(28_000)
     }
+}
+
+/// Compare two `serviceUrl`s for the auth cross-check, ignoring a trailing
+/// slash and ASCII case (Bot Framework lowercases the token claim, and the
+/// trailing slash is stamped inconsistently across activities).
+fn service_urls_match(a: &str, b: &str) -> bool {
+    let norm = |s: &str| s.trim_end_matches('/').to_ascii_lowercase();
+    norm(a) == norm(b)
 }
 
 /// Parse `{serviceUrl}|{conversationId}` or return `(default_service_url, raw)`.
@@ -529,5 +601,80 @@ service_url = "https://smba.trafficmanager.net/emea/"
         token_mock.assert_async().await;
         send_mock.assert_async().await;
         ch.stop().await.unwrap();
+    }
+
+    // 9. ingest_webhook before start() refuses with NotStarted (the JWT
+    //    validator is only bound once the audience app_id is resolved).
+    #[tokio::test]
+    async fn ingest_webhook_before_start_errors_not_started() {
+        let ch = MsTeamsChannel::new("test", cfg(), MemCreds::empty());
+        let req = WebhookRequest {
+            method: "POST".into(),
+            headers: vec![("authorization".into(), "Bearer x.y.z".into())],
+            body: r#"{"type":"message"}"#.into(),
+            ..Default::default()
+        };
+        let err = ch
+            .ingest_webhook(&req)
+            .await
+            .expect_err("expected NotStarted");
+        assert!(matches!(err, ChannelError::NotStarted), "got {err:?}");
+    }
+
+    // 10. ingest_webhook with no Authorization header surfaces Auth — the host
+    //     must never reach the body parse for an unauthenticated request.
+    #[tokio::test]
+    async fn ingest_webhook_missing_auth_header_errors_auth() {
+        let mut server = mockito::Server::new_async().await;
+        let token_mock = server
+            .mock("POST", "/token")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"access_token":"tk","expires_in":3600,"token_type":"Bearer"}"#)
+            .create_async()
+            .await;
+        let creds = MemCreds::with(&[
+            ("msteams.test.app_id", "app-id-value"),
+            ("msteams.test.app_password", "app-secret-value"),
+        ]);
+        let mut ch =
+            MsTeamsChannel::with_token_url("test", cfg(), creds, format!("{}/token", server.url()));
+        ch.start().await.unwrap();
+        token_mock.assert_async().await;
+
+        let req = WebhookRequest {
+            method: "POST".into(),
+            headers: vec![],
+            body: r#"{"type":"message"}"#.into(),
+            ..Default::default()
+        };
+        let err = ch.ingest_webhook(&req).await.expect_err("expected Auth");
+        assert!(matches!(err, ChannelError::Auth(_)), "got {err:?}");
+        // The unauthenticated body must NOT have been parsed/enqueued. (start()
+        // enqueues a Connected lifecycle event, so assert specifically that no
+        // MessageReceived was enqueued rather than full emptiness.)
+        let events = ch.poll_events().await.unwrap();
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, ChannelEvent::MessageReceived { .. })),
+            "no message must be enqueued when the auth header is missing"
+        );
+    }
+
+    #[test]
+    fn service_urls_match_ignores_trailing_slash_and_case() {
+        assert!(service_urls_match(
+            "https://smba.trafficmanager.net/amer/",
+            "https://smba.trafficmanager.net/amer"
+        ));
+        assert!(service_urls_match(
+            "https://SMBA.trafficmanager.net/amer",
+            "https://smba.trafficmanager.net/amer/"
+        ));
+        assert!(!service_urls_match(
+            "https://smba.trafficmanager.net/amer",
+            "https://evil.example.com/amer"
+        ));
     }
 }


### PR DESCRIPTION
Closes the highest-value parity gap from the overnight audit: MS Teams was the last channel that was mute-to-input. Its Activity parser had no auth, so the inbound webhook host deliberately did not route it.

This adds **Bot Framework inbound JWT validation** (`src/auth.rs`): the `Authorization: Bearer <JWT>` is verified before any Activity field is trusted —
- **RS256-only** (never reads the token's `alg` header → blocks alg-confusion / `none`),
- **audience** == our Microsoft App ID, **issuer** == `https://api.botframework.com`, **exp/nbf** enforced,
- signing key resolved by `kid` from the published JWKS (OpenID metadata → `jwks_uri`), 24h-cached with one forced refetch on an unknown kid (rotation).

`ingest_webhook` now overrides the trait default → the host routes msteams once a valid JWT is presented; the JWT `serviceurl` claim must match the Activity's serviceUrl (replay guard). `jsonwebtoken` enabled with the pure-Rust `rust_crypto` provider (10.x needs an explicit CryptoProvider; pure-Rust keeps the Windows lane clean).

Gate green: fmt + clippy --workspace --all-targets + nextest **8158**. Test suite covers accept-valid + reject wrong-aud/iss/expired/sig/alg-none/hs256-confusion + JWKS selection/cache/refetch + ingest_webhook auth gating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)