### PR TITLE
feat(tools): Parallel free search default + Firecrawl/Exa/SearXNG ladder

### DIFF
--- a/crates/wcore-agent/src/tool_backends/chained_web.rs
+++ b/crates/wcore-agent/src/tool_backends/chained_web.rs
@@ -1,0 +1,145 @@
+//! Generic primary → fallback wrapper for `WebBackend`.
+//!
+//! The factory wires every selected search backend (Firecrawl, Parallel,
+//! Tavily, Exa, SearXNG, Brave) as `ChainedWebBackend { primary, DuckDuckGo }`
+//! so search never hard-fails: if the primary returns a structured `Err`
+//! (transport failure, non-2xx, unparseable / zombie payload, or a
+//! validation-rejected empty set), the call falls through to DuckDuckGo.
+//!
+//! A *successful* primary response is final — including a legitimately empty
+//! one would never reach here, because every backend returns `Err` (not
+//! `Ok{web:[]}`) when it has no valid results, matching the existing
+//! DuckDuckGo convention. So `Ok` always carries real results.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use wcore_tools::web_tools::{CrawlRequest, ExtractRequest, WebBackend, WebOutcome};
+
+/// Wraps a primary backend with a fallback (always DuckDuckGo in practice).
+/// On any primary `Err`, the same operation is retried on the fallback.
+pub struct ChainedWebBackend {
+    primary: Arc<dyn WebBackend>,
+    fallback: Arc<dyn WebBackend>,
+}
+
+impl ChainedWebBackend {
+    pub fn new(primary: Arc<dyn WebBackend>, fallback: Arc<dyn WebBackend>) -> Self {
+        Self { primary, fallback }
+    }
+}
+
+#[async_trait]
+impl WebBackend for ChainedWebBackend {
+    async fn search(&self, query: &str, limit: u32) -> WebOutcome {
+        match self.primary.search(query, limit).await {
+            WebOutcome::Ok { payload } => WebOutcome::Ok { payload },
+            WebOutcome::Err { message } => {
+                tracing::debug!(
+                    "web search: primary '{}' failed ({message}); falling back to '{}'",
+                    self.primary.backend_id(),
+                    self.fallback.backend_id()
+                );
+                self.fallback.search(query, limit).await
+            }
+        }
+    }
+
+    async fn extract(&self, req: ExtractRequest) -> WebOutcome {
+        // Primary first (Firecrawl can extract); only fall back on Err.
+        match self.primary.extract(req.clone()).await {
+            WebOutcome::Ok { payload } => WebOutcome::Ok { payload },
+            WebOutcome::Err { .. } => self.fallback.extract(req).await,
+        }
+    }
+
+    async fn crawl(&self, req: CrawlRequest) -> WebOutcome {
+        match self.primary.crawl(req.clone()).await {
+            WebOutcome::Ok { payload } => WebOutcome::Ok { payload },
+            WebOutcome::Err { .. } => self.fallback.crawl(req).await,
+        }
+    }
+
+    fn backend_id(&self) -> &str {
+        "chained"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use wcore_tools::web_tools::CapturingWebBackend;
+
+    /// Tiny double that always errors — stands in for an unreachable primary.
+    struct ErrBackend;
+    #[async_trait]
+    impl WebBackend for ErrBackend {
+        async fn search(&self, _q: &str, _l: u32) -> WebOutcome {
+            WebOutcome::Err {
+                message: "boom".into(),
+            }
+        }
+        async fn extract(&self, _r: ExtractRequest) -> WebOutcome {
+            WebOutcome::Err {
+                message: "boom".into(),
+            }
+        }
+        async fn crawl(&self, _r: CrawlRequest) -> WebOutcome {
+            WebOutcome::Err {
+                message: "boom".into(),
+            }
+        }
+        fn backend_id(&self) -> &str {
+            "err"
+        }
+    }
+
+    #[tokio::test]
+    async fn falls_back_to_fallback_on_primary_error() {
+        let fb = Arc::new(CapturingWebBackend::new().with_search_payload(json!({
+            "web": [{"title": "ddg", "url": "https://x/", "snippet": "ok"}]
+        })));
+        let chain = ChainedWebBackend::new(Arc::new(ErrBackend), fb.clone());
+        let out = chain.search("q", 5).await;
+        assert!(
+            matches!(out, WebOutcome::Ok { .. }),
+            "should serve fallback result"
+        );
+        assert_eq!(
+            fb.snapshot().len(),
+            1,
+            "fallback must be invoked exactly once"
+        );
+    }
+
+    #[tokio::test]
+    async fn does_not_fall_back_when_primary_succeeds() {
+        let primary = Arc::new(CapturingWebBackend::new().with_search_payload(json!({
+            "web": [{"title": "p", "url": "https://p/", "snippet": "ok"}]
+        })));
+        let fb = Arc::new(CapturingWebBackend::new());
+        let chain = ChainedWebBackend::new(primary, fb.clone());
+        let out = chain.search("q", 5).await;
+        assert!(matches!(out, WebOutcome::Ok { .. }));
+        assert_eq!(
+            fb.snapshot().len(),
+            0,
+            "fallback must NOT be touched on primary success"
+        );
+    }
+
+    #[tokio::test]
+    async fn extract_prefers_primary_then_falls_back() {
+        let fb = Arc::new(CapturingWebBackend::new().with_extract_payload(json!({"results": []})));
+        let chain = ChainedWebBackend::new(Arc::new(ErrBackend), fb.clone());
+        let req = ExtractRequest {
+            urls: vec!["https://x/".into()],
+            format: None,
+            use_llm_processing: false,
+        };
+        let out = chain.extract(req).await;
+        assert!(matches!(out, WebOutcome::Ok { .. }));
+        assert_eq!(fb.snapshot().len(), 1);
+    }
+}

--- a/crates/wcore-agent/src/tool_backends/exa_web.rs
+++ b/crates/wcore-agent/src/tool_backends/exa_web.rs
@@ -1,0 +1,132 @@
+//! Exa neural search backend. Requires `EXA_API_KEY`.
+//!
+//! API docs: <https://docs.exa.ai/reference/search>. POSTs to
+//! `https://api.exa.ai/search` with an `x-api-key` header and requests inline
+//! text contents so each result carries a snippet.
+
+use async_trait::async_trait;
+use serde_json::{Value, json};
+use wcore_egress::EgressClient as Client;
+
+use super::build_ssrf_safe_tool_client;
+use wcore_tools::web_tools::{CrawlRequest, ExtractRequest, WebBackend, WebOutcome};
+
+const EXA_URL: &str = "https://api.exa.ai/search";
+/// Exa `text` contents can be large; cap the snippet so results stay compact.
+const SNIPPET_CAP: usize = 1000;
+
+pub struct ExaWebBackend {
+    client: Client,
+    api_key: String,
+}
+
+impl ExaWebBackend {
+    pub fn new(api_key: String) -> Self {
+        Self {
+            client: build_ssrf_safe_tool_client(),
+            api_key,
+        }
+    }
+}
+
+#[async_trait]
+impl WebBackend for ExaWebBackend {
+    async fn search(&self, query: &str, limit: u32) -> WebOutcome {
+        let body = json!({
+            "query": query,
+            "numResults": limit.clamp(1, 20),
+            "contents": { "text": true },
+        });
+        let resp = match self
+            .client
+            .post(EXA_URL)
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .header("x-api-key", &self.api_key)
+            .timeout(std::time::Duration::from_secs(15))
+            .body(body.to_string())
+            .send()
+            .await
+        {
+            Ok(r) => r,
+            Err(e) => {
+                return WebOutcome::Err {
+                    message: format!("exa request failed: {e}"),
+                };
+            }
+        };
+        let status = resp.status();
+        let txt = resp.text().await.unwrap_or_default();
+        if !status.is_success() {
+            return WebOutcome::Err {
+                message: format!(
+                    "exa returned HTTP {}: {}",
+                    status.as_u16(),
+                    txt.chars().take(300).collect::<String>()
+                ),
+            };
+        }
+        let parsed: Value = match serde_json::from_str(&txt) {
+            Ok(v) => v,
+            Err(e) => {
+                return WebOutcome::Err {
+                    message: format!("exa response was not JSON: {e}"),
+                };
+            }
+        };
+        let raw = parsed
+            .get("results")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default();
+        let mut results: Vec<Value> = Vec::new();
+        for r in raw {
+            let url = r
+                .get("url")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .trim()
+                .to_string();
+            let title = r
+                .get("title")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .trim()
+                .to_string();
+            if title.is_empty() || !(url.starts_with("http://") || url.starts_with("https://")) {
+                continue;
+            }
+            let snippet: String = r
+                .get("text")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .chars()
+                .take(SNIPPET_CAP)
+                .collect();
+            results.push(json!({ "title": title, "url": url, "snippet": snippet }));
+        }
+        if results.is_empty() {
+            return WebOutcome::Err {
+                message: "exa returned no valid results".to_string(),
+            };
+        }
+        WebOutcome::Ok {
+            payload: json!({ "web": results }),
+        }
+    }
+
+    async fn extract(&self, _req: ExtractRequest) -> WebOutcome {
+        WebOutcome::Err {
+            message: "Exa extract not wired; use the WebFetch tool on a specific URL.".to_string(),
+        }
+    }
+
+    async fn crawl(&self, _req: CrawlRequest) -> WebOutcome {
+        WebOutcome::Err {
+            message: "Exa crawl not supported.".to_string(),
+        }
+    }
+
+    fn backend_id(&self) -> &str {
+        "exa"
+    }
+}

--- a/crates/wcore-agent/src/tool_backends/exa_web.rs
+++ b/crates/wcore-agent/src/tool_backends/exa_web.rs
@@ -130,3 +130,39 @@ impl WebBackend for ExaWebBackend {
         "exa"
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Live smoke test against the real Exa `/search` endpoint. `#[ignore]`d;
+    /// run with `EXA_API_KEY=… cargo test -p wcore-agent --lib
+    /// exa_web::tests::live_ -- --ignored --nocapture`.
+    #[tokio::test]
+    #[ignore = "live network + paid key: needs EXA_API_KEY"]
+    async fn live_exa_search_returns_results() {
+        let Some(key) = std::env::var("EXA_API_KEY")
+            .ok()
+            .filter(|s| !s.trim().is_empty())
+        else {
+            eprintln!("SKIP live_exa: EXA_API_KEY unset");
+            return;
+        };
+        match ExaWebBackend::new(key)
+            .search("latest stable rust compiler version", 3)
+            .await
+        {
+            WebOutcome::Ok { payload } => {
+                let web = payload
+                    .get("web")
+                    .and_then(Value::as_array)
+                    .expect("web[] present");
+                assert!(!web.is_empty(), "expected >=1 exa result");
+                let url = web[0].get("url").and_then(Value::as_str).unwrap_or("");
+                assert!(url.starts_with("http"), "url must be http(s): {url}");
+                eprintln!("LIVE EXA OK — {} results; first: {url}", web.len());
+            }
+            WebOutcome::Err { message } => panic!("live exa returned Err: {message}"),
+        }
+    }
+}

--- a/crates/wcore-agent/src/tool_backends/firecrawl_web.rs
+++ b/crates/wcore-agent/src/tool_backends/firecrawl_web.rs
@@ -1,0 +1,136 @@
+//! Firecrawl web search backend. Requires `FIRECRAWL_API_KEY`; honors an
+//! optional `FIRECRAWL_API_URL` for self-hosted instances.
+//!
+//! API docs: <https://docs.firecrawl.dev/api-reference/endpoint/search>.
+//! This first cut wires **search** only; extract/crawl return the standard
+//! "use WebFetch" message (Firecrawl's `/scrape` + `/crawl` are a follow-up).
+
+use async_trait::async_trait;
+use serde_json::{Value, json};
+use wcore_egress::EgressClient as Client;
+
+use super::build_ssrf_safe_tool_client;
+use super::shared::read_env_key;
+use wcore_tools::web_tools::{CrawlRequest, ExtractRequest, WebBackend, WebOutcome};
+
+const DEFAULT_BASE: &str = "https://api.firecrawl.dev";
+
+pub struct FirecrawlWebBackend {
+    client: Client,
+    api_key: String,
+    base_url: String,
+}
+
+impl FirecrawlWebBackend {
+    pub fn new(api_key: String) -> Self {
+        let base_url = read_env_key("FIRECRAWL_API_URL")
+            .map(|u| u.trim_end_matches('/').to_string())
+            .unwrap_or_else(|| DEFAULT_BASE.to_string());
+        Self {
+            client: build_ssrf_safe_tool_client(),
+            api_key,
+            base_url,
+        }
+    }
+}
+
+#[async_trait]
+impl WebBackend for FirecrawlWebBackend {
+    async fn search(&self, query: &str, limit: u32) -> WebOutcome {
+        let url = format!("{}/v1/search", self.base_url);
+        let body = json!({ "query": query, "limit": limit.clamp(1, 20) });
+        let resp = match self
+            .client
+            .post(&url)
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .header(
+                reqwest::header::AUTHORIZATION,
+                format!("Bearer {}", self.api_key),
+            )
+            .timeout(std::time::Duration::from_secs(20))
+            .body(body.to_string())
+            .send()
+            .await
+        {
+            Ok(r) => r,
+            Err(e) => {
+                return WebOutcome::Err {
+                    message: format!("firecrawl request failed: {e}"),
+                };
+            }
+        };
+        let status = resp.status();
+        let txt = resp.text().await.unwrap_or_default();
+        if !status.is_success() {
+            return WebOutcome::Err {
+                message: format!(
+                    "firecrawl returned HTTP {}: {}",
+                    status.as_u16(),
+                    txt.chars().take(300).collect::<String>()
+                ),
+            };
+        }
+        let parsed: Value = match serde_json::from_str(&txt) {
+            Ok(v) => v,
+            Err(e) => {
+                return WebOutcome::Err {
+                    message: format!("firecrawl response was not JSON: {e}"),
+                };
+            }
+        };
+        let raw = parsed
+            .get("data")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default();
+        let mut results: Vec<Value> = Vec::new();
+        for r in raw {
+            let url = r
+                .get("url")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .trim()
+                .to_string();
+            let title = r
+                .get("title")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .trim()
+                .to_string();
+            if !(url.starts_with("http://") || url.starts_with("https://")) {
+                continue;
+            }
+            let snippet = r
+                .get("description")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_string();
+            results.push(json!({ "title": title, "url": url, "snippet": snippet }));
+        }
+        if results.is_empty() {
+            return WebOutcome::Err {
+                message: "firecrawl returned no valid results".to_string(),
+            };
+        }
+        WebOutcome::Ok {
+            payload: json!({ "web": results }),
+        }
+    }
+
+    async fn extract(&self, _req: ExtractRequest) -> WebOutcome {
+        WebOutcome::Err {
+            message: "Firecrawl extract not yet wired in wayland-core; use the WebFetch tool."
+                .to_string(),
+        }
+    }
+
+    async fn crawl(&self, _req: CrawlRequest) -> WebOutcome {
+        WebOutcome::Err {
+            message: "Firecrawl crawl not yet wired in wayland-core.".to_string(),
+        }
+    }
+
+    fn backend_id(&self) -> &str {
+        "firecrawl"
+    }
+}

--- a/crates/wcore-agent/src/tool_backends/firecrawl_web.rs
+++ b/crates/wcore-agent/src/tool_backends/firecrawl_web.rs
@@ -134,3 +134,39 @@ impl WebBackend for FirecrawlWebBackend {
         "firecrawl"
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Live smoke test against the real Firecrawl `/v1/search` endpoint.
+    /// `#[ignore]`d; run with `FIRECRAWL_API_KEY=… cargo test -p wcore-agent
+    /// --lib firecrawl_web::tests::live_ -- --ignored --nocapture`.
+    #[tokio::test]
+    #[ignore = "live network + paid key: needs FIRECRAWL_API_KEY"]
+    async fn live_firecrawl_search_returns_results() {
+        let Some(key) = std::env::var("FIRECRAWL_API_KEY")
+            .ok()
+            .filter(|s| !s.trim().is_empty())
+        else {
+            eprintln!("SKIP live_firecrawl: FIRECRAWL_API_KEY unset");
+            return;
+        };
+        match FirecrawlWebBackend::new(key)
+            .search("latest stable rust compiler version", 3)
+            .await
+        {
+            WebOutcome::Ok { payload } => {
+                let web = payload
+                    .get("web")
+                    .and_then(Value::as_array)
+                    .expect("web[] present");
+                assert!(!web.is_empty(), "expected >=1 firecrawl result");
+                let url = web[0].get("url").and_then(Value::as_str).unwrap_or("");
+                assert!(url.starts_with("http"), "url must be http(s): {url}");
+                eprintln!("LIVE FIRECRAWL OK — {} results; first: {url}", web.len());
+            }
+            WebOutcome::Err { message } => panic!("live firecrawl returned Err: {message}"),
+        }
+    }
+}

--- a/crates/wcore-agent/src/tool_backends/mod.rs
+++ b/crates/wcore-agent/src/tool_backends/mod.rs
@@ -43,12 +43,15 @@ use wcore_tools::notion_tool::NotionBackend;
 use wcore_tools::transcription_tools::{AudioFetcher, TranscriptionBackend};
 use wcore_tools::vision_tools::{ImageFetcher, VisionBackend};
 use wcore_tools::web_fetch::FetchBackend;
-use wcore_tools::web_tools::WebBackend;
+use wcore_tools::web_tools::{CrawlRequest, ExtractRequest, WebBackend, WebOutcome};
 
 // -- Sub-modules: one file per backend (v0.9.0 W1 B0 split). --
 pub mod anthropic_vision;
 pub mod brave_web;
+pub mod chained_web;
 pub mod duckduckgo_web;
+pub mod exa_web;
+pub mod firecrawl_web;
 pub mod gemini_vision;
 pub mod http_fetch;
 pub mod http_github;
@@ -57,6 +60,8 @@ pub mod http_linear;
 pub mod http_notion;
 pub mod openai_compat_whisper;
 pub mod openai_vision;
+pub mod parallel_web;
+pub mod searxng_web;
 pub mod shared;
 pub mod tavily_web;
 
@@ -80,7 +85,10 @@ pub mod voice_mode;
 // -- Re-exports so existing consumers keep using `wcore_agent::tool_backends::X`. --
 pub use anthropic_vision::AnthropicVisionBackend;
 pub use brave_web::BraveWebBackend;
+pub use chained_web::ChainedWebBackend;
 pub use duckduckgo_web::DuckDuckGoWebBackend;
+pub use exa_web::ExaWebBackend;
+pub use firecrawl_web::FirecrawlWebBackend;
 pub use gemini_vision::GeminiVisionBackend;
 pub use http_fetch::HttpFetchBackend;
 pub use http_github::HttpGitHubBackend;
@@ -89,6 +97,8 @@ pub use http_linear::HttpLinearBackend;
 pub use http_notion::HttpNotionBackend;
 pub use openai_compat_whisper::OpenAiCompatWhisperBackend;
 pub use openai_vision::OpenAiVisionBackend;
+pub use parallel_web::ParallelWebBackend;
+pub use searxng_web::SearxngWebBackend;
 pub use shared::read_env_key;
 pub use tavily_web::TavilyWebBackend;
 
@@ -166,27 +176,139 @@ pub fn build_fetch_backend() -> Arc<dyn FetchBackend> {
     Arc::new(HttpFetchBackend::new())
 }
 
-/// Pick the best available `WebBackend` based on what the user has
-/// configured in their environment, with sensible free-of-charge
-/// fallbacks.
+/// Explicit web-backend selection via `WAYLAND_WEB_BACKEND`.
+///
+/// This is an EXPLICIT override layered ON TOP of the key-presence priority
+/// ladder below — distinct from the vision/transcription builders, which are
+/// key-presence-only. `auto` (the default / unset / unrecognized) runs the
+/// full ladder.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WebBackendChoice {
+    Auto,
+    Parallel,
+    DuckDuckGo,
+    Off,
+}
+
+fn resolve_backend_choice(raw: Option<&str>) -> WebBackendChoice {
+    match raw.map(|s| s.trim().to_ascii_lowercase()).as_deref() {
+        Some("off") | Some("none") | Some("disabled") => WebBackendChoice::Off,
+        Some("duckduckgo") | Some("ddg") => WebBackendChoice::DuckDuckGo,
+        Some("parallel") => WebBackendChoice::Parallel,
+        _ => WebBackendChoice::Auto,
+    }
+}
+
+/// One-time privacy disclosure for the anonymous Parallel default — emitted
+/// the first time the keyless/`parallel` path is selected, not on every search.
+fn disclose_parallel_once() {
+    static ONCE: std::sync::Once = std::sync::Once::new();
+    ONCE.call_once(|| {
+        tracing::info!(
+            "web search: using Parallel.ai free search (anonymous). Your search queries are sent \
+             to parallel.ai. Set WAYLAND_WEB_BACKEND=duckduckgo to keep queries on DuckDuckGo, \
+             =off to disable, or set FIRECRAWL_API_KEY / TAVILY_API_KEY / EXA_API_KEY / \
+             SEARXNG_URL / BRAVE_SEARCH_API_KEY for a configured provider."
+        );
+    });
+}
+
+/// Pick the active `WebBackend`. Explicit `WAYLAND_WEB_BACKEND` wins; otherwise
+/// the first configured key (Hermes preference order) is used. Every selected
+/// primary is wrapped so it falls back to DuckDuckGo on failure — DDG is the
+/// floor for all tiers except an explicit `off`.
 ///
 /// Resolution order (first match wins):
