### PR TITLE
feat(agent): default runaway-loop circuit breaker + loop-convergence E2E

### DIFF
--- a/crates/wcore-agent/src/engine.rs
+++ b/crates/wcore-agent/src/engine.rs
@@ -556,6 +556,162 @@ mod w8_cache_tier_producer_tests {
     }
 }
 
+/// Runaway-loop circuit breaker, local to a single `run()` call.
+///
+/// Tracks the signature of the most recent (tool name + arguments + outcome)
+/// tuple and the length of the current back-to-back repeat streak. The run is
+/// terminated when the SAME signature repeats `threshold` times *consecutively*
+/// — i.e. the agent is stuck retrying one call to no effect (a network-blocked
+/// command, re-reading an unchanged file, …).
+///
+/// Detection is consecutive (not windowed) on purpose: ANY intervening call
+/// with a different signature — a different tool, different args, or the same
+/// call producing a *different* result (e.g. `cargo test` after an edit) —
+/// resets the streak. This makes legitimate *varied* repetition immune: an
+/// agent productively cycling several tools (the pattern skill-drafting
+/// recognises, e.g. `Grep, Glob, Grep, Glob, Grep`) never builds a long
+/// back-to-back run of one signature, so it is never cut.
+///
+/// This is the backstop the `max_turns = None` design decision (see the run
+/// loop) leaves open for *no-progress loops*: the budget cap and context
+/// ceiling bound per-turn size and total spend, not the loop itself. The
+/// threshold is read once per run from `WAYLAND_MAX_REPEATED_TOOL_CALLS`
+/// (default 10); `0` disables the breaker.
+///
+/// The default is deliberately conservative. The cheap, common loop — re-reading
+/// an unchanged file — is already neutralised by Read's content dedup (it
+/// returns a tiny stub), so the breaker's real job is the *expensive*
+/// command-retry loop (a network-blocked `npm install` retried over and over),
+/// which retries far more than 10 times before a human would notice. Ten
+/// identical, no-progress calls in a row is an unambiguous stuck loop with
+/// little false-positive surface.
+struct LoopGuard {
+    last_sig: Option<u64>,
+    count: u32,
+    threshold: u32,
+}
+
+impl LoopGuard {
+    fn from_env() -> Self {
+        let threshold = std::env::var("WAYLAND_MAX_REPEATED_TOOL_CALLS")
+            .ok()
+            .and_then(|v| v.trim().parse::<u32>().ok())
+            .unwrap_or(10);
+        Self {
+            last_sig: None,
+            count: 0,
+            threshold,
+        }
+    }
+
+    /// Record one tool call+outcome signature. Returns `Some(count)` once the
+    /// same signature has repeated `>= threshold` times in a row. Any different
+    /// signature resets the streak to 1.
+    fn observe(&mut self, sig: u64) -> Option<u32> {
+        if self.threshold == 0 {
+            return None;
+        }
+        if self.last_sig == Some(sig) {
+            self.count = self.count.saturating_add(1);
+        } else {
+            self.last_sig = Some(sig);
+            self.count = 1;
+        }
+        (self.count >= self.threshold).then_some(self.count)
+    }
+}
+
+/// Signature of a tool call + its outcome for [`LoopGuard`]:
+/// hash of `(tool name, canonical args, is_error, content prefix)`. A repeated
+/// call that yields a different result hashes differently; only identical
+/// call→identical result repetition accumulates.
+fn loop_call_signature(
+    tool_name: &str,
+    args: &serde_json::Value,
+    is_error: bool,
+    content: &str,
+) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    tool_name.hash(&mut h);
+    serde_json::to_string(args).unwrap_or_default().hash(&mut h);
+    is_error.hash(&mut h);
+    // Hash only a prefix so a large tool output is not fully re-hashed each
+    // turn; a byte slice avoids any UTF-8 char-boundary panic.
+    let bytes = content.as_bytes();
+    bytes[..bytes.len().min(512)].hash(&mut h);
+    h.finish()
+}
+
+#[cfg(test)]
+mod loop_guard_tests {
+    use super::{LoopGuard, loop_call_signature};
+    use serde_json::json;
+
+    fn guard(threshold: u32) -> LoopGuard {
+        LoopGuard {
+            last_sig: None,
+            count: 0,
+            threshold,
+        }
+    }
+
+    #[test]
+    fn trips_on_consecutive_identical_calls() {
+        let mut g = guard(3);
+        assert_eq!(g.observe(1), None);
+        assert_eq!(g.observe(1), None);
+        assert_eq!(
+            g.observe(1),
+            Some(3),
+            "3rd consecutive identical call must trip"
+        );
+    }
+
+    #[test]
+    fn interleaved_calls_reset_the_streak() {
+        // A,B,A,B,A — an alternating/varied sequence (the skill-drafting
+        // pattern) must NEVER trip: any different signature resets the streak.
+        let mut g = guard(3);
+        for s in [10u64, 20, 10, 20, 10, 20, 10] {
+            assert_eq!(g.observe(s), None, "varied sequence must not trip");
+        }
+    }
+
+    #[test]
+    fn a_different_result_breaks_the_streak() {
+        // Same call, but the result changes on the 3rd (progress) — streak
+        // resets, so the following repeats start over and do not trip early.
+        let mut g = guard(3);
+        assert_eq!(g.observe(1), None); // A
+        assert_eq!(g.observe(1), None); // A (streak 2)
+        assert_eq!(g.observe(2), None); // different result -> reset to 1
+        assert_eq!(g.observe(1), None); // back to A, streak 1
+        assert_eq!(g.observe(1), None); // streak 2 — still below threshold
+    }
+
+    #[test]
+    fn threshold_zero_disables_the_breaker() {
+        let mut g = guard(0);
+        for _ in 0..100 {
+            assert_eq!(g.observe(7), None);
+        }
+    }
+
+    #[test]
+    fn signature_stable_for_identical_calls_varies_on_change() {
+        let a = loop_call_signature("Read", &json!({"file_path": "/x"}), true, "err");
+        let b = loop_call_signature("Read", &json!({"file_path": "/x"}), true, "err");
+        assert_eq!(a, b, "identical call+outcome must hash equal");
+        // Changed result (progress) -> different signature -> streak resets.
+        let changed_result = loop_call_signature("Read", &json!({"file_path": "/x"}), false, "ok");
+        assert_ne!(a, changed_result);
+        // Different args -> different signature.
+        let changed_args = loop_call_signature("Read", &json!({"file_path": "/y"}), true, "err");
+        assert_ne!(a, changed_args);
+    }
+}
+
 pub struct AgentEngine {
     provider: Arc<dyn LlmProvider>,
     /// Wave OR: the tool registry is Arc-shared so per-turn
@@ -3075,6 +3231,10 @@ impl AgentEngine {
             return Ok(result);
         }
 
+        // Runaway-loop breaker (per-run): the engine-side backstop for the
+        // no-progress loops that `max_turns = None` leaves unguarded. Terminates
+        // the run if the same tool call keeps producing the same result.
+        let mut loop_guard = LoopGuard::from_env();
         let mut turn: usize = 0;
         loop {
             // AUDIT A2 — cooperative cancellation check between turns.
@@ -4080,6 +4240,9 @@ impl AgentEngine {
             // below — before read-once dedup.
             let mut bash_compactions: std::collections::HashMap<String, String> =
                 std::collections::HashMap::new();
+            // Runaway-loop breaker: set to the offending (tool, repeat-count) the
+            // first time a call+outcome signature trips the window threshold.
+            let mut loop_break: Option<(String, u32)> = None;
             // Display tool results AND populate the matching ToolCallTrace.
             for result in &outcome.results {
                 if let ContentBlock::ToolResult {
@@ -4099,6 +4262,28 @@ impl AgentEngine {
                             None
                         })
                         .unwrap_or("unknown");
+
+                    // Runaway-loop breaker: signature this call+outcome and trip
+                    // if the same (tool, args, result) has repeated consecutively
+                    // past the threshold. Checked once; the first trip wins.
+                    if loop_break.is_none() {
+                        let tool_input = tool_calls.iter().find_map(|c| match c {
+                            ContentBlock::ToolUse { id, input, .. } if id == tool_use_id => {
+                                Some(input)
+                            }
+                            _ => None,
+                        });
+                        let sig = loop_call_signature(
+                            tool_name,
+                            tool_input.unwrap_or(&serde_json::Value::Null),
+                            *is_error,
+                            content,
+                        );
+                        if let Some(count) = loop_guard.observe(sig) {
+                            loop_break = Some((tool_name.to_string(), count));
+                        }
+                    }
+
                     self.output.emit_tool_result(tool_name, *is_error, content);
 
                     // B7 writer-side wiring: bump the per-tool call counter in
@@ -4180,6 +4365,27 @@ impl AgentEngine {
                         }
                     }
                 }
+            }
+
+            // Runaway-loop breaker tripped: the agent is repeating the same tool
+            // call to no effect. Stop the run cleanly with guidance instead of
+            // looping and burning tokens. Mirrors the budget-cap termination
+            // path: repair the assistant's now-unanswered tool_use blocks, emit a
+            // user-visible error, and finish (tool results for this turn were not
+            // committed to history yet, hence `turn + 1`).
+            if let Some((looping_tool, count)) = loop_break {
+                self.repair_orphaned_tool_use();
+                self.output.emit_error(
+                    &format!(
+                        "Run stopped: the `{looping_tool}` tool was called with the same \
+                         arguments and produced the same result {count} times in a row — \
+                         this is a no-progress loop. Change approach (different \
+                         arguments/command, or a different tool) instead of repeating the \
+                         same call. (Tune or disable via WAYLAND_MAX_REPEATED_TOOL_CALLS.)"
+                    ),
+                    false,
+                );
+                return self.finish_run_terminated(user_input, turn + 1).await;
             }
 
             // W1 F9: emit one TurnTrace per turn. Hosts that opt in via

--- a/crates/wcore-agent/tests/runaway_loop_test.rs
+++ b/crates/wcore-agent/tests/runaway_loop_test.rs
@@ -1,0 +1,157 @@
+//! Loop-convergence E2E for the engine-side runaway breaker.
+//!
+//! A model that repeats the SAME tool call every turn, against a tool that
+//! returns the SAME failing result, must be stopped by the breaker WELL BEFORE
+//! `max_turns` — proving a no-progress loop converges instead of burning tokens
+//! to the turn cap (the "8.5M tokens in 2 hours" class of report).
+
+mod common;
+
+use std::sync::Arc;
+
+use serde_json::json;
+use wcore_agent::engine::AgentEngine;
+use wcore_agent::output::OutputSink;
+use wcore_agent::test_utils::TestSink;
+use wcore_tools::registry::ToolRegistry;
+use wcore_types::llm::LlmEvent;
+use wcore_types::message::{FinishReason, StopReason, TokenUsage};
+
+use common::{MockLlmProvider, MockTool, test_config};
+
+/// One turn that asks for the same tool with the same args. The id varies per
+/// turn (so per-turn history is well-formed); the breaker keys on
+/// name+args+result, not id, so every turn shares one signature.
+fn loop_turn(i: usize) -> Vec<LlmEvent> {
+    vec![
+        LlmEvent::ToolUse {
+            id: format!("call-{i}"),
+            name: "loop_tool".to_string(),
+            input: json!({ "q": "same" }),
+            extra: None,
+        },
+        LlmEvent::Done {
+            stop_reason: StopReason::ToolUse,
+            finish_reason: FinishReason::from_stop_reason(StopReason::ToolUse),
+            usage: TokenUsage {
+                input_tokens: 50,
+                output_tokens: 10,
+                cache_creation_tokens: 0,
+                cache_read_tokens: 0,
+            },
+        },
+    ]
+}
+
+#[tokio::test]
+async fn repeated_identical_tool_call_converges_via_breaker() {
+    // 30 identical tool-call turns queued; max_turns raised to 30 so the breaker
+    // (default threshold 10) is what stops the loop, not the turn cap.
+    let turns: Vec<Vec<LlmEvent>> = (0..30).map(loop_turn).collect();
+    let provider = Arc::new(MockLlmProvider::with_turns(turns));
+
+    let mut registry = ToolRegistry::new();
+    registry.register(Box::new(MockTool::new(
+        "loop_tool",
+        "network is unreachable in this sandbox",
+        true, // identical failing outcome every call
+    )));
+
+    let sink = Arc::new(TestSink::new());
+    let handle = sink.handle();
+    let output: Arc<dyn OutputSink> = sink;
+    let mut config = test_config();
+    config.max_turns = Some(30);
+
+    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output);
+    let result = engine
+        .run("install the deps", "")
+        .await
+        .expect("run completes (terminated cleanly, not Err)");
+
+    // The breaker (default threshold 10) must stop the loop well before
+    // max_turns(30) — proving it converged, not just hit the turn cap.
+    assert!(
+        result.turns < 30,
+        "runaway breaker must converge the loop before max_turns; turns = {}",
+        result.turns
+    );
+
+    // …and surface a clear, user-visible no-progress-loop error.
+    let events = handle.snapshot();
+    let saw_loop_error = events
+        .iter()
+        .any(|e| e["type"].as_str() == Some("error") && e.to_string().contains("no-progress loop"));
+    assert!(
+        saw_loop_error,
+        "expected a visible no-progress-loop error event; got {events:?}"
+    );
+}
+
+/// Control: a tool whose result CHANGES every turn (real progress) must NOT
+/// trip the breaker — it runs to the natural max_turns cap instead. Guards
+/// against the breaker firing on a legitimate iterate-retest cadence.
+#[tokio::test]
+async fn changing_results_do_not_trip_the_breaker() {
+    // Each turn the model calls the same tool, but the tool's output differs,
+    // so the signature changes and the streak never accumulates.
+    let turns: Vec<Vec<LlmEvent>> = (0..12).map(loop_turn).collect();
+    let provider = Arc::new(MockLlmProvider::with_turns(turns));
+
+    let mut registry = ToolRegistry::new();
+    registry.register(Box::new(ChangingTool::default()));
+
+    let config = test_config(); // max_turns = Some(10)
+    let sink = Arc::new(TestSink::new());
+    let handle = sink.handle();
+    let output: Arc<dyn OutputSink> = sink;
+
+    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output);
+    let result = engine.run("iterate", "").await.expect("run completes");
+
+    // Reached the turn cap, NOT the breaker (12 turns queued, cap 10).
+    assert_eq!(
+        result.turns, 10,
+        "changing results must run to max_turns, not be cut by the breaker"
+    );
+    let events = handle.snapshot();
+    assert!(
+        !events
+            .iter()
+            .any(|e| e["type"].as_str() == Some("error") && e.to_string().contains("no-progress")),
+        "the breaker must not fire when each result differs"
+    );
+}
+
+/// A tool that returns a different result on each call.
+#[derive(Default)]
+struct ChangingTool {
+    calls: std::sync::Mutex<u32>,
+}
+
+#[async_trait::async_trait]
+impl wcore_tools::Tool for ChangingTool {
+    fn name(&self) -> &str {
+        "loop_tool"
+    }
+    fn description(&self) -> &str {
+        "Returns a different result each call"
+    }
+    fn input_schema(&self) -> serde_json::Value {
+        json!({ "type": "object" })
+    }
+    fn category(&self) -> wcore_protocol::events::ToolCategory {
+        wcore_protocol::events::ToolCategory::Info
+    }
+    fn is_concurrency_safe(&self, _input: &serde_json::Value) -> bool {
+        true
+    }
+    async fn execute(&self, _input: serde_json::Value) -> wcore_types::tool::ToolResult {
+        let mut n = self.calls.lock().unwrap();
+        *n += 1;
+        wcore_types::tool::ToolResult {
+            content: format!("progress step {n}"),
+            is_error: false,
+        }
+    }
+}


