### PR TITLE
fix(security): migrate jsonwebtoken to aws_lc_rs, drop rsa (RUSTSEC-2023-0071)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -28,22 +28,9 @@
 # Format reference: https://docs.rs/cargo-audit/latest/cargo_audit/
 
 [advisories]
-# ── rsa 0.9.x — RUSTSEC-2023-0071 (Marvin Attack, timing sidechannel) ──────
-# Parent trace (`cargo tree -i rsa`): rsa 0.9.10 <- jsonwebtoken 10.3.0, with
-# TWO consumers:
-#   1. wcore-channel-msteams — Bot Framework inbound JWT *verification* with
-#      Microsoft's PUBLIC JWKS keys. RS256 verify never touches a private key,
-#      never decrypts/signs → the vulnerable path is unreachable here.
-#   2. wcore-providers (Vertex AI) — *signs* a service-account JWT (RS256) with
-#      the operator's OWN RSA private key to mint a Google access token. This
-#      IS a private-key op (the advisory's target surface), but practical
-#      exploitability is low: signing is infrequent (token refresh ~hourly),
-#      runs locally, is NOT remotely attacker-triggerable at the volume/timing
-#      precision a Marvin attack needs, and exposes no timing oracle to any
-#      remote party (the signature goes to Google's token endpoint, not back to
-#      an attacker). No fixed `rsa` release exists ("No fixed upgrade available").
-# Permanent remediation (tracked): migrate jsonwebtoken to the `aws_lc_rs`
-# CryptoProvider (constant-time AWS-LC, drops the pure-Rust `rsa` crate),
-# pending Windows-CI validation of the C-toolchain build — `rust_crypto` was
-# chosen originally for a Windows-clean pure-Rust build.
-ignore = ["RUSTSEC-2023-0071"]
+# The ignore list is EMPTY again. RUSTSEC-2023-0071 (rsa Marvin Attack) was
+# ELIMINATED AT THE SOURCE, not ignored: jsonwebtoken migrated `rust_crypto`
+# -> `aws_lc_rs` in wcore-channel-msteams + wcore-providers, dropping the
+# pure-Rust `rsa` crate from the tree (`cargo tree -i rsa` -> not found).
+# aws-lc-rs was already present via rustls, so this added no build surface.
+ignore = []

--- a/.github/osv-scanner.toml
+++ b/.github/osv-scanner.toml
@@ -84,23 +84,11 @@ id = "RUSTSEC-2024-0370"
 ignoreUntil = "2026-09-02T00:00:00Z"
 reason = "proc-macro-error: build-time proc-macro, no runtime surface; transitive via utoipa-gen <- utoipa <- wcore-acp. Already accepted by cargo-audit. Tracked; revisit on utoipa 5.x."
 
-# ── rsa 0.9.x (VULNERABILITY — Marvin Attack timing sidechannel) ──────────
-# The only vulnerability-class (not warning-class) entry in this file, so it
-# is dispositioned with care. Parent trace: rsa 0.9.10 <- jsonwebtoken 10.3.0,
-# TWO consumers: wcore-channel-msteams (RS256 JWT *verify* with Microsoft
-# PUBLIC keys — vulnerable private-key path unreachable) and wcore-providers
-# (Vertex AI *signs* a service-account JWT with the operator's RSA private key
-# — the advisory's target surface). The signing path's practical exploitability
-# is low: infrequent (~hourly token refresh), local, not remotely
-# attacker-triggerable at Marvin timing precision, and no timing oracle is
-# exposed to a remote party. No fixed `rsa` release exists. Permanent fix
-# (tracked): migrate jsonwebtoken to the aws_lc_rs CryptoProvider (constant-time
-# AWS-LC, drops rsa), pending Windows-CI validation of its C-toolchain build.
-# Aligned with the cargo-audit ignore set (.cargo/audit.toml).
-[[IgnoredVulns]]
-id = "RUSTSEC-2023-0071"
-ignoreUntil = "2026-09-02T00:00:00Z"
-reason = "rsa Marvin Attack: jsonwebtoken <- {msteams JWT verify (public key, unreachable) + Vertex JWT sign (local, infrequent, no remote timing oracle)}. No upstream fix. Tracked: migrate to aws_lc_rs provider. Aligned with cargo-audit ignore."
+# NOTE: RUSTSEC-2023-0071 (rsa 0.9.x, Marvin Attack) was ELIMINATED AT THE
+# SOURCE, not ignored: jsonwebtoken migrated rust_crypto -> aws_lc_rs in
+# wcore-channel-msteams + wcore-providers, dropping the pure-Rust `rsa` crate
+# (`cargo tree -i rsa` -> not found). aws-lc-rs was already in the tree via
+# rustls, so no new build surface.
 
 # NOTE: RUSTSEC-2026-0002 (lru 0.12.5, unsound) was ELIMINATED AT THE SOURCE,
 # not ignored — ratatui upgraded 0.29 -> 0.30, which moved lru to 0.16.x. The

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -319,6 +319,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
+ "untrusted 0.7.1",
  "zeroize",
 ]
 