-/// 1. `TAVILY_API_KEY` — Tavily (paid; best LLM-tuned results)
-/// 2. `BRAVE_SEARCH_API_KEY` — Brave Search API (free tier 2000/mo)
-/// 3. **Default**: DuckDuckGo HTML scrape (free, no key required)
+/// * `WAYLAND_WEB_BACKEND` = `off` | `duckduckgo` | `parallel` (explicit override)
+/// * `FIRECRAWL_API_KEY` → Firecrawl
+/// * `PARALLEL_API_KEY` → Parallel (keyed REST)
+/// * `TAVILY_API_KEY` → Tavily
+/// * `EXA_API_KEY` → Exa
+/// * `SEARXNG_URL` → SearXNG (public instance; URL-gated)
+/// * `BRAVE_SEARCH_API_KEY` → Brave
+/// * default → Parallel free MCP → DuckDuckGo
 pub fn build_web_search_backend() -> Arc<dyn WebBackend> {
+    fn ddg() -> Arc<dyn WebBackend> {
+        Arc::new(DuckDuckGoWebBackend::new())
+    }
+    fn chain(primary: Arc<dyn WebBackend>) -> Arc<dyn WebBackend> {
+        Arc::new(ChainedWebBackend::new(primary, ddg()))
+    }
+
+    // A. Explicit override always wins.
+    match resolve_backend_choice(std::env::var("WAYLAND_WEB_BACKEND").ok().as_deref()) {
+        WebBackendChoice::Off => {
+            tracing::info!("web search: disabled (WAYLAND_WEB_BACKEND=off)");
+            return Arc::new(DisabledWebBackend);
+        }
+        WebBackendChoice::DuckDuckGo => {
+            tracing::info!("web search: DuckDuckGo (WAYLAND_WEB_BACKEND=duckduckgo)");
+            return ddg();
+        }
+        WebBackendChoice::Parallel => {
+            disclose_parallel_once();
+            return chain(Arc::new(ParallelWebBackend::free()));
+        }
+        WebBackendChoice::Auto => {}
+    }
+
+    // 1..6 — Hermes preference order, first key present wins; each floors on DDG.
+    if let Some(key) = read_env_key("FIRECRAWL_API_KEY") {
+        tracing::info!("web search: Firecrawl (FIRECRAWL_API_KEY found)");
+        return chain(Arc::new(FirecrawlWebBackend::new(key)));
+    }
+    if let Some(key) = read_env_key("PARALLEL_API_KEY") {
+        tracing::info!("web search: Parallel keyed (PARALLEL_API_KEY found)");
+        return chain(Arc::new(ParallelWebBackend::keyed(key)));
+    }
     if let Some(key) = read_env_key("TAVILY_API_KEY") {
-        tracing::info!("web search: using Tavily (TAVILY_API_KEY found)");
-        return Arc::new(TavilyWebBackend::new(key));
+        tracing::info!("web search: Tavily (TAVILY_API_KEY found)");
+        return chain(Arc::new(TavilyWebBackend::new(key)));
+    }
+    if let Some(key) = read_env_key("EXA_API_KEY") {
+        tracing::info!("web search: Exa (EXA_API_KEY found)");
+        return chain(Arc::new(ExaWebBackend::new(key)));
+    }
+    if let Some(url) = read_env_key("SEARXNG_URL") {
+        tracing::info!("web search: SearXNG (SEARXNG_URL found)");
+        return chain(Arc::new(SearxngWebBackend::new(url)));
     }
     if let Some(key) = read_env_key("BRAVE_SEARCH_API_KEY") {
-        tracing::info!("web search: using Brave (BRAVE_SEARCH_API_KEY found)");
-        return Arc::new(BraveWebBackend::new(key));
+        tracing::info!("web search: Brave (BRAVE_SEARCH_API_KEY found)");
+        return chain(Arc::new(BraveWebBackend::new(key)));
     }
-    tracing::info!(
-        "web search: using DuckDuckGo (free default; set TAVILY_API_KEY / BRAVE_SEARCH_API_KEY for premium)"
-    );
-    Arc::new(DuckDuckGoWebBackend::new())
+
+    // 7 — keyless default: Parallel free → DuckDuckGo, with privacy disclosure.
+    disclose_parallel_once();
+    chain(Arc::new(ParallelWebBackend::free()))
+}
+
+/// `WebBackend` returned when `WAYLAND_WEB_BACKEND=off` — every call fails
+/// loudly so the model knows web search is intentionally disabled.
+pub struct DisabledWebBackend;
+
+#[async_trait]
+impl WebBackend for DisabledWebBackend {
+    async fn search(&self, _query: &str, _limit: u32) -> WebOutcome {
+        disabled_err()
+    }
+    async fn extract(&self, _req: ExtractRequest) -> WebOutcome {
+        disabled_err()
+    }
+    async fn crawl(&self, _req: CrawlRequest) -> WebOutcome {
+        disabled_err()
+    }
+    fn backend_id(&self) -> &str {
+        "disabled"
+    }
+}
+
+fn disabled_err() -> WebOutcome {
+    WebOutcome::Err {
+        message: "web search is disabled (WAYLAND_WEB_BACKEND=off). Unset it or set it to \
+                  `auto`/`duckduckgo`/`parallel` to re-enable."
+            .to_string(),
+    }
 }
 
 /// Pick the best available vision backend from env keys.
