### PR TITLE
fix: ALSA optional (#14), config scroll (#16), mutation-nightly noise (#1-#5)

### DIFF
--- a/.github/workflows/mutants-nightly.yml
+++ b/.github/workflows/mutants-nightly.yml
@@ -125,6 +125,13 @@ jobs:
         run: |
           mkdir -p .blackboard/E2E-MUTATION-BASELINE
 
+          # Clear any stale output from a cached `target/` restore. A leftover
+          # mutants.out/lock.json produced "Resource temporarily unavailable"
+          # lock waits, and a half-written run produced "File exists (os error
+          # 17)" — both crashed cargo-mutants before it printed a summary,
+          # which is what filed the empty "surviving mutants: none" issues.
+          rm -rf "target/mutants-${CRATE}"
+
           IN_PLACE_FLAG=""
           if [ "${IN_PLACE}" = "true" ]; then
             IN_PLACE_FLAG="--in-place"
@@ -140,14 +147,25 @@ jobs:
             --output "target/mutants-${CRATE}" \
             ${SHARD_ARG} \
             2>&1 | tee ".blackboard/E2E-MUTATION-BASELINE/${CRATE}.log"
-          MUTANTS_EXIT=$?
+          MUTANTS_EXIT=${PIPESTATUS[0]}   # cargo's code, not tee's
 
-          # Parse summary line
-          SUMMARY=$(grep "mutants tested in" ".blackboard/E2E-MUTATION-BASELINE/${CRATE}.log" | tail -1 || echo "no summary")
+          # Parse the summary line, e.g.
+          #   "54 mutants tested in 2m: 9 missed, 28 caught, 17 unviable".
+          # If the run crashed before printing it, the grep finds nothing and
+          # `real_data` is false — the report step then skips issue filing so
+          # we never post a content-free issue again.
+          SUMMARY=$(grep "mutants tested in" ".blackboard/E2E-MUTATION-BASELINE/${CRATE}.log" | tail -1)
+          if [ -n "${SUMMARY}" ]; then
+            REAL_DATA="true"
+          else
+            REAL_DATA="false"
+            SUMMARY="no summary (cargo-mutants did not complete — exit ${MUTANTS_EXIT})"
+          fi
+          echo "real_data=${REAL_DATA}" >> "$GITHUB_OUTPUT"
           echo "summary=${SUMMARY}" >> "$GITHUB_OUTPUT"
           echo "exit_code=${MUTANTS_EXIT}" >> "$GITHUB_OUTPUT"
 
-          # Compute catch rate
+          # Compute catch rate from the summary (0/N/A when there is none).
           CAUGHT=$(echo "${SUMMARY}" | grep -oE '[0-9]+ caught' | grep -oE '[0-9]+' || echo 0)
           MISSED=$(echo "${SUMMARY}" | grep -oE '[0-9]+ missed' | grep -oE '[0-9]+' || echo 0)
           VIABLE=$((CAUGHT + MISSED))
@@ -160,15 +178,22 @@ jobs:
           echo "caught=${CAUGHT}" >> "$GITHUB_OUTPUT"
           echo "missed=${MISSED}" >> "$GITHUB_OUTPUT"
 
-          # Collect missed mutants for the issue body
-          MISSED_LINES=$(grep "^MISSED" ".blackboard/E2E-MUTATION-BASELINE/${CRATE}.log" | head -20 || echo "none")
+          # Collect missed mutants for the issue body.
+          MISSED_LINES=$(grep "^MISSED" ".blackboard/E2E-MUTATION-BASELINE/${CRATE}.log" | head -20)
+          [ -z "${MISSED_LINES}" ] && MISSED_LINES="none"
           {
             printf 'missed_mutants<<MUTANTS_EOF\n'
             printf '%s\n' "${MISSED_LINES}"
             printf 'MUTANTS_EOF\n'
           } >> "$GITHUB_OUTPUT"
 
-          exit 0   # Always succeed the step; failures reported via issue
+          # Surface a crash as a visible workflow annotation (the uploaded log
+          # artifact has the detail) instead of an empty issue-tracker entry.
+          if [ "${REAL_DATA}" != "true" ]; then
+            echo "::warning title=mutants ${CRATE}::cargo-mutants did not produce a summary (exit ${MUTANTS_EXIT}); see the uploaded log artifact"
+          fi
+
+          exit 0   # Never fail the matrix leg; results flow via issue/annotation
         shell: bash
 
       # Safety: --in-place may leave mutated source if the job is cancelled.
@@ -190,9 +215,12 @@ jobs:
             target/mutants-${{ matrix.crate }}/mutants.out/
           retention-days: 30
 
-      # Open (or update) a GitHub issue when survived mutants detected
+      # Open (or update) a GitHub issue ONLY when cargo-mutants actually
+      # completed (real_data) AND found surviving mutants (missed != 0). A
+      # crash with no summary files no issue — it surfaces as the ::warning::
+      # annotation above instead, so the tracker never collects empty stubs.
       - name: Report red result to issue tracker
-        if: steps.mutants.outputs.exit_code != '0' || steps.mutants.outputs.missed != '0'
+        if: steps.mutants.outputs.real_data == 'true' && steps.mutants.outputs.missed != '0'
         uses: actions/github-script@v7
         env:
           CRATE: ${{ matrix.crate }}

--- a/crates/wcore-agent/Cargo.toml
+++ b/crates/wcore-agent/Cargo.toml
@@ -159,8 +159,12 @@ tempfile.workspace     = true
 tar.workspace          = true
 flate2.workspace       = true
 tokio-postgres.workspace = true
-cpal.workspace         = true
-hound.workspace        = true
+# Issue #14 — voice_mode mic-capture deps. Optional + gated behind the
+# off-by-default `voice` feature so the default binary does NOT link the OS
+# audio lib (libasound.so.2 / ALSA on Linux), which must not be a hard
+# runtime dependency of a TUI. Enable with `--features voice`.
+cpal  = { workspace = true, optional = true }
+hound = { workspace = true, optional = true }
 
 workspace-hack.workspace = true
 
@@ -188,6 +192,12 @@ live-bedrock   = []
 # downloaded. Synthesis runtime is stubbed for v0.9.0 — turning the
 # feature on does not yet produce audio. Wire-up tracked for v0.9.1.
 piper_tts      = []
+# Issue #14 — voice_mode mic capture (cpal + hound). OFF by default: cpal
+# links the OS audio library (ALSA/libasound.so.2 on Linux, CoreAudio on
+# macOS, WASAPI on Windows). A TUI must not hard-require ALSA at runtime, so
+# the default binary is built without it. Enable voice input with
+# `cargo build -p wcore-cli --features voice` (wcore-cli re-exports this).
+voice          = ["dep:cpal", "dep:hound"]
 
 [dev-dependencies]
 # Self-reference with test-utils feature so wcore-agent's own

--- a/crates/wcore-agent/src/bootstrap.rs
+++ b/crates/wcore-agent/src/bootstrap.rs
@@ -767,6 +767,11 @@ impl AgentBootstrap {
         // `is_available() == false`. Registered AFTER the TTS/STT block so
         // the LLM observability surfaces are wired before the voice loop
         // is reachable.
+        //
+        // Issue #14 — gated behind the off-by-default `voice` feature; the
+        // default binary ships without cpal so it does not hard-link
+        // libasound.so.2 (ALSA) on Linux.
+        #[cfg(feature = "voice")]
         if let Some(vm) = crate::tool_backends::voice_mode::build_voice_mode_backend() {
             registry.register(Box::new(wcore_tools::voice_mode::VoiceModeTool::new(vm)));
         }

--- a/crates/wcore-agent/src/tool_backends/mod.rs
+++ b/crates/wcore-agent/src/tool_backends/mod.rs
@@ -72,6 +72,9 @@ pub mod postgres_schema;
 pub mod tts;
 pub mod video_analyze;
 // v0.9.0 W1 B10 — cpal-backed audio recorder + OS-shell player.
+// Issue #14 — gated behind the off-by-default `voice` feature so the default
+// binary does not pull cpal → libasound.so.2 (ALSA) on Linux.
+#[cfg(feature = "voice")]
 pub mod voice_mode;
 
 // -- Re-exports so existing consumers keep using `wcore_agent::tool_backends::X`. --

--- a/crates/wcore-cli/Cargo.toml
+++ b/crates/wcore-cli/Cargo.toml
@@ -50,6 +50,10 @@ harness-failure-injection = []
 workflow = []
 monitor = []
 review_artifact = []
+# Issue #14 — re-export wcore-agent's optional `voice` feature so the binary
+# can be built with mic capture: `cargo build -p wcore-cli --features voice`.
+# OFF by default to keep libasound.so.2 (ALSA) off the default Linux binary.
+voice = ["wcore-agent/voice"]
 
 [dependencies]
 async-trait.workspace    = true

--- a/crates/wcore-cli/src/tui/surfaces/config.rs
+++ b/crates/wcore-cli/src/tui/surfaces/config.rs
@@ -1868,6 +1868,11 @@ impl ConfigSurface {
 
         let mut lines: Vec<Line> = Vec::new();
         let mut last_category: Option<&'static str> = None;
+        // Issue #16: track the line index of the focused row so the body can
+        // scroll to keep it on screen. The catalog (23+ entries, two lines
+        // each, plus category headers) overflows a short terminal; without a
+        // scroll offset every row past `body_area.height` was unreachable.
+        let mut focus_line = 0usize;
         for (idx, entry) in PROVIDER_CATALOG.iter().enumerate() {
             if Some(entry.category) != last_category {
                 if last_category.is_some() {
@@ -1881,6 +1886,11 @@ impl ConfigSurface {
             }
             let status = resolve_provider_status(entry);
             let focused = idx == self.providers_focus;
+            if focused {
+                // The name line is the next push; its hint follows on the line
+                // after, so we anchor the scroll on this index.
+                focus_line = lines.len();
+            }
             let marker = if focused { "▸ " } else { "  " };
             let name_style = if focused {
                 Style::default().fg(t.orange).add_modifier(Modifier::BOLD)
@@ -1910,7 +1920,21 @@ impl ConfigSurface {
                 Style::default().fg(t.text_muted),
             )));
         }
-        frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), body_area);
+        // Issue #16: scroll the body so the focused row (and its hint line)
+        // stay visible. With focus near the top this is 0 (no scroll); as
+        // focus moves below the fold the offset advances, clamped so the last
+        // page never scrolls past the final row.
+        let visible = body_area.height as usize;
+        let total = lines.len();
+        let scroll_y = (focus_line + 2)
+            .saturating_sub(visible)
+            .min(total.saturating_sub(visible)) as u16;
+        frame.render_widget(
+            Paragraph::new(lines)
+                .wrap(Wrap { trim: false })
+                .scroll((scroll_y, 0)),
+            body_area,
+        );
 
         frame.render_widget(
             Paragraph::new(Line::from(vec![
@@ -2961,6 +2985,61 @@ mod tests {
         // `esc` returns to the overview.
         surface.handle_key(key(KeyCode::Esc), &mut app);
         assert_eq!(surface.tier, Tier::Overview);
+    }
+
+    /// Issue #16: when the provider catalog overflows a short terminal, moving
+    /// focus to the last entry must scroll it into view. Asserts on the
+    /// RENDERED buffer (not just the focus index): the last provider's name is
+    /// absent when focus is at the top (below the fold) and present once it is
+    /// focused (scrolled in). Before the fix the offset was never applied, so
+    /// the row stayed permanently off-screen and unreachable.
+    #[test]
+    fn providers_tier_scrolls_focused_row_into_view_issue_16() {
+        fn render_at(surface: &mut ConfigSurface, app: &App, h: u16) -> String {
+            let theme = Theme::no_color();
+            let mut terminal = Terminal::new(TestBackend::new(80, h)).expect("test terminal");
+            terminal
+                .draw(|f| surface.render(f, f.area(), app, &theme))
+                .expect("render config surface");
+            let buf = terminal.backend().buffer();
+            let mut out = String::new();
+            for y in 0..buf.area.height {
+                for x in 0..buf.area.width {
+                    out.push_str(buf[(x, y)].symbol());
+                }
+                out.push('\n');
+            }
+            out
+        }
+
+        let mut app = App::new();
+        let mut surface = ConfigSurface::new();
+        surface.on_enter(&mut app);
+        surface.tier = Tier::Providers;
+
+        // The test only proves something if the catalog overflows the viewport.
+        assert!(
+            PROVIDER_CATALOG.len() > 10,
+            "test assumes the provider catalog overflows a short terminal"
+        );
+        let last = PROVIDER_CATALOG.len() - 1;
+        let last_name = PROVIDER_CATALOG[last].name;
+
+        // Focus at the top: the last row sits below the fold and is not drawn.
+        surface.providers_focus = 0;
+        let top = render_at(&mut surface, &app, 14);
+        assert!(
+            !top.contains(last_name),
+            "last provider ({last_name}) must be off-screen when focus is at the top:\n{top}"
+        );
+
+        // Focus on the last row: it must scroll into view.
+        surface.providers_focus = last;
+        let bottom = render_at(&mut surface, &app, 14);
+        assert!(
+            bottom.contains(last_name),
+            "last provider ({last_name}) must scroll into view when focused:\n{bottom}"
+        );
     }
 
     /// Pressing Enter on a non-deferred entry with env vars opens the


### PR DESCRIPTION
Three independent fixes, each gated on the build box (clippy `--workspace --all-targets`, voice-feature compile, `cargo tree` proof, full wcore-cli nextest).

## #14 — ALSA is a hard dependency
`cpal` (voice_mode mic capture) was an unconditional dep of wcore-agent, so the released linux binary hard-linked `libasound.so.2` and crashed on a stock Debian/Proxmox guest with no ALSA — even though the TUI never uses voice.

Gated `cpal` + `hound` behind a new **off-by-default `voice` feature** on wcore-agent (re-exported by wcore-cli). `voice_mode` module + bootstrap registration are now `#[cfg(feature = "voice")]`; the engine already degrades gracefully when the tool is absent.

- `cargo tree -p wcore-cli -i cpal` → **absent by default** (no ALSA)
- `cargo tree -p wcore-cli --features voice -i cpal` → present (voice still works)
- Build voice input with `cargo build -p wcore-cli --features voice`

Closes #14.

## #16 — Unable to scroll in /config providers
The providers list rendered all 23+ rows into a `Paragraph` with no scroll offset, so on a short terminal every row past the fold was unreachable (down-arrow moved an invisible selection). Now tracks the focused row's line index and applies a clamped scroll offset so it stays visible. Added a render-assertion test (asserts the last provider scrolls into view when focused, absent when at the top).

Closes #16.

## #1–#5 — empty nightly mutation issues
The `mutants-nightly` job filed an empty issue per crate every night ("Catch rate N/A", "surviving mutants: none"). Cause: when cargo-mutants crashed before printing a summary (stale `mutants.out` lock; `--in-place` file race), the issue-filing gate still fired on `exit_code != 0`, posting content-free issues.

- Clear stale `target/mutants-<crate>` before each run (fixes the lock / "File exists" crashes that a cached target restore caused)
- File an issue **only** when a real summary parsed **and** `missed != 0`; crashes now surface as a `::warning::` annotation + log artifact, never an empty issue
- `PIPESTATUS[0]` so the captured exit code is cargo's, not tee's

The five empty stub issues are being closed as noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)