### PR TITLE
feat(discord): idempotency nonce on outbound sends (HIGH-7)

### DIFF
--- a/crates/wcore-channel-discord/src/lib.rs
+++ b/crates/wcore-channel-discord/src/lib.rs
@@ -220,9 +220,15 @@ impl Channel for DiscordChannel {
             .reply_to
             .as_deref()
             .map(|m| rest::MessageReference { message_id: m });
+        // Generate the dedup nonce once and reuse it across the retry loop
+        // inside `rest::send_message` (HIGH-7): a retry after a lost success
+        // re-sends the same nonce, which Discord dedupes instead of posting
+        // a duplicate.
+        let nonce = rest::next_nonce();
         let body = rest::CreateMessageBody {
             content: &msg.text,
             message_reference: reference,
+            nonce: Some(&nonce),
         };
         let result = rest::send_message(
             &self.http,

--- a/crates/wcore-channel-discord/src/rest.rs
+++ b/crates/wcore-channel-discord/src/rest.rs
@@ -41,6 +41,30 @@ pub struct CreateMessageBody<'a> {
     pub content: &'a str,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message_reference: Option<MessageReference<'a>>,
+    /// Optimistic-send dedup token (≤25 chars). Discord deduplicates
+    /// create-message requests that carry the same `nonce` from the same
+    /// author within a short window, so reusing ONE nonce across the retry
+    /// loop turns a retry-after-a-lost-success into a no-op instead of a
+    /// duplicate post (HIGH-7).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nonce: Option<&'a str>,
+}
+
+/// Generate a process-unique nonce for Discord's optimistic-send dedup.
+/// The global monotonic counter guarantees uniqueness within a process;
+/// the wall-clock millis prefix keeps it distinct across restarts. The
+/// `-` separator makes the `{ms}-{n}` concatenation unambiguous, and the
+/// whole string stays well under Discord's 25-char cap.
+pub(crate) fn next_nonce() -> String {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::{SystemTime, UNIX_EPOCH};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0);
+    format!("{ms:x}-{n:x}")
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -344,5 +368,62 @@ mod reaction_tests {
             .await
             .expect_err("403 should error");
         assert!(matches!(err, DiscordError::Auth(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn next_nonce_is_unique_and_within_cap() {
+        let a = next_nonce();
+        let b = next_nonce();
+        assert_ne!(a, b, "nonces must be unique per call");
+        assert!(
+            a.len() <= 25 && b.len() <= 25,
+            "nonce must fit Discord's 25-char cap"
+        );
+    }
+
+    #[tokio::test]
+    async fn send_reuses_one_nonce_across_a_retry() {
+        // First attempt 503 (transient → retry), second 200. Both requests
+        // must carry the SAME nonce so Discord dedupes the retry.
+        let mut server = mockito::Server::new_async().await;
+        let nonce = next_nonce();
+        let body_matcher =
+            mockito::Matcher::Regex(format!(r#""nonce":"{}""#, regex_escape(&nonce)));
+        let first = server
+            .mock("POST", "/api/v10/channels/c1/messages")
+            .match_body(body_matcher.clone())
+            .with_status(503)
+            .expect(1)
+            .create_async()
+            .await;
+        let second = server
+            .mock("POST", "/api/v10/channels/c1/messages")
+            .match_body(body_matcher)
+            .with_status(200)
+            .with_body(r#"{"id":"m1","channel_id":"c1"}"#)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let http = wcore_egress::EgressClient::new();
+        let body = CreateMessageBody {
+            content: "hi",
+            message_reference: None,
+            nonce: Some(&nonce),
+        };
+        let msg = send_message(&http, &server.url(), "tok", "c1", &body)
+            .await
+            .expect("retry should succeed on the 200");
+        assert_eq!(msg.id, "m1");
+        // Both mocks asserting proves the identical nonce went out twice.
+        first.assert_async().await;
+        second.assert_async().await;
+    }
+
+    /// Escape the regex metacharacter that can appear in a nonce (`-` is
+    /// literal in a char class but safe outside; the only other is none —
+    /// the nonce is `[0-9a-f-]`). Kept tiny and local.
+    fn regex_escape(s: &str) -> String {
+        s.replace('-', r"\-")
     }
 }


### PR DESCRIPTION
## What

Closes the deferred **HIGH-7** (outbound idempotency) for the one connector with a native dedup key. Discord's create-message `nonce` is an optimistic-send token — Discord deduplicates create requests carrying the same nonce from the same author within a short window. The Discord send path already retries (5 attempts; backoff on 5xx/network/429), so a retry *after a lost success* could post a duplicate. Generating one nonce per logical send and reusing it across the retry loop turns that retry into a server-side no-op instead of a dup.

## How

- `CreateMessageBody` gains an optional `nonce` (skipped when `None`).
- `next_nonce()`: process-monotonic counter (uniqueness) + wall-clock millis prefix (cross-restart distinctness), formatted `{ms:x}-{n:x}`, well under Discord's 25-char cap.
- `send_message` generates the nonce once *before* the retry loop; the body is already reused across attempts, so every retry carries the same nonce.

## Scope (honest per-platform)

This is Discord-specific because it's the only connector with a platform dedup key:
- **Matrix** — already idempotent via its `txn_id` in the send URL.
- **Telegram** — send is single-attempt (no retry → no dup window).
- **Slack / WhatsApp** — their send endpoints expose no idempotency key, so the retry-after-lost-success dup risk is inherent and bounded by their retry policies. Documented, not faked.

## Tests / gate

Nonce uniqueness + 25-char cap; a 503-then-200 retry asserts the **same** nonce is sent on both attempts (proving reuse across the loop). The existing send test uses `PartialJsonString`, so the new field doesn't break it.

Gate green on the Hetzner box: `fmt --check`, `clippy --workspace --all-targets -D warnings`, `nextest --workspace` **8185/8185**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)