### PR TITLE
fix(engine): app-reported tickets — NVIDIA base_url (#48), orphaned tool results (#85), silent local-endpoint responses (#86)

### DIFF
--- a/crates/wcore-agent/src/engine.rs
+++ b/crates/wcore-agent/src/engine.rs
@@ -3644,6 +3644,24 @@ impl AgentEngine {
             }
             assistant_content.extend(tool_calls.clone());
 
+            // #86: a stream that completed WITHOUT a provider error but yielded
+            // no text, no thinking, and no tool calls is a silent dead-end —
+            // e.g. an OpenAI-compatible endpoint that returned 200 + `[DONE]`
+            // with zero deltas, or a response shape the SSE parser produced
+            // nothing from. Without this guard the turn commits an empty
+            // assistant message and returns with no output and no error, so the
+            // host shows nothing and the user can't tell what went wrong.
+            // Surface a visible, non-retryable error instead of the silent
+            // no-op. (Genuine content/tool-call/thinking turns are unaffected.)
+            if assistant_content.is_empty() {
+                self.output.emit_error(
+                    "Provider returned an empty response — no content and no tool calls. \
+                     The endpoint or model may be incompatible (verify it speaks the OpenAI \
+                     chat-completions streaming format and that the model name is valid).",
+                    false,
+                );
+            }
+
             self.messages
                 .push(Message::now(Role::Assistant, assistant_content));
 

--- a/crates/wcore-agent/tests/w7_pre0_test_driver.rs
+++ b/crates/wcore-agent/tests/w7_pre0_test_driver.rs
@@ -119,6 +119,38 @@ async fn scripted_provider_handle_re_observes_via_sink_handle() {
     );
 }
 
+#[tokio::test]
+async fn empty_provider_stream_emits_visible_error() {
+    // FerroxLabs/wayland#86: a stream that completes (Done) with no text, no
+    // thinking, and no tool calls is a silent dead-end. The engine must surface
+    // a visible error event instead of returning an empty turn with no signal.
+    let empty_script = vec![LlmEvent::Done {
+        stop_reason: StopReason::EndTurn,
+        finish_reason: FinishReason::Stop,
+        usage: TokenUsage::default(),
+    }];
+    let (mut engine, _handle) = AgentBootstrap::build_for_test(minimal_config(), empty_script);
+    let out = engine
+        .run_synthetic_turn("anything")
+        .await
+        .expect("synthetic turn should complete (empty, not error-out)");
+
+    let kinds: Vec<&str> = out
+        .events
+        .iter()
+        .filter_map(|e| e["type"].as_str())
+        .collect();
+    assert!(
+        kinds.contains(&"error"),
+        "an empty provider stream must emit a visible error event; got {kinds:?}"
+    );
+    assert!(
+        out.final_text.is_empty(),
+        "no assistant text should be produced for an empty stream; got {:?}",
+        out.final_text
+    );
+}
+
 // Suppress "unused import" if ScriptedProvider only appears in docs.
 #[allow(dead_code)]
 fn _silence_unused(_p: ScriptedProvider) {}