@@ -449,7 +450,7 @@ dependencies = [
  "hmac 0.13.0",
  "http 0.2.12",
  "http 1.4.1",
- "p256 0.11.1",
+ "p256",
  "percent-encoding",
  "ring",
  "sha2 0.11.0",
@@ -733,12 +734,6 @@ name = "base16ct"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
-
-[[package]]
-name = "base16ct"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
@@ -1980,10 +1975,8 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
- "generic-array",
  "rand_core 0.6.4",
  "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -2204,7 +2197,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid 0.9.6",
- "pem-rfc7468",
  "zeroize",
 ]
 
@@ -2289,7 +2281,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "const-oid 0.9.6",
  "crypto-common 0.1.7",
  "subtle",
 ]
@@ -2413,23 +2404,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
 dependencies = [
  "der 0.6.1",
- "elliptic-curve 0.12.3",
- "rfc6979 0.3.1",
+ "elliptic-curve",
+ "rfc6979",
  "signature 1.6.4",
-]
-
-[[package]]
-name = "ecdsa"
-version = "0.16.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
-dependencies = [
- "der 0.7.10",
- "digest 0.10.7",
- "elliptic-curve 0.13.8",
- "rfc6979 0.4.0",
- "signature 2.2.0",
- "spki 0.7.3",
 ]
 
 [[package]]