@@ -366,6 +488,38 @@ mod tests {
     use wcore_tools::notion_tool::{HttpMethod as NoMethod, NotionOutcome, NotionRequest};
     use wcore_tools::url_safety::is_safe_url;
     use wcore_tools::web_fetch::{FetchOutcome, FetchRequest};
+
+    #[test]
+    fn resolve_backend_choice_maps_overrides() {
+        assert_eq!(resolve_backend_choice(Some("off")), WebBackendChoice::Off);
+        assert_eq!(
+            resolve_backend_choice(Some("DISABLED")),
+            WebBackendChoice::Off
+        );
+        assert_eq!(
+            resolve_backend_choice(Some(" DuckDuckGo ")),
+            WebBackendChoice::DuckDuckGo
+        );
+        assert_eq!(
+            resolve_backend_choice(Some("ddg")),
+            WebBackendChoice::DuckDuckGo
+        );
+        assert_eq!(
+            resolve_backend_choice(Some("parallel")),
+            WebBackendChoice::Parallel
+        );
+        assert_eq!(
+            resolve_backend_choice(Some("garbage")),
+            WebBackendChoice::Auto
+        );
+        assert_eq!(resolve_backend_choice(None), WebBackendChoice::Auto);
+    }
+
+    #[tokio::test]
+    async fn disabled_backend_errors_on_every_op() {
+        let b = DisabledWebBackend;
+        assert!(matches!(b.search("q", 5).await, WebOutcome::Err { .. }));
+    }
 
     #[test]
     fn parse_json_or_raw_handles_json() {

--- a/crates/wcore-agent/src/tool_backends/parallel_web.rs
+++ b/crates/wcore-agent/src/tool_backends/parallel_web.rs
@@ -471,4 +471,37 @@ mod tests {
         let err = r#"{"jsonrpc":"2.0","id":"call-1","error":{"code":-32000,"message":"nope"}}"#;
         assert!(parse_mcp_body(err, "call-1").is_err());
     }
+
+    /// Live end-to-end smoke test against the real Parallel free MCP endpoint
+    /// (the zero-config default backend). Exercises the full production path —
+    /// `EgressClient`, the 3-step handshake, envelope parse, and result mapping.
+    /// `#[ignore]`d so CI never depends on a third-party network; run manually:
+    /// `cargo test -p wcore-agent --lib parallel_web::tests::live_ -- --ignored --nocapture`
+    #[tokio::test]
+    #[ignore = "live network: hits the real https://search.parallel.ai/mcp endpoint"]
+    async fn live_parallel_free_search_returns_results() {
+        let backend = ParallelWebBackend::free();
+        match backend
+            .search("latest stable rust compiler version", 5)
+            .await
+        {
+            WebOutcome::Ok { payload } => {
+                let web = payload
+                    .get("web")
+                    .and_then(Value::as_array)
+                    .expect("web[] present");
+                assert!(!web.is_empty(), "expected >=1 result from live Parallel");
+                let first = &web[0];
+                let url = first.get("url").and_then(Value::as_str).unwrap_or("");
+                let title = first.get("title").and_then(Value::as_str).unwrap_or("");
+                assert!(url.starts_with("http"), "result url must be http(s): {url}");
+                assert!(!title.is_empty(), "result title must be non-empty");
+                eprintln!(
+                    "LIVE PARALLEL OK — {} results; first: {url} | {title}",
+                    web.len()
+                );
+            }
+            WebOutcome::Err { message } => panic!("live parallel search returned Err: {message}"),
+        }
+    }
 }

--- a/crates/wcore-agent/src/tool_backends/parallel_web.rs
+++ b/crates/wcore-agent/src/tool_backends/parallel_web.rs
@@ -1,0 +1,474 @@
+//! Parallel.ai web search backend.
+//!
+//! Two paths, selected by whether a key is configured:
+//!
+//! * **Free (no key)** — the anonymous hosted Search MCP at
+//!   `https://search.parallel.ai/mcp` (Streamable-HTTP JSON-RPC). One search =
+//!   a 3-step handshake: `initialize` → `notifications/initialized` →
+//!   `tools/call web_search`. The response envelope arrives as `application/json`
+//!   OR `text/event-stream` (SSE); both are buffered and decoded by the same
+//!   path. NO Authorization header — sending an empty bearer flips the server
+//!   to 401. This is the zero-config default web backend.
+//! * **Keyed (`PARALLEL_API_KEY`)** — the REST endpoint
+//!   `https://api.parallel.ai/v1/search` with an `x-api-key` header, a single
+//!   POST. Higher limits, no handshake.
+//!
+//! Both return per-result `{url, title, excerpts[]}`, mapped to the engine's
+//! `{"web":[{title,url,snippet}]}` shape. Results are validated (http(s) URL +
+//! non-empty title) — a zombie `200` ("please upgrade") or an empty/invalid set
+//! becomes `WebOutcome::Err` so the `ChainedWebBackend` falls through to
+//! DuckDuckGo.
+//!
+//! Session caching across calls is deliberately NOT done in this first cut: a
+//! full handshake per search is what the reference clients do, and the tight
+//! per-call budget + DDG fallback cover the latency. (Optimization for later.)
+
+use std::time::Duration;
+
+use async_trait::async_trait;
+use reqwest::header::{ACCEPT, CONTENT_TYPE};
+use serde_json::{Value, json};
+use wcore_egress::EgressClient as Client;
+
+use super::build_ssrf_safe_tool_client;
+use wcore_tools::web_tools::{CrawlRequest, ExtractRequest, WebBackend, WebOutcome};
+
+const MCP_URL: &str = "https://search.parallel.ai/mcp";
+const MCP_PROTOCOL: &str = "2025-06-18";
+const REST_URL: &str = "https://api.parallel.ai/v1/search";
+/// Per-HTTP-request ceiling (each handshake leg / the REST call).
+const STEP_TIMEOUT: Duration = Duration::from_secs(8);
+/// Whole-handshake budget for the free MCP path (covers all 3 round trips).
+const MCP_OVERALL_TIMEOUT: Duration = Duration::from_secs(12);
+
+/// Parallel.ai backend. `api_key = None` → free MCP; `Some` → keyed REST.
+pub struct ParallelWebBackend {
+    client: Client,
+    api_key: Option<String>,
+}
+
+impl ParallelWebBackend {
+    /// Free anonymous MCP backend — the zero-config default.
+    pub fn free() -> Self {
+        Self {
+            client: build_ssrf_safe_tool_client(),
+            api_key: None,
+        }
+    }
+
+    /// Keyed REST backend (`PARALLEL_API_KEY`).
+    pub fn keyed(api_key: String) -> Self {
+        Self {
+            client: build_ssrf_safe_tool_client(),
+            api_key: Some(api_key),
+        }
+    }
+
+    /// Keyed REST search: single POST with `x-api-key`.
+    async fn rest_search(&self, key: &str, query: &str, limit: u32) -> WebOutcome {
+        let body = json!({
+            "search_queries": [query],
+            "advanced_settings": { "max_results": limit.clamp(1, 20) },
+        });
+        let resp = match self
+            .client
+            .post(REST_URL)
+            .header(CONTENT_TYPE, "application/json")
+            .header("x-api-key", key)
+            .timeout(STEP_TIMEOUT)
+            .body(body.to_string())
+            .send()
+            .await
+        {
+            Ok(r) => r,
+            Err(e) => {
+                return WebOutcome::Err {
+                    message: format!("parallel rest request failed: {e}"),
+                };
+            }
+        };
+        let status = resp.status();
+        let txt = resp.text().await.unwrap_or_default();
+        if !status.is_success() {
+            return WebOutcome::Err {
+                message: format!(
+                    "parallel rest returned HTTP {}: {}",
+                    status.as_u16(),
+                    txt.chars().take(300).collect::<String>()
+                ),
+            };
+        }
+        match serde_json::from_str::<Value>(&txt) {
+            Ok(v) => map_parallel_results(&v, limit as usize),
+            Err(e) => WebOutcome::Err {
+                message: format!("parallel rest response was not JSON: {e}"),
+            },
+        }
+    }
+
+    /// One free-MCP search: 3-step handshake then parse the tool payload.
+    async fn mcp_call(&self, query: &str, _limit: u32) -> Result<Value, String> {
+        // 1. initialize — capture the optional session id from the header.
+        let init_body = json!({
+            "jsonrpc": "2.0", "id": "init-1", "method": "initialize",
+            "params": {
+                "protocolVersion": MCP_PROTOCOL,
+                "capabilities": {},
+                "clientInfo": { "name": "wayland-core", "version": env!("CARGO_PKG_VERSION") },
+            },
+        });
+        let resp = self
+            .client
+            .post(MCP_URL)
+            .header(CONTENT_TYPE, "application/json")
+            .header(ACCEPT, "application/json, text/event-stream")
+            .timeout(STEP_TIMEOUT)
+            .body(init_body.to_string())
+            .send()
+            .await
+            .map_err(|e| format!("initialize request failed: {e}"))?;
+        if !resp.status().is_success() {
+            return Err(format!(
+                "initialize returned HTTP {}",
+                resp.status().as_u16()
+            ));
+        }
+        let session = resp
+            .headers()
+            .get("mcp-session-id")
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.to_string());
+        let _ = resp.text().await; // drain init body (capabilities unused)
+
+        // 2. notifications/initialized (a notification; server returns 202).
+        let mut note = self
+            .client
+            .post(MCP_URL)
+            .header(CONTENT_TYPE, "application/json")
+            .header(ACCEPT, "application/json, text/event-stream")
+            .timeout(STEP_TIMEOUT);
+        if let Some(ref sid) = session {
+            note = note.header("Mcp-Session-Id", sid.as_str());
+        }
+        note.body(json!({"jsonrpc": "2.0", "method": "notifications/initialized"}).to_string())
+            .send()
+            .await
+            .map_err(|e| format!("initialized notification failed: {e}"))?;
+
+        // 3. tools/call web_search.
+        let call_body = json!({
+            "jsonrpc": "2.0", "id": "call-1", "method": "tools/call",
+            "params": {
+                "name": "web_search",
+                "arguments": { "objective": query, "search_queries": [query] },
+            },
+        });
+        let mut call = self
+            .client
+            .post(MCP_URL)
+            .header(CONTENT_TYPE, "application/json")
+            .header(ACCEPT, "application/json, text/event-stream")
+            .timeout(STEP_TIMEOUT);
+        if let Some(ref sid) = session {
+            call = call.header("Mcp-Session-Id", sid.as_str());
+        }
+        let resp = call
+            .body(call_body.to_string())
+            .send()
+            .await
+            .map_err(|e| format!("tools/call request failed: {e}"))?;
+        let status = resp.status();
+        let text = resp
+            .text()
+            .await
+            .map_err(|e| format!("tools/call body read failed: {e}"))?;
+        if !status.is_success() {
+            return Err(format!(
+                "tools/call returned HTTP {}: {}",
+                status.as_u16(),
+                text.chars().take(300).collect::<String>()
+            ));
+        }
+        parse_mcp_body(&text, "call-1")
+    }
+}
+
+#[async_trait]
+impl WebBackend for ParallelWebBackend {
+    async fn search(&self, query: &str, limit: u32) -> WebOutcome {
+        if let Some(ref key) = self.api_key {
+            return self.rest_search(key, query, limit).await;
+        }
+        match tokio::time::timeout(MCP_OVERALL_TIMEOUT, self.mcp_call(query, limit)).await {
+            Ok(Ok(payload)) => map_parallel_results(&payload, limit as usize),
+            Ok(Err(e)) => WebOutcome::Err {
+                message: format!("parallel search failed: {e}"),
+            },
+            Err(_) => WebOutcome::Err {
+                message: "parallel search timed out".to_string(),
+            },
+        }
+    }
+
+    async fn extract(&self, _req: ExtractRequest) -> WebOutcome {
+        WebOutcome::Err {
+            message: "extract not supported by the Parallel search backend; use the WebFetch tool \
+                      on a specific URL, or set FIRECRAWL_API_KEY."
+                .to_string(),
+        }
+    }
+
+    async fn crawl(&self, _req: CrawlRequest) -> WebOutcome {
+        WebOutcome::Err {
+            message: "crawl not supported by the Parallel search backend; set FIRECRAWL_API_KEY."
+                .to_string(),
+        }
+    }
+
+    fn backend_id(&self) -> &str {
+        "parallel"
+    }
+}
+
+/// Map a Parallel payload (`{results:[{url,title,excerpts}]}`) into the engine
+/// `{"web":[{title,url,snippet}]}` shape, validating each result. Returns `Err`
+/// on an error-shaped payload (`isError`) or when no result has a valid http(s)
+/// URL + non-empty title — so the chain falls back to DuckDuckGo.
+fn map_parallel_results(payload: &Value, limit: usize) -> WebOutcome {
+    if payload.get("isError").and_then(Value::as_bool) == Some(true) {
+        return WebOutcome::Err {
+            message: "parallel returned an error payload".to_string(),
+        };
+    }
+    let raw = payload
+        .get("results")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let mut results: Vec<Value> = Vec::new();
+    for r in raw {
+        let url = r
+            .get("url")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .trim()
+            .to_string();
+        let title = r
+            .get("title")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .trim()
+            .to_string();
+        if title.is_empty() || !(url.starts_with("http://") || url.starts_with("https://")) {
+            continue;
+        }
+        let snippet = r
+            .get("excerpts")
+            .and_then(Value::as_array)
+            .map(|a| {
+                a.iter()
+                    .filter_map(Value::as_str)
+                    .collect::<Vec<_>>()
+                    .join("\n\n")
+            })
+            .unwrap_or_default();
+        results.push(json!({ "title": title, "url": url, "snippet": snippet }));
+        if results.len() >= limit.max(1) {
+            break;
+        }
+    }
+    if results.is_empty() {
+        return WebOutcome::Err {
+            message: "parallel returned no valid results".to_string(),
+        };
+    }
+    WebOutcome::Ok {
+        payload: json!({ "web": results }),
+    }
+}
+
+/// Decode an MCP response body (plain JSON or SSE) and extract the `tools/call`
+/// tool payload for `req_id`.
+fn parse_mcp_body(text: &str, req_id: &str) -> Result<Value, String> {
+    let msgs = iter_mcp_messages(text);
+    let envelope = select_envelope(&msgs, req_id)
+        .ok_or_else(|| "parallel mcp: no JSON-RPC result/error in response".to_string())?;
+    extract_tool_payload(&envelope)
+}
+
+/// Yield JSON-RPC objects from a plain-JSON body (one object/array) or an SSE
+/// body (`data:` lines, events separated by blank lines).
+fn iter_mcp_messages(text: &str) -> Vec<Value> {
+    let mut out: Vec<Value> = Vec::new();
+    let body = text.trim();
+    if body.is_empty() {
+        return out;
+    }
+    if body.starts_with('{') || body.starts_with('[') {
+        if let Ok(v) = serde_json::from_str::<Value>(body) {
+            push_object(&mut out, v);
+        }
+        return out;
+    }
+    let mut data_lines: Vec<String> = Vec::new();
+    for raw in body.split('\n') {
+        let line = raw.strip_suffix('\r').unwrap_or(raw);
+        if let Some(rest) = line.strip_prefix("data:") {
+            data_lines.push(rest.strip_prefix(' ').unwrap_or(rest).to_string());
+        } else if line.trim().is_empty() {
+            flush_sse_event(&mut data_lines, &mut out);
+        }
+    }
+    flush_sse_event(&mut data_lines, &mut out);
+    out
+}
+
+fn flush_sse_event(data_lines: &mut Vec<String>, out: &mut Vec<Value>) {
+    if data_lines.is_empty() {
+        return;
+    }
+    if let Ok(v) = serde_json::from_str::<Value>(&data_lines.join("\n")) {
+        push_object(out, v);
+    }
+    data_lines.clear();
+}
+
+fn push_object(out: &mut Vec<Value>, v: Value) {
+    match v {
+        Value::Array(items) => {
+            for item in items {
+                if item.is_object() {
+                    out.push(item);
+                }
+            }
+        }
+        other if other.is_object() => out.push(other),
+        _ => {}
+    }
+}
+
+/// Pick the result/error message whose `id` matches `req_id` (scanning past
+/// progress notifications); fall back to the last result/error-bearing message.
+fn select_envelope(msgs: &[Value], req_id: &str) -> Option<Value> {
+    let mut fallback: Option<Value> = None;
+    for m in msgs {
+        if m.get("result").is_none() && m.get("error").is_none() {
+            continue;
+        }
+        if m.get("id").and_then(Value::as_str) == Some(req_id) {
+            return Some(m.clone());
+        }
+        fallback = Some(m.clone());
+    }
+    fallback
+}
+
+/// Extract the tool result payload from a `tools/call` envelope — prefer
+/// `result.structuredContent`, else the first JSON-parseable text block.
+fn extract_tool_payload(envelope: &Value) -> Result<Value, String> {
+    if let Some(err) = envelope.get("error") {
+        return Err(format!(
+            "parallel mcp error: {}",
+            err.to_string().chars().take(300).collect::<String>()
+        ));
+    }
+    let result = envelope.get("result").cloned().unwrap_or(Value::Null);
+    if result.get("isError").and_then(Value::as_bool) == Some(true) {
+        return Err("parallel mcp tool reported isError".to_string());
+    }
+    if let Some(sc) = result.get("structuredContent")
+        && sc.is_object()
+    {
+        return Ok(sc.clone());
+    }
+    if let Some(content) = result.get("content").and_then(Value::as_array) {
+        for block in content {
+            if block.get("type").and_then(Value::as_str) == Some("text")
+                && let Some(t) = block.get("text").and_then(Value::as_str)
+                && let Ok(parsed) = serde_json::from_str::<Value>(t)
+                && parsed.is_object()
+            {
+                return Ok(parsed);
+            }
+        }
+    }
+    Err("parallel mcp returned no parseable content".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_valid_results() {
+        let p = json!({"results": [
+            {"url": "https://a/", "title": "A", "excerpts": ["x", "y"]},
+            {"url": "https://b/", "title": "B", "excerpts": ["z"]},
+        ]});
+        match map_parallel_results(&p, 5) {
+            WebOutcome::Ok { payload } => {
+                let web = payload.get("web").and_then(Value::as_array).unwrap();
+                assert_eq!(web.len(), 2);
+                assert_eq!(web[0]["title"], json!("A"));
+                assert_eq!(web[0]["snippet"], json!("x\n\ny"));
+            }
+            other => panic!("expected Ok, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_zombie_and_empty_and_invalid_urls() {
+        assert!(matches!(
+            map_parallel_results(&json!({"isError": true}), 5),
+            WebOutcome::Err { .. }
+        ));
+        assert!(matches!(
+            map_parallel_results(&json!({"results": []}), 5),
+            WebOutcome::Err { .. }
+        ));
+        // no http(s) url / empty title -> filtered -> Err
+        assert!(matches!(
+            map_parallel_results(&json!({"results": [{"url": "ftp://x/", "title": "T"}]}), 5),
+            WebOutcome::Err { .. }
+        ));
+        assert!(matches!(
+            map_parallel_results(&json!({"results": [{"url": "https://x/", "title": ""}]}), 5),
+            WebOutcome::Err { .. }
+        ));
+    }
+
+    #[test]
+    fn respects_limit() {
+        let p = json!({"results": [
+            {"url": "https://a/", "title": "A"},
+            {"url": "https://b/", "title": "B"},
+            {"url": "https://c/", "title": "C"},
+        ]});
+        match map_parallel_results(&p, 2) {
+            WebOutcome::Ok { payload } => {
+                assert_eq!(payload["web"].as_array().unwrap().len(), 2);
+            }
+            other => panic!("expected Ok, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_plain_json_envelope() {
+        let plain = r#"{"jsonrpc":"2.0","id":"call-1","result":{"structuredContent":{"results":[{"url":"https://a/","title":"A","excerpts":["x"]}]}}}"#;
+        let payload = parse_mcp_body(plain, "call-1").expect("should parse");
+        assert!(payload.get("results").is_some());
+    }
+
+    #[test]
+    fn parses_sse_envelope_skipping_progress() {
+        let sse = "event: message\ndata: {\"jsonrpc\":\"2.0\",\"method\":\"notifications/progress\"}\n\nevent: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":\"call-1\",\"result\":{\"content\":[{\"type\":\"text\",\"text\":\"{\\\"results\\\":[{\\\"url\\\":\\\"https://a/\\\",\\\"title\\\":\\\"A\\\"}]}\"}]}}\n\n";
+        let payload = parse_mcp_body(sse, "call-1").expect("should parse SSE");
+        assert_eq!(payload["results"][0]["title"], json!("A"));
+    }
+
+    #[test]
+    fn surfaces_jsonrpc_error() {
+        let err = r#"{"jsonrpc":"2.0","id":"call-1","error":{"code":-32000,"message":"nope"}}"#;
+        assert!(parse_mcp_body(err, "call-1").is_err());
+    }
+}

--- a/crates/wcore-agent/src/tool_backends/searxng_web.rs
+++ b/crates/wcore-agent/src/tool_backends/searxng_web.rs
@@ -1,0 +1,182 @@
+//! SearXNG meta-search backend. Gated by `SEARXNG_URL` (your own or a public
+//! instance) — wayland-core ships the connector, not the instance.
+//!
+//! GETs `<SEARXNG_URL>/search?q=<query>&format=json` and maps the JSON
+//! `results[]` (sorted by `score` desc, per Hermes) into the engine shape.
+//!
+//! ⚠️ The instance must be **publicly resolvable**: requests go through the
+//! SSRF-safe client, so a `SEARXNG_URL` pointing at `localhost`/a private IP is
+//! rejected by the DNS resolver. Self-hosters must expose SearXNG behind a
+//! public hostname for now (a scoped `WAYLAND_SEARXNG_ALLOW_PRIVATE` opt-in is
+//! a planned follow-up).
+
+use async_trait::async_trait;
+use serde_json::{Value, json};
+use wcore_egress::EgressClient as Client;
+
+use super::build_ssrf_safe_tool_client;
+use super::shared::urlencode;
+use wcore_tools::web_tools::{CrawlRequest, ExtractRequest, WebBackend, WebOutcome};
+
+pub struct SearxngWebBackend {
+    client: Client,
+    base_url: String,
+}
+
+impl SearxngWebBackend {
+    pub fn new(base_url: String) -> Self {
+        Self {
+            client: build_ssrf_safe_tool_client(),
+            base_url: base_url.trim_end_matches('/').to_string(),
+        }
+    }
+}
+
+#[async_trait]
+impl WebBackend for SearxngWebBackend {
+    async fn search(&self, query: &str, limit: u32) -> WebOutcome {
+        let url = format!(
+            "{}/search?q={}&format=json",
+            self.base_url,
+            urlencode(query)
+        );
+        let resp = match self
+            .client
+            .get(&url)
+            .header(reqwest::header::ACCEPT, "application/json")
+            .timeout(std::time::Duration::from_secs(15))
+            .send()
+            .await
+        {
+            Ok(r) => r,
+            Err(e) => {
+                return WebOutcome::Err {
+                    message: format!("searxng request failed: {e}"),
+                };
+            }
+        };
+        let status = resp.status();
+        let txt = resp.text().await.unwrap_or_default();
+        if !status.is_success() {
+            return WebOutcome::Err {
+                message: format!(
+                    "searxng returned HTTP {}: {}",
+                    status.as_u16(),
+                    txt.chars().take(300).collect::<String>()
+                ),
+            };
+        }
+        let parsed: Value = match serde_json::from_str(&txt) {
+            Ok(v) => v,
+            Err(e) => {
+                return WebOutcome::Err {
+                    message: format!("searxng response was not JSON: {e}"),
+                };
+            }
+        };
+        map_searxng_results(&parsed, limit as usize)
+    }
+
+    async fn extract(&self, _req: ExtractRequest) -> WebOutcome {
+        WebOutcome::Err {
+            message: "SearXNG does not support extract; use the WebFetch tool on a URL."
+                .to_string(),
+        }
+    }
+
+    async fn crawl(&self, _req: CrawlRequest) -> WebOutcome {
+        WebOutcome::Err {
+            message: "SearXNG does not support crawl.".to_string(),
+        }
+    }
+
+    fn backend_id(&self) -> &str {
+        "searxng"
+    }
+}
+
+/// Map a SearXNG JSON response into the engine shape: sort by `score` desc,
+/// validate http(s) URL + title, cap to `limit`.
+fn map_searxng_results(parsed: &Value, limit: usize) -> WebOutcome {
+    let mut raw = parsed
+        .get("results")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    // Sort by score descending (missing score sorts last).
+    raw.sort_by(|a, b| {
+        let sb = b.get("score").and_then(Value::as_f64).unwrap_or(0.0);
+        let sa = a.get("score").and_then(Value::as_f64).unwrap_or(0.0);
+        sb.partial_cmp(&sa).unwrap_or(std::cmp::Ordering::Equal)
+    });
+    let mut results: Vec<Value> = Vec::new();
+    for r in raw {
+        let url = r
+            .get("url")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .trim()
+            .to_string();
+        let title = r
+            .get("title")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .trim()
+            .to_string();
+        if title.is_empty() || !(url.starts_with("http://") || url.starts_with("https://")) {
+            continue;
+        }
+        let snippet = r
+            .get("content")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string();
+        results.push(json!({ "title": title, "url": url, "snippet": snippet }));
+        if results.len() >= limit.max(1) {
+            break;
+        }
+    }
+    if results.is_empty() {
+        return WebOutcome::Err {
+            message: "searxng returned no valid results".to_string(),
+        };
+    }
+    WebOutcome::Ok {
+        payload: json!({ "web": results }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sorts_by_score_desc_and_caps() {
+        let parsed = json!({"results": [
+            {"title": "low", "url": "https://low/", "content": "c", "score": 0.1},
+            {"title": "high", "url": "https://high/", "content": "c", "score": 0.9},
+            {"title": "mid", "url": "https://mid/", "content": "c", "score": 0.5},
+        ]});
+        match map_searxng_results(&parsed, 2) {
+            WebOutcome::Ok { payload } => {
+                let web = payload["web"].as_array().unwrap();
+                assert_eq!(web.len(), 2, "capped to limit");
+                assert_eq!(web[0]["title"], json!("high"));
+                assert_eq!(web[1]["title"], json!("mid"));
+            }
+            other => panic!("expected Ok, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_empty_and_invalid() {
+        assert!(matches!(
+            map_searxng_results(&json!({"results": []}), 5),
+            WebOutcome::Err { .. }
+        ));
+        assert!(matches!(
+            map_searxng_results(&json!({"results": [{"title": "x", "url": "ftp://x/"}]}), 5),
+            WebOutcome::Err { .. }
+        ));
+    }
+}

--- a/crates/wcore-safety/src/pii.rs
+++ b/crates/wcore-safety/src/pii.rs
@@ -59,6 +59,8 @@ static PATTERNS: &[(&str, &str)] = &[
     ("TAVILY_API_KEY", r"tvly-[A-Za-z0-9]{20,}"),
     // Exa search API key.
     ("EXA_API_KEY", r"exa_[A-Za-z0-9]{20,}"),
+    // Firecrawl API key.
+    ("FIRECRAWL_API_KEY", r"fc-[A-Za-z0-9]{20,}"),
     // BrowserBase live API key.
     ("BROWSERBASE_KEY", r"bb_live_[A-Za-z0-9_\-]{20,}"),
     // Telegram bot tokens: <digits>:<>=30 url-safe chars>, with optional "bot" prefix.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -257,3 +257,44 @@ Bedrock / Vertex) is documented in §2 of the same doc and still
 requires real credentials to fill in — that path is gated behind the
 `live-api` Cargo feature on `wcore-agent` and currently exits with a
 runbook pointer.
+
+## Web search backends
+
+The `web` tool (search / extract / crawl) dispatches through a pluggable
+`WebBackend`. The active backend is chosen at startup by
+`build_web_search_backend()`. **Every selected backend falls back to
+DuckDuckGo on failure** (transport error, non-2xx, or no valid results),
+so search never hard-fails — except when explicitly disabled.
+
+**Selection order (first match wins):**
+
+| Priority | Trigger | Backend |
+|----------|---------|---------|
+| override | `WAYLAND_WEB_BACKEND=off` | disabled (no fallback) |
+| override | `WAYLAND_WEB_BACKEND=duckduckgo` | DuckDuckGo only |
+| override | `WAYLAND_WEB_BACKEND=parallel` | Parallel free → DDG |
+| 1 | `FIRECRAWL_API_KEY` (+ optional `FIRECRAWL_API_URL`) | Firecrawl → DDG |
+| 2 | `PARALLEL_API_KEY` | Parallel REST → DDG |
+| 3 | `TAVILY_API_KEY` | Tavily → DDG |
+| 4 | `EXA_API_KEY` | Exa → DDG |
+| 5 | `SEARXNG_URL` | SearXNG → DDG |
+| 6 | `BRAVE_SEARCH_API_KEY` | Brave → DDG |
+| default | *(no keys)* | **Parallel free → DDG** |
+
+`WAYLAND_WEB_BACKEND` is an explicit override that wins over key presence;
+`auto` (or unset / unrecognized) runs the ladder. The order matches the Hermes
+agent's preference (firecrawl → parallel → tavily → exa → searxng → brave → ddg).
+
+**Default (no config):** the engine uses Parallel.ai's free, anonymous Search
+MCP (`https://search.parallel.ai/mcp`) — ranked URLs with query-relevant
+excerpts, no API key. **Privacy:** your search queries are sent to parallel.ai.
+A one-time log notes this on first use; set `WAYLAND_WEB_BACKEND=duckduckgo` to
+keep queries on DuckDuckGo, or `=off` to disable web search entirely.
+
+**SearXNG** is gated by `SEARXNG_URL` (your own or a public instance — the
+engine ships the connector, not the instance). The instance must be **publicly
+resolvable**: requests go through the SSRF-safe client, so a `SEARXNG_URL`
+pointing at `localhost` / a private IP is rejected. (A scoped opt-in for
+private SearXNG instances is a planned follow-up.)
+
+API keys are redacted from logs / model context by `wcore-safety` PII scrubbing.


### PR DESCRIPTION
## What

Replaces the DuckDuckGo HTML-scrape default with a cost/quality **web-search ladder**. DuckDuckGo rate-limits hard and is fragile (regex-scrapes HTML); this makes a real, keyless agent search engine the default while keeping DDG as a universal safety net.

**Selection order** (`WAYLAND_WEB_BACKEND` override on top, then first env key present — Hermes preference order):

```
Firecrawl -> Parallel(keyed REST) -> Tavily -> Exa -> SearXNG -> Brave -> (no keys) Parallel free MCP -> DuckDuckGo
```

Every selected backend is wrapped `ChainedWebBackend{primary, DuckDuckGo}`, so search **never hard-fails** (except an explicit `off`).

## New backends (each implements the existing `WebBackend` trait)

- **ParallelWebBackend** — free anonymous Search MCP (`search.parallel.ai/mcp`; 3-step JSON-RPC handshake, SSE-or-plain-JSON envelope parsing, result validation that rejects zombie/empty payloads → falls back to DDG) **plus** a keyed REST path (`PARALLEL_API_KEY`).
- **FirecrawlWebBackend** (+ optional `FIRECRAWL_API_URL` self-host), **ExaWebBackend**, **SearxngWebBackend** (`SEARXNG_URL`, score-sorted; public instances only — the SSRF-safe client rejects private IPs).
- **ChainedWebBackend** — generic primary → DuckDuckGo fallback (search/extract/crawl).

## Config & privacy

- `WAYLAND_WEB_BACKEND=off|duckduckgo|parallel|auto` — explicit override that wins over key presence.
- One-time **privacy disclosure** log when the anonymous Parallel default is used (queries leave the machine; how to opt out).
- PII scrubbing gains the Firecrawl key pattern. Documented in `docs/tools.md`.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` → **clean**.
- New unit tests green: `tool_backends::` (204 passed) incl. result-mapping, MCP SSE/JSON envelope parsing, zombie/empty rejection, score-sort, fallback-chain logic; `pii::` (47 passed).
- Designed with cross-research (codex + gemini) and an adversarial plan audit — see `.planning/2026-06-14-WEBSEARCH-PHASE0-BUILD-PLAN.md`.

## Notes

- Provider-blind: needs no Flux/LLM infrastructure. A future grounded-chat tier (Sonar via Flux/Perplexity) slots in later as an opt-in config target.
- Firecrawl extract/crawl and a private-SearXNG opt-in (`WAYLAND_SEARXNG_ALLOW_PRIVATE`) are noted follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)