### PR TITLE
MCP boot resilience + /doctor surfacing

### DIFF
--- a/crates/wcore-agent/src/bootstrap.rs
+++ b/crates/wcore-agent/src/bootstrap.rs
@@ -96,6 +96,10 @@ pub struct BootstrapResult {
         tokio::task::JoinHandle<()>,
         tokio::sync::watch::Sender<bool>,
     )>,
+    /// Servers dropped by a pre-connect gate (e.g. an unreachable stdio
+    /// command). They never reached connect_all/health(), so they are
+    /// carried here so the boot snapshot can render a skipped (⊘) row.
+    pub skipped_mcp_servers: Vec<(String, String)>,
 }
 
 /// Wave OL: plugin-provider router. Called after plugin discovery + init
@@ -354,6 +358,11 @@ impl AgentBootstrap {
             )
             .await;
         let mut plugin_runtime_keepalives: Vec<crate::plugins::LoadedRuntimeHandle> = Vec::new();
+        // A4c: declarative stdio MCP servers dropped by the pre-connect
+        // reachability gate are collected here (name, reason) so the boot
+        // snapshot can render a skipped (⊘) row in /mcp and /doctor instead
+        // of dropping them silently into an info-log.
+        let mut skipped_mcp_servers: Vec<(String, String)> = Vec::new();
         for record in plugin_loader.take_on_disk_dispatches() {
             if let Err(reason) = &record.load_result {
                 tracing::warn!(
@@ -428,6 +437,10 @@ impl AgentBootstrap {
                                 "declarative plugin MCP server did not start cleanly — \
                                  skipping registration (hooks stay log-only)"
                             );
+                            skipped_mcp_servers.push((
+                                spec.name.clone(),
+                                "stdio command not launchable — skipped before connect (check the plugin command/PATH)".to_string(),
+                            ));
                         }
                     }
                 }
@@ -2523,6 +2536,7 @@ impl AgentBootstrap {
             cron_runner,
             inbound_subscriber,
             inbound_webhook,
+            skipped_mcp_servers,
         })
     }
 }
@@ -2711,4 +2725,27 @@ fn build_fallback_providers(config: &Config) -> Vec<(String, Arc<dyn LlmProvider
         fallbacks.push((entry.to_string(), provider));
     }
     fallbacks
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use wcore_plugin_api::{McpServerSpec, McpTransport};
+
+    /// A4c: a declarative stdio MCP server whose command cannot be launched
+    /// must fail the reachability gate. This is the only pre-connect skip on
+    /// this branch, and a `false` here is what feeds the skipped (⊘) row.
+    #[test]
+    fn unreachable_stdio_command_is_not_reachable() {
+        let spec = McpServerSpec {
+            name: "bogus-server".to_string(),
+            transport: McpTransport::Stdio {
+                command: "wayland-nonexistent-mcp-command-xyz".to_string(),
+                args: Vec::new(),
+            },
+            env: HashMap::new(),
+        };
+        assert!(!declarative_mcp_server_is_reachable(&spec));
+    }
 }

