### PR TITLE
fix(ci): disposition rsa RUSTSEC-2023-0071 (Marvin Attack) to unblock audit

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -28,4 +28,22 @@
 # Format reference: https://docs.rs/cargo-audit/latest/cargo_audit/
 
 [advisories]
-ignore = []
+# ── rsa 0.9.x — RUSTSEC-2023-0071 (Marvin Attack, timing sidechannel) ──────
+# Parent trace (`cargo tree -i rsa`): rsa 0.9.10 <- jsonwebtoken 10.3.0, with
+# TWO consumers:
+#   1. wcore-channel-msteams — Bot Framework inbound JWT *verification* with
+#      Microsoft's PUBLIC JWKS keys. RS256 verify never touches a private key,
+#      never decrypts/signs → the vulnerable path is unreachable here.
+#   2. wcore-providers (Vertex AI) — *signs* a service-account JWT (RS256) with
+#      the operator's OWN RSA private key to mint a Google access token. This
+#      IS a private-key op (the advisory's target surface), but practical
+#      exploitability is low: signing is infrequent (token refresh ~hourly),
+#      runs locally, is NOT remotely attacker-triggerable at the volume/timing
+#      precision a Marvin attack needs, and exposes no timing oracle to any
+#      remote party (the signature goes to Google's token endpoint, not back to
+#      an attacker). No fixed `rsa` release exists ("No fixed upgrade available").
+# Permanent remediation (tracked): migrate jsonwebtoken to the `aws_lc_rs`
+# CryptoProvider (constant-time AWS-LC, drops the pure-Rust `rsa` crate),
+# pending Windows-CI validation of the C-toolchain build — `rust_crypto` was
+# chosen originally for a Windows-clean pure-Rust build.
+ignore = ["RUSTSEC-2023-0071"]

--- a/.github/osv-scanner.toml
+++ b/.github/osv-scanner.toml
@@ -84,6 +84,24 @@ id = "RUSTSEC-2024-0370"
 ignoreUntil = "2026-09-02T00:00:00Z"
 reason = "proc-macro-error: build-time proc-macro, no runtime surface; transitive via utoipa-gen <- utoipa <- wcore-acp. Already accepted by cargo-audit. Tracked; revisit on utoipa 5.x."
 
+# ── rsa 0.9.x (VULNERABILITY — Marvin Attack timing sidechannel) ──────────
+# The only vulnerability-class (not warning-class) entry in this file, so it
+# is dispositioned with care. Parent trace: rsa 0.9.10 <- jsonwebtoken 10.3.0,
+# TWO consumers: wcore-channel-msteams (RS256 JWT *verify* with Microsoft
+# PUBLIC keys — vulnerable private-key path unreachable) and wcore-providers
+# (Vertex AI *signs* a service-account JWT with the operator's RSA private key
+# — the advisory's target surface). The signing path's practical exploitability
+# is low: infrequent (~hourly token refresh), local, not remotely
+# attacker-triggerable at Marvin timing precision, and no timing oracle is
+# exposed to a remote party. No fixed `rsa` release exists. Permanent fix
+# (tracked): migrate jsonwebtoken to the aws_lc_rs CryptoProvider (constant-time
+# AWS-LC, drops rsa), pending Windows-CI validation of its C-toolchain build.
+# Aligned with the cargo-audit ignore set (.cargo/audit.toml).
+[[IgnoredVulns]]
+id = "RUSTSEC-2023-0071"
+ignoreUntil = "2026-09-02T00:00:00Z"
+reason = "rsa Marvin Attack: jsonwebtoken <- {msteams JWT verify (public key, unreachable) + Vertex JWT sign (local, infrequent, no remote timing oracle)}. No upstream fix. Tracked: migrate to aws_lc_rs provider. Aligned with cargo-audit ignore."
+
 # NOTE: RUSTSEC-2026-0002 (lru 0.12.5, unsound) was ELIMINATED AT THE SOURCE,
 # not ignored — ratatui upgraded 0.29 -> 0.30, which moved lru to 0.16.x. The
 # vulnerable lru 0.12.5 is gone from the tree. (The migration was a single


### PR DESCRIPTION
## Problem

CI's `cargo audit` leg (`CI (linux-containerized)` + `CI (macos-latest)`) is red on `error: 1 vulnerability found!` — **rsa 0.9.10, RUSTSEC-2023-0071 (Marvin Attack timing sidechannel)**. All 6 platform Builds are green; this is a dependency-advisory gate, not a code failure.

It was **latent since the msteams JWT merge** (which added `jsonwebtoken` + `rust_crypto` → `rsa`) and only surfaced now: the rapid merge-train kept cancelling interim CI runs (`cancel-in-progress`), and the workflow run-level never completes because the self-hosted Windows `CI (Array)` leg queues forever (FerroxLabs has no self-hosted runner) — so the job-level audit failure was never surfaced until I inspected jobs directly.

## Disposition

Parent trace (`cargo tree -i rsa`): `rsa 0.9.10 <- jsonwebtoken 10.3.0`, two consumers:
- **wcore-channel-msteams** — RS256 JWT *verification* with Microsoft's **public** JWKS keys. No private-key op; the vulnerable path is unreachable.
- **wcore-providers (Vertex AI)** — *signs* a service-account JWT with the operator's **own** RSA private key. This **is** the advisory's target surface, but practical exploitability is low: signing is infrequent (~hourly token refresh), local, not remotely attacker-triggerable at the volume/timing precision a Marvin attack needs, and exposes no timing oracle to any remote party (the signature goes to Google's token endpoint). **No fixed `rsa` release exists.**

Documented ignore added to **both** gating scanners (`.cargo/audit.toml` + `.github/osv-scanner.toml`) with parent trace, threat-model note, and a tracking item — matching the repo's existing disposition policy.

## Permanent fix (deferred — needs your call)

Migrate `jsonwebtoken` to the **`aws_lc_rs`** CryptoProvider (constant-time AWS-LC, drops the pure-Rust `rsa` crate entirely). Deferred because `rust_crypto` was originally chosen for a Windows-clean pure-Rust build, and the aws_lc_rs C-toolchain build needs Windows-CI validation before switching. Tracked in both config files (`ignoreUntil = 2026-09-02`).

## Verification

`cargo audit` exits **0** on the box with the ignore applied (0 vulnerabilities, 6 allowed warnings). Both TOML files parse cleanly. Config-only — no code change, so clippy/nextest are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)