### PR TITLE
feat: native per-command Bash output compaction

### DIFF
--- a/crates/wcore-agent/src/engine.rs
+++ b/crates/wcore-agent/src/engine.rs
@@ -529,6 +529,11 @@ pub struct AgentEngine {
     cache_detector: CacheBreakDetector,
     compaction_level: wcore_compact::CompactionLevel,
     toon_enabled: bool,
+    /// Token-opt: native Bash output compaction gate (cargo/git/test/grep).
+    /// Resolved from `ProviderCompat::compact_bash()` at construction. When
+    /// on, verbose Bash tool output is compacted into the model's transcript
+    /// copy (the human still sees full output) before read-once dedup.
+    compact_bash: bool,
     /// W4 (Task 8): engine-advertised capability flags. Mirrored to
     /// `Capabilities.*` when emitting Ready/ConfigChanged.
     advertised_capabilities: wcore_config::tools::AdvertisedCapabilitiesConfig,
@@ -994,6 +999,7 @@ impl AgentEngine {
             cache_detector: CacheBreakDetector::new(),
             compaction_level: config.compact.compaction,
             toon_enabled: config.compact.toon,
+            compact_bash: config.compat.compact_bash(),
             advertised_capabilities: config.advertised_capabilities.clone(),
             per_turn_costs: Vec::new(),
             mcp_curation: config.mcp.curation.clone(),
@@ -1153,6 +1159,7 @@ impl AgentEngine {
             cache_detector: CacheBreakDetector::new(),
             compaction_level: config.compact.compaction,
             toon_enabled: config.compact.toon,
+            compact_bash: config.compat.compact_bash(),
             advertised_capabilities: config.advertised_capabilities.clone(),
             per_turn_costs: Vec::new(),
             mcp_curation: config.mcp.curation.clone(),
@@ -3866,6 +3873,12 @@ impl AgentEngine {
             // concurrent borrow conflict.
             let tool_call_batch_size = tool_call_traces.len().max(1) as u128;
 
+            // Token-opt: native Bash output compactions collected during the
+            // display loop (where the per-call traces are still live), keyed
+            // by tool_use_id, then applied to the model's transcript copy
+            // below — before read-once dedup.
+            let mut bash_compactions: std::collections::HashMap<String, String> =
+                std::collections::HashMap::new();
             // Display tool results AND populate the matching ToolCallTrace.
             for result in &outcome.results {
                 if let ContentBlock::ToolResult {
@@ -3910,6 +3923,38 @@ impl AgentEngine {
                         // env gate now governs (previously the gated builder
                         // method had zero callers).
                         *trace = trace.clone().with_result_snippet(content);
+
+                        // Token-opt: native Bash output compaction. The human
+                        // already saw full output via `emit_tool_result`
+                        // above; compact only the model's copy (applied below,
+                        // before read-once dedup) and record the savings here
+                        // while the trace is live. Fail-open inside
+                        // `compact_bash` — never drops the error signal.
+                        if self.compact_bash && tool_name == "Bash" {
+                            let command = tool_calls
+                                .iter()
+                                .find_map(|c| match c {
+                                    ContentBlock::ToolUse { id, input, .. }
+                                        if id == tool_use_id =>
+                                    {
+                                        input.get("command").and_then(|v| v.as_str())
+                                    }
+                                    _ => None,
+                                })
+                                .unwrap_or("");
+                            let c = wcore_tools::bash_compact::compact_bash(
+                                command,
+                                content,
+                                parse_bash_exit_code(content),
+                            );
+                            if c.compacted_bytes < c.raw_bytes {
+                                trace.record_compaction(
+                                    c.raw_bytes as u64,
+                                    c.compacted_bytes as u64,
+                                );
+                                bash_compactions.insert(tool_use_id.clone(), c.content);
+                            }
+                        }
                     }
                 }
             }
@@ -3971,6 +4016,23 @@ impl AgentEngine {
             // turn with zero external edits keeps `tool_results_content`
             // = `outcome.results` verbatim.
             let mut tool_results_content = outcome.results;
+            // Token-opt: swap the compacted Bash output into the model's copy
+            // (the host/human already received the full result via
+            // `emit_tool_result`). Done before dedup so identical compacted
+            // outputs collapse to a backref.
+            if !bash_compactions.is_empty() {
+                for block in &mut tool_results_content {
+                    if let ContentBlock::ToolResult {
+                        tool_use_id,
+                        content,
+                        ..
+                    } = block
+                        && let Some(compacted) = bash_compactions.remove(tool_use_id)
+                    {
+                        *content = compacted;
+                    }
+                }
+            }
             // Token-opt (read-once): rewrite repeated Grep/Glob/Bash outputs to a
             // backref before they enter the transcript. The user already saw the
             // full output via `emit_tool_result` above; only the model's copy is
@@ -5665,6 +5727,18 @@ pub(crate) fn is_hook_lifecycle_line(line: &str) -> bool {
         || line.starts_with("on_session_end fired")
 }
 
+/// Parse the leading `Exit code: N` line of a Bash tool result, defaulting to
+/// 0 when absent or unparseable. Lets the compactor bias toward preserving the
+/// failure reason on a non-zero exit.
+fn parse_bash_exit_code(content: &str) -> i32 {
+    content
+        .lines()
+        .next()
+        .and_then(|l| l.strip_prefix("Exit code:"))
+        .and_then(|n| n.trim().parse().ok())
+        .unwrap_or(0)
+}
+
 fn truncate_for_trace(s: &str, max: usize) -> String {
     if s.len() <= max {
         return s.to_string();
@@ -5766,6 +5840,7 @@ mod set_config_tests {
             cache_detector: super::CacheBreakDetector::new(),
             compaction_level: wcore_compact::CompactionLevel::default(),
             toon_enabled: false,
+            compact_bash: false,
             advertised_capabilities: wcore_config::tools::AdvertisedCapabilitiesConfig::default(),
             per_turn_costs: Vec::new(),
             mcp_curation: wcore_config::config::McpCurationPolicy::default(),
@@ -6486,6 +6561,7 @@ mod phase6_tests {
             cache_detector: super::CacheBreakDetector::new(),
             compaction_level: wcore_compact::CompactionLevel::default(),
             toon_enabled: false,
+            compact_bash: false,
             advertised_capabilities: wcore_config::tools::AdvertisedCapabilitiesConfig::default(),
             per_turn_costs: Vec::new(),
             mcp_curation: wcore_config::config::McpCurationPolicy::default(),
@@ -6766,6 +6842,7 @@ mod compact_tests {
             cache_detector: super::CacheBreakDetector::new(),
             compaction_level: wcore_compact::CompactionLevel::default(),
             toon_enabled: false,
+            compact_bash: false,
             advertised_capabilities: wcore_config::tools::AdvertisedCapabilitiesConfig::default(),
             per_turn_costs: Vec::new(),
             mcp_curation: wcore_config::config::McpCurationPolicy::default(),
@@ -7730,6 +7807,7 @@ mod plan_mode_tests {
             cache_detector: super::CacheBreakDetector::new(),
             compaction_level: wcore_compact::CompactionLevel::default(),
             toon_enabled: false,
+            compact_bash: false,
             advertised_capabilities: wcore_config::tools::AdvertisedCapabilitiesConfig::default(),
             per_turn_costs: Vec::new(),
             mcp_curation: wcore_config::config::McpCurationPolicy::default(),
@@ -8143,6 +8221,7 @@ mod hook_integration_tests {
             cache_detector: super::CacheBreakDetector::new(),
             compaction_level: wcore_compact::CompactionLevel::default(),
             toon_enabled: false,
+            compact_bash: false,
             advertised_capabilities: wcore_config::tools::AdvertisedCapabilitiesConfig::default(),
             per_turn_costs: Vec::new(),
             mcp_curation: wcore_config::config::McpCurationPolicy::default(),
@@ -8805,6 +8884,7 @@ mod approval_bridge_engine_tests {
             cache_detector: super::CacheBreakDetector::new(),
             compaction_level: wcore_compact::CompactionLevel::default(),
             toon_enabled: false,
+            compact_bash: false,
             advertised_capabilities: wcore_config::tools::AdvertisedCapabilitiesConfig::default(),
             per_turn_costs: Vec::new(),
             mcp_curation: wcore_config::config::McpCurationPolicy::default(),
@@ -9030,6 +9110,7 @@ mod user_model_writeback_tests {
             cache_detector: super::CacheBreakDetector::new(),
             compaction_level: wcore_compact::CompactionLevel::default(),
             toon_enabled: false,
+            compact_bash: false,
             advertised_capabilities: wcore_config::tools::AdvertisedCapabilitiesConfig::default(),
             per_turn_costs: Vec::new(),
             mcp_curation: wcore_config::config::McpCurationPolicy::default(),

--- a/crates/wcore-agent/src/engine.rs
+++ b/crates/wcore-agent/src/engine.rs
@@ -3952,6 +3952,14 @@ impl AgentEngine {
                                     c.raw_bytes as u64,
                                     c.compacted_bytes as u64,
                                 );
+                                tracing::debug!(
+                                    target: "wcore_agent::compaction",
+                                    command = %command,
+                                    raw_bytes = c.raw_bytes,
+                                    compacted_bytes = c.compacted_bytes,
+                                    saved_bytes = c.raw_bytes - c.compacted_bytes,
+                                    "bash output compacted"
+                                );
                                 bash_compactions.insert(tool_use_id.clone(), c.content);
                             }
                         }

--- a/crates/wcore-agent/tests/output_compaction_test.rs
+++ b/crates/wcore-agent/tests/output_compaction_test.rs
@@ -493,3 +493,102 @@ fn case_8_toon_system_prompt_injection() {
 
     eprintln!("[compaction:B] ✓ TOON system prompt injection verified");
 }
+
+// ---------------------------------------------------------------------------
+// B Layer: Case 9 — native Bash output compaction reaches the LLM
+// ---------------------------------------------------------------------------
+
+/// End-to-end proof that engine-level Bash output compaction shrinks the
+/// model's transcript copy of a verbose `cargo` run. Drives a real
+/// `AgentEngine` turn with a `Bash` tool returning 300 lines of compile spam
+/// and asserts the tool-result content captured in the follow-up LLM request
+/// is compacted (shorter, mid-run spam dropped). The generic content
+/// compaction is turned OFF so the only shrinkage is the Bash compactor.
+#[tokio::test]
+async fn case_9_bash_output_compaction_reaches_llm() {
+    let body: String = (0..300)
+        .map(|i| format!("   Compiling crate{i} v0.1.0"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let raw = format!("Exit code: 0\nSTDOUT:\n{body}\nSTDERR:\n");
+
+    let captured: Arc<Mutex<Vec<LlmRequest>>> = Arc::new(Mutex::new(Vec::new()));
+    let provider = CapturingProvider {
+        inner: MockLlmProvider::with_turns(vec![
+            vec![
+                LlmEvent::ToolUse {
+                    id: "b1".to_string(),
+                    name: "Bash".to_string(),
+                    input: json!({ "command": "cargo build" }),
+                    extra: None,
+                },
+                LlmEvent::Done {
+                    stop_reason: StopReason::ToolUse,
+                    finish_reason: wcore_types::message::FinishReason::from_stop_reason(
+                        StopReason::ToolUse,
+                    ),
+                    usage: TokenUsage::default(),
+                },
+            ],
+            vec![
+                LlmEvent::TextDelta("done".to_string()),
+                LlmEvent::Done {
+                    stop_reason: StopReason::EndTurn,
+                    finish_reason: wcore_types::message::FinishReason::from_stop_reason(
+                        StopReason::EndTurn,
+                    ),
+                    usage: TokenUsage::default(),
+                },
+            ],
+        ]),
+        captured: captured.clone(),
+    };
+
+    // Isolate Bash compaction from the generic content compaction.
+    let mut config = test_config();
+    config.compact.compaction = CompactionLevel::Off;
+    config.compact.toon = false;
+
+    let mut registry = ToolRegistry::new();
+    registry.register(Box::new(MockTool::new("Bash", &raw, false)));
+
+    let output: Arc<dyn OutputSink> = Arc::new(NullSink);
+    let mut engine = AgentEngine::new_with_provider(Arc::new(provider), config, registry, output);
+
+    engine
+        .run("run cargo build", "")
+        .await
+        .expect("engine.run should succeed");
+
+    let requests = captured.lock().unwrap();
+    assert!(
+        requests.len() >= 2,
+        "expected an initial request plus a follow-up after the tool call"
+    );
+    let second = &requests[1];
+    let mut found = false;
+    for msg in &second.messages {
+        for block in &msg.content {
+            if let ContentBlock::ToolResult { content, .. } = block {
+                found = true;
+                eprintln!(
+                    "[compaction:B] Case 9: LLM saw {} chars (raw {})",
+                    content.len(),
+                    raw.len()
+                );
+                assert!(
+                    content.len() < raw.len(),
+                    "LLM should see compacted Bash output ({} >= {} raw)",
+                    content.len(),
+                    raw.len()
+                );
+                assert!(
+                    !content.contains("Compiling crate150"),
+                    "mid-run compile spam should be dropped: {content}"
+                );
+            }
+        }
+    }
+    assert!(found, "follow-up request should carry the Bash ToolResult");
+    eprintln!("[compaction:B] ✓ LLM received compacted Bash output");
+}

--- a/crates/wcore-config/src/compat.rs
+++ b/crates/wcore-config/src/compat.rs
@@ -108,6 +108,12 @@ pub struct ProviderCompat {
     /// or arbitrage logic lives here.
     pub input_optimization: Option<String>,
 
+    /// Token-opt: when `true` (the default), the engine compacts verbose Bash
+    /// output (cargo/git/test/grep) before it enters the model's transcript.
+    /// `None` ⇒ use the resolver default (ON). See `compact_bash()`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub compact_bash: Option<bool>,
+
     /// Force the OpenAI chat-vs-responses API surface for this provider,
     /// overriding the per-model family default
     /// (`openai_compat::model_uses_responses_api`).
@@ -482,6 +488,7 @@ impl ProviderCompat {
                 .cost_per_cache_write_token
                 .or(defaults.cost_per_cache_write_token),
             input_optimization: user.input_optimization.or(defaults.input_optimization),
+            compact_bash: user.compact_bash.or(defaults.compact_bash),
             uses_responses_api: user.uses_responses_api.or(defaults.uses_responses_api),
         }
     }
@@ -549,6 +556,13 @@ impl ProviderCompat {
     /// (the default when unset) means the client must optimize itself.
     pub fn input_optimization(&self) -> &str {
         self.input_optimization.as_deref().unwrap_or("client")
+    }
+
+    /// Resolved gate for native Bash output compaction. Defaults ON: verbose
+    /// cargo/git/test/grep output is compacted before reaching the model's
+    /// transcript unless a provider/profile sets `compact_bash = false`.
+    pub fn compact_bash(&self) -> bool {
+        self.compact_bash.unwrap_or(true)
     }
 
     /// Optional override for the OpenAI chat-vs-responses API surface.
@@ -1150,6 +1164,16 @@ mod d2_tier2_provider_cost_tests {
 #[cfg(test)]
 mod input_optimization_tests {
     use super::*;
+
+    /// Native Bash compaction defaults ON (unset ⇒ true) and honours an
+    /// explicit `false` override.
+    #[test]
+    fn compact_bash_defaults_on_and_honors_override() {
+        let mut c = ProviderCompat::default();
+        assert!(c.compact_bash(), "default must be ON");
+        c.compact_bash = Some(false);
+        assert!(!c.compact_bash());
+    }
 
     /// Flux Router is a server-side routing layer → "router".
     #[test]

--- a/crates/wcore-observability/src/trace.rs
+++ b/crates/wcore-observability/src/trace.rs
@@ -131,6 +131,57 @@ impl ToolCallTrace {
     }
 }
 
+/// Aggregate native Bash output-compaction savings across a set of tool-call
+/// traces — the data behind the `gain`-style savings report. Built from the
+/// `compaction_bytes` each `ToolCallTrace` carries, which already flows to the
+/// host in every emitted `TurnTrace`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CompactionSavings {
+    /// Number of tool calls whose output was compacted.
+    pub calls: u64,
+    /// Total raw bytes before compaction (summed over those calls).
+    pub raw_bytes: u64,
+    /// Total bytes after compaction (summed over those calls).
+    pub compacted_bytes: u64,
+}
+
+impl CompactionSavings {
+    /// Bytes saved (`raw - compacted`, floored at 0).
+    pub fn saved_bytes(&self) -> u64 {
+        self.raw_bytes.saturating_sub(self.compacted_bytes)
+    }
+
+    /// Savings as a fraction of raw bytes in `[0.0, 1.0]`; 0.0 when nothing
+    /// was compacted.
+    pub fn ratio(&self) -> f64 {
+        if self.raw_bytes == 0 {
+            0.0
+        } else {
+            self.saved_bytes() as f64 / self.raw_bytes as f64
+        }
+    }
+
+    /// Fold another tally into this one.
+    pub fn add(&mut self, other: &CompactionSavings) {
+        self.calls += other.calls;
+        self.raw_bytes += other.raw_bytes;
+        self.compacted_bytes += other.compacted_bytes;
+    }
+}
+
+/// Sum the Bash output-compaction savings recorded across `traces`.
+pub fn aggregate_compaction(traces: &[ToolCallTrace]) -> CompactionSavings {
+    let mut out = CompactionSavings::default();
+    for t in traces {
+        if let Some((raw, compacted)) = t.compaction_bytes {
+            out.calls += 1;
+            out.raw_bytes += raw;
+            out.compacted_bytes += compacted;
+        }
+    }
+    out
+}
+
 /// One turn of the agent loop: the LLM call + every tool call it triggered.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TurnTrace {
@@ -445,6 +496,28 @@ mod tests {
     fn tool_call_trace_new_sets_source_product() {
         let t = ToolCallTrace::new("c1".into(), "Read".into(), json!({}));
         assert_eq!(t.source_product, SOURCE_PRODUCT);
+    }
+
+    #[test]
+    fn aggregate_compaction_sums_savings_and_ratio() {
+        let mut a = ToolCallTrace::new("a".into(), "Bash".into(), json!({}));
+        a.record_compaction(1000, 200);
+        let mut b = ToolCallTrace::new("b".into(), "Bash".into(), json!({}));
+        b.record_compaction(500, 250);
+        // A non-compacted call must not contribute.
+        let c = ToolCallTrace::new("c".into(), "Read".into(), json!({}));
+
+        let s = aggregate_compaction(&[a, b, c]);
+        assert_eq!(s.calls, 2);
+        assert_eq!(s.raw_bytes, 1500);
+        assert_eq!(s.compacted_bytes, 450);
+        assert_eq!(s.saved_bytes(), 1050);
+        assert!((s.ratio() - 0.7).abs() < 1e-9);
+
+        // Empty input yields a zero tally with a safe 0.0 ratio.
+        let empty = aggregate_compaction(&[]);
+        assert_eq!(empty, CompactionSavings::default());
+        assert_eq!(empty.ratio(), 0.0);
     }
 
     #[test]

--- a/crates/wcore-observability/src/trace.rs
+++ b/crates/wcore-observability/src/trace.rs
@@ -70,6 +70,11 @@ pub struct ToolCallTrace {
     /// absent from v0.6.1 traces and from snippet-disabled runs.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub result_snippet: Option<String>,
+    /// `(raw_bytes, compacted_bytes)` when this tool call's output was
+    /// compacted by native Bash compaction. `None` when not compacted. Feeds
+    /// the `gain`-style savings report.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub compaction_bytes: Option<(u64, u64)>,
     pub source_product: String,
 }
 
@@ -88,8 +93,15 @@ impl ToolCallTrace {
             cancelled: false,
             partial: false,
             result_snippet: None,
+            compaction_bytes: None,
             source_product: SOURCE_PRODUCT.to_string(),
         }
+    }
+
+    /// Record native Bash output-compaction savings on this trace. Stored as
+    /// `(raw_bytes, compacted_bytes)` for the savings report.
+    pub fn record_compaction(&mut self, raw_bytes: u64, compacted_bytes: u64) {
+        self.compaction_bytes = Some((raw_bytes, compacted_bytes));
     }
 
     /// Attach a `result_snippet`, truncating to `RESULT_SNIPPET_MAX` bytes
@@ -433,6 +445,21 @@ mod tests {
     fn tool_call_trace_new_sets_source_product() {
         let t = ToolCallTrace::new("c1".into(), "Read".into(), json!({}));
         assert_eq!(t.source_product, SOURCE_PRODUCT);
+    }
+
+    #[test]
+    fn tool_call_trace_round_trips_compaction_bytes() {
+        let mut t = ToolCallTrace::new("c1".into(), "Bash".into(), json!({}));
+        // Absent by default, and elided from the wire when None.
+        assert_eq!(t.compaction_bytes, None);
+        let none_json = serde_json::to_string(&t).unwrap();
+        assert!(!none_json.contains("compaction_bytes"));
+
+        t.record_compaction(1000, 200);
+        assert_eq!(t.compaction_bytes, Some((1000, 200)));
+        let s = serde_json::to_string(&t).unwrap();
+        let back: ToolCallTrace = serde_json::from_str(&s).unwrap();
+        assert_eq!(back.compaction_bytes, Some((1000, 200)));
     }
 
     #[test]

--- a/crates/wcore-tools/src/bash_compact.rs
+++ b/crates/wcore-tools/src/bash_compact.rs
@@ -1,0 +1,164 @@
+//! Native per-command Bash output compaction (RTK-style, engine-owned).
+//!
+//! `compact_bash` shrinks verbose shell-command output (cargo/git/test/grep)
+//! to a signal-preserving compact form before it enters the model's
+//! transcript. It is deterministic (engine-side), fail-open (never drops the
+//! error signal; any parser uncertainty falls back to a generic classifier,
+//! then to raw), and size-gated (small output is returned verbatim).
+//!
+//! Dispatch is on the command PREFIX (program + subcommand). Each parser
+//! returns `Some(compacted)` only when it confidently parsed; `None` falls
+//! through to the generic classifier. This keeps each parser isolated (one
+//! file each) and makes the whole thing fail-open by construction.
+
+mod cargo;
+mod classifier;
+mod git;
+mod grep;
+mod testrun;
+
+/// Output below either bound is returned verbatim — never pay compaction cost
+/// or risk info loss on already-small output.
+const SIZE_GATE_LINES: usize = 40;
+const SIZE_GATE_BYTES: usize = 8 * 1024;
+
+/// Lines of raw tail always appended after a non-trivial compaction — exit
+/// status / final error usually lands here, so this is the insurance against
+/// a parser/classifier that missed it.
+const GUARANTEED_TAIL_LINES: usize = 10;
+
+/// Result of a compaction attempt: the (possibly unchanged) content plus the
+/// byte accounting for savings telemetry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Compacted {
+    pub content: String,
+    pub raw_bytes: usize,
+    pub compacted_bytes: usize,
+}
+
+impl Compacted {
+    fn unchanged(raw: &str) -> Self {
+        Self {
+            content: raw.to_string(),
+            raw_bytes: raw.len(),
+            compacted_bytes: raw.len(),
+        }
+    }
+}
+
+/// Compact the output of `command` (the full Bash command string) given its
+/// `raw` combined output and `exit_code`. Fail-open: returns `raw` unchanged
+/// when small, unrecognised, or on any parser miss.
+pub fn compact_bash(command: &str, raw: &str, exit_code: i32) -> Compacted {
+    // Size gate: leave small output alone.
+    if raw.len() <= SIZE_GATE_BYTES && raw.lines().count() <= SIZE_GATE_LINES {
+        return Compacted::unchanged(raw);
+    }
+
+    let compacted_body = dispatch(command, raw, exit_code)
+        .or_else(|| classifier::compact(raw))
+        .map(|body| with_guaranteed_tail(&body, raw));
+
+    match compacted_body {
+        // Only accept the compaction if it actually shrank the output.
+        Some(body) if body.len() < raw.len() => Compacted {
+            raw_bytes: raw.len(),
+            compacted_bytes: body.len(),
+            content: body,
+        },
+        _ => Compacted::unchanged(raw),
+    }
+}
+
+/// Route to a per-command parser by command prefix. `None` ⇒ no confident
+/// parser ⇒ caller falls back to the classifier.
+fn dispatch(command: &str, raw: &str, exit_code: i32) -> Option<String> {
+    match program_and_sub(command) {
+        ("cargo", _) => cargo::compact(raw, exit_code),
+        ("git", _) => git::compact(raw, exit_code),
+        ("grep", _) | ("rg", _) | ("find", _) => grep::compact(raw, exit_code),
+        ("pytest", _) | ("jest", _) | ("vitest", _) => testrun::compact(raw, exit_code),
+        ("go", Some("test")) => testrun::compact(raw, exit_code),
+        ("python", _) | ("python3", _) | ("node", _) => testrun::compact(raw, exit_code),
+        _ => None,
+    }
+}
+
+/// Extract the leading program name and (optionally) its first subcommand,
+/// stripping common wrappers/prefixes (`sudo`, `vx`, `pnpm`, `yarn`, `npx`,
+/// env `K=V`). For a `&&`/`;` chain, classify the LAST segment (its output
+/// dominates). Lowercased basename.
+pub(crate) fn program_and_sub(command: &str) -> (&str, Option<&str>) {
+    let segment = command
+        .rsplit(|c| c == ';' || c == '&')
+        .map(str::trim)
+        .find(|s| !s.is_empty())
+        .unwrap_or(command.trim());
+
+    let mut toks = segment.split_whitespace().filter(|t| {
+        // Skip env assignments and known wrappers.
+        !t.contains('=')
+            && !matches!(
+                *t,
+                "sudo" | "vx" | "pnpm" | "yarn" | "npx" | "npm" | "command" | "time"
+            )
+    });
+    let prog = toks.next().unwrap_or("");
+    let prog = prog.rsplit(['/', '\\']).next().unwrap_or(prog);
+    let sub = toks.next();
+    (prog, sub)
+}
+
+/// Append the last `GUARANTEED_TAIL_LINES` raw lines after the compacted body
+/// (deduped if the body already ends with them).
+fn with_guaranteed_tail(body: &str, raw: &str) -> String {
+    let tail: Vec<&str> = raw.lines().collect();
+    let start = tail.len().saturating_sub(GUARANTEED_TAIL_LINES);
+    let tail_block = tail[start..].join("\n");
+    if body.trim_end().ends_with(tail_block.trim_end()) {
+        return body.to_string();
+    }
+    format!("{body}\n--- last {GUARANTEED_TAIL_LINES} lines ---\n{tail_block}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn small_output_is_returned_verbatim() {
+        let raw = "Exit code: 0\nSTDOUT:\nhello\nSTDERR:\n";
+        let got = compact_bash("git status", raw, 0);
+        assert_eq!(got.content, raw);
+        assert_eq!(got.raw_bytes, got.compacted_bytes);
+    }
+
+    #[test]
+    fn unrecognised_large_output_falls_back_not_errors() {
+        let raw = "x\n".repeat(200);
+        let got = compact_bash("some-weird-cmd --flag", &raw, 0);
+        // Fail-open: never panics, never larger than raw.
+        assert!(got.compacted_bytes <= got.raw_bytes);
+    }
+
+    #[test]
+    fn program_and_sub_strips_wrappers_and_chains() {
+        assert_eq!(program_and_sub("cargo test"), ("cargo", Some("test")));
+        assert_eq!(
+            program_and_sub("vx cargo nextest run"),
+            ("cargo", Some("nextest"))
+        );
+        assert_eq!(
+            program_and_sub("RUST_LOG=debug cargo build"),
+            ("cargo", Some("build"))
+        );
+        assert_eq!(
+            program_and_sub("cd /x && git status"),
+            ("git", Some("status"))
+        );
+        assert_eq!(
+            program_and_sub("/usr/bin/grep -r foo ."),
+            ("grep", Some("-r"))
+        );
+    }
+}

--- a/crates/wcore-tools/src/bash_compact.rs
+++ b/crates/wcore-tools/src/bash_compact.rs
@@ -90,7 +90,7 @@ fn dispatch(command: &str, raw: &str, exit_code: i32) -> Option<String> {
 /// dominates). Lowercased basename.
 pub(crate) fn program_and_sub(command: &str) -> (&str, Option<&str>) {
     let segment = command
-        .rsplit(|c| c == ';' || c == '&')
+        .rsplit([';', '&'])
         .map(str::trim)
         .find(|s| !s.is_empty())
         .unwrap_or(command.trim());

--- a/crates/wcore-tools/src/bash_compact/cargo.rs
+++ b/crates/wcore-tools/src/bash_compact/cargo.rs
@@ -1,0 +1,4 @@
+//! cargo output parser. STUB — real logic in Stage-B Task 8.
+pub(super) fn compact(_raw: &str, _exit_code: i32) -> Option<String> {
+    None
+}

--- a/crates/wcore-tools/src/bash_compact/cargo.rs
+++ b/crates/wcore-tools/src/bash_compact/cargo.rs
@@ -1,4 +1,224 @@
-//! cargo output parser. STUB — real logic in Stage-B Task 8.
-pub(super) fn compact(_raw: &str, _exit_code: i32) -> Option<String> {
-    None
+//! Block-aware compaction for `cargo build/check/clippy/test/nextest` output.
+//!
+//! The goal is to drop the high-volume, low-signal noise (`Compiling …`,
+//! `Checking …`, passing `... ok` test lines) while PRESERVING the full
+//! diagnostic signal. A compiler diagnostic is not a single line: an
+//! `error[E…]:` / `error:` / `warning:` trigger is followed by an indented
+//! continuation block (the `-->` location, the `|` code frame, and `= help`/
+//! `= note` annotations). We keep the trigger together with its whole block so
+//! the surviving text is still actionable, not just a bare headline.
+//!
+//! For test output we keep the `test result:` summary, `FAILED` test names, and
+//! each failure's `failures:` / `---- … ----` panic block, dropping the passing
+//! lines in between.
+//!
+//! Returns `None` when the output does not look like cargo at all, so the
+//! caller can fall through to a generic classifier.
+
+/// Hard cap on retained lines so a pathological build (thousands of errors)
+/// can't defeat the point of compaction.
+const MAX_KEPT_LINES: usize = 200;
+
+/// Compact verbose cargo output, preserving error/test signal block-aware.
+///
+/// Returns `Some(compacted)` when the output is recognizably cargo and was
+/// parsed; `None` when it does not look like cargo (no recognizable marker).
+pub(super) fn compact(raw: &str, exit_code: i32) -> Option<String> {
+    if !looks_like_cargo(raw) {
+        return None;
+    }
+
+    // A non-zero exit biases us toward keeping diagnostics: it confirms the
+    // build/test actually failed, so error and failure blocks are the signal.
+    let failed = exit_code != 0;
+
+    let lines: Vec<&str> = raw.lines().collect();
+    let mut kept: Vec<&str> = Vec::new();
+    let mut idx = 0;
+
+    while idx < lines.len() {
+        if kept.len() >= MAX_KEPT_LINES {
+            break;
+        }
+
+        let line = lines[idx];
+        let trimmed = line.trim_start();
+
+        // Always keep the terminal "could not compile" verdict.
+        if line.contains("could not compile") {
+            kept.push(line);
+            idx += 1;
+            continue;
+        }
+
+        // Diagnostic trigger: keep the line plus its full continuation block.
+        if is_diagnostic_trigger(trimmed) {
+            kept.push(line);
+            idx += 1;
+            while idx < lines.len() && kept.len() < MAX_KEPT_LINES {
+                if is_continuation(lines[idx]) {
+                    kept.push(lines[idx]);
+                    idx += 1;
+                } else {
+                    break;
+                }
+            }
+            continue;
+        }
+
+        // Test summary line.
+        if trimmed.starts_with("test result:") {
+            kept.push(line);
+            idx += 1;
+            continue;
+        }
+
+        // A FAILED test name or a panic line on its own.
+        if trimmed.contains("FAILED") || trimmed.contains("panicked") {
+            kept.push(line);
+            idx += 1;
+            continue;
+        }
+
+        // `failures:` header, then the per-failure `---- … ----` blocks and
+        // their indented panic/assertion bodies.
+        if trimmed.starts_with("failures:") {
+            kept.push(line);
+            idx += 1;
+            continue;
+        }
+
+        // A `---- name stdout ----` failure header: keep it plus the indented /
+        // non-empty body lines that follow (the captured panic output).
+        if is_failure_header(trimmed) {
+            kept.push(line);
+            idx += 1;
+            while idx < lines.len() && kept.len() < MAX_KEPT_LINES {
+                let body = lines[idx];
+                let body_trimmed = body.trim_start();
+                // Stop at the next failure header or a fresh `test ` line.
+                if is_failure_header(body_trimmed) || body_trimmed.starts_with("test ") {
+                    break;
+                }
+                if body.is_empty() {
+                    idx += 1;
+                    continue;
+                }
+                kept.push(body);
+                idx += 1;
+            }
+            continue;
+        }
+
+        // Everything else (Compiling/Checking spam, `... ok`, running headers,
+        // blank lines) is dropped.
+        idx += 1;
+    }
+
+    // If we matched nothing structural, fall through to the generic
+    // classifier rather than returning an empty result. `failed` only
+    // sharpens intent here; an empty match is uninformative either way.
+    if kept.is_empty() {
+        let _ = failed;
+        return None;
+    }
+
+    Some(kept.join("\n"))
+}
+
+/// Cheap detection: does this text contain any cargo-shaped marker at all?
+fn looks_like_cargo(raw: &str) -> bool {
+    raw.contains("Compiling ")
+        || raw.contains("Checking ")
+        || raw.contains("error[")
+        || raw.contains("error:")
+        || raw.contains("warning:")
+        || raw.contains("test result:")
+}
+
+/// A diagnostic trigger line (already left-trimmed).
+fn is_diagnostic_trigger(trimmed: &str) -> bool {
+    trimmed.starts_with("error[")
+        || trimmed.starts_with("error:")
+        || trimmed.starts_with("warning:")
+}
+
+/// Is `line` (RAW, not trimmed) a continuation of a diagnostic block?
+///
+/// Continuations are blank lines, indented lines, or the rustc frame markers
+/// `-->`, `|`, `=`. We test indentation on the raw line because the location /
+/// code-frame markers are themselves indented in real output.
+fn is_continuation(line: &str) -> bool {
+    if line.is_empty() {
+        return true;
+    }
+    if line.starts_with(char::is_whitespace) {
+        return true;
+    }
+    let trimmed = line.trim_start();
+    if trimmed.starts_with("-->") || trimmed.starts_with('|') || trimmed.starts_with('=') {
+        return true;
+    }
+    // rustc code-frame gutter lines: `10 | bar.foo();` or `LL | ...`. After the
+    // leading line-number (digits) or `LL` marker and spaces comes a `|`.
+    let after_gutter = trimmed.trim_start_matches(|c: char| c.is_ascii_digit() || c == 'L');
+    after_gutter.trim_start().starts_with('|') && after_gutter.len() < trimmed.len()
+}
+
+/// A `---- some::test stdout ----` style failure header (already left-trimmed).
+fn is_failure_header(trimmed: &str) -> bool {
+    trimmed.starts_with("----") && trimmed.ends_with("----") && trimmed.len() > 4
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn big(body: &str) -> String {
+        let noise = (0..100)
+            .map(|i| format!("   Compiling crate{i} v0.1.0"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        format!("{noise}\n{body}")
+    }
+
+    #[test]
+    fn keeps_error_with_its_code_frame_block() {
+        let raw = big("error[E0599]: no method named `foo` found\n \
+             --> src/x.rs:10:20\n   |\n10 |     bar.foo();\n   |         ^^^ method not found\n   = help: did you mean `food`?\n\
+             error: could not compile `x` due to previous error");
+        let out = compact(&raw, 1).expect("cargo output should compact");
+        assert!(out.contains("error[E0599]"));
+        assert!(
+            out.contains("--> src/x.rs:10:20"),
+            "must keep the location line (block-aware)"
+        );
+        assert!(
+            out.contains("method not found"),
+            "must keep the code-frame continuation"
+        );
+        assert!(out.contains("could not compile"));
+        assert!(!out.contains("Compiling crate50"), "must drop compile spam");
+        assert!(out.len() < raw.len());
+    }
+
+    #[test]
+    fn keeps_test_summary_and_failures_only() {
+        let raw = big("running 200 tests\n\
+             test a::ok ... ok\ntest a::ok2 ... ok\n\
+             test a::boom ... FAILED\n\
+             failures:\n---- a::boom stdout ----\nthread 'a::boom' panicked at 'assertion failed: x == y'\n\
+             test result: FAILED. 199 passed; 1 failed");
+        let out = compact(&raw, 101).expect("compact");
+        assert!(out.contains("test result: FAILED. 199 passed; 1 failed"));
+        assert!(out.contains("a::boom"));
+        assert!(out.contains("panicked at"));
+        assert!(!out.contains("a::ok2 ... ok"), "drop passing tests");
+        assert!(out.len() < raw.len());
+    }
+
+    #[test]
+    fn returns_none_for_non_cargo_text() {
+        assert!(compact("totally unrelated output\n".repeat(50).as_str(), 0).is_none());
+    }
 }

--- a/crates/wcore-tools/src/bash_compact/classifier.rs
+++ b/crates/wcore-tools/src/bash_compact/classifier.rs
@@ -1,0 +1,86 @@
+//! Generic output-shape fallback compactor — used when no per-command parser
+//! confidently handled the output. Classifies the output SHAPE (not the
+//! command) and keeps the signal: error/warn/fail lines + counts, else a
+//! head+tail with an omission marker. Returns `None` only if it would not
+//! shrink the output.
+
+/// Lines kept from the head and tail in the `raw` (unclassifiable) case.
+const HEAD_LINES: usize = 15;
+const TAIL_LINES: usize = 5;
+
+pub(super) fn compact(raw: &str) -> Option<String> {
+    let lines: Vec<&str> = raw.lines().collect();
+
+    // Error/warning/failure-bearing output: keep only those lines + a count.
+    let signal: Vec<&str> = lines
+        .iter()
+        .copied()
+        .filter(|l| {
+            let t = l.trim_start();
+            t.contains("error")
+                || t.contains("Error")
+                || t.contains("ERROR")
+                || t.contains("warning")
+                || t.contains("FAIL")
+                || t.contains("failed")
+                || t.starts_with('✗')
+                || t.starts_with('×')
+        })
+        .collect();
+
+    if !signal.is_empty() && signal.len() < lines.len() {
+        let kept: Vec<&str> = signal.iter().copied().take(40).collect();
+        return Some(format!(
+            "[compacted: {} of {} lines — error/warn/fail only]\n{}",
+            kept.len(),
+            lines.len(),
+            kept.join("\n")
+        ));
+    }
+
+    // Otherwise head + tail with an omission marker.
+    if lines.len() > HEAD_LINES + TAIL_LINES + 2 {
+        let head = lines[..HEAD_LINES].join("\n");
+        let tail = lines[lines.len() - TAIL_LINES..].join("\n");
+        let omitted = lines.len() - HEAD_LINES - TAIL_LINES;
+        return Some(format!("{head}\n... ({omitted} lines omitted) ...\n{tail}"));
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn keeps_only_error_lines_when_present() {
+        let mut raw = String::new();
+        for i in 0..100 {
+            raw.push_str(&format!("compiling unit {i}\n"));
+        }
+        raw.push_str("error: boom happened\n");
+        let out = compact(&raw).expect("should compact");
+        assert!(out.contains("error: boom happened"));
+        assert!(!out.contains("compiling unit 50"));
+        assert!(out.len() < raw.len());
+    }
+
+    #[test]
+    fn head_tail_when_no_signal() {
+        let raw = (0..100)
+            .map(|i| format!("line {i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let out = compact(&raw).expect("should compact");
+        assert!(out.contains("line 0"));
+        assert!(out.contains("line 99"));
+        assert!(out.contains("lines omitted"));
+        assert!(out.len() < raw.len());
+    }
+
+    #[test]
+    fn returns_none_for_already_small() {
+        assert!(compact("a\nb\nc").is_none());
+    }
+}

--- a/crates/wcore-tools/src/bash_compact/git.rs
+++ b/crates/wcore-tools/src/bash_compact/git.rs
@@ -1,4 +1,263 @@
-//! git output parser. STUB — real logic in Stage-B Task 9.
-pub(super) fn compact(_raw: &str, _exit_code: i32) -> Option<String> {
+//! git output parser.
+//!
+//! Compacts verbose `git status` / `git log` / `git diff` output down to the
+//! load-bearing signal so it costs fewer tokens in the agent context:
+//!
+//! * `git status` (long form) — collapse each section into a `<label>: <count>`
+//!   header followed by a capped path list (`… N more` when truncated).
+//! * `git log` (verbose form) — drop `Author:` / `Date:` / blank noise and keep
+//!   the indented subject lines (oneline-ish), prefixed with the short hash.
+//! * `git diff` — keep the `diff --git` / `@@` structure and drop unchanged
+//!   context lines once the diff is large.
+//!
+//! Returns `Some(compacted)` only when the input confidently looks like git
+//! output; otherwise `None` so the caller falls through to the raw text.
+
+/// Maximum number of paths shown per `git status` group before truncating.
+const STATUS_PATH_CAP: usize = 10;
+
+/// Line count above which a `git diff` drops unchanged context lines.
+const DIFF_CONTEXT_DROP_THRESHOLD: usize = 40;
+
+pub(super) fn compact(raw: &str, exit_code: i32) -> Option<String> {
+    // exit_code is informational here; the textual markers are authoritative.
+    let _ = exit_code;
+
+    if looks_like_log(raw) {
+        return compact_log(raw);
+    }
+    if looks_like_diff(raw) {
+        return compact_diff(raw);
+    }
+    if looks_like_status(raw) {
+        return compact_status(raw);
+    }
     None
+}
+
+/// A verbose `git log` entry starts with `commit <40 hex>` and usually carries
+/// `Author:` / `Date:` lines.
+fn looks_like_log(raw: &str) -> bool {
+    raw.lines()
+        .any(|line| line.strip_prefix("commit ").is_some_and(is_full_hash))
+        && raw.lines().any(|line| line.starts_with("Author:"))
+}
+
+fn looks_like_diff(raw: &str) -> bool {
+    raw.lines().any(|line| line.starts_with("diff --git"))
+}
+
+fn looks_like_status(raw: &str) -> bool {
+    raw.lines().any(|line| {
+        line.starts_with("On branch ")
+            || line.starts_with("Changes not staged")
+            || line.starts_with("Changes to be committed")
+            || line.starts_with("Untracked files")
+            || line.trim_start().starts_with("modified:")
+            || line.trim_start().starts_with("new file:")
+    })
+}
+
+fn is_full_hash(s: &str) -> bool {
+    let hash = s.split_whitespace().next().unwrap_or(s);
+    hash.len() == 40 && hash.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
+// ----- git log ------------------------------------------------------------
+
+fn compact_log(raw: &str) -> Option<String> {
+    let mut out = Vec::new();
+    let mut pending_hash: Option<String> = None;
+
+    for line in raw.lines() {
+        if let Some(rest) = line.strip_prefix("commit ")
+            && is_full_hash(rest)
+        {
+            let hash = rest.split_whitespace().next().unwrap_or(rest);
+            pending_hash = Some(hash.chars().take(7).collect());
+            continue;
+        }
+        if line.starts_with("Author:")
+            || line.starts_with("Date:")
+            || line.starts_with("Merge:")
+            || line.trim().is_empty()
+        {
+            continue;
+        }
+        // Indented body line — the first one after a commit is the subject.
+        let trimmed = line.trim_start();
+        if let Some(hash) = pending_hash.take() {
+            out.push(format!("{hash} {trimmed}"));
+        }
+        // Subsequent body lines are dropped (oneline form keeps the subject only).
+    }
+
+    if out.is_empty() {
+        return None;
+    }
+    Some(out.join("\n"))
+}
+
+// ----- git status ----------------------------------------------------------
+
+/// One section of a `git status` long-form listing.
+struct StatusGroup {
+    label: String,
+    paths: Vec<String>,
+}
+
+fn compact_status(raw: &str) -> Option<String> {
+    let mut groups: Vec<StatusGroup> = Vec::new();
+    let mut branch: Option<String> = None;
+
+    for line in raw.lines() {
+        if let Some(rest) = line.strip_prefix("On branch ") {
+            branch = Some(rest.trim().to_string());
+            continue;
+        }
+
+        // Section headers end with ':' and are not indented.
+        if !line.starts_with('\t') && !line.starts_with(' ') && line.trim_end().ends_with(':') {
+            let label = line.trim_end().trim_end_matches(':').to_string();
+            groups.push(StatusGroup {
+                label,
+                paths: Vec::new(),
+            });
+            continue;
+        }
+
+        // Indented entries belong to the current (last) group.
+        let entry = line.trim_start();
+        if entry.is_empty() || !(line.starts_with('\t') || line.starts_with("    ")) {
+            continue;
+        }
+        // Git annotates some lines with hints like "(use ...)"; skip those.
+        if entry.starts_with('(') {
+            continue;
+        }
+        if let Some(group) = groups.last_mut() {
+            // Strip the change-type label ("modified:   path" -> "modified:" + path).
+            let path = match entry.split_once(':') {
+                Some((kind, rest)) if is_change_kind(kind) => {
+                    format!("{}: {}", kind.trim(), rest.trim())
+                }
+                _ => entry.to_string(),
+            };
+            group.paths.push(path);
+        }
+    }
+
+    // Require at least one group with content to claim a confident parse.
+    if groups.iter().all(|g| g.paths.is_empty()) {
+        return None;
+    }
+
+    let mut out = Vec::new();
+    if let Some(b) = branch {
+        out.push(format!("On branch {b}"));
+    }
+
+    for group in &groups {
+        if group.paths.is_empty() {
+            continue;
+        }
+        out.push(format!("{}: {}", group.label, group.paths.len()));
+
+        for path in group.paths.iter().take(STATUS_PATH_CAP) {
+            out.push(format!("  {path}"));
+        }
+        if group.paths.len() > STATUS_PATH_CAP {
+            let more = group.paths.len() - STATUS_PATH_CAP;
+            out.push(format!("  … {more} more"));
+        }
+    }
+
+    Some(out.join("\n"))
+}
+
+/// Recognized `git status` change-type prefixes (the bit before the colon).
+fn is_change_kind(kind: &str) -> bool {
+    matches!(
+        kind.trim(),
+        "modified" | "new file" | "deleted" | "renamed" | "copied" | "typechange"
+    )
+}
+
+// ----- git diff ------------------------------------------------------------
+
+fn compact_diff(raw: &str) -> Option<String> {
+    let line_count = raw.lines().count();
+    let drop_context = line_count > DIFF_CONTEXT_DROP_THRESHOLD;
+
+    let mut out = Vec::new();
+    for line in raw.lines() {
+        if line.starts_with("diff --git")
+            || line.starts_with("@@")
+            || line.starts_with("+++")
+            || line.starts_with("---")
+            || line.starts_with("index ")
+            || line.starts_with("new file")
+            || line.starts_with("deleted file")
+            || line.starts_with("rename ")
+        {
+            out.push(line.to_string());
+            continue;
+        }
+        // Added / removed lines are always signal.
+        if line.starts_with('+') || line.starts_with('-') {
+            out.push(line.to_string());
+            continue;
+        }
+        // Unchanged context lines (leading single space) — drop when large.
+        if drop_context && line.starts_with(' ') {
+            continue;
+        }
+        out.push(line.to_string());
+    }
+
+    if out.is_empty() {
+        return None;
+    }
+    Some(out.join("\n"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn status_groups_by_change_type() {
+        let mut raw = String::from("On branch main\nChanges not staged for commit:\n");
+        for i in 0..50 {
+            raw.push_str(&format!("\tmodified:   file{i}.rs\n"));
+        }
+        raw.push_str("Untracked files:\n");
+        for i in 0..30 {
+            raw.push_str(&format!("\tnew{i}.rs\n"));
+        }
+        let out = compact(&raw, 0).expect("git status compacts");
+        assert!(out.contains("modified"));
+        assert!(out.to_lowercase().contains("50") || out.contains("modified: 50"));
+        assert!(out.len() < raw.len());
+    }
+
+    #[test]
+    fn log_is_oneline() {
+        let mut raw = String::new();
+        for i in 0..40 {
+            raw.push_str(&format!(
+                "commit {:040x}\nAuthor: a <a@b>\nDate: now\n\n    subject {i}\n\n",
+                i
+            ));
+        }
+        let out = compact(&raw, 0).expect("git log compacts");
+        assert!(out.contains("subject 0"));
+        assert!(!out.contains("Author: a"), "drop author/date noise");
+        assert!(out.len() < raw.len());
+    }
+
+    #[test]
+    fn returns_none_for_non_git() {
+        assert!(compact(&"random\n".repeat(60), 0).is_none());
+    }
 }

--- a/crates/wcore-tools/src/bash_compact/git.rs
+++ b/crates/wcore-tools/src/bash_compact/git.rs
@@ -1,0 +1,4 @@
+//! git output parser. STUB — real logic in Stage-B Task 9.
+pub(super) fn compact(_raw: &str, _exit_code: i32) -> Option<String> {
+    None
+}

--- a/crates/wcore-tools/src/bash_compact/grep.rs
+++ b/crates/wcore-tools/src/bash_compact/grep.rs
@@ -1,0 +1,4 @@
+//! grep/find output parser. STUB — real logic in Stage-B Task 11.
+pub(super) fn compact(_raw: &str, _exit_code: i32) -> Option<String> {
+    None
+}

--- a/crates/wcore-tools/src/bash_compact/grep.rs
+++ b/crates/wcore-tools/src/bash_compact/grep.rs
@@ -1,4 +1,204 @@
-//! grep/find output parser. STUB — real logic in Stage-B Task 11.
-pub(super) fn compact(_raw: &str, _exit_code: i32) -> Option<String> {
-    None
+//! Compaction for `grep` / `ripgrep` / `find` output.
+//!
+//! Search tools emit one result per line, and the volume is dominated by the
+//! per-match content (`grep -n` / `rg` produce `path:line:content`) or by bare
+//! paths (`find`). Once a search returns dozens of hits, the per-line content
+//! stops being useful for orientation: what matters is *which files* matched
+//! and *how many* times. We summarize to a match count, a unique-file count,
+//! and the first K unique paths, keeping raw match lines only when the result
+//! set is small enough to read in full.
+//!
+//! Returns `None` when the output does not look like grep/find output, so the
+//! caller can fall through to a generic classifier.
+
+/// Below this many matches we keep the raw lines (still adding a summary
+/// header); above it we collapse to the file-set summary.
+const KEEP_RAW_THRESHOLD: usize = 15;
+
+/// How many unique paths to list in a summary before truncating.
+const MAX_LISTED_FILES: usize = 20;
+
+/// A parsed grep-shaped match line: the file path it belongs to.
+struct Match<'a> {
+    file: &'a str,
+}
+
+/// Compact verbose grep/rg/find output to a file-set summary.
+///
+/// Returns `Some(compacted)` when the output is recognizably grep/rg or find
+/// output and was parsed; `None` when neither shape dominates (e.g. prose).
+pub(super) fn compact(raw: &str, exit_code: i32) -> Option<String> {
+    // The exit code carries no extra signal here: grep returns 1 on "no match"
+    // and find returns 0 either way, so we classify purely on output shape.
+    let _ = exit_code;
+
+    let non_empty: Vec<&str> = raw.lines().filter(|l| !l.trim().is_empty()).collect();
+    if non_empty.is_empty() {
+        return None;
+    }
+
+    let grep_hits = non_empty
+        .iter()
+        .filter(|l| parse_grep_line(l).is_some())
+        .count();
+    let find_hits = non_empty.iter().filter(|l| looks_like_path(l)).count();
+
+    // Require a clear majority of one shape; otherwise this isn't search output.
+    let majority = non_empty.len() / 2;
+    if grep_hits > majority && grep_hits >= find_hits {
+        Some(compact_grep(&non_empty))
+    } else if find_hits > majority {
+        Some(compact_find(&non_empty))
+    } else {
+        None
+    }
+}
+
+/// Summarize grep/rg match lines.
+fn compact_grep(lines: &[&str]) -> String {
+    let matches: Vec<Match> = lines.iter().filter_map(|l| parse_grep_line(l)).collect();
+    let total = matches.len();
+    let files = unique_in_order(matches.iter().map(|m| m.file));
+
+    let header = format!("{total} matches in {} files:", files.len());
+
+    if total <= KEEP_RAW_THRESHOLD {
+        // Small result set: keep the raw match lines under the header.
+        let mut out = String::with_capacity(header.len() + lines.len() * 16);
+        out.push_str(&header);
+        for line in lines {
+            if parse_grep_line(line).is_some() {
+                out.push('\n');
+                out.push_str(line);
+            }
+        }
+        out
+    } else {
+        summarize_paths(&header, &files)
+    }
+}
+
+/// Summarize `find`-style bare paths.
+fn compact_find(lines: &[&str]) -> String {
+    let paths = unique_in_order(
+        lines
+            .iter()
+            .filter(|l| looks_like_path(l))
+            .map(|l| l.trim()),
+    );
+    let header = format!("{} paths:", paths.len());
+    summarize_paths(&header, &paths)
+}
+
+/// Append the first `MAX_LISTED_FILES` paths to `header`, with a truncation
+/// footer when the set is larger.
+fn summarize_paths(header: &str, paths: &[&str]) -> String {
+    let mut out = String::with_capacity(header.len() + paths.len().min(MAX_LISTED_FILES) * 32);
+    out.push_str(header);
+    for path in paths.iter().take(MAX_LISTED_FILES) {
+        out.push('\n');
+        out.push_str(path);
+    }
+    if paths.len() > MAX_LISTED_FILES {
+        out.push_str(&format!("\n… and {} more", paths.len() - MAX_LISTED_FILES));
+    }
+    out
+}
+
+/// Parse a line as `path:line:content` (grep -n / ripgrep). The match key is
+/// the file path. We split into at most three parts and require the middle
+/// part to be all digits — that's what distinguishes a real `file:line:` hit
+/// from an arbitrary line that merely contains a colon.
+fn parse_grep_line(line: &str) -> Option<Match<'_>> {
+    let mut parts = line.splitn(3, ':');
+    let file = parts.next()?;
+    let lineno = parts.next()?;
+    // `content` may legitimately be empty (a blank matched line), but the
+    // `file:line:` prefix must be present, so the third split must exist.
+    parts.next()?;
+
+    if file.is_empty() || lineno.is_empty() || !lineno.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    Some(Match { file })
+}
+
+/// Does this line look like a bare filesystem path (find output)? It must have
+/// no colon (which would make it grep-shaped) and either contain a path
+/// separator or a file-extension dot.
+fn looks_like_path(line: &str) -> bool {
+    let trimmed = line.trim();
+    if trimmed.is_empty() || trimmed.contains(':') {
+        return false;
+    }
+    trimmed.contains('/') || (trimmed.contains('.') && !trimmed.contains(' '))
+}
+
+/// Collect items preserving first-seen order, dropping later duplicates.
+fn unique_in_order<'a, I: Iterator<Item = &'a str>>(items: I) -> Vec<&'a str> {
+    let mut seen: Vec<&str> = Vec::new();
+    for item in items {
+        if !seen.contains(&item) {
+            seen.push(item);
+        }
+    }
+    seen
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn grep_summarizes_to_unique_files() {
+        let mut raw = String::new();
+        for i in 0..200 {
+            raw.push_str(&format!("src/file{}.rs:{}:    let x = foo();\n", i % 10, i));
+        }
+        let out = compact(&raw, 0).expect("grep compacts");
+        assert!(out.to_lowercase().contains("match"));
+        assert!(out.contains("file0.rs"));
+        assert!(out.len() < raw.len());
+        // 10 unique files, 200 matches.
+        assert!(out.contains("10") && out.contains("200"));
+    }
+
+    #[test]
+    fn returns_none_for_non_grep() {
+        assert!(compact(&"plain text\n".repeat(60), 0).is_none());
+    }
+
+    #[test]
+    fn small_grep_keeps_raw_lines() {
+        let raw = "src/a.rs:1:foo\nsrc/b.rs:2:bar\nsrc/a.rs:9:baz";
+        let out = compact(raw, 0).expect("compacts");
+        assert!(out.starts_with("3 matches in 2 files:"));
+        assert!(out.contains("src/a.rs:1:foo"));
+        assert!(out.contains("src/b.rs:2:bar"));
+    }
+
+    #[test]
+    fn find_summarizes_bare_paths() {
+        let mut raw = String::new();
+        for i in 0..50 {
+            raw.push_str(&format!("src/dir{i}/file.rs\n"));
+        }
+        let out = compact(&raw, 0).expect("find compacts");
+        assert!(out.starts_with("50 paths:"));
+        assert!(out.contains("src/dir0/file.rs"));
+        assert!(out.contains("… and 30 more"));
+    }
+
+    #[test]
+    fn large_grep_truncates_file_list() {
+        let mut raw = String::new();
+        for i in 0..100 {
+            raw.push_str(&format!("src/f{i}.rs:1:hit\n"));
+        }
+        let out = compact(&raw, 0).expect("compacts");
+        assert!(out.starts_with("100 matches in 100 files:"));
+        assert!(out.contains("… and 80 more"));
+        // Raw content lines are dropped above the threshold.
+        assert!(!out.contains(":1:hit"));
+    }
 }

--- a/crates/wcore-tools/src/bash_compact/testrun.rs
+++ b/crates/wcore-tools/src/bash_compact/testrun.rs
@@ -1,0 +1,4 @@
+//! test-runner output parser. STUB — real logic in Stage-B Task 10.
+pub(super) fn compact(_raw: &str, _exit_code: i32) -> Option<String> {
+    None
+}

--- a/crates/wcore-tools/src/bash_compact/testrun.rs
+++ b/crates/wcore-tools/src/bash_compact/testrun.rs
@@ -1,4 +1,157 @@
-//! test-runner output parser. STUB — real logic in Stage-B Task 10.
-pub(super) fn compact(_raw: &str, _exit_code: i32) -> Option<String> {
-    None
+//! Block-aware compaction for non-cargo test-runner output
+//! (pytest / jest / vitest / go test).
+//!
+//! Verbose test runs are mostly passing lines (`… PASSED`, `✓ …`,
+//! `--- PASS: …`) that carry no signal once the run is over. We keep the
+//! pass/fail SUMMARY line, the names of the FAILING tests, the `FAILURES`
+//! header, and each failure's full detail block (assertion lines starting with
+//! `>` or `E `, indented tracebacks, `thread '…' panicked` lines), and drop the
+//! passing lines in between.
+//!
+//! Returns `None` when the output does not contain any recognizable
+//! test-runner summary or failure marker, so the caller can fall through to a
+//! generic classifier.
+
+/// Hard cap on retained lines so a pathological run (thousands of failures)
+/// can't defeat the point of compaction.
+const MAX_KEPT_LINES: usize = 200;
+
+/// Compact verbose test-runner output, preserving the summary and failures.
+///
+/// Returns `Some(compacted)` when the output is a recognizable test summary
+/// (pytest / jest / vitest / go test) and was parsed; `None` when no test
+/// marker is present.
+pub(super) fn compact(raw: &str, exit_code: i32) -> Option<String> {
+    // `exit_code` is part of the stable signature; a non-zero exit only
+    // corroborates the failure markers we already detect from text, so we do
+    // not branch on it here.
+    let _ = exit_code;
+
+    if !looks_like_test_output(raw) {
+        return None;
+    }
+
+    let mut kept: Vec<&str> = Vec::new();
+
+    for line in raw.lines() {
+        if kept.len() >= MAX_KEPT_LINES {
+            break;
+        }
+        if is_passing_line(line) {
+            continue;
+        }
+        if is_kept_line(line) {
+            kept.push(line);
+        }
+    }
+
+    if kept.is_empty() {
+        return None;
+    }
+
+    Some(kept.join("\n"))
+}
+
+/// True when the output contains at least one test-runner summary or failure
+/// marker. Arbitrary noise text returns false.
+fn looks_like_test_output(raw: &str) -> bool {
+    raw.lines().any(|line| {
+        is_summary_line(line)
+            || is_failures_header(line)
+            || line.contains("--- FAIL:")
+            || line.contains("FAILED")
+            || line.contains("PASSED")
+    })
+}
+
+/// A pass/fail summary line: pytest's `N failed, M passed` banner, jest/vitest's
+/// `Tests:` line, or any line pairing a digit with `passed`/`failed`.
+fn is_summary_line(line: &str) -> bool {
+    let lower = line.to_ascii_lowercase();
+    if lower.contains("tests:") {
+        return true;
+    }
+    let has_digit = line.chars().any(|c| c.is_ascii_digit());
+    has_digit && (lower.contains("passed") || lower.contains("failed"))
+}
+
+/// The pytest `=== FAILURES ===` section header (with or without the `=` rule).
+fn is_failures_header(line: &str) -> bool {
+    let trimmed = line.trim_matches('=').trim();
+    trimmed == "FAILURES"
+}
+
+/// Lines we keep: summaries, failure markers, the FAILURES header, per-failure
+/// detail/traceback lines, and pytest `___ test_name ___` failure headers.
+fn is_kept_line(line: &str) -> bool {
+    if is_summary_line(line) || is_failures_header(line) {
+        return true;
+    }
+
+    // Failure markers across runners.
+    if line.contains("FAILED")
+        || line.contains("--- FAIL:")
+        || line.contains('✗')
+        || line.starts_with("FAIL")
+    {
+        return true;
+    }
+
+    // pytest per-test failure header, e.g. `___ test_boom ___`.
+    if is_underscore_header(line) {
+        return true;
+    }
+
+    // Assertion / traceback detail lines.
+    let trimmed = line.trim_start();
+    if trimmed.starts_with('>') || trimmed.starts_with("E ") {
+        return true;
+    }
+    if line.contains("panicked") {
+        return true;
+    }
+
+    false
+}
+
+/// pytest underscore-delimited failure header: `___ test_name ___`.
+fn is_underscore_header(line: &str) -> bool {
+    let trimmed = line.trim();
+    trimmed.starts_with('_') && trimmed.ends_with('_') && trimmed.contains(char::is_alphabetic)
+}
+
+/// Lines that indicate a passing test and should be dropped.
+fn is_passing_line(line: &str) -> bool {
+    line.contains("PASSED")
+        || line.contains("--- PASS:")
+        || line.contains('✓')
+        || line.ends_with(" ok")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pytest_keeps_failures_and_traceback() {
+        let mut raw = String::new();
+        for i in 0..80 {
+            raw.push_str(&format!("tests/test_{i}.py::ok PASSED\n"));
+        }
+        raw.push_str("tests/test_x.py::boom FAILED\n");
+        raw.push_str("=================== FAILURES ===================\n");
+        raw.push_str("___ test_boom ___\n>   assert x == y\nE   assert 1 == 2\n");
+        raw.push_str("=========== 1 failed, 80 passed in 2.0s ===========\n");
+        let out = compact(&raw, 1).expect("pytest compacts");
+        assert!(out.contains("1 failed, 80 passed"));
+        assert!(out.contains("test_boom"));
+        assert!(out.contains("assert 1 == 2"));
+        assert!(!out.contains("test_40.py::ok PASSED"), "drop passing tests");
+        assert!(out.len() < raw.len());
+    }
+
+    #[test]
+    fn returns_none_without_summary() {
+        assert!(compact(&"noise\n".repeat(60), 0).is_none());
+    }
 }

--- a/crates/wcore-tools/src/lib.rs
+++ b/crates/wcore-tools/src/lib.rs
@@ -14,6 +14,9 @@ pub mod assert_fact;
 // a read-only operation allowlist; mutating ops rejected. Sandboxed via Tier S.
 pub mod aws_cli_tool;
 pub mod bash;
+// Native per-command Bash output compaction (cargo/git/test/grep) — engine-owned,
+// fail-open, size-gated. See `.planning/2026-06-11-NATIVE-BASH-COMPACTION-DESIGN.md`.
+pub mod bash_compact;
 // T3-3.2.1: pure-string binary extension filter ported from hermes (sub-wave 2).
 pub mod binary_extensions;
 // T3-3.1.1: clarify_tool ported from wayland-hermes (sub-wave 1).

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -362,6 +362,41 @@ In `--json-stream` mode, the compaction level can be changed at runtime via `set
 {"type": "set_config", "compaction": "full"}
 ```
 
+### Native Bash Output Compaction
+
+On top of the generic levels above, the engine compacts verbose **Bash** tool
+output per-command before it enters the model's transcript. It parses the
+output grammar of common dev commands and reconstructs a compact,
+signal-preserving form:
+
+| Command | What is kept |
+|---------|--------------|
+| `cargo build/check/clippy/test/nextest` | each `error[E…]`/`warning` **with its full code-frame block** (`-->` location, code frame, `= help`), the `could not compile` verdict, and `test result:` + `FAILED` names + panic blocks. Drops `Compiling …` spam and passing `... ok` lines. |
+| `git status` / `diff` / `log` | status grouped by change-type with counts + capped path lists; diff structure (`@@` hunks, `+/-`); log collapsed to one line per commit (drops `Author:`/`Date:`). |
+| `pytest` / `jest` / `vitest` / `go test` | the pass/fail summary, failing test names, and each failure's full traceback/assertion block. Drops passing lines. |
+| `grep` / `rg` / `find` | total match count + unique-file count + the first paths. |
+| anything else (fallback) | a generic shape classifier keeps error/warn/fail lines, else a head+tail with an omission marker. |
+
+Properties:
+
+- **Default on.** Resolved from `ProviderCompat::compact_bash()`.
+- **Fail-open.** A parser that can't confidently parse falls through to the
+  classifier, then to the raw output — the error signal is never dropped, and
+  a non-trivial compaction always appends the last raw lines as a guaranteed
+  tail. Output below ~40 lines / 8 KB is passed through verbatim.
+- **Human sees full output.** Only the model's transcript copy is compacted;
+  the host/terminal still receives the complete result via the live stream.
+- **Telemetry.** Per-call `(raw_bytes, compacted_bytes)` is recorded on the
+  tool-call trace (`compaction_bytes`) and a `wcore_agent::compaction` debug
+  line is emitted, feeding a savings ("gain") report.
+
+Disable it per provider/profile in `ProviderCompat`:
+
+```toml
+[providers.<name>.compat]
+compact_bash = false   # default: true
+```
+
 ## Skills lifecycle (W9)
 
 When `observability.skills_lifecycle = true` in `wcore.toml`, three subsystems become available to the engine:


### PR DESCRIPTION
Compacts verbose **Bash** tool output (cargo/git/test/grep) into the model's transcript before it costs tokens — deterministic, engine-owned, fail-open, signal-preserving — with per-call savings telemetry. Built ourselves (no external proxy). Full gate green on the box: clippy `--workspace --all-targets`, `nextest --workspace` 8214 passed.

## How it works
A hybrid compactor in `wcore-tools::bash_compact`: per-command block-aware parsers for the high-value commands plus a generic output-shape classifier fallback. It runs **engine-side** in the tool-result loop (`engine.rs`) — *after* the full result is emitted to the host and *before* read-once dedup — so the human still sees full output and identical compacted outputs still collapse. Gated by `ProviderCompat::compact_bash()` (default on), Bash-only.

### Per-command parsers
- **cargo** (`build/check/clippy/test/nextest`): keeps each `error[E…]`/`warning` **with its full code-frame block** (the IJFW span-drop fix), the `could not compile` verdict, and `test result:` + `FAILED` names + panic blocks; drops `Compiling …` spam and passing `... ok` lines.
- **git** (`status/diff/log`): status grouped by change-type with counts + capped paths; diff structure; log → oneline subjects.
- **test runners** (`pytest/jest/vitest/go test`): summary + failing names + tracebacks; drops passing lines.
- **grep/rg/find**: total matches + unique-file count + first K paths.
- **fallback classifier**: keeps error/warn/fail lines, else head+tail with an omission marker.

### Safety (fail-open by construction)
- Size-gated passthrough (≤~40 lines / 8 KB returned verbatim).
- A parser that can't confidently parse → classifier → raw. Never drops the error signal.
- Guaranteed raw tail appended after any non-trivial compaction.
- Compaction is only accepted if it actually shrank the output.

### Gate & telemetry
- `compact_bash: Option<bool>` on `ProviderCompat` (default on; `compact_bash = false` to disable per provider/profile).
- Per-call `(raw_bytes, compacted_bytes)` recorded on `ToolCallTrace.compaction_bytes` (flows to the host in every `TurnTrace`); `CompactionSavings` + `aggregate_compaction()` compute the gain report; a `wcore_agent::compaction` debug line is emitted per compacted call.

## Tests
- 19 `bash_compact` unit tests (dispatcher, classifier, 4 parsers).
- `compat::…::compact_bash_defaults_on_and_honors_override`.
- `trace::…::tool_call_trace_round_trips_compaction_bytes`, `aggregate_compaction_sums_savings_and_ratio`.
- **End-to-end** (`output_compaction_test::case_9`): drives a real `AgentEngine` turn with a Bash tool returning 300 lines and asserts the LLM's follow-up request carries the *compacted* copy.

Docs: `docs/advanced.md` → Output Compaction → Native Bash Output Compaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)