--- a/crates/wcore-agent/src/plugins/mcp_delivery.rs
+++ b/crates/wcore-agent/src/plugins/mcp_delivery.rs
@@ -106,7 +106,19 @@ pub async fn connect_plugin_mcp_servers(
         .map(|s| (s.name.clone(), translate_mcp_server_spec(s)))
         .collect();
 
-    match wcore_mcp::manager::McpManager::connect_all(&configs).await {
+    // Plugin MCP servers are third-party code from installed marketplace
+    // plugins; a broken one must not dominate boot. Give them a tighter
+    // connect budget than config-declared servers (which keep the 30s default
+    // in `connect_all`) so a wedged plugin server caps the boot delay at 8s
+    // instead of 30s. The cause of any skip is still preserved in the
+    // manager's health() map (surfaced in /doctor).
+    const PLUGIN_CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(8);
+    match wcore_mcp::manager::McpManager::connect_all_with_connect_timeout(
+        &configs,
+        PLUGIN_CONNECT_TIMEOUT,
+    )
+    .await
+    {
         Ok(mgr) => {
             let mgr = Arc::new(mgr);
             wcore_mcp::tool_proxy::register_mcp_tools(tool_registry, &mgr, builtin_names, &configs);

--- a/crates/wcore-cli/src/doctor/mod.rs
+++ b/crates/wcore-cli/src/doctor/mod.rs
@@ -86,7 +86,7 @@ pub async fn collect() -> DoctorReport {
 /// Public entry point invoked from `main.rs` when the `--doctor` flag
 /// is passed. Performs all checks, prints the report, returns the
 /// platform-appropriate exit code.
-pub async fn run() -> ExitCode {
+pub async fn run(probe_mcp: bool) -> ExitCode {
     let report = collect().await;
     let version = &report.version;
     println!("wayland-core doctor v{version}\n");
@@ -134,6 +134,10 @@ pub async fn run() -> ExitCode {
         "\nSummary: {passed} passed, {failed} missing, {warned} warning, \
          {skipped} skipped, {manual} manual"
     );
+
+    // A4b: list declared MCP servers (and optionally probe). Informational
+    // only — never flips the exit code below.
+    print_mcp_section(probe_mcp).await;
 
     if failed > 0 {
         ExitCode::from(1)
@@ -364,6 +368,122 @@ async fn check_ollama() -> CheckResult {
                 "or set OLLAMA_BASE_URL=<endpoint> to point at a remote daemon".into(),
             ],
         },
+    }
+}
+
+// -- A4b: MCP section ---------------------------------------------------
+
+/// A4b: print the CLI-only MCP section AFTER the standard doctor summary.
+///
+/// Bare `--doctor` (`probe == false`) is side-effect-free: it only LISTS
+/// declared MCP servers (config-cascaded + on-disk plugin manifests) by
+/// reading config and files — it never spawns a stdio command or dials a
+/// URL. `--probe-mcp` (`probe == true`) opts into a real connect-test of
+/// the config-declared servers via [`wcore_mcp::manager::McpManager`].
+///
+/// This section is informational and best-effort: every fallible step is
+/// matched and degraded to a printed note, so it can NEVER panic or flip
+/// the doctor exit code (which is computed by the caller from the check
+/// rows, not from anything printed here). It is deliberately kept out of
+/// [`collect`]/[`CheckResult`] so it does NOT duplicate the live MCP
+/// section the TUI `/doctor` surface already renders.
+async fn print_mcp_section(probe: bool) {
+    println!();
+    println!("MCP servers (declared):");
+
+    // --- config-declared servers (cascaded), best-effort load ---
+    match wcore_config::config::Config::resolve(&wcore_config::config::CliArgs::default()) {
+        Ok(cfg) => {
+            if cfg.mcp.servers.is_empty() {
+                println!("  (none declared in config)");
+            } else {
+                let mut names: Vec<&String> = cfg.mcp.servers.keys().collect();
+                names.sort();
+                for name in names {
+                    let s = &cfg.mcp.servers[name];
+                    let transport = format!("{:?}", s.transport).to_lowercase();
+                    let target = s
+                        .command
+                        .clone()
+                        .or_else(|| s.url.clone())
+                        .unwrap_or_default();
+                    println!("  [config] {name:<20} {transport:<14} {target}");
+                }
+            }
+        }
+        Err(e) => println!("  (config not loaded: {e})"),
+    }
+
+    // --- plugin-declared servers (scan on-disk manifests, NO spawn) ---
+    // Plugin install root = dirs::data_dir()/wayland-core/plugins (matches
+    // `plugin::run`'s default install root in plugin/mod.rs).
+    if let Some(base) = dirs::data_dir() {
+        let plugins_root = base.join("wayland-core").join("plugins");
+        let mut found_any = false;
+        if let Ok(entries) = std::fs::read_dir(&plugins_root) {
+            let mut manifests: Vec<std::path::PathBuf> = entries
+                .flatten()
+                .map(|e| e.path().join("plugin.toml"))
+                .filter(|p| p.is_file())
+                .collect();
+            manifests.sort();
+            for manifest_path in manifests {
+                if let Ok(text) = std::fs::read_to_string(&manifest_path)
+                    && let Ok(m) = toml::from_str::<wcore_plugin_api::PluginManifest>(&text)
+                    && let Some(spec) = &m.mcp_server
+                {
+                    if !found_any {
+                        println!("MCP servers (plugin-declared):");
+                        found_any = true;
+                    }
+                    let transport = format!("{:?}", spec.transport).to_lowercase();
+                    let plugin = manifest_path
+                        .parent()
+                        .and_then(|p| p.file_name())
+                        .and_then(|s| s.to_str())
+                        .unwrap_or("?")
+                        .to_string();
+                    println!("  [plugin:{plugin}] {:<20} {transport}", spec.name);
+                }
+            }
+        }
+    }
+
+    // --- optional probe ---
+    if probe {
+        println!();
+        println!("Probing config-declared MCP servers (connect-test)...");
+        match wcore_config::config::Config::resolve(&wcore_config::config::CliArgs::default()) {
+            Ok(cfg) if !cfg.mcp.servers.is_empty() => {
+                match wcore_mcp::manager::McpManager::connect_all(&cfg.mcp.servers).await {
+                    Ok(mgr) => {
+                        let mut names: Vec<&String> = mgr.health().keys().collect();
+                        names.sort();
+                        for name in names {
+                            use wcore_mcp::manager::McpServerHealth::*;
+                            let line = match &mgr.health()[name] {
+                                Ready { tool_count } => {
+                                    format!("  ● {name:<20} ready ({tool_count} tools)")
+                                }
+                                Failed { reason } => format!("  ✕ {name:<20} failed: {reason}"),
+                                TimedOut { after } => {
+                                    format!("  ⏱ {name:<20} timed out after {after:?}")
+                                }
+                                Skipped { reason } => format!("  ⊘ {name:<20} skipped: {reason}"),
+                            };
+                            println!("{line}");
+                        }
+                    }
+                    Err(e) => println!("  (probe failed: {e})"),
+                }
+            }
+            Ok(_) => println!("  (no config-declared servers to probe)"),
+            Err(e) => println!("  (config not loaded: {e})"),
+        }
+        println!("  Note: plugin-declared servers are probed at session boot, not here.");
+    } else {
+        println!();
+        println!("Run with --probe-mcp to connect-test the config-declared servers.");
     }
 }
 

--- a/crates/wcore-cli/src/main.rs
+++ b/crates/wcore-cli/src/main.rs
@@ -2437,7 +2437,16 @@ async fn run_json_stream_mode(
                     }
                     Err(e) => {
                         eprintln!("[mcp] connect_one failed for '{name}': {e:#}");
-                        output.emit_error(&format!("AddMcpServer '{name}' failed: {e:#}"), false);
+                        let reason = format!("{e:#}");
+                        output
+                            .emit_error(&format!("AddMcpServer '{name}' failed: {reason}"), false);
+                        // Companion to the McpReady success emit: tell the host /
+                        // TUI *why* this server's tools never appeared so /doctor
+                        // can surface it, instead of the failure only hitting stderr.
+                        let _ = writer.emit(&ProtocolEvent::McpFailed {
+                            name: name.clone(),
+                            reason,
+                        });
                     }
                 }
             }

--- a/crates/wcore-cli/src/main.rs
+++ b/crates/wcore-cli/src/main.rs
@@ -1658,11 +1658,16 @@ async fn run_tui_mode(
                 .collect()
         })
         .unwrap_or_default();
+    // Snapshot EVERY attempted server (from `health()`), not just the live ones
+    // (`server_names()`): a server that failed or timed out at connect has no
+    // live entry but the user still needs to see why in `/mcp` and `/doctor`.
     let mut mcp_snapshot: Vec<tui::McpServerInfo> = Vec::new();
     for mgr in &result.mcp_managers {
-        for name in mgr.server_names() {
-            let alive = mgr.server_is_alive(&name);
-            mcp_snapshot.push(tui::McpServerInfo { name, alive });
+        for (name, health) in mgr.health() {
+            mcp_snapshot.push(tui::McpServerInfo {
+                name: name.clone(),
+                health: health.clone(),
+            });
         }
     }
 

--- a/crates/wcore-cli/src/main.rs
+++ b/crates/wcore-cli/src/main.rs
@@ -1581,7 +1581,16 @@ async fn run_tui_mode(
         bootstrap = bootstrap.resume(session);
     }
 
-    let result = bootstrap.build().await?;
+    // Enter the TUI terminal up front so the engine build — which connects
+    // every configured + installed-plugin MCP server (bounded per-server) on
+    // the boot critical path — runs behind a branded splash instead of a blank
+    // terminal. Single alt-screen entry; the SAME terminal is handed to
+    // `run_attached` below (entering it twice would corrupt the screen). The
+    // RAII guard restores the terminal on any `?`-early-return between here and
+    // `run_attached`.
+    let mcp_count = bootstrap.config().mcp.servers.len();
+    let (mut boot_terminal, boot_guard) = tui::enter()?;
+    let result = tui::splash_while(&mut boot_terminal, mcp_count, bootstrap.build()).await?;
     let mut engine = result.engine;
 
     // L2 / D016 boot parity: fold the `[default] user` display name into the
@@ -1696,7 +1705,9 @@ async fn run_tui_mode(
         restored_turns,
         restored_tool_cards,
     };
-    tui::run(Some(session)).await?;
+    // Hand the splash terminal (already in the alt-screen) + its guard to the
+    // main loop — no second alt-screen entry.
+    tui::run_attached(boot_terminal, boot_guard, Some(session)).await?;
 
     // The TUI has exited — shut MCP servers down cleanly.
     for mgr in &result.mcp_managers {

--- a/crates/wcore-cli/src/main.rs
+++ b/crates/wcore-cli/src/main.rs
@@ -317,6 +317,12 @@ struct Cli {
     #[arg(long)]
     doctor: bool,
 
+    /// A4b: when running --doctor, actually CONNECT-TEST each declared MCP
+    /// server (spawns stdio commands / dials URLs) instead of only listing
+    /// them. Off by default so bare --doctor stays side-effect-free.
+    #[arg(long, requires = "doctor")]
+    probe_mcp: bool,
+
     /// W4 F19: run the skills audit. Writes JSON to
     /// .wayland-core/skills-audit.json and renders Markdown to stdout.
     #[arg(long)]
@@ -939,7 +945,7 @@ async fn run() -> anyhow::Result<ExitCode> {
     // mode so a misconfigured environment can be diagnosed without
     // touching config files, OAuth, or the engine bootstrap.
     if cli.doctor {
-        return Ok(doctor::run().await);
+        return Ok(doctor::run(cli.probe_mcp).await);
     }
 
     // Handle --config-path

--- a/crates/wcore-cli/src/main.rs
+++ b/crates/wcore-cli/src/main.rs
@@ -1679,6 +1679,16 @@ async fn run_tui_mode(
             });
         }
     }
+    // A4c: servers dropped by the pre-connect reachability gate never reach a
+    // manager's `health()`, so surface them here as a distinct skipped (⊘) row.
+    for (name, reason) in &result.skipped_mcp_servers {
+        mcp_snapshot.push(tui::McpServerInfo {
+            name: name.clone(),
+            health: wcore_mcp::manager::McpServerHealth::Skipped {
+                reason: reason.clone(),
+            },
+        });
+    }
 
     // The `TuiEngine` controller keeps the last `tx` clone so it can
     // synthesize the `StreamEnd` the engine never emits itself.

--- a/crates/wcore-cli/src/tui/app.rs
+++ b/crates/wcore-cli/src/tui/app.rs
@@ -1168,6 +1168,14 @@ pub enum McpServerStatus {
         /// Number of tools the server advertised in its `McpReady` event.
         tool_count: usize,
     },
+    /// The server's connect attempt failed cleanly (transport / handshake);
+    /// `reason` is the preserved cause, surfaced in `/doctor`.
+    Failed {
+        /// Human-readable failure cause from the connect attempt.
+        reason: String,
+    },
+    /// The server's connect attempt exceeded its per-server budget.
+    TimedOut,
 }
 
 // ─────────────────────────────────────────────────────────────────────────

--- a/crates/wcore-cli/src/tui/app.rs
+++ b/crates/wcore-cli/src/tui/app.rs
@@ -1176,6 +1176,9 @@ pub enum McpServerStatus {
     },
     /// The server's connect attempt exceeded its per-server budget.
     TimedOut,
+    /// The server was skipped by a pre-connect gate (e.g. unreachable
+    /// command); reason explains why. Rendered as a skipped (⊘) row.
+    Skipped { reason: String },
 }
 
 // ─────────────────────────────────────────────────────────────────────────

--- a/crates/wcore-cli/src/tui/engine_bridge.rs
+++ b/crates/wcore-cli/src/tui/engine_bridge.rs
@@ -1510,17 +1510,52 @@ impl TuiEngine {
             let manager = match wcore_mcp::manager::McpManager::connect_all(&single).await {
                 Ok(mgr) => std::sync::Arc::new(mgr),
                 Err(e) => {
+                    let reason = format!("{e}");
+                    let _ = tx.send(ProtocolEvent::McpFailed {
+                        name: name.clone(),
+                        reason: reason.clone(),
+                    });
                     let _ = tx.send(ProtocolEvent::Error {
                         msg_id: None,
                         error: ErrorInfo {
                             code: "mcp_add".to_string(),
-                            message: format!("Couldn't connect MCP server '{name}': {e}"),
+                            message: format!("Couldn't connect MCP server '{name}': {reason}"),
                             retryable: false,
                         },
                     });
                     return;
                 }
             };
+            // `connect_all` is non-fatal per-server: a server that failed or
+            // timed out still returns `Ok` with the cause recorded in
+            // `health()`, not `Err`. Surface that honestly instead of falling
+            // through and reporting "connected, 0 tools".
+            use wcore_mcp::manager::McpServerHealth;
+            match manager.health().get(&name) {
+                Some(McpServerHealth::Ready { .. }) => {}
+                other => {
+                    let reason = match other {
+                        Some(McpServerHealth::Failed { reason }) => reason.clone(),
+                        Some(McpServerHealth::TimedOut { after }) => {
+                            format!("connect timed out after {after:?}")
+                        }
+                        _ => "server did not connect".to_string(),
+                    };
+                    let _ = tx.send(ProtocolEvent::McpFailed {
+                        name: name.clone(),
+                        reason: reason.clone(),
+                    });
+                    let _ = tx.send(ProtocolEvent::Error {
+                        msg_id: None,
+                        error: ErrorInfo {
+                            code: "mcp_add".to_string(),
+                            message: format!("MCP server '{name}' failed to connect: {reason}"),
+                            retryable: false,
+                        },
+                    });
+                    return;
+                }
+            }
             // Register the freshly discovered tools onto the LIVE registry.
             // `registry_mut` only hands out a `&mut` when the registry Arc is
             // uncontended — a turn in flight holds a clone, so we report busy
@@ -1537,11 +1572,21 @@ impl TuiEngine {
                         &builtin_names,
                         config.deferred.unwrap_or(true),
                     );
-                    let tool_count = manager
+                    let tool_names: Vec<String> = manager
                         .all_tools()
                         .iter()
                         .filter(|(sn, _)| *sn == name.as_str())
-                        .count();
+                        .map(|(_, t)| t.name.clone())
+                        .collect();
+                    let tool_count = tool_names.len();
+                    // Update the TUI's live mcp_status (so /doctor reflects the
+                    // add) — the bridge's McpReady arm records Ready{tool_count}.
+                    // Previously this path emitted only Info, leaving mcp_status
+                    // stale after a live `/mcp add`.
+                    let _ = tx.send(ProtocolEvent::McpReady {
+                        name: name.clone(),
+                        tools: tool_names,
+                    });
                     format!(
                         "MCP server '{name}' connected. {tool_count} tool(s) available now. \
                          Type /mcp to see all servers."

--- a/crates/wcore-cli/src/tui/engine_bridge.rs
+++ b/crates/wcore-cli/src/tui/engine_bridge.rs
@@ -540,12 +540,24 @@ pub struct SkillInfo {
     pub user_invocable: bool,
 }
 
-/// One configured MCP server in the [`EngineInventory`] snapshot.
+/// One *attempted* MCP server in the [`EngineInventory`] snapshot — including
+/// servers that failed or timed out at connect (they never become live but the
+/// user still needs to see *why* in `/mcp` and `/doctor`).
 #[derive(Debug, Clone)]
 pub struct McpServerInfo {
     pub name: String,
-    /// Live transport state captured at snapshot time.
-    pub alive: bool,
+    /// Connect outcome captured at snapshot time (Ready / Failed / TimedOut).
+    pub health: wcore_mcp::manager::McpServerHealth,
+}
+
+impl McpServerInfo {
+    /// Whether the server is connected and serving tools.
+    pub fn is_connected(&self) -> bool {
+        matches!(
+            self.health,
+            wcore_mcp::manager::McpServerHealth::Ready { .. }
+        )
+    }
 }
 
 /// One registered hook in the [`EngineInventory`] snapshot.

--- a/crates/wcore-cli/src/tui/mod.rs
+++ b/crates/wcore-cli/src/tui/mod.rs
@@ -383,6 +383,29 @@ async fn run_loop(
                 guard.session.turns = s.restored_turns;
                 guard.session.tool_cards = s.restored_tool_cards;
             }
+            // Seed mcp_status from the boot health snapshot so `/doctor` shows
+            // MCP server health the first time it opens. Boot-time MCP connect
+            // does NOT emit McpReady/McpFailed to the TUI (only the inventory
+            // snapshot carries it); live `/mcp add` events update these entries
+            // afterward through the same map.
+            for info in &s.engine.inventory().mcp_servers {
+                let status = match &info.health {
+                    wcore_mcp::manager::McpServerHealth::Ready { tool_count } => {
+                        app::McpServerStatus::Ready {
+                            tool_count: *tool_count,
+                        }
+                    }
+                    wcore_mcp::manager::McpServerHealth::Failed { reason } => {
+                        app::McpServerStatus::Failed {
+                            reason: reason.clone(),
+                        }
+                    }
+                    wcore_mcp::manager::McpServerHealth::TimedOut { .. } => {
+                        app::McpServerStatus::TimedOut
+                    }
+                };
+                guard.mcp_status.insert(info.name.clone(), status);
+            }
         }
         spawn_bridge(s.events, app.clone(), wake.clone());
         router = router.with_engine(s.engine);

--- a/crates/wcore-cli/src/tui/mod.rs
+++ b/crates/wcore-cli/src/tui/mod.rs
@@ -263,6 +263,21 @@ pub fn context_view_from(config: &wcore_config::config::Config) -> app::ContextV
 /// on a clean quit. The terminal is restored on every exit path — clean
 /// return, error, or panic.
 pub async fn run(session: Option<TuiSession>) -> Result<()> {
+    let (terminal, guard) = enter()?;
+    run_attached(terminal, guard, session).await
+}
+
+/// Enter the full-screen TUI: raw mode, the alt-screen (+ bracketed paste,
+/// focus reporting, mouse capture), the panic-restore hook, and the RAII
+/// terminal guard. Returns the live `Terminal` and its guard so the caller
+/// can render a boot splash on it *before* a session exists, then hand both
+/// to [`run_attached`]. Entering the alt-screen exactly once here is what lets
+/// the splash and the main loop share one terminal — entering it twice
+/// corrupts the screen.
+pub fn enter() -> Result<(
+    Terminal<CrosstermBackend<Stdout>>,
+    terminal_guard::TerminalGuard,
+)> {
     enable_raw_mode().context("failed to enable terminal raw mode")?;
     // Enter the alt-screen and ask the terminal to bracket pastes. With
     // bracketed paste on, a paste arrives as one `Event::Paste` blob the
@@ -298,18 +313,96 @@ pub async fn run(session: Option<TuiSession>) -> Result<()> {
     // every non-panic exit path, including the `?`-bubble below if
     // `Terminal::new` fails. The panic path is covered by
     // `install_panic_hook` above.
-    let _guard = terminal_guard::TerminalGuard::new();
+    let guard = terminal_guard::TerminalGuard::new();
 
     let backend = CrosstermBackend::new(stdout());
-    let mut terminal = Terminal::new(backend).context("failed to initialize terminal")?;
+    let terminal = Terminal::new(backend).context("failed to initialize terminal")?;
+    Ok((terminal, guard))
+}
 
-    // Run the loop, capturing its result so the terminal is always
-    // restored before `run` returns regardless of how the loop ended.
-    // `_guard`'s Drop will also call `restore_terminal()` when this
-    // function returns, which is idempotent (see `restore_terminal`).
+/// Run the render/poll loop on an already-entered terminal (see [`enter`]),
+/// restoring it on every exit path. Split from [`run`] so the boot path can
+/// render a splash on the same terminal while the engine builds.
+pub async fn run_attached(
+    mut terminal: Terminal<CrosstermBackend<Stdout>>,
+    guard: terminal_guard::TerminalGuard,
+    session: Option<TuiSession>,
+) -> Result<()> {
+    // Run the loop, capturing its result so the terminal is always restored
+    // before returning regardless of how the loop ended. `guard`'s Drop also
+    // calls `restore_terminal()` (idempotent).
     let loop_result = run_loop(&mut terminal, session).await;
-    drop(_guard);
+    drop(guard);
     loop_result
+}
+
+/// Render a branded boot splash on `terminal` while `fut` (the engine build)
+/// runs, returning `fut`'s output the instant it completes. The splash is
+/// driven by a `select!` against a frame ticker — `fut` is polled in place
+/// (no `tokio::spawn`, so it needs no `'static`/`Send`), and the spinner
+/// animates at ~11fps so a multi-second MCP connect shows live progress
+/// instead of a blank terminal.
+pub async fn splash_while<F: std::future::Future>(
+    terminal: &mut Terminal<CrosstermBackend<Stdout>>,
+    mcp_count: usize,
+    fut: F,
+) -> F::Output {
+    let theme = theme::Theme::detect();
+    tokio::pin!(fut);
+    let mut ticker = tokio::time::interval(std::time::Duration::from_millis(90));
+    let mut frame: u64 = 0;
+    loop {
+        tokio::select! {
+            out = &mut fut => return out,
+            _ = ticker.tick() => {
+                let _ = terminal.draw(|f| draw_splash(f, &theme, mcp_count, frame));
+                frame = frame.wrapping_add(1);
+            }
+        }
+    }
+}
+
+/// Paint one frame of the boot splash: the wordmark centred over a spinner
+/// line. `mcp_count` is the *config-declared* server count known before the
+/// connect runs (installed-plugin servers are discovered during build, so the
+/// copy stays honest by not claiming a total).
+fn draw_splash(f: &mut ratatui::Frame, theme: &theme::Theme, mcp_count: usize, frame: u64) {
+    use ratatui::layout::{Alignment, Constraint, Layout};
+    use ratatui::style::{Modifier, Style};
+    use ratatui::text::{Line, Span};
+    use ratatui::widgets::{Block, Paragraph};
+
+    let area = f.area();
+    let bg = Style::default().bg(theme.bg);
+    f.render_widget(Block::default().style(bg), area);
+
+    let spinner = widgets::spinner_frame(frame);
+    let sub = if mcp_count > 0 {
+        format!(
+            "{spinner}  starting engine · connecting {mcp_count} MCP server{}…",
+            if mcp_count == 1 { "" } else { "s" }
+        )
+    } else {
+        format!("{spinner}  starting engine · connecting tools & MCP servers…")
+    };
+    let lines = vec![
+        Line::from(Span::styled(
+            "WAYLAND CORE",
+            bg.fg(theme.orange).add_modifier(Modifier::BOLD),
+        )),
+        Line::from(""),
+        Line::from(Span::styled(sub, bg.fg(theme.text_muted))),
+    ];
+    let [_, mid, _] = Layout::vertical([
+        Constraint::Percentage(45),
+        Constraint::Length(3),
+        Constraint::Min(0),
+    ])
+    .areas(area);
+    f.render_widget(
+        Paragraph::new(lines).alignment(Alignment::Center).style(bg),
+        mid,
+    );
 }
 
 /// The async draw/poll loop. Hosts the engine event bridge alongside the

--- a/crates/wcore-cli/src/tui/mod.rs
+++ b/crates/wcore-cli/src/tui/mod.rs
@@ -496,6 +496,11 @@ async fn run_loop(
                     wcore_mcp::manager::McpServerHealth::TimedOut { .. } => {
                         app::McpServerStatus::TimedOut
                     }
+                    wcore_mcp::manager::McpServerHealth::Skipped { reason } => {
+                        app::McpServerStatus::Skipped {
+                            reason: reason.clone(),
+                        }
+                    }
                 };
                 guard.mcp_status.insert(info.name.clone(), status);
             }

--- a/crates/wcore-cli/src/tui/protocol_bridge.rs
+++ b/crates/wcore-cli/src/tui/protocol_bridge.rs
@@ -714,6 +714,29 @@ fn apply_event_inner(app: &mut App, event: ProtocolEvent) {
                 }
             });
         }