@@ -2469,37 +2446,16 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
 dependencies = [
- "base16ct 0.1.1",
+ "base16ct",
  "crypto-bigint 0.4.9",
  "der 0.6.1",
  "digest 0.10.7",
- "ff 0.12.1",
+ "ff",
  "generic-array",
- "group 0.12.1",
+ "group",
  "pkcs8 0.9.0",
  "rand_core 0.6.4",
- "sec1 0.3.0",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "elliptic-curve"
-version = "0.13.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
-dependencies = [
- "base16ct 0.2.0",
- "crypto-bigint 0.5.5",
- "digest 0.10.7",
- "ff 0.13.1",
- "generic-array",
- "group 0.13.0",
- "hkdf",
- "pem-rfc7468",
- "pkcs8 0.10.2",
- "rand_core 0.6.4",
- "sec1 0.7.3",
+ "sec1",
  "subtle",
  "zeroize",
 ]
@@ -2706,16 +2662,6 @@ name = "ff"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
-dependencies = [
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
-name = "ff"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
  "rand_core 0.6.4",
  "subtle",
@@ -3113,7 +3059,6 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
- "zeroize",
 ]
 
 [[package]]
@@ -3222,18 +3167,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
 dependencies = [
- "ff 0.12.1",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
-name = "group"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
-dependencies = [
- "ff 0.13.1",
+ "ff",
  "rand_core 0.6.4",
  "subtle",
 ]
@@ -3385,15 +3319,6 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "hkdf"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
-dependencies = [
- "hmac 0.12.1",
 ]
 
 [[package]]
@@ -4084,19 +4009,13 @@ version = "10.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
 dependencies = [
+ "aws-lc-rs",
  "base64 0.22.1",
- "ed25519-dalek",
  "getrandom 0.2.17",
- "hmac 0.12.1",
  "js-sys",
- "p256 0.13.2",
- "p384",
  "pem",
- "rand 0.8.6",
- "rsa",
  "serde",
  "serde_json",
- "sha2 0.10.9",
  "signature 2.2.0",
  "simple_asn1",
 ]
@@ -4178,9 +4097,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-dependencies = [
- "spin",
-]
 
 [[package]]
 name = "lazycell"
@@ -4882,22 +4798,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint-dig"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
-dependencies = [
- "lazy_static",
- "libm",
- "num-integer",
- "num-iter",
- "num-traits",
- "rand 0.8.6",
- "smallvec",
- "zeroize",
-]
-
-[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4930,17 +4830,6 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
-dependencies = [
- "autocfg",
- "num-integer",
  "num-traits",
 ]
 
@@ -5429,32 +5318,8 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
 dependencies = [
- "ecdsa 0.14.8",
- "elliptic-curve 0.12.3",
- "sha2 0.10.9",
-]
-
-[[package]]
-name = "p256"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
-dependencies = [
- "ecdsa 0.16.9",
- "elliptic-curve 0.13.8",
- "primeorder",
- "sha2 0.10.9",
-]
-
-[[package]]
-name = "p384"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
-dependencies = [
- "ecdsa 0.16.9",
- "elliptic-curve 0.13.8",
- "primeorder",
+ "ecdsa",
+ "elliptic-curve",
  "sha2 0.10.9",
 ]
 
@@ -5535,15 +5400,6 @@ checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
  "base64 0.22.1",
  "serde_core",
-]
-
-[[package]]
-name = "pem-rfc7468"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
-dependencies = [
- "base64ct",
 ]
 
 [[package]]
@@ -5697,17 +5553,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "pkcs1"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
-dependencies = [
- "der 0.7.10",
- "pkcs8 0.10.2",
- "spki 0.7.3",
-]
 
 [[package]]
 name = "pkcs8"
@@ -5939,15 +5784,6 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "primeorder"
-version = "0.13.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
-dependencies = [
- "elliptic-curve 0.13.8",
 ]
 
 [[package]]
@@ -6574,16 +6410,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rfc6979"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
-dependencies = [
- "hmac 0.12.1",
- "subtle",
-]
-
-[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6593,7 +6419,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -6618,26 +6444,6 @@ dependencies = [
  "libc",
  "rtoolbox",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "rsa"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
-dependencies = [
- "const-oid 0.9.6",
- "digest 0.10.7",
- "num-bigint-dig",
- "num-integer",
- "num-traits",
- "pkcs1",
- "pkcs8 0.10.2",
- "rand_core 0.6.4",
- "signature 2.2.0",
- "spki 0.7.3",
- "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -6820,7 +6626,7 @@ dependencies = [
  "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -6935,24 +6741,10 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
 dependencies = [
- "base16ct 0.1.1",
+ "base16ct",
  "der 0.6.1",
  "generic-array",
  "pkcs8 0.9.0",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "sec1"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
-dependencies = [
- "base16ct 0.2.0",
- "der 0.7.10",
- "generic-array",
- "pkcs8 0.10.2",
  "subtle",
  "zeroize",
 ]
@@ -7317,7 +7109,6 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -7381,12 +7172,6 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "spki"
@@ -8451,6 +8236,12 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"

--- a/crates/wcore-channel-msteams/Cargo.toml
+++ b/crates/wcore-channel-msteams/Cargo.toml
@@ -8,10 +8,15 @@ description = "Microsoft Teams channel adapter for Wayland-Core — Bot Framewor
 [dependencies]
 async-trait = { workspace = true }
 chrono = { workspace = true, features = ["serde"] }
-# `rust_crypto`: jsonwebtoken 10.x requires an explicit CryptoProvider feature
-# (no default). Pure-Rust provider — no C toolchain, so the Windows CI lane
-# builds cleanly. Needed because this crate actually verifies RS256 JWTs.
-jsonwebtoken = { workspace = true, features = ["rust_crypto"] }
+# `aws_lc_rs`: jsonwebtoken 10.x requires an explicit CryptoProvider feature
+# (no default). We use aws_lc_rs (constant-time AWS-LC) NOT the pure-Rust
+# `rust_crypto` provider, because rust_crypto pulls the `rsa` crate which
+# carries RUSTSEC-2023-0071 (Marvin Attack timing sidechannel, no upstream
+# fix). aws-lc-rs is ALREADY in the tree (rustls's default crypto provider)
+# and its aws-lc-sys C build compiles green on every CI target incl.
+# aarch64-pc-windows-msvc — so this adds no new build surface and drops `rsa`
+# at the source. Used here to verify RS256 JWTs.
+jsonwebtoken = { workspace = true, features = ["aws_lc_rs"] }
 reqwest = { workspace = true, features = ["json"] }
 wcore-egress = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/crates/wcore-providers/Cargo.toml
+++ b/crates/wcore-providers/Cargo.toml
@@ -24,7 +24,12 @@ tracing.workspace      = true
 dirs.workspace         = true
 url.workspace          = true
 base64.workspace       = true
-jsonwebtoken.workspace = true
+# aws_lc_rs CryptoProvider (NOT rust_crypto) so this crate's RS256 Vertex
+# service-account JWT *signing* never links the `rsa` crate (RUSTSEC-2023-0071).
+# Must be declared explicitly: previously this rode on wcore-channel-msteams's
+# feature unification, which is fragile (isolated builds of this crate had no
+# crypto backend). See that crate's Cargo.toml note.
+jsonwebtoken = { workspace = true, features = ["aws_lc_rs"] }
 chrono.workspace       = true
 parking_lot.workspace  = true
 


### PR DESCRIPTION
## What

Eliminates the `rsa` Marvin Attack advisory (RUSTSEC-2023-0071) **at the source** instead of suppressing it (reverses the #12 documented ignore). Switches `jsonwebtoken`'s CryptoProvider from `rust_crypto` (pure-Rust, pulls the unfixable `rsa` crate) to `aws_lc_rs` (constant-time AWS-LC) in both consumers: `wcore-channel-msteams` (RS256 verify) and `wcore-providers` (RS256 Vertex service-account sign).

## Why it's zero-risk (the deferral was based on a wrong assumption)

The #12 PR deferred this fearing the `aarch64-pc-windows-msvc` aws-lc-sys C-build would break. **Empirically false for this repo:** `aws-lc-rs` + `aws-lc-sys` are *already* in the tree as **rustls's default crypto provider**, and the **green** `aarch64-pc-windows-msvc` CI build already shows `Compiling aws-lc-sys v0.41.0` today. So this migration adds **no new C-build / Windows surface** — it just makes jsonwebtoken use the aws-lc-rs that's already there, and drops the pure-Rust `rsa` stack.

`wcore-providers` now declares the feature explicitly (it previously rode on msteams' feature unification — latent fragility: isolated builds had no crypto backend).

## Verification (on the box)

- `cargo tree -i rsa` → **"did not match any packages"** (rsa dropped; deps 1021 → 1005)
- `cargo audit` exits **0 with an EMPTY ignore list** — advisory gone, nothing suppressed
- `clippy --workspace --all-targets -D warnings` clean
- `nextest --workspace` **8185/8185** — RS256 **sign** (Vertex) + **verify** (msteams) behavior preserved
- `Cargo.lock` regenerated on the box and pulled back

Removes the rsa entries from `.cargo/audit.toml` and `.github/osv-scanner.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)