### PR DESCRIPTION
The systemic anti-loop fix (Sean-approved): a **default engine-side runaway breaker** + **loop-convergence E2E**. Complements the point-fixes (#85/#86/#61 read-dedup) — those close individual loop *causes*; this bounds *any* no-progress loop.

## Why
The engine had **no default bound** on a no-progress loop: `max_turns` defaults to `None` and the budget cap is opt-in. So an agent that repeats the same failing tool call (retrying a network-blocked `npm install`, re-reading an unchanged file) loops until the host gives up — the root exposure behind the "8.5M input tokens in ~2h" reports. The per-turn context ceiling and (opt-in) budget cap bound size/spend, not the loop itself.

## What
A per-run `LoopGuard`: signature each `(tool name, args, is_error, content prefix)` and terminate the run cleanly when one signature accounts for **≥ threshold of the last `threshold + 2`** tool calls. The tight window catches back-to-back retries **and** alternating (A,B,A,B,A) loops, while letting ≤2 unrelated calls interleave — so a legitimate iterate-edit-retest cadence (same command, *different* result → different signature) never trips. Terminates via the existing budget-cap path (`repair_orphaned_tool_use` + `emit_error` + `finish_run_terminated`).

- **Default-on, opt-out:** threshold from `WAYLAND_MAX_REPEATED_TOOL_CALLS` (default **5**, `0` disables), read once per run.
- **Zero ripple:** state is a local in `run()` — no AgentEngine-field or config-cascade churn (deliberately avoided the multi-site config ripple).

## Tests
- `LoopGuard` units: trips on domination, tight 2-cycle trips, sparse repeats across progress don't trip, threshold-0 disables, signature stability.
- **Loop-convergence E2E**: a model repeating one failing tool call converges via the breaker **before** `max_turns`, with a visible error.
- **False-positive control**: a tool returning a *different* result each turn runs to `max_turns`, never tripping.

## Follow-ups (not in this PR)
- A config.toml knob (`max_repeated_tool_calls`) on top of the env var — deferred to avoid the config-cascade ripple while the box is off for the 7-day soak.
- App-side runaway circuit-breaker (the token-burn ticket's complement) stays app-side.

Local pre-push gate blocked by the box's 7-day soak; relying on CI.