+        ProtocolEvent::McpFailed { name, reason } => {
+            // Companion to McpReady: record the failure (with its cause) on
+            // `mcp_status` so `/doctor` can surface *why* the server's tools
+            // never appeared, plus a transient toast. Not a transcript turn —
+            // a broken server is a status concern, not conversation.
+            let toast_msg = format!("{name} failed · {reason}");
+            let now = Instant::now();
+            app.set_transient(|prev| {
+                let mut mcp_status = prev.mcp_status.clone();
+                mcp_status.insert(
+                    name.clone(),
+                    crate::tui::app::McpServerStatus::Failed {
+                        reason: reason.clone(),
+                    },
+                );
+                crate::tui::state::TransientSlice {
+                    toast: Some(toast_msg.clone()),
+                    toast_at: Some(now),
+                    mcp_status,
+                    ..prev.clone()
+                }
+            });
+        }
         ProtocolEvent::BudgetExceeded {
             reason,
             observed,
@@ -2892,6 +2915,39 @@ mod tests {
             }
             other => panic!("expected Ready, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn mcp_failed_records_the_cause_on_status_without_a_transcript_turn() {
+        // A3: a failed MCP server must surface its cause on `mcp_status`
+        // (so `/doctor` can show *why* the tools never appeared) and a
+        // transient toast — never a transcript turn.
+        let mut app = App::new();
+        apply_event(
+            &mut app,
+            ProtocolEvent::McpFailed {
+                name: "stripe".into(),
+                reason: "spawn node: ENOENT".into(),
+            },
+        );
+        assert_eq!(
+            app.session.turns.len(),
+            0,
+            "McpFailed must not create a transcript turn"
+        );
+        match app
+            .mcp_status
+            .get("stripe")
+            .expect("app.mcp_status should record the failed server")
+        {
+            crate::tui::app::McpServerStatus::Failed { reason } => {
+                assert_eq!(reason, "spawn node: ENOENT");
+            }
+            other => panic!("expected Failed, got {other:?}"),
+        }
+        let toast = app.toast.as_ref().expect("McpFailed should set a toast");
+        assert!(toast.contains("stripe"), "toast names the server: {toast}");
+        assert!(toast.contains("failed"), "toast marks the failure: {toast}");
     }
 
     #[test]

--- a/crates/wcore-cli/src/tui/protocol_bridge.rs
+++ b/crates/wcore-cli/src/tui/protocol_bridge.rs
@@ -2890,6 +2890,7 @@ mod tests {
             crate::tui::app::McpServerStatus::Ready { tool_count } => {
                 assert_eq!(*tool_count, 2);
             }
+            other => panic!("expected Ready, got {other:?}"),
         }
     }
 