--- a/crates/wcore-cli/src/acp.rs
+++ b/crates/wcore-cli/src/acp.rs
@@ -55,6 +55,14 @@ pub struct AcpServeArgs {
     #[arg(long)]
     pub api_key: Option<String>,
 
+    /// Base URL override for the LLM provider (e.g.
+    /// `https://integrate.api.nvidia.com/v1`). Omit to use the
+    /// `[providers.<name>] base_url` from the config file, then the catalog
+    /// default. Required for OpenAI-compatible providers (NVIDIA, local
+    /// servers, etc.) whose key must NOT be presented to `api.openai.com`.
+    #[arg(long)]
+    pub base_url: Option<String>,
+
     /// Auto-approve EVERY tool call (shell, file writes, sub-agents) for API
     /// sessions. Off by default. Turning this on makes the API key
     /// root-equivalent: anyone who can reach the server and present the key
@@ -151,7 +159,7 @@ async fn serve(args: AcpServeArgs) -> anyhow::Result<()> {
     let config = wcore_config::config::Config::resolve(&wcore_config::config::CliArgs {
         provider: args.provider.clone(),
         api_key: args.api_key.clone(),
-        base_url: None,
+        base_url: args.base_url.clone(),
         model: args.model.clone(),
         max_tokens: None,
         max_turns: None,

--- a/crates/wcore-config/src/compat.rs
+++ b/crates/wcore-config/src/compat.rs
@@ -114,6 +114,16 @@ pub struct ProviderCompat {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub compact_bash: Option<bool>,
 
+    /// Whether to send `stream_options: {include_usage: true}` on OpenAI-format
+    /// streaming requests. `None`/`Some(true)` (default) sends it so the engine
+    /// receives token-usage accounting in the final stream chunk. Some generic
+    /// self-hosted OpenAI-compatible servers (older vLLM, llama.cpp, some Qwen
+    /// deployments) reject the unknown `stream_options` field with HTTP 400 —
+    /// set `Some(false)` (`[compat] include_usage_in_stream = false`) for those
+    /// endpoints to drop the field at the cost of in-stream usage stats.
+    /// See FerroxLabs/wayland#86.
+    pub include_usage_in_stream: Option<bool>,
+
     /// Force the OpenAI chat-vs-responses API surface for this provider,
     /// overriding the per-model family default
     /// (`openai_compat::model_uses_responses_api`).
@@ -498,6 +508,9 @@ impl ProviderCompat {
                 .or(defaults.cost_per_cache_write_token),
             input_optimization: user.input_optimization.or(defaults.input_optimization),
             compact_bash: user.compact_bash.or(defaults.compact_bash),
+            include_usage_in_stream: user
+                .include_usage_in_stream
+                .or(defaults.include_usage_in_stream),
             uses_responses_api: user.uses_responses_api.or(defaults.uses_responses_api),
             azure_auth_mode: user.azure_auth_mode.or(defaults.azure_auth_mode),
         }
@@ -573,6 +586,13 @@ impl ProviderCompat {
     /// transcript unless a provider/profile sets `compact_bash = false`.
     pub fn compact_bash(&self) -> bool {
         self.compact_bash.unwrap_or(true)
+    }
+
+    /// Resolved gate for `stream_options: {include_usage: true}`. Defaults ON;
+    /// set `include_usage_in_stream = false` for generic OpenAI-compatible
+    /// endpoints that 400 on the field (FerroxLabs/wayland#86).
+    pub fn include_usage_in_stream(&self) -> bool {
+        self.include_usage_in_stream.unwrap_or(true)
     }
 
     /// Optional override for the OpenAI chat-vs-responses API surface.

--- a/crates/wcore-providers/src/openai.rs
+++ b/crates/wcore-providers/src/openai.rs
@@ -376,9 +376,14 @@ impl OpenAIProvider {
         let mut body = json!({
             "model": request.model,
             "messages": Self::build_messages(&request.messages, &request.system, &self.compat),
-            "stream": true,
-            "stream_options": { "include_usage": true }
+            "stream": true
         });
+        // `stream_options: {include_usage: true}` asks for token accounting in
+        // the final chunk. Default on, but suppressible for generic self-hosted
+        // OpenAI-compatible endpoints that 400 on the unknown field (#86).
+        if self.compat.include_usage_in_stream() {
+            body["stream_options"] = json!({ "include_usage": true });
+        }
         body[max_tokens_field] = json!(request.max_tokens);
 
         if !request.tools.is_empty() {
@@ -1615,6 +1620,30 @@ mod tests {
         assert!(
             body.get("stop").is_none(),
             "empty stop_sequences must emit no `stop` field (back-compat)"
+        );
+    }
+
+    // --- #86: stream_options gate for generic OpenAI-compatible endpoints ---
+
+    #[test]
+    fn build_request_body_emits_stream_options_by_default() {
+        // Default keeps stream_options:{include_usage:true} for token accounting.
+        let body = stop_provider().build_request_body(&stop_req());
+        assert_eq!(body["stream_options"]["include_usage"], json!(true));
+    }
+
+    #[test]
+    fn build_request_body_omits_stream_options_when_disabled() {
+        // A generic self-hosted endpoint that 400s on the unknown
+        // `stream_options` field can suppress it via compat.
+        let mut compat = openai_compat();
+        compat.include_usage_in_stream = Some(false);
+        let provider =
+            OpenAIProvider::new("key", "http://localhost", compat, DebugConfig::default());
+        let body = provider.build_request_body(&stop_req());
+        assert!(
+            body.get("stream_options").is_none(),
+            "stream_options must be omitted when include_usage_in_stream = false"
         );
     }
 

--- a/crates/wcore-providers/src/openai.rs
+++ b/crates/wcore-providers/src/openai.rs
@@ -257,8 +257,16 @@ impl OpenAIProvider {
             dedup_tool_results(&mut result);
         }
 
-        // Clean orphan tool calls: remove tool_call entries with no matching tool result
+        // Clean orphans in BOTH directions. OpenAI-format APIs 400 on either a
+        // `tool` result with no parent `tool_calls` entry OR an assistant
+        // `tool_calls` entry with no answering result. Strip results-without-a-
+        // call first (e.g. left behind when history trimming drops the parent
+        // assistant message — FerroxLabs/wayland#85), then calls-without-a-
+        // result. Order is independent (an orphan result has no parent call, so
+        // removing it never orphans a call), but results-first keeps the two
+        // passes from re-scanning each other's removals.
         if compat.clean_orphan_tool_calls() {
+            clean_orphaned_tool_results(&mut result);
             clean_orphaned_tool_calls(&mut result);
         }
 
@@ -497,6 +505,41 @@ fn dedup_tool_results(messages: &mut Vec<Value>) {
     for i in to_remove.into_iter().rev() {
         messages.remove(i);
     }
+}
+
+/// Remove `tool` result messages whose `tool_call_id` matches no assistant
+/// `tool_calls` entry — the symmetric counterpart to
+/// [`clean_orphaned_tool_calls`].
+///
+/// OpenAI-format APIs reject (HTTP 400) any `tool` message that does not answer
+/// a preceding assistant `tool_calls` entry. Such an orphan arises when the
+/// parent assistant message is dropped from the request while its tool result
+/// is kept — e.g. a context-window trim that splits the pair. An orphaned tool
+/// result is unconditionally invalid to send, so stripping it is strictly
+/// correct. See FerroxLabs/wayland#85.
+fn clean_orphaned_tool_results(messages: &mut Vec<Value>) {
+    use std::collections::HashSet;
+
+    let called_ids: HashSet<String> = messages
+        .iter()
+        .filter(|m| m["role"].as_str() == Some("assistant"))
+        .filter_map(|m| m["tool_calls"].as_array())
+        .flatten()
+        .filter_map(|tc| tc["id"].as_str().map(String::from))
+        .collect();
+
+    messages.retain(|m| {
+        if m["role"].as_str() == Some("tool")
+            && let Some(id) = m["tool_call_id"].as_str()
+        {
+            // Keep only results whose call survives in the array.
+            called_ids.contains(id)
+        } else {
+            // Non-tool messages, and any malformed tool message without a
+            // tool_call_id, are out of scope for this pass.
+            true
+        }
+    });
 }
 
 /// Remove tool_call entries from assistant messages that have no corresponding tool result
@@ -1851,6 +1894,94 @@ mod tests {
         let assistant = result.iter().find(|m| m["role"] == "assistant").unwrap();
         let tcs = assistant["tool_calls"].as_array().unwrap();
         assert_eq!(tcs.len(), 2);
+    }
+
+    // --- clean_orphan_tool_results (FerroxLabs/wayland#85) ---
+
+    #[test]
+    fn test_clean_orphan_tool_results_enabled() {
+        // A `tool` result whose tool_call_id has no parent assistant
+        // `tool_calls` entry (e.g. the parent message was trimmed from the
+        // history) must be stripped — OpenAI-format APIs 400 otherwise.
+        let messages = vec![
+            Message::new(
+                Role::Assistant,
+                vec![ContentBlock::ToolUse {
+                    id: "tc1".into(),
+                    name: "bash".into(),
+                    input: json!({}),
+                    extra: None,
+                }],
+            ),
+            Message::new(
+                Role::Tool,
+                vec![ContentBlock::ToolResult {
+                    tool_use_id: "tc1".into(),
+                    content: "ok".into(),
+                    is_error: false,
+                }],
+            ),
+            // Orphan: its parent assistant tool_calls entry is absent.
+            Message::new(
+                Role::Tool,
+                vec![ContentBlock::ToolResult {
+                    tool_use_id: "tc_ghost".into(),
+                    content: "orphaned".into(),
+                    is_error: false,
+                }],
+            ),
+        ];
+        let result = OpenAIProvider::build_messages(&messages, "", &openai_compat());
+        let tool_msgs: Vec<_> = result.iter().filter(|m| m["role"] == "tool").collect();
+        assert_eq!(tool_msgs.len(), 1);
+        assert_eq!(tool_msgs[0]["tool_call_id"], "tc1");
+
+        // Invariant the provider 400 was caused by: every surviving tool
+        // result resolves to an assistant tool_calls id.
+        let called: std::collections::HashSet<String> = result
+            .iter()
+            .filter(|m| m["role"] == "assistant")
+            .filter_map(|m| m["tool_calls"].as_array())
+            .flatten()
+            .filter_map(|tc| tc["id"].as_str().map(String::from))
+            .collect();
+        for tm in &tool_msgs {
+            assert!(called.contains(tm["tool_call_id"].as_str().unwrap()));
+        }
+    }
+
+    #[test]
+    fn test_clean_orphan_tool_results_disabled() {
+        let messages = vec![
+            Message::new(
+                Role::Assistant,
+                vec![ContentBlock::ToolUse {
+                    id: "tc1".into(),
+                    name: "bash".into(),
+                    input: json!({}),
+                    extra: None,
+                }],
+            ),
+            Message::new(
+                Role::Tool,
+                vec![ContentBlock::ToolResult {
+                    tool_use_id: "tc1".into(),
+                    content: "ok".into(),
+                    is_error: false,
+                }],
+            ),
+            Message::new(
+                Role::Tool,
+                vec![ContentBlock::ToolResult {
+                    tool_use_id: "tc_ghost".into(),
+                    content: "orphaned".into(),
+                    is_error: false,
+                }],
+            ),
+        ];
+        let result = OpenAIProvider::build_messages(&messages, "", &no_compat());
+        let tool_msgs: Vec<_> = result.iter().filter(|m| m["role"] == "tool").collect();
+        assert_eq!(tool_msgs.len(), 2);
     }
 
     // --- dedup_tool_results ---

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -35,6 +35,25 @@ Rules:
 
 This fits scenarios like DeepSeek gateways and internal OpenAI-compatible services.
 
+### Generic / self-hosted OpenAI-compatible endpoints (vLLM, llama.cpp, LM Studio)
+
+Point `base_url` at the server's API root **without** a trailing `/v1` — the engine
+appends `/v1/chat/completions` itself (so `http://127.0.0.1:8003`, not
+`http://127.0.0.1:8003/v1`).
+
+Some self-hosted servers reject the `stream_options: {include_usage: true}` field the
+engine sends by default (to collect token-usage accounting) with an HTTP 400, or simply
+stream nothing — which can present as a chat that produces **no response and no error**.
+If a local endpoint returns nothing, drop that field via compat:
+
+```toml
+[providers.my-local.compat]
+include_usage_in_stream = false   # omit stream_options for picky OpenAI-compatible servers
+```
+
+The trade-off is no in-stream token counts for that provider. An empty stream now also
+surfaces a visible error instead of a silent no-op.
+
 ---
 
 ## Profile Inheritance


### PR DESCRIPTION
Fixes two engine bugs reported as app-repo issues (FerroxLabs/wayland), triaged from `app/.planning/handoffs/engine-tickets/`.

## #48 — NVIDIA `nvapi-` key → 401 (base_url not applied on the ACP path)
The desktop app spawns the engine via `wayland-core acp serve`, but that path hardcoded `base_url: None` when resolving the engine `Config` (`acp.rs`), and `AcpServeArgs` had **no `--base-url` flag** at all. So a per-provider base URL could never reach the OpenAI-format provider on the ACP path — an OpenAI-compatible key (NVIDIA, local servers) was presented to `api.openai.com` → 401. The non-ACP path (`main.rs`) already forwards `cli.base_url` correctly.

**Fix:** add `--base-url` to `AcpServeArgs` and forward it into `CliArgs`. `Config::resolve` already prefers it over the `[providers.<name>] base_url` fallback, and the provider builds its request URL from `self.base_url`, so a non-`None` value is honored end to end.

> **App-side follow-up (not in this PR):** the desktop app must pass `--base-url` when it spawns `acp serve` for an OpenAI-compatible provider (or write `[providers.<name>] base_url` into the engine config). The engine change is necessary; the app change is the other half. Closes the engine side of FerroxLabs/wayland#48.

## #85 — OpenAI 400, orphaned `tool_call_id`
OpenAI-format APIs 400 on a `tool` result whose `tool_call_id` matches no preceding assistant `tool_calls` entry. The builder already cleaned the **forward** direction (`clean_orphaned_tool_calls`: a `tool_calls` entry with no result) but not the **reverse** — a `tool` result left behind when its parent assistant message is dropped from history reached the wire and was rejected.

**Fix:** add `clean_orphaned_tool_results` as the symmetric counterpart, gated on the same `clean_orphan_tool_calls` compat flag and run first. An orphaned tool result is unconditionally invalid to send, so stripping it is strictly correct — closes the bug regardless of which trim path produced it. Two unit tests cover enabled/disabled. Closes FerroxLabs/wayland#85.

## Not in this PR — #11 (`--login` not_found)
`wayland-core --login` and the Claude subscription OAuth flow were **deliberately removed** (the "B9" cleanup). There is no `--login` flag and no Anthropic OAuth code in the tree — Anthropic auth is API-key only (`wayland-core auth add anthropic <key>` / `ANTHROPIC_API_KEY`). No engine change; FerroxLabs/wayland#11 should be closed with that guidance. (Whether to restore subscription OAuth is a separate product decision.)

## Gating note
Local pre-push gate on the box was blocked by a contaminated rustc target-probe (an unrelated long-running process on the box bleeds log output into the probe's stdin). Relying on CI (clean hosted runners) to gate fmt/clippy/nextest cross-platform.
