### PR TITLE
fix(agent): don't surface a cache full-miss as a user error (#101)

### DIFF
--- a/crates/wcore-agent/src/engine.rs
+++ b/crates/wcore-agent/src/engine.rs
@@ -3611,8 +3611,17 @@ impl AgentEngine {
             if let Some(diagnostic) = self.cache_detector.check_response(cache_stats) {
                 match &diagnostic {
                     CacheDiagnostic::FullMiss { cause } => {
-                        self.output
-                            .emit_error(&format!("Cache full miss: {cause:?}"), false);
+                        // #101: a full cache miss is diagnostic telemetry, NOT a
+                        // user error. A `TtlExpiry` (the prompt cache's TTL lapsed
+                        // because the user paused between turns) is expected, and
+                        // surfacing it as an error mid-chat alarms users over
+                        // normal behaviour. Gate it behind the same
+                        // `cache_diagnostics` debug flag as the partial/healthy
+                        // arms so only operators who opt in ever see it.
+                        if self.compact_config.cache_diagnostics {
+                            self.output
+                                .emit_info(&format!("Cache full miss (cause: {cause:?})"));
+                        }
                     }
                     CacheDiagnostic::PartialMiss { hit_rate, cause } => {
                         if self.compact_config.cache_diagnostics {


### PR DESCRIPTION
App-reported (FerroxLabs/wayland #101): "Cache full miss: TtlExpiry" appears as an **error** mid-chat for normal behaviour.

**Root cause:** `engine.rs` cache-diagnostic `FullMiss` arm used `emit_error` unconditionally, while the sibling `PartialMiss`/`Healthy` arms gate `emit_info` behind the `cache_diagnostics` debug flag. A full cache miss is telemetry, not a failure — a `TtlExpiry` just means the prompt cache's TTL lapsed because the user paused between turns (expected).

**Fix:** `FullMiss` now emits **info** gated on `cache_diagnostics`, consistent with the other two arms — so normal users never see a scary error, and operators who opt into diagnostics still get the signal. One-arm consistency change; no existing test asserts the old error.

Local pre-push gate blocked by the box's 7-day soak; relying on CI. Closes FerroxLabs/wayland#101