--- a/crates/wcore-cli/src/tui/surfaces/diagnostics.rs
+++ b/crates/wcore-cli/src/tui/surfaces/diagnostics.rs
@@ -913,7 +913,37 @@ impl DiagnosticsSurface {
             lines.push(status_row(state, &row.name, &detail, t));
         }
 
-        // ── 4. Recent engine errors ─────────────────────────────────
+        // ── 4. MCP servers ──────────────────────────────────────────
+        // Seeded at boot from the connect-health snapshot (tui::run) and
+        // updated live by McpReady / McpFailed events. A failed or timed-out
+        // server is the answer to "why aren't my plugin's tools showing up".
+        lines.push(Line::from(""));
+        push_section_header(&mut lines, t, "MCP SERVERS");
+        if app.mcp_status.is_empty() {
+            lines.push(Line::from(Span::styled(
+                "  none configured",
+                Style::default().fg(t.text_muted),
+            )));
+        } else {
+            let mut names: Vec<&String> = app.mcp_status.keys().collect();
+            names.sort();
+            for name in names {
+                let (state, detail) = match &app.mcp_status[name] {
+                    crate::tui::app::McpServerStatus::Ready { tool_count } => {
+                        (HealthState::Ok, format!("ready · {tool_count} tools"))
+                    }
+                    crate::tui::app::McpServerStatus::Failed { reason } => {
+                        (HealthState::Fail, format!("failed · {reason}"))
+                    }
+                    crate::tui::app::McpServerStatus::TimedOut => {
+                        (HealthState::Fail, "timed out at connect".to_string())
+                    }
+                };
+                lines.push(status_row(state, name, &detail, t));
+            }
+        }
+
+        // ── 5. Recent engine errors ─────────────────────────────────
         lines.push(Line::from(""));
         push_section_header(&mut lines, t, "RECENT ERRORS");
         let errors = collect_recent_errors(app);
