### PR TITLE
fix(ijfw): PATHEXT-aware npx detection on Windows (closes #6)

### DIFF
--- a/crates/wayland-ijfw/src/mcp.rs
+++ b/crates/wayland-ijfw/src/mcp.rs
@@ -40,10 +40,52 @@ pub fn default_server_spec() -> McpServerSpec {
 /// declares `register_mcp_server = true`, so the registry must be
 /// present.
 ///
+/// Build a [`std::process::Command`] that runs `program` with Windows
+/// PATHEXT shim resolution.
+///
+/// **Issue #6:** on Windows, Node ships `npx` as `npx.cmd` / `npx.ps1`
+/// (there is no `npx.exe`), and a bare `Command::new("npx")` does NOT
+/// resolve `.cmd`/`.bat`/`.ps1` shims — Rust's std only appends `.exe`. So
+/// the presence/reachability probes below were failing on Windows even when
+/// npx was installed and on PATH, which silently skipped MCP registration.
+/// Routing the probe through `cmd /C` makes the Windows shell apply PATHEXT,
+/// mirroring how the wcore-mcp stdio transport spawns the server itself
+/// (`shell_command_builder` → `cmd /C …`). On Unix `npx` is a real binary /
+/// symlink, so we spawn it directly.
+///
+/// (This plugin can't reuse `wcore_config::shell` — audit F2 forbids any
+/// `wcore-*` core dep — so the cmd-wrapping is inlined here.)
+#[cfg(windows)]
+fn shim_aware_command(program: &str) -> std::process::Command {
+    let mut c = std::process::Command::new("cmd");
+    c.arg("/C").arg(program);
+    c
+}
+
+#[cfg(not(windows))]
+fn shim_aware_command(program: &str) -> std::process::Command {
+    std::process::Command::new(program)
+}
+
+/// `true` if `program <version_arg>` starts and exits 0 — a fast PATH (+
+/// PATHEXT on Windows) presence check. Used to gate MCP registration on npx
+/// being installed.
+fn command_available(program: &str, version_arg: &str) -> bool {
+    shim_aware_command(program)
+        .arg(version_arg)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
 /// F-060 / B4: gate on `npx` being present on PATH AND the server being
 /// reachable. Two-stage probe:
 ///
-/// 1. `npx --version` presence check (fast).
+/// 1. `npx --version` presence check (fast; PATHEXT-aware on Windows so it
+///    recognises `npx.cmd` — issue #6).
 /// 2. If the transport is `Stdio { command: "node", args: [path, …] }`,
 ///    check the script path exists with `std::fs::metadata`.  Otherwise,
 ///    run the command with a 2-second timeout (`--help` or similar) to
@@ -60,17 +102,9 @@ pub fn register(ctx: &mut PluginContext<'_>) -> PluginResult<()> {
         }
     })?;
 
-    // Stage 1: npx presence (fast, no startup cost).
-    let npx_available = std::process::Command::new("npx")
-        .arg("--version")
-        .stdin(std::process::Stdio::null())
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status()
-        .map(|s| s.success())
-        .unwrap_or(false);
-
-    if !npx_available {
+    // Stage 1: npx presence (fast, no startup cost). PATHEXT-aware so the
+    // Windows `npx.cmd` shim is found (issue #6).
+    if !command_available("npx", "--version") {
         tracing::info!(
             "ijfw-memory: npx not found on PATH — skipping MCP registration \
              (install Node.js to enable)"
@@ -135,7 +169,10 @@ fn mcp_server_is_reachable(spec: &wcore_plugin_api::mcp_server_spec::McpServerSp
             let mut probe_args: Vec<&str> = args.iter().map(String::as_str).collect();
             probe_args.push("--help");
 
-            let mut cmd = std::process::Command::new(command);
+            // PATHEXT-aware (issue #6): on Windows this becomes
+            // `cmd /C npx -y @ijfw/memory-server --help` so the `npx.cmd`
+            // shim resolves; on Unix it spawns `npx …` directly.
+            let mut cmd = shim_aware_command(command);
             cmd.args(&probe_args)
                 .stdin(std::process::Stdio::null())
                 .stdout(std::process::Stdio::null())
@@ -199,5 +236,35 @@ mod tests {
             }
             _ => panic!("expected stdio transport for default IJFW MCP server"),
         }
+    }
+
+    // Issue #6: the probe must route through `cmd /C` on Windows so the
+    // `npx.cmd` PATHEXT shim resolves; on Unix it spawns the program direct.
+    #[test]
+    fn shim_aware_command_routes_through_cmd_on_windows() {
+        let cmd = shim_aware_command("npx");
+        let program = cmd.get_program().to_string_lossy().to_string();
+        let args: Vec<String> = cmd
+            .get_args()
+            .map(|a| a.to_string_lossy().to_string())
+            .collect();
+        #[cfg(windows)]
+        {
+            assert_eq!(program, "cmd");
+            assert_eq!(args, vec!["/C".to_string(), "npx".to_string()]);
+        }
+        #[cfg(not(windows))]
+        {
+            assert_eq!(program, "npx");
+            assert!(args.is_empty());
+        }
+    }
+
+    #[test]
+    fn command_available_is_false_for_absent_binary() {
+        assert!(!command_available(
+            "wayland-ijfw-definitely-absent-binary-xyz",
+            "--version"
+        ));
     }
 }


### PR DESCRIPTION
Closes #6.

## Verified the report

On Windows, Node ships `npx` as `npx.cmd` / `npx.ps1` (no `npx.exe`), and a bare `std::process::Command::new("npx")` does **not** resolve `.cmd`/`.bat`/`.ps1` shims — Rust's std only appends `.exe`. The IJFW MCP registration gated on two such raw probes (`wayland-ijfw/src/mcp.rs`): Stage 1 `npx --version` presence + Stage 2 `<cmd> --help` smoke-test. Both fail on Windows even when npx is installed and on PATH → the log `"npx not found on PATH — skipping MCP registration"` and built-in MCP registration is silently skipped. Confirmed valid and correctly diagnosed.

## Fix (detection only)

Route both probes through `cmd /C` on Windows via a `shim_aware_command` helper, so the shell applies PATHEXT and resolves `npx.cmd`. On Unix npx is a real binary/symlink → spawn directly. This mirrors how wcore-mcp's stdio transport already spawns the server (`shell_command_builder` → `cmd /C`). The plugin can't reuse `wcore_config::shell` (audit **F2** forbids any `wcore-*` core dep), so the cmd-wrapping is inlined.

## Deliberately NOT changed

- **The actual MCP spawn** (`command = "npx"`) was already correct — wcore-mcp's stdio transport `cmd /C`-wraps `npx`/`node`/`python` on Windows for exactly this reason.
- **The bundled sample configs** (`docs/mcp.md`, hook examples using `command = "npx"`) are correct as-is — the transport / hook-runner do the `cmd /C` wrapping. Changing them to `cmd /c npx` would *double-wrap*. The reporter's secondary "sample config" concern is a non-issue once the transport behaviour is accounted for.

So the bug was purely the detection probe.

## Tests / gate

A structural test asserts the probe routes through `cmd /C` on Windows / spawns direct on Unix (no npx install needed), plus an absent-binary negative. The `#[cfg(windows)]` branch (3 std-only lines) is compiled by CI's `Build (windows-msvc)`.

Gate green on the box: `fmt --check`, `clippy --workspace --all-targets -D warnings`, `nextest` (wayland-ijfw **20/20**; full `--workspace` 8200/8201 — the one miss is the pre-existing flaky `http_fetch_honors_per_call_timeout`, which passes in isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)