### PR TITLE
feat(channels): inbound media fetch — transcribe/describe attachments before the turn

### DIFF
--- a/crates/wcore-agent/src/bootstrap.rs
+++ b/crates/wcore-agent/src/bootstrap.rs
@@ -2214,12 +2214,32 @@ impl AgentBootstrap {
                         .map(|c| (c.name, c.inbound))
                         .collect();
 
+                // Inbound-media enricher: resolve image/audio attachments to
+                // derived text (description/transcript) before the turn
+                // prompt is built, reusing the SAME backends + SSRF-safe
+                // fetchers the agent's vision/transcribe tools use. Inert
+                // (and skipped) when neither backend has an API key wired.
+                let media_enricher = {
+                    let enricher = crate::channel_media::ChannelMediaEnricher::new(
+                        crate::tool_backends::build_vision_backend(),
+                        crate::tool_backends::build_image_fetcher(),
+                        crate::tool_backends::build_transcription_backend(),
+                        crate::tool_backends::build_audio_fetcher(),
+                    );
+                    if enricher.is_inert() {
+                        None
+                    } else {
+                        Some(Arc::new(enricher))
+                    }
+                };
+
                 let dispatcher: Arc<dyn crate::channel_inbound::TurnDispatcher> =
                     Arc::new(crate::channel_dispatch::ChannelTurnDispatcher::new(
                         config_for_dispatch,
                         self.workspace.clone(),
                         provider.clone(),
                         postures,
+                        media_enricher,
                     ));
                 let subscriber = crate::channel_inbound::InboundSubscriber::new(
                     std::sync::Arc::clone(&lifted),

--- a/crates/wcore-agent/src/channel_dispatch.rs
+++ b/crates/wcore-agent/src/channel_dispatch.rs
@@ -55,6 +55,7 @@ use wcore_providers::LlmProvider;
 
 use crate::bootstrap::AgentBootstrap;
 use crate::channel_inbound::TurnDispatcher;
+use crate::channel_media::ChannelMediaEnricher;
 use crate::channel_tools::ChannelToolScope;
 use crate::engine::AgentEngine;
 use crate::output::OutputSink;
@@ -76,6 +77,11 @@ pub struct ChannelTurnDispatcher {
     /// `Arc<Mutex<AgentEngine>>` so concurrent turns for the SAME session
     /// serialise on the inner mutex while different sessions run freely.
     engines: Arc<Mutex<HashMap<String, Arc<Mutex<AgentEngine>>>>>,
+    /// Optional inbound-media enricher. `Some` only when the host wired a
+    /// vision and/or transcription backend; otherwise inbound attachments
+    /// stay bare-URL summaries. Resolves image/audio attachments to derived
+    /// text before the turn prompt is built.
+    media: Option<Arc<ChannelMediaEnricher>>,
 }
 
 impl ChannelTurnDispatcher {
@@ -89,6 +95,7 @@ impl ChannelTurnDispatcher {
         cwd: String,
         provider: Arc<dyn LlmProvider>,
         postures: HashMap<String, ChannelToolScope>,
+        media: Option<Arc<ChannelMediaEnricher>>,
     ) -> Self {
         Self {
             config,
@@ -96,6 +103,26 @@ impl ChannelTurnDispatcher {
             provider,
             postures,
             engines: Arc::new(Mutex::new(HashMap::new())),
+            media,
+        }
+    }
+
+    /// Build the turn prompt, eagerly enriching inbound media first when an
+    /// enricher is installed and the message carries attachments. The
+    /// enrichment mutates a per-turn clone — the kernel's `IncomingMessage`
+    /// is left untouched.
+    async fn prompt_for(
+        &self,
+        channel_name: &str,
+        msg: &wcore_channels::IncomingMessage,
+    ) -> String {
+        match &self.media {
+            Some(media) if !msg.attachments.is_empty() => {
+                let mut enriched = msg.clone();
+                media.enrich(&mut enriched.attachments, channel_name).await;
+                build_turn_prompt(&enriched)
+            }
+            _ => build_turn_prompt(msg),
         }
     }
 
@@ -239,10 +266,15 @@ fn build_turn_prompt(msg: &wcore_channels::IncomingMessage) -> String {
     for (i, att) in msg.attachments.iter().enumerate() {
         let kind = format!("{:?}", att.kind);
         let ty = att.content_type.as_deref().unwrap_or("unknown type");
-        // Prefer the transcription when present (e.g. a voice note already
-        // transcribed by the connector); else describe the media reference.
+        // Prefer derived text when present — a transcript for audio, a
+        // description for images (populated by the connector or by the
+        // inbound-media enricher); else describe the bare media reference.
         if let Some(t) = att.transcribed.as_deref() {
-            out.push_str(&format!("\n  {}. {kind} ({ty}) — transcript: {t}", i + 1));
+            let label = match att.kind {
+                wcore_channels::MediaKind::Image => "description",
+                _ => "transcript",
+            };
+            out.push_str(&format!("\n  {}. {kind} ({ty}) — {label}: {t}", i + 1));
         } else {
             out.push_str(&format!("\n  {}. {kind} ({ty}) — {}", i + 1, att.url));
         }
@@ -271,7 +303,7 @@ impl TurnDispatcher for ChannelTurnDispatcher {
         // inbound event); the dedupe cache upstream already guarantees one
         // dispatch per id.
         let msg_id = msg.id.clone();
-        let prompt = build_turn_prompt(msg);
+        let prompt = self.prompt_for(channel_name, msg).await;
         let result = {
             let mut guard = engine.lock().await;
             guard.run(&prompt, &msg_id).await?
@@ -315,6 +347,25 @@ mod tests {
         assert!(p.contains("Image (image/png) — https://x/a.png"));
         assert!(p.contains("Audio (unknown type) — transcript: hi there"));
         assert!(p.trim_end().ends_with(']'));
+    }
+
+    #[test]
+    fn turn_prompt_labels_enriched_image_as_description() {
+        // An image whose `transcribed` was populated by the media enricher
+        // surfaces under a "description" label (not "transcript").
+        let mut msg = wcore_channels::IncomingMessage::new("m1", "c1", "alice", "look", 0);
+        msg.attachments = vec![wcore_channels::Attachment {
+            url: "https://x/a.png".into(),
+            content_type: Some("image/png".into()),
+            kind: wcore_channels::MediaKind::Image,
+            transcribed: Some("a red bicycle".into()),
+            ..Default::default()
+        }];
+        let p = build_turn_prompt(&msg);
+        assert!(
+            p.contains("Image (image/png) — description: a red bicycle"),
+            "got: {p}"
+        );
     }
 
     #[test]

--- a/crates/wcore-agent/src/channel_media.rs
+++ b/crates/wcore-agent/src/channel_media.rs
@@ -1,0 +1,387 @@
+//! Inbound media enrichment for channel turns.
+//!
+//! A channel message can carry typed [`Attachment`]s (an image, a voice
+//! note, …). By default the dispatcher only *summarises* them into the
+//! prompt — the model is told "an image arrived at <url>" but never sees
+//! the content. For conversational channels the agent also has no vision /
+//! transcription tool to reach for (those tools are not in the
+//! `Conversational` allowlist), so the media is effectively invisible.
+//!
+//! This module closes that gap: before the turn prompt is built, the
+//! [`ChannelMediaEnricher`] eagerly resolves each attachment to *derived
+//! text* — a transcript for audio, a description for images — and writes it
+//! into [`Attachment::transcribed`], which `build_turn_prompt` already
+//! prefers over the bare URL.
+//!
+//! ## Reuse, not reimplementation
+//!
+//! The enricher does **not** re-implement fetching, SSRF defense, size
+//! caps, or MIME sniffing. It holds the real [`VisionAnalyzeTool`] /
+//! [`TranscribeAudioTool`] (built only when the host wired a backend) and
+//! calls their `execute()` surface, parsing the derived text out of the
+//! result. Every safety check the agent-facing tool enforces (SSRF-guarded
+//! fetch via the host fetcher, the 20/25 MB hard cap, magic-byte MIME
+//! validation, the structured-error contract) is therefore enforced here
+//! too, for free.
+//!
+//! ## Fail-soft
+//!
+//! Enrichment is best-effort: any failure (no backend, fetch error,
+//! unsupported format, SSRF block, timeout) logs and leaves the attachment
+//! as a plain URL summary. A media problem must never fail the turn — the
+//! agent still receives the text and the attachment reference.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde_json::{Value, json};
+use wcore_channels::{Attachment, MediaKind};
+use wcore_tools::Tool;
+use wcore_tools::transcription_tools::{AudioFetcher, TranscribeAudioTool, TranscriptionBackend};
+use wcore_tools::vision_tools::{ImageFetcher, VisionAnalyzeTool, VisionBackend};
+
+/// Max characters of derived text injected per attachment. A long
+/// transcript or verbose description must not blow the turn's prompt
+/// budget; anything beyond this is truncated with a marker.
+const MAX_DERIVED_CHARS: usize = 2_000;
+
+/// Per-attachment wall-clock cap for the whole fetch + model round trip.
+/// The underlying fetchers already cap their own connect/read timeouts;
+/// this bounds the *combined* fetch-then-analyze so a slow provider cannot
+/// stall a channel turn indefinitely.
+const ENRICH_TIMEOUT: Duration = Duration::from_secs(45);
+
+/// Vision prompt for eager image enrichment. Kept terse — the goal is a
+/// compact, prompt-budget-friendly description plus any visible text, not
+/// an essay.
+const IMAGE_DESCRIBE_PROMPT: &str =
+    "Concisely describe this image for a chat assistant, and quote any visible text verbatim.";
+
+/// Resolves inbound attachments to derived text (audio→transcript,
+/// image→description) using the host-wired vision / transcription tools.
+///
+/// Construct via [`ChannelMediaEnricher::new`]. When neither a vision nor a
+/// transcription backend is configured the enricher is *inert*
+/// ([`Self::is_inert`]) and the caller should skip installing it.
+pub struct ChannelMediaEnricher {
+    /// `Some` only when a vision backend was wired. Holds the real tool so
+    /// SSRF/cap/sniff are reused.
+    vision: Option<VisionAnalyzeTool>,
+    /// `Some` only when a transcription backend was wired.
+    transcription: Option<TranscribeAudioTool>,
+    timeout: Duration,
+}
+
+impl ChannelMediaEnricher {
+    /// Build an enricher from the optional backends and their fetchers
+    /// (the same components `bootstrap` wires into the agent's
+    /// `vision_analyze` / `transcribe_audio` tools). A `None` backend means
+    /// that media class is left as a plain summary.
+    pub fn new(
+        vision_backend: Option<Arc<dyn VisionBackend>>,
+        vision_fetcher: Arc<dyn ImageFetcher>,
+        transcription_backend: Option<Arc<dyn TranscriptionBackend>>,
+        audio_fetcher: Arc<dyn AudioFetcher>,
+    ) -> Self {
+        Self {
+            vision: vision_backend.map(|b| VisionAnalyzeTool::new(b, vision_fetcher)),
+            transcription: transcription_backend
+                .map(|b| TranscribeAudioTool::new(b, audio_fetcher)),
+            timeout: ENRICH_TIMEOUT,
+        }
+    }
+
+    /// `true` when no backend is wired — the enricher would do nothing, so
+    /// the caller can avoid installing it (and the per-turn clone of the
+    /// message it implies).
+    pub fn is_inert(&self) -> bool {
+        self.vision.is_none() && self.transcription.is_none()
+    }
+
+    /// Enrich each attachment in place. Best-effort and fail-soft: an
+    /// attachment that already carries `transcribed`, has a non-HTTP(S)
+    /// `url`, is of an unsupported kind, or fails to resolve is left
+    /// untouched.
+    pub async fn enrich(&self, attachments: &mut [Attachment], channel: &str) {
+        for att in attachments.iter_mut() {
+            // A connector may have already produced text (e.g. a platform
+            // that ships voice-note transcripts). Never overwrite it.
+            if att.transcribed.is_some() {
+                continue;
+            }
+            if !is_http_url(&att.url) {
+                continue;
+            }
+            let derived = match att.kind {
+                MediaKind::Audio => self.transcribe(&att.url, channel).await,
+                MediaKind::Image => self.describe_image(&att.url, channel).await,
+                // Video / Document / Other carry no eager backend in v1.
+                _ => None,
+            };
+            if let Some(text) = derived {
+                let (text, truncated) = truncate(text, MAX_DERIVED_CHARS);
+                tracing::info!(
+                    target: "wcore_agent::channel_media",
+                    channel,
+                    kind = ?att.kind,
+                    chars = text.len(),
+                    truncated,
+                    "inbound media enriched"
+                );
+                att.transcribed = Some(text);
+            }
+        }
+    }
+
+    /// Transcribe an audio attachment, or `None` if transcription is not
+    /// wired / the attempt failed.
+    async fn transcribe(&self, url: &str, channel: &str) -> Option<String> {
+        let tool = self.transcription.as_ref()?;
+        let content = self
+            .execute_bounded(tool, json!({ "audio_url": url }), channel, "audio")
+            .await?;
+        json_string_field(&content, "transcript")
+    }
+
+    /// Describe an image attachment, or `None` if vision is not wired / the
+    /// attempt failed.
+    async fn describe_image(&self, url: &str, channel: &str) -> Option<String> {
+        let tool = self.vision.as_ref()?;
+        let content = self
+            .execute_bounded(
+                tool,
+                json!({ "image_url": url, "question": IMAGE_DESCRIBE_PROMPT }),
+                channel,
+                "image",
+            )
+            .await?;
+        json_string_field(&content, "analysis")
+    }
+
+    /// Run a tool's `execute` under the enrichment timeout, returning the
+    /// raw JSON `content` string on success. Errors and timeouts log and
+    /// return `None` so the caller falls back to the summary.
+    async fn execute_bounded(
+        &self,
+        tool: &dyn Tool,
+        input: Value,
+        channel: &str,
+        media: &'static str,
+    ) -> Option<String> {
+        match tokio::time::timeout(self.timeout, tool.execute(input)).await {
+            Ok(result) if !result.is_error => Some(result.content),
+            Ok(result) => {
+                tracing::warn!(
+                    target: "wcore_agent::channel_media",
+                    channel,
+                    media,
+                    error = %result.content,
+                    "inbound media enrichment failed"
+                );
+                None
+            }
+            Err(_) => {
+                tracing::warn!(
+                    target: "wcore_agent::channel_media",
+                    channel,
+                    media,
+                    timeout_secs = self.timeout.as_secs(),
+                    "inbound media enrichment timed out"
+                );
+                None
+            }
+        }
+    }
+}
+
+/// Only `http`/`https` URLs are fetchable. A connector that failed to
+/// resolve a download URL leaves a raw platform reference (e.g. a Telegram
+/// `file_id`) in `url`; that is not fetchable, so skip it.
+fn is_http_url(url: &str) -> bool {
+    url.starts_with("http://") || url.starts_with("https://")
+}
+
+/// Pull a non-empty string field out of a tool's JSON result body.
+fn json_string_field(content: &str, field: &str) -> Option<String> {
+    let value: Value = serde_json::from_str(content).ok()?;
+    let text = value.get(field)?.as_str()?.trim();
+    if text.is_empty() {
+        None
+    } else {
+        Some(text.to_string())
+    }
+}
+
+/// Truncate to at most `max` characters (char-boundary safe), appending a
+/// marker when cut. Returns `(text, was_truncated)`.
+fn truncate(text: String, max: usize) -> (String, bool) {
+    if text.chars().count() <= max {
+        return (text, false);
+    }
+    let cut: String = text.chars().take(max).collect();
+    (format!("{cut}… [truncated]"), true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wcore_tools::transcription_tools::{CapturingTranscriptionBackend, StaticAudioFetcher};
+    use wcore_tools::vision_tools::{CapturingVisionBackend, StaticImageFetcher};
+
+    /// Minimal valid PNG header — passes `detect_image_mime` + min-size.
+    fn png_bytes() -> Vec<u8> {
+        let mut v = b"\x89PNG\r\n\x1a\n".to_vec();
+        v.extend_from_slice(&[0u8; 64]);
+        v
+    }
+
+    /// Minimal valid OGG header — passes `detect_audio_mime` + min-size.
+    fn ogg_bytes() -> Vec<u8> {
+        let mut v = b"OggS".to_vec();
+        v.extend_from_slice(&[0u8; 64]);
+        v
+    }
+
+    fn image_att(url: &str) -> Attachment {
+        Attachment {
+            url: url.into(),
+            content_type: Some("image/png".into()),
+            kind: MediaKind::Image,
+            ..Default::default()
+        }
+    }
+
+    fn audio_att(url: &str) -> Attachment {
+        Attachment {
+            url: url.into(),
+            content_type: Some("audio/ogg".into()),
+            kind: MediaKind::Audio,
+            ..Default::default()
+        }
+    }
+
+    fn vision_only(canned: &str) -> ChannelMediaEnricher {
+        ChannelMediaEnricher::new(
+            Some(Arc::new(CapturingVisionBackend::new(canned))),
+            Arc::new(StaticImageFetcher::new(png_bytes())),
+            None,
+            Arc::new(StaticAudioFetcher::new(Vec::new())),
+        )
+    }
+
+    fn audio_only(canned: &str) -> ChannelMediaEnricher {
+        ChannelMediaEnricher::new(
+            None,
+            Arc::new(StaticImageFetcher::new(Vec::new())),
+            Some(Arc::new(CapturingTranscriptionBackend::new(canned))),
+            Arc::new(StaticAudioFetcher::new(ogg_bytes())),
+        )
+    }
+
+    #[tokio::test]
+    async fn enriches_image_into_description() {
+        let enricher = vision_only("a red bicycle leaning on a wall");
+        let mut atts = vec![image_att("https://example.com/bike.png")];
+        enricher.enrich(&mut atts, "telegram").await;
+        assert_eq!(
+            atts[0].transcribed.as_deref(),
+            Some("a red bicycle leaning on a wall")
+        );
+    }
+
+    #[tokio::test]
+    async fn enriches_audio_into_transcript() {
+        let enricher = audio_only("meet me at noon");
+        let mut atts = vec![audio_att("https://example.com/voice.ogg")];
+        enricher.enrich(&mut atts, "telegram").await;
+        assert_eq!(atts[0].transcribed.as_deref(), Some("meet me at noon"));
+    }
+
+    #[tokio::test]
+    async fn preserves_connector_supplied_transcript() {
+        let enricher = audio_only("model transcript that must not be used");
+        let mut atts = vec![Attachment {
+            url: "https://example.com/voice.ogg".into(),
+            kind: MediaKind::Audio,
+            transcribed: Some("connector transcript".into()),
+            ..Default::default()
+        }];
+        enricher.enrich(&mut atts, "telegram").await;
+        assert_eq!(atts[0].transcribed.as_deref(), Some("connector transcript"));
+    }
+
+    #[tokio::test]
+    async fn skips_non_http_reference() {
+        // A bare Telegram file_id (getFile fell back) is not fetchable.
+        let enricher = vision_only("never produced");
+        let mut atts = vec![image_att("BAADBAADrwADBREAAYag")];
+        enricher.enrich(&mut atts, "telegram").await;
+        assert!(atts[0].transcribed.is_none());
+    }
+
+    #[tokio::test]
+    async fn skips_unsupported_kind() {
+        let enricher = vision_only("never produced");
+        let mut atts = vec![Attachment {
+            url: "https://example.com/report.pdf".into(),
+            kind: MediaKind::Document,
+            ..Default::default()
+        }];
+        enricher.enrich(&mut atts, "telegram").await;
+        assert!(atts[0].transcribed.is_none());
+    }
+
+    #[tokio::test]
+    async fn image_skipped_when_only_transcription_wired() {
+        let enricher = audio_only("audio backend present, vision absent");
+        let mut atts = vec![image_att("https://example.com/x.png")];
+        enricher.enrich(&mut atts, "telegram").await;
+        assert!(
+            atts[0].transcribed.is_none(),
+            "image must stay a summary when no vision backend is wired"
+        );
+    }
+
+    #[tokio::test]
+    async fn long_derived_text_is_truncated() {
+        let huge = "x".repeat(MAX_DERIVED_CHARS + 500);
+        let enricher = vision_only(&huge);
+        let mut atts = vec![image_att("https://example.com/big.png")];
+        enricher.enrich(&mut atts, "telegram").await;
+        let got = atts[0].transcribed.as_deref().unwrap();
+        assert!(got.ends_with("… [truncated]"), "expected truncation marker");
+        assert!(
+            got.chars().count() <= MAX_DERIVED_CHARS + " … [truncated]".chars().count(),
+            "truncated text must respect the cap"
+        );
+    }
+
+    #[tokio::test]
+    async fn inert_enricher_is_a_noop() {
+        let enricher = ChannelMediaEnricher::new(
+            None,
+            Arc::new(StaticImageFetcher::new(Vec::new())),
+            None,
+            Arc::new(StaticAudioFetcher::new(Vec::new())),
+        );
+        assert!(enricher.is_inert());
+        let mut atts = vec![image_att("https://example.com/x.png")];
+        enricher.enrich(&mut atts, "telegram").await;
+        assert!(atts[0].transcribed.is_none());
+    }
+
+    #[test]
+    fn truncate_below_cap_is_unchanged() {
+        let (text, cut) = truncate("short".to_string(), 100);
+        assert_eq!(text, "short");
+        assert!(!cut);
+    }
+
+    #[test]
+    fn is_http_url_matches_only_web_schemes() {
+        assert!(is_http_url("https://example.com/a.png"));
+        assert!(is_http_url("http://example.com/a.png"));
+        assert!(!is_http_url("file:///etc/passwd"));
+        assert!(!is_http_url("BAADBAADrwADBREAAYag"));
+    }
+}

--- a/crates/wcore-agent/src/lib.rs
+++ b/crates/wcore-agent/src/lib.rs
@@ -29,6 +29,11 @@ pub mod channel_tools;
 // to avoid channel recursion) and drives an agent turn from each admitted
 // inbound message, returning the reply text the subscriber sends back.
 pub mod channel_dispatch;
+// Inbound media enrichment: resolves channel attachments (image/audio) to
+// derived text (description/transcript) via the host-wired vision /
+// transcription tools before the turn prompt is built. Inert when no
+// backend is configured. Consumed by `channel_dispatch` + `bootstrap`.
+pub mod channel_media;
 // FleetDispatcher-class fix (audit 2026-05-24): bridges SendMessageTool's
 // `MessageTransport` boundary to the host's `ChannelManager` so the LLM
 // can drive Telegram/Discord/Slack/etc. through user-configured channels.

--- a/crates/wcore-channels/src/event.rs
+++ b/crates/wcore-channels/src/event.rs
@@ -75,7 +75,9 @@ pub struct Attachment {
     /// Coarse media class.
     #[serde(default)]
     pub kind: MediaKind,
-    /// Transcribed text (audio/voice notes) once produced.
+    /// Derived text from the media once produced — a transcript for audio /
+    /// voice notes, a description for images. Populated either by the
+    /// connector or by the host's inbound-media enricher.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub transcribed: Option<String>,
 }


### PR DESCRIPTION
## What

Closes the #1 channel-parity gap from the parity audit: inbound attachments were only **summarised** into the prompt (the model was told an image/voice note arrived at a URL but never saw the content), and a conversational-posture channel agent has no vision/transcribe tool to reach for — so the media was effectively invisible.

This adds eager **inbound media enrichment**: before the turn prompt is built, each attachment is resolved to *derived text* — a **transcript** for audio, a **description** for images — into `Attachment.transcribed`, which `build_turn_prompt` already prefers over the bare URL. Images now surface under a `description:` label.

## How

- New `wcore-agent/src/channel_media.rs` — `ChannelMediaEnricher`.
- **Reuse, not reimplementation:** the enricher holds the real `VisionAnalyzeTool` / `TranscribeAudioTool` (built only when a backend has an API key) and calls their `execute()` surface. Every existing safety check is inherited for free — SSRF-guarded fetch via the same fetchers the agent tools use, the 20/25 MB hard cap, magic-byte MIME validation, the structured-error contract.
- **Fail-soft + bounded:** per-attachment 45s timeout; any failure (no backend, fetch error, unsupported format, SSRF block, timeout) logs and leaves the plain URL summary. A media problem never fails the turn. Derived text truncated to 2000 chars to protect the prompt budget.
- **Inert when unconfigured:** no vision/transcription API key → enricher is skipped entirely (no behaviour change, no per-turn message clone).
- Wired in `bootstrap` behind the existing channel-inbound path; threaded through `ChannelTurnDispatcher` as an `Option`.
- Connector-supplied transcripts are never overwritten; non-HTTP references (e.g. an unresolved Telegram `file_id`) are skipped.

Telegram is the immediate beneficiary — its inbound already resolves a real `getFile` HTTPS download URL. Other connectors light up as they populate fetchable URLs.

## Scope (v1)

Audio + image. Video/document stay summary-only. Passing raw bytes as multimodal blocks straight to the engine would need an engine-API change — deferred; pre-captioning via the configured vision model is the v1 path.

## Tests / gate

11 enricher unit tests (image/audio enrich, connector-transcript preserved, non-http + unsupported-kind skipped, vision-absent skip, inert no-op, truncation, helpers) + a dispatcher `description`-label test.

Gate green on the Hetzner box: `cargo fmt --all --check`, `clippy --workspace --all-targets -D warnings`, `nextest run --workspace` **8168/8168 passing** (+10 from this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)