@@ -934,7 +964,7 @@ impl DiagnosticsSurface {
             }
         }
 
-        // ── 5. Token budget ─────────────────────────────────────────
+        // ── 6. Token budget ─────────────────────────────────────────
         lines.push(Line::from(""));
         push_section_header(&mut lines, t, "TOKEN BUDGET");
         let budget = token_budget_view(app);
@@ -1778,6 +1808,48 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn doctor_shows_an_mcp_section_with_ready_and_failed_servers() {
+        // A4: the MCP SERVERS section answers "why aren't my plugin's tools
+        // showing up" — a ready server shows its tool count, a failed one its
+        // preserved cause. Tall terminal so the section is not below the fold.
+        let mut s = DiagnosticsSurface::new();
+        let mut app = App::new();
+        app.mcp_status.insert(
+            "notion".into(),
+            crate::tui::app::McpServerStatus::Ready { tool_count: 6 },
+        );
+        app.mcp_status.insert(
+            "claude-mem".into(),
+            crate::tui::app::McpServerStatus::Failed {
+                reason: "spawn node".into(),
+            },
+        );
+        s.on_enter(&mut app);
+        let out = render_tall(&mut s, &app);
+        assert!(
+            out.contains("MCP SERVERS"),
+            "section header missing:\n{out}"
+        );
+        assert!(out.contains("notion"), "ready server missing:\n{out}");
+        assert!(out.contains("ready"), "ready state missing:\n{out}");
+        assert!(out.contains("claude-mem"), "failed server missing:\n{out}");
+        assert!(out.contains("failed"), "failure state missing:\n{out}");
+    }
+
+    #[test]
+    fn doctor_mcp_section_reads_none_configured_when_empty() {
+        let mut s = DiagnosticsSurface::new();
+        let mut app = App::new(); // empty mcp_status
+        s.on_enter(&mut app);
+        let out = render_tall(&mut s, &app);
+        assert!(out.contains("MCP SERVERS"));
+        assert!(
+            out.contains("none configured"),
+            "empty state missing:\n{out}"
+        );
     }
 
     #[test]

--- a/crates/wcore-cli/src/tui/surfaces/diagnostics.rs
+++ b/crates/wcore-cli/src/tui/surfaces/diagnostics.rs
@@ -938,6 +938,9 @@ impl DiagnosticsSurface {
                     crate::tui::app::McpServerStatus::TimedOut => {
                         (HealthState::Fail, "timed out at connect".to_string())
                     }
+                    crate::tui::app::McpServerStatus::Skipped { reason } => {
+                        (HealthState::Warn, format!("⊘ skipped · {reason}"))
+                    }
                 };
                 lines.push(status_row(state, name, &detail, t));
             }
@@ -1827,6 +1830,14 @@ mod tests {
                 reason: "spawn node".into(),
             },
         );
+        // A4c: a server dropped by the pre-connect reachability gate shows as a
+        // distinct "skipped" row (Warn, not Fail — a skip is a decision).
+        app.mcp_status.insert(
+            "ghost-plugin".into(),
+            crate::tui::app::McpServerStatus::Skipped {
+                reason: "stdio command not launchable".into(),
+            },
+        );
         s.on_enter(&mut app);
         let out = render_tall(&mut s, &app);
         assert!(
@@ -1837,6 +1848,11 @@ mod tests {
         assert!(out.contains("ready"), "ready state missing:\n{out}");
         assert!(out.contains("claude-mem"), "failed server missing:\n{out}");
         assert!(out.contains("failed"), "failure state missing:\n{out}");
+        assert!(
+            out.contains("ghost-plugin"),
+            "skipped server missing:\n{out}"
+        );
+        assert!(out.contains("skipped"), "skipped state missing:\n{out}");
     }
 
     #[test]

--- a/crates/wcore-cli/src/tui/surfaces/mod.rs
+++ b/crates/wcore-cli/src/tui/surfaces/mod.rs
@@ -2296,12 +2296,19 @@ fn render_mcp_list(inv: Option<&EngineInventory>) -> String {
     }
     let mut out = format!("MCP servers ({}):\n", servers.len());
     for s in servers {
-        let (mark, state) = if s.alive {
-            ("●", "connected")
-        } else {
-            ("○", "down")
+        use wcore_mcp::manager::McpServerHealth;
+        let line = match &s.health {
+            McpServerHealth::Ready { tool_count } => {
+                format!("  ● {}  (connected, {tool_count} tools)\n", s.name)
+            }
+            McpServerHealth::Failed { reason } => {
+                format!("  ✗ {}  (failed: {reason})\n", s.name)
+            }
+            McpServerHealth::TimedOut { after } => {
+                format!("  ⏱ {}  (timed out after {after:?})\n", s.name)
+            }
         };
-        out.push_str(&format!("  {mark} {}  ({state})\n", s.name));
+        out.push_str(&line);
     }
     out.push_str(
         "\nAdd one live with: /mcp add <name> <url-or-command>. \
@@ -3426,11 +3433,13 @@ mod tests {
             mcp_servers: vec![
                 McpServerInfo {
                     name: "github".to_string(),
-                    alive: true,
+                    health: wcore_mcp::manager::McpServerHealth::Ready { tool_count: 4 },
                 },
                 McpServerInfo {
                     name: "stripe".to_string(),
-                    alive: false,
+                    health: wcore_mcp::manager::McpServerHealth::Failed {
+                        reason: "connection refused".to_string(),
+                    },
                 },
             ],
             hooks: vec![HookInfo {
@@ -3448,8 +3457,12 @@ mod tests {
 
         let mcp = render_mcp_list(Some(&inv));
         assert!(mcp.contains("MCP servers (2)"));
-        assert!(mcp.contains("● github  (connected)"));
-        assert!(mcp.contains("○ stripe  (down)"));
+        assert!(mcp.contains("● github  (connected, 4 tools)"));
+        // A failed server is now surfaced with its preserved cause, not "down".
+        assert!(
+            mcp.contains("✗ stripe  (failed: connection refused)"),
+            "got: {mcp}"
+        );
 
         let hooks = render_hooks_list(Some(&inv));
         assert!(hooks.contains("Hooks registered (1)"));

--- a/crates/wcore-cli/src/tui/surfaces/mod.rs
+++ b/crates/wcore-cli/src/tui/surfaces/mod.rs
@@ -2307,6 +2307,9 @@ fn render_mcp_list(inv: Option<&EngineInventory>) -> String {
             McpServerHealth::TimedOut { after } => {
                 format!("  ⏱ {}  (timed out after {after:?})\n", s.name)
             }
+            McpServerHealth::Skipped { reason } => {
+                format!("  ⊘ {}  (skipped: {reason})\n", s.name)
+            }
         };
         out.push_str(&line);
     }
@@ -3467,6 +3470,30 @@ mod tests {
         let hooks = render_hooks_list(Some(&inv));
         assert!(hooks.contains("Hooks registered (1)"));
         assert!(hooks.contains("lint-gate  [pre-tool-use]"));
+    }
+
+    #[test]
+    fn render_mcp_list_renders_skipped_server_with_glyph_a4c() {
+        use crate::tui::engine_bridge::McpServerInfo;
+
+        // A4c: a server dropped by the pre-connect reachability gate is carried
+        // in the inventory as `McpServerHealth::Skipped` and must render as a
+        // distinct ⊘ row explaining the skip — never silently absent.
+        let inv = EngineInventory {
+            skills: Vec::new(),
+            mcp_servers: vec![McpServerInfo {
+                name: "ghost-plugin".to_string(),
+                health: wcore_mcp::manager::McpServerHealth::Skipped {
+                    reason: "stdio command not launchable".to_string(),
+                },
+            }],
+            hooks: Vec::new(),
+        };
+
+        let mcp = render_mcp_list(Some(&inv));
+        assert!(mcp.contains('⊘'), "got: {mcp}");
+        assert!(mcp.contains("skipped"), "got: {mcp}");
+        assert!(mcp.contains("ghost-plugin"), "got: {mcp}");
     }
 
     #[test]

--- a/crates/wcore-cli/tests/doctor_smoke.rs
+++ b/crates/wcore-cli/tests/doctor_smoke.rs
@@ -90,6 +90,30 @@ fn doctor_exit_code_is_deterministic() {
 }
 
 #[test]
+fn doctor_prints_mcp_section_and_does_not_probe_by_default() {
+    // A4b: bare `--doctor` must render the CLI-only MCP section AND, since
+    // it is side-effect-free by default, print the `--probe-mcp` hint
+    // instead of connect-testing anything. The presence of the hint (and
+    // the absence of the "Probing ..." banner) proves the default path did
+    // NOT spawn any stdio command or dial any URL.
+    let out = run_doctor();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    assert!(
+        stdout.contains("MCP servers (declared):"),
+        "stdout missing MCP section header:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("Run with --probe-mcp"),
+        "bare --doctor must print the probe hint (proving it did not probe):\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("Probing config-declared MCP servers"),
+        "bare --doctor must NOT connect-test (no probe banner expected):\n{stdout}"
+    );
+}
+
+#[test]
 fn doctor_marks_macos_accessibility_correctly_for_platform() {
     // On macOS the row is rendered as MANUAL; on every other platform
     // it is SKIPPED. Either way the label must appear.

--- a/crates/wcore-cli/tests/harness_failure_injection.rs
+++ b/crates/wcore-cli/tests/harness_failure_injection.rs
@@ -262,6 +262,24 @@ fn wedged_mcp_server_does_not_hang_boot() {
     let start = Instant::now();
     let h = PtyHarness::spawn(home.path(), &[]);
 
+    // (a0) BOOT SPLASH (B1) — the user must see branded "connecting MCP
+    // servers…" progress, NOT a blank terminal, while the wedged server burns
+    // its 30s connect budget. The splash paints within a couple seconds (long
+    // before the connect resolves); pre-B1 the screen was blank until
+    // `build()` returned. This is the regression guard for the blank-screen
+    // failure mode the user reported.
+    let splashed = h.wait_for(
+        |s| s.contains("starting engine") || s.contains("connecting"),
+        Duration::from_secs(6),
+        "boot splash to paint while the wedged MCP server is still connecting",
+    );
+    assert!(
+        splashed,
+        "boot splash did NOT paint within 6s — blank-screen regression.\n\
+         --- last screen ---\n{}\n--- end ---",
+        h.screen_text()
+    );
+
     // (a) BOOT TERMINATES — the TUI must render the WAYLAND wordmark
     // within 35s despite the wedged server. The bound is chosen as
     // 30s (CONNECT_TIMEOUT) + 5s slack; any longer and a regression

--- a/crates/wcore-mcp/src/manager.rs
+++ b/crates/wcore-mcp/src/manager.rs
@@ -38,9 +38,38 @@ struct McpServer {
     supports_resources: bool,
 }
 
+/// The connect-time outcome for one server, kept on the manager so the cause of
+/// a failure survives boot instead of vanishing into a `tracing::warn`.
+///
+/// Every server name ever *attempted* (config or plugin) gets exactly one entry
+/// in [`McpManager::health`], even the ones that never produced a live
+/// [`McpServer`]. This is the source of truth for the `/doctor` MCP section and
+/// the `McpFailed` protocol event — `servers` stays the source of truth for
+/// *live tools*.
+#[derive(Debug, Clone)]
+pub enum McpServerHealth {
+    /// Connected and serving `tool_count` tools.
+    Ready { tool_count: usize },
+    /// Connect attempt returned a clean error (transport/init/handshake).
+    Failed { reason: String },
+    /// Connect attempt exceeded the per-server budget before erroring.
+    TimedOut { after: Duration },
+}
+
+/// Internal: the three-way result of one bounded connect attempt. Lets the
+/// connect loop record `TimedOut` vs `Failed` distinctly (the boundary between
+/// them is lost once flattened to a single `McpError`).
+enum ConnectOutcome {
+    Ok(Box<McpServer>),
+    Failed(String),
+    TimedOut(Duration),
+}
+
 /// Manages connections to multiple MCP servers
 pub struct McpManager {
     servers: HashMap<String, McpServer>,
+    /// Per-server connect outcome (every attempted server, including failures).
+    health: HashMap<String, McpServerHealth>,
     /// Monotonically increasing request ID counter for all JSON-RPC calls
     next_id: AtomicU64,
 }
@@ -67,53 +96,66 @@ impl McpManager {
         connect_timeout: Duration,
     ) -> Result<Self, McpError> {
         let connect_futures = configs.iter().map(|(name, config)| async move {
-            let result = Self::connect_server_bounded(name, config, connect_timeout).await;
-            (name.clone(), result)
+            let outcome = Self::connect_server_outcome(name, config, connect_timeout).await;
+            (name.clone(), outcome)
         });
 
         let results = futures::future::join_all(connect_futures).await;
 
         let mut servers = HashMap::new();
-        for (name, result) in results {
-            match result {
-                Ok(server) => {
+        let mut health = HashMap::new();
+        for (name, outcome) in results {
+            match outcome {
+                ConnectOutcome::Ok(server) => {
                     eprintln!(
                         "[mcp] Connected to '{}': {} tools, resources={}",
                         name,
                         server.tools.len(),
                         server.supports_resources,
                     );
-                    servers.insert(name, server);
+                    health.insert(
+                        name.clone(),
+                        McpServerHealth::Ready {
+                            tool_count: server.tools.len(),
+                        },
+                    );
+                    servers.insert(name, *server);
                 }
-                Err(e) => {
-                    // Non-fatal: continue with other servers.
-                    tracing::warn!(target: "mcp.manager", server = %name, error = %e, "failed to connect MCP server");
+                ConnectOutcome::Failed(reason) => {
+                    // Non-fatal: continue with other servers, but keep the
+                    // cause so `/doctor` can surface it (was: log-and-forget).
+                    tracing::warn!(target: "mcp.manager", server = %name, error = %reason, "failed to connect MCP server");
+                    health.insert(name, McpServerHealth::Failed { reason });
+                }
+                ConnectOutcome::TimedOut(after) => {
+                    tracing::warn!(target: "mcp.manager", server = %name, ?after, "MCP server connect timed out");
+                    health.insert(name, McpServerHealth::TimedOut { after });
                 }
             }
         }
 
         Ok(Self {
             servers,
+            health,
             next_id: AtomicU64::new(10),
         })
     }
 
-    /// `connect_server` wrapped in a connect-budget timeout (audit C2). On
-    /// elapse, returns a transport error so the caller skips the server
+    /// `connect_server` wrapped in a connect-budget timeout (audit C2),
+    /// returning a three-way [`ConnectOutcome`] so the caller can record
+    /// `TimedOut` vs `Failed` distinctly. On elapse the server is skipped
     /// exactly as if it had failed to connect.
-    async fn connect_server_bounded(
+    async fn connect_server_outcome(
         name: &str,
         config: &McpServerConfig,
         connect_timeout: Duration,
-    ) -> Result<McpServer, McpError> {
+    ) -> ConnectOutcome {
         match timeout(connect_timeout, Self::connect_server(name, config)).await {
-            Ok(result) => result,
+            Ok(Ok(server)) => ConnectOutcome::Ok(Box::new(server)),
+            Ok(Err(e)) => ConnectOutcome::Failed(e.to_string()),
             Err(_) => {
                 warn!(server = %name, "[mcp] connect timed out — skipping server");
-                Err(McpError::Transport(format!(
-                    "connect to '{}' timed out after {:?}",
-                    name, connect_timeout
-                )))
+                ConnectOutcome::TimedOut(connect_timeout)
             }
         }
     }
@@ -129,16 +171,41 @@ impl McpManager {
         name: String,
         config: &McpServerConfig,
     ) -> Result<Vec<String>, McpError> {
-        let server = Self::connect_server_bounded(&name, config, CONNECT_TIMEOUT).await?;
-        let tool_names: Vec<String> = server.tools.iter().map(|t| t.name.clone()).collect();
-        eprintln!(
-            "[mcp] Connected to '{}': {} tools, resources={}",
-            name,
-            server.tools.len(),
-            server.supports_resources,
-        );
-        self.servers.insert(name, server);
-        Ok(tool_names)
+        match Self::connect_server_outcome(&name, config, CONNECT_TIMEOUT).await {
+            ConnectOutcome::Ok(server) => {
+                let tool_names: Vec<String> = server.tools.iter().map(|t| t.name.clone()).collect();
+                eprintln!(
+                    "[mcp] Connected to '{}': {} tools, resources={}",
+                    name,
+                    server.tools.len(),
+                    server.supports_resources,
+                );
+                self.health.insert(
+                    name.clone(),
+                    McpServerHealth::Ready {
+                        tool_count: server.tools.len(),
+                    },
+                );
+                self.servers.insert(name, *server);
+                Ok(tool_names)
+            }
+            ConnectOutcome::Failed(reason) => {
+                self.health.insert(
+                    name,
+                    McpServerHealth::Failed {
+                        reason: reason.clone(),
+                    },
+                );
+                Err(McpError::Transport(reason))
+            }
+            ConnectOutcome::TimedOut(after) => {
+                self.health
+                    .insert(name.clone(), McpServerHealth::TimedOut { after });
+                Err(McpError::Transport(format!(
+                    "connect to '{name}' timed out after {after:?}"
+                )))
+            }
+        }
     }
 
     /// Connect to a single MCP server: create transport, initialize, discover tools
@@ -338,6 +405,13 @@ impl McpManager {
         self.servers.keys().cloned().collect()
     }
 
+    /// Per-server connect outcomes (every *attempted* server, including those
+    /// that failed or timed out and have no live entry in `servers`). The
+    /// source of truth for the `/doctor` MCP section — keyed by server name.
+    pub fn health(&self) -> &HashMap<String, McpServerHealth> {
+        &self.health
+    }
+
     /// Whether this manager hosts a connected server named `name`. No
     /// allocation (unlike `server_names`, which clones every key) — preferred
     /// for hot per-dispatch lookups.
@@ -429,7 +503,9 @@ impl McpManager {
         entries: Vec<(&str, bool, Box<dyn super::transport::McpTransport>)>,
     ) -> Self {
         let mut servers = HashMap::new();
+        let mut health = HashMap::new();
         for (name, supports_resources, transport) in entries {
+            health.insert(name.to_string(), McpServerHealth::Ready { tool_count: 0 });
             servers.insert(
                 name.to_string(),
                 McpServer {
@@ -442,6 +518,7 @@ impl McpManager {
         }
         Self {
             servers,
+            health,
             next_id: AtomicU64::new(10),
         }
     }
@@ -452,7 +529,14 @@ impl McpManager {
     #[cfg(any(test, feature = "test-utils"))]
     pub fn new_for_test_with_tools(entries: Vec<TestServerEntry>) -> Self {
         let mut servers = HashMap::new();
+        let mut health = HashMap::new();
         for (name, supports_resources, transport, tools) in entries {
+            health.insert(
+                name.to_string(),
+                McpServerHealth::Ready {
+                    tool_count: tools.len(),
+                },
+            );
             servers.insert(
                 name.to_string(),
                 McpServer {
@@ -465,6 +549,7 @@ impl McpManager {
         }
         Self {
             servers,
+            health,
             next_id: AtomicU64::new(10),
         }
     }
@@ -895,6 +980,131 @@ mod tests {
         // The healthy server connected; the hung one was skipped.
         let names = manager.server_names();
         assert_eq!(names, vec!["healthy".to_string()], "got {names:?}");
+    }
+
+    // -----------------------------------------------------------------------
+    // Health capture (Slice A1) — every *attempted* server gets exactly one
+    // `health()` entry, with the failure cause preserved (was log-and-forget).
+    // -----------------------------------------------------------------------
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn health_records_timeout_for_a_hung_server() {
+        use wcore_config::config::TransportType;
+
+        let hung = McpServerConfig {
+            transport: TransportType::Stdio,
+            command: Some("sh".into()),
+            args: Some(vec!["-c".into(), "sleep 60".into()]),
+            env: None,
+            url: None,
+            headers: None,
+            deferred: None,
+        };
+        let mut configs = HashMap::new();
+        configs.insert("hung".to_string(), hung);
+
+        let manager =
+            McpManager::connect_all_with_connect_timeout(&configs, Duration::from_millis(300))
+                .await
+                .expect("connect_all ok");
+
+        // No live server, but the timeout is recorded with its cause.
+        assert!(manager.server_names().is_empty());
+        match manager.health().get("hung") {
+            Some(McpServerHealth::TimedOut { after }) => {
+                assert_eq!(*after, Duration::from_millis(300));
+            }
+            other => panic!("expected TimedOut, got {other:?}"),
+        }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn health_records_failure_for_an_unspawnable_server() {
+        use wcore_config::config::TransportType;
+
+        // A command that cannot spawn → clean transport error, not a timeout.
+        let broken = McpServerConfig {
+            transport: TransportType::Stdio,
+            command: Some("/nonexistent/wayland-mcp-binary-xyz".into()),
+            args: None,
+            env: None,
+            url: None,
+            headers: None,
+            deferred: None,
+        };
+        let mut configs = HashMap::new();
+        configs.insert("broken".to_string(), broken);
+
+        let manager =
+            McpManager::connect_all_with_connect_timeout(&configs, Duration::from_secs(5))
+                .await
+                .expect("connect_all ok");
+
+        assert!(manager.server_names().is_empty());
+        match manager.health().get("broken") {
+            Some(McpServerHealth::Failed { reason }) => {
+                assert!(!reason.is_empty(), "failure reason must be preserved");
+            }
+            other => panic!("expected Failed, got {other:?}"),
+        }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn health_records_ready_with_tool_count_and_covers_every_attempt() {
+        use wcore_config::config::TransportType;
+
+        // Healthy fixture advertising exactly one tool.
+        let healthy_script = r#"
+            while IFS= read -r line; do
+              case "$line" in
+                *initialize*) printf '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-03-26","capabilities":{}}}\n' ;;
+                *tools/list*) printf '{"jsonrpc":"2.0","id":2,"result":{"tools":[{"name":"echo","description":"e","inputSchema":{"type":"object"}}]}}\n' ;;
+              esac
+            done
+        "#;
+        let healthy = McpServerConfig {
+            transport: TransportType::Stdio,
+            command: Some("sh".into()),
+            args: Some(vec!["-c".into(), healthy_script.into()]),
+            env: None,
+            url: None,
+            headers: None,
+            deferred: None,
+        };
+        let hung = McpServerConfig {
+            transport: TransportType::Stdio,
+            command: Some("sh".into()),
+            args: Some(vec!["-c".into(), "sleep 60".into()]),
+            env: None,
+            url: None,
+            headers: None,
+            deferred: None,
+        };
+        let mut configs = HashMap::new();
+        configs.insert("healthy".to_string(), healthy);
+        configs.insert("hung".to_string(), hung);
+
+        let manager =
+            McpManager::connect_all_with_connect_timeout(&configs, Duration::from_millis(600))
+                .await
+                .expect("connect_all ok");
+
+        // Every attempted server is in `health` — even the one with no live entry.
+        assert_eq!(manager.health().len(), 2, "both attempts recorded");
+        match manager.health().get("healthy") {
+            Some(McpServerHealth::Ready { tool_count }) => assert_eq!(*tool_count, 1),
+            other => panic!("expected Ready{{1}}, got {other:?}"),
+        }
+        assert!(
+            matches!(
+                manager.health().get("hung"),
+                Some(McpServerHealth::TimedOut { .. })
+            ),
+            "hung attempt must still be recorded"
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/crates/wcore-mcp/src/manager.rs
+++ b/crates/wcore-mcp/src/manager.rs
@@ -54,6 +54,10 @@ pub enum McpServerHealth {
     Failed { reason: String },
     /// Connect attempt exceeded the per-server budget before erroring.
     TimedOut { after: Duration },
+    /// Registration was skipped by a gate BEFORE any connect was attempted
+    /// (e.g. an unreachable transport command). No manager populates this —
+    /// it exists so a boot snapshot can carry skipped servers uniformly.
+    Skipped { reason: String },
 }
 
 /// Internal: the three-way result of one bounded connect attempt. Lets the

--- a/crates/wcore-protocol/src/events.rs
+++ b/crates/wcore-protocol/src/events.rs
@@ -91,6 +91,15 @@ pub enum ProtocolEvent {
         name: String,
         tools: Vec<String>,
     },
+    /// An MCP server failed (or timed out) at connect. The companion to
+    /// [`McpReady`]: it carries the preserved failure cause so a host /
+    /// the TUI `/doctor` view can tell the user *why* a server's tools never
+    /// appeared, instead of the server silently vanishing. Additive — hosts
+    /// that don't recognise it drop it per the W0 decoder contract.
+    McpFailed {
+        name: String,
+        reason: String,
+    },
     /// W1: F9 structured trace for one turn. Gated by the W0-reserved
     /// `capabilities.structured_traces` flag — the engine only emits this
     /// variant when the corresponding ProtocolSink builder was configured


### PR DESCRIPTION
Fixes two MCP defects surfaced while live-testing the plugin marketplace: a broken/slow MCP server blocked boot behind a **blank screen** (up to 30s), and connect **failures were invisible** — logged then discarded, with nothing in `/doctor` or `/mcp`.

## What changed (8 commits)

**Health capture & visibility (A1–A4a)**
- `7314090d` — `McpManager` captures per-server connect health (`Ready`/`Failed`/`TimedOut`) instead of discarding it; `health()` accessor.
- `64bd809b` — thread that health into the inventory snapshot (`McpServerInfo.health`); `/mcp` panel renders rich status.
- `7cb578db` — `ProtocolEvent::McpFailed` so connect failures reach the UI; live `/mcp add` now reports honestly instead of "connected, 0 tools".
- `3ae48418` — `/doctor` MCP SERVERS section (TUI), seeded from the boot snapshot.

**Boot no longer blanks (B1, B3)**
- `ccdc57e3` — cap plugin MCP connect at 8s (vs the 30s config budget) so one broken plugin can't dominate boot.
- `9739f5d7` *(headline)* — branded boot splash: `tui::run` split into `enter()` / `splash_while()` / `run_attached()`; the engine build (which connects every MCP server on the boot critical path) now runs behind a wordmark+spinner+"connecting N MCP servers…" instead of a blank terminal. Single alt-screen entry (no double-init). Verified: a wedged MCP server paints the splash <6s while the connect budget burns, and boot still reaches the workspace.

**Completeness (A4c, A4b)**
- `d0f44ed4` — pre-connect-skipped servers surface as a distinct `⊘` row. Generic `McpServerHealth::Skipped { reason }` carries servers dropped by the reachability gate (an unlaunchable stdio command) into the snapshot; rendered in `/mcp` and a Warn row in `/doctor`. Variant is gate-agnostic, so the marketplace install-consent skip populates the same row for free when that lands.
- `100e7792` — `wayland-core --doctor` now lists declared MCP servers (config-cascaded + plugin manifests) **without spawning anything** — bare `--doctor` stays side-effect-free. New `--probe-mcp` (requires `--doctor`) opt-in connect-tests the config servers and reports ready/failed/timed-out/⊘. Kept entirely inside `doctor::run()` — `collect()`/`Outcome` untouched, so it does not duplicate the TUI section.

## Verification
Pre-flight gated green on the box: workspace `clippy --all-targets -D warnings` clean; `cargo audit` 0 vulnerabilities; nextest green for the affected crates (wcore-mcp / wcore-agent / wcore-cli). Secrets/cleanup/security review of the diff clean — no new spawn surface (`--probe-mcp` only launches the user's own config servers via the sanctioned shell-quoted path + F-016 env allow-list). Opening this PR to run the full multi-OS CI matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)