### PR TITLE
feat(config): config cockpit — paste-to-connect, editors, /doctor health, /effective, channels, discovery

### DIFF
--- a/crates/wcore-channels-registry/src/lib.rs
+++ b/crates/wcore-channels-registry/src/lib.rs
@@ -212,11 +212,20 @@ pub async fn auto_register_from_user_config(
     mgr: &mut ChannelManager,
     credentials: Arc<dyn CredentialsStore>,
 ) -> Result<usize, ChannelLoadError> {
-    let dir = dirs::home_dir()
-        .ok_or_else(|| ChannelLoadError::Config("no home dir".to_string()))?
-        .join(".wayland")
-        .join("channels");
-    auto_register_from_dir(mgr, &dir, credentials).await
+    auto_register_from_dir(mgr, &channels_dir(), credentials).await
+}
+
+/// The canonical channels directory: `$WAYLAND_HOME/channels` (or
+/// `~/.wayland/channels` when unset).
+///
+/// F-019 fix: this resolves through [`wcore_config::config::profile_home`],
+/// which honors `WAYLAND_HOME`. The previous loader joined
+/// `dirs::home_dir()/.wayland/channels` directly, so a sandboxed/test process
+/// under `WAYLAND_HOME` read the host user's real channel configs (the same
+/// class of leak as the OAuth-token path). Both the engine loader and the TUI
+/// Integrations view resolve the directory through here, so they never diverge.
+pub fn channels_dir() -> PathBuf {
+    wcore_config::config::profile_home().join("channels")
 }
 
 /// Test-visible variant of [`auto_register_from_user_config`] that
@@ -342,6 +351,96 @@ pub async fn auto_register_from_dir(
     Ok(registered)
 }
 
+/// A read-only, **secret-free** summary of one on-disk channel config, for the
+/// TUI Integrations view (`/doctor`). Only key *names* are surfaced — never an
+/// option or secret *value* — so the summary needs no redaction and can never
+/// leak a credential.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ChannelSummary {
+    /// Channel instance name (the file stem).
+    pub name: String,
+    /// Platform tag (`"slack"`, `"telegram"`, …); empty on a parse failure.
+    pub platform: String,
+    /// Whether the channel is enabled (auto-started at boot).
+    pub enabled: bool,
+    /// Whether `platform` maps to a known factory. An unknown platform is the
+    /// answer to "why isn't my channel loading".
+    pub known_platform: bool,
+    /// The configured `[options]` key names (no values).
+    pub option_keys: Vec<String>,
+    /// The referenced `[secrets]` key names (no values).
+    pub secret_keys: Vec<String>,
+    /// `Some(message)` if the file could not be read/parsed — surfaced so a
+    /// broken config is visible rather than silently absent.
+    pub parse_error: Option<String>,
+}
+
+/// Scan a channels directory into secret-free [`ChannelSummary`] rows, sorted
+/// by filename. A missing/unreadable directory yields an empty list; an
+/// unreadable or unparseable file yields a summary carrying its `parse_error`
+/// (so the operator can see *why* a channel isn't loading) rather than being
+/// dropped. Read-only: never constructs a channel or touches the network.
+pub fn scan_channel_summaries(dir: &Path) -> Vec<ChannelSummary> {
+    let mut out = Vec::new();
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return out;
+    };
+    let mut paths: Vec<PathBuf> = entries
+        .filter_map(|r| r.ok())
+        .map(|e| e.path())
+        .filter(|p| p.extension().and_then(|s| s.to_str()) == Some("toml"))
+        .collect();
+    paths.sort();
+
+    for path in paths {
+        let stem = path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("?")
+            .to_string();
+        let broken = |msg: String| ChannelSummary {
+            name: stem.clone(),
+            platform: String::new(),
+            enabled: false,
+            known_platform: false,
+            option_keys: Vec::new(),
+            secret_keys: Vec::new(),
+            parse_error: Some(msg),
+        };
+        let body = match std::fs::read_to_string(&path) {
+            Ok(s) => s,
+            Err(e) => {
+                out.push(broken(format!("read failed: {e}")));
+                continue;
+            }
+        };
+        match toml::from_str::<ChannelConfig>(&body) {
+            Ok(cfg) => {
+                let mut option_keys: Vec<String> = cfg.options.keys().cloned().collect();
+                option_keys.sort();
+                let mut secret_keys: Vec<String> = cfg.secrets.keys().cloned().collect();
+                secret_keys.sort();
+                out.push(ChannelSummary {
+                    known_platform: channel_factory_for(&cfg.platform).is_some(),
+                    name: cfg.name,
+                    platform: cfg.platform,
+                    enabled: cfg.enabled,
+                    option_keys,
+                    secret_keys,
+                    parse_error: None,
+                });
+            }
+            Err(e) => out.push(broken(e.to_string())),
+        }
+    }
+    out
+}
+
+/// Scan the user's [`channels_dir`] into secret-free summaries.
+pub fn scan_user_channels() -> Vec<ChannelSummary> {
+    scan_channel_summaries(&channels_dir())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -382,6 +481,65 @@ mod tests {
 
     fn creds() -> Arc<dyn CredentialsStore> {
         MemStore::new()
+    }
+
+    #[test]
+    fn scan_summaries_reports_status_and_never_leaks_secret_values() {
+        let dir = TempDir::new().unwrap();
+        // Known platform, enabled, with options + a secret reference.
+        std::fs::write(
+            dir.path().join("myslack.toml"),
+            "name = \"myslack\"\nplatform = \"slack\"\nenabled = true\n\
+             [options]\nchannel = \"#general\"\n\
+             [secrets]\nbot_token = \"keychain:slack:SECRETVALUE\"\n",
+        )
+        .unwrap();
+        // Known platform but disabled.
+        std::fs::write(
+            dir.path().join("mytg.toml"),
+            "name = \"mytg\"\nplatform = \"telegram\"\nenabled = false\n",
+        )
+        .unwrap();
+        // Unknown platform — the "why isn't it loading" case.
+        std::fs::write(
+            dir.path().join("weird.toml"),
+            "name = \"weird\"\nplatform = \"carrierpigeon\"\n",
+        )
+        .unwrap();
+        // Unparseable file — must surface as a parse_error, not vanish.
+        std::fs::write(dir.path().join("broken.toml"), "name = = not valid").unwrap();
+
+        let summaries = scan_channel_summaries(dir.path());
+        let by = |n: &str| {
+            summaries
+                .iter()
+                .find(|c| c.name == n)
+                .unwrap_or_else(|| panic!("missing summary {n}"))
+        };
+
+        let slack = by("myslack");
+        assert_eq!(slack.platform, "slack");
+        assert!(slack.known_platform && slack.enabled);
+        assert!(slack.option_keys.contains(&"channel".to_string()));
+        assert!(slack.secret_keys.contains(&"bot_token".to_string()));
+
+        assert!(!by("mytg").enabled, "disabled channel must read disabled");
+        assert!(
+            !by("weird").known_platform,
+            "unknown platform must read unknown"
+        );
+        assert!(
+            summaries.iter().any(|c| c.parse_error.is_some()),
+            "the broken file must surface a parse_error"
+        );
+
+        // The secret VALUE must never appear anywhere in the summaries — only
+        // the key NAME (`bot_token`) is surfaced.
+        let dump = format!("{summaries:?}");
+        assert!(
+            !dump.contains("SECRETVALUE"),
+            "a secret value leaked into the summary:\n{dump}"
+        );
     }
 
     #[test]

--- a/crates/wcore-cli/Cargo.toml
+++ b/crates/wcore-cli/Cargo.toml
@@ -61,6 +61,10 @@ voice = ["wcore-agent/voice"]
 async-trait.workspace    = true
 wcore-agent.workspace    = true
 wcore-agents-pack.workspace = true
+# S10: read-only Integrations view in `/doctor` scans the on-disk channel
+# configs (`scan_user_channels`) through the same WAYLAND_HOME-correct path the
+# engine loader uses. Already in the graph transitively via wcore-agent.
+wcore-channels-registry = { path = "../wcore-channels-registry" }
 wcore-compact.workspace  = true
 wcore-config.workspace   = true
 wcore-memory.workspace   = true

--- a/crates/wcore-cli/src/tui/app.rs
+++ b/crates/wcore-cli/src/tui/app.rs
@@ -1228,6 +1228,23 @@ pub struct ConfigView {
     /// to the provider preset. Carried so the Config surface's Expert tier
     /// seeds + persists the real pricing values instead of placeholders.
     pub compat_costs: CompatCosts,
+    /// `[tools] auto_approve` — every tool call is auto-approved without a
+    /// per-call prompt. Surfaced by the Essentials Tools row.
+    pub tools_auto_approve: bool,
+    /// Number of entries in `[tools] allow_list` (the pre-approved tools).
+    /// Carried as a count (not the Vec) because the Essentials row shows
+    /// "N allowed"; the full editor is an Advanced/collection slice.
+    pub tools_allow_count: usize,
+    /// `[tools] verify_edits` — re-read files after Write/Edit and feed a
+    /// verification-failed note back into the next turn.
+    pub tools_verify_edits: bool,
+    /// `[budget] max_cost_usd` — the per-session spend cap, or `None` for no
+    /// cap. The Essentials Wallet row shows + edits this; real session spend
+    /// comes from `App::cost` (never fabricated).
+    pub budget_max_cost_usd: Option<f64>,
+    /// `[budget] max_wall_time_secs` — the runaway wall-clock guard, or
+    /// `None`. Shown on the Safety row alongside the turn ceiling.
+    pub budget_max_wall_secs: Option<u64>,
 }
 
 /// The four `ProviderCompat` cost-per-token overrides surfaced by the

--- a/crates/wcore-cli/src/tui/app.rs
+++ b/crates/wcore-cli/src/tui/app.rs
@@ -210,8 +210,6 @@ pub struct App {
     pub active_agent_transcript_id: Option<String>,
     /// v0.9.3 — one-shot onboarding state for first-spawn hint.
     pub onboarding_state: crate::tui::onboarding::OnboardingState,
-    /// v0.9.4 — turn index of the reasoning block focused for Tab+Enter expand.
-    pub focused_reasoning_turn_idx: Option<usize>,
     /// v0.9.2 W10: monotonic revision bumped once per value-changing
     /// `transient` write (a no-op `set` does NOT bump it). A `Store`
     /// subscriber installed in [`App::with_initial_surface`] increments this
@@ -340,7 +338,6 @@ impl App {
             agent_last_event: HashMap::new(),
             active_agent_transcript_id: None,
             onboarding_state: crate::tui::onboarding::OnboardingState::default(),
-            focused_reasoning_turn_idx: None,
             transient_rev,
             // D019: no snapshots taken yet — the store is built lazily on the
             // first turn that ends with touched files.
@@ -545,7 +542,6 @@ impl App {
         self.surface_stack.clear();
         self.active_agent_transcript_id = None;
         self.reasoning_expanded.clear();
-        self.focused_reasoning_turn_idx = None;
         // ForgeFlows-Live Phase 2: drop inferred workflows on /new alongside
         // the sub-agent state they are grouped from.
         self.workflows.clear();
@@ -1411,7 +1407,7 @@ mod tests {
 
         let mut app = App::new();
 
-        // Populate all six fields that reset_agents must clear.
+        // Populate the fields that reset_agents must clear.
         app.agent_last_event
             .insert("spawn:test".to_string(), Instant::now());
         app.agent_glow
@@ -1422,7 +1418,6 @@ mod tests {
         });
         app.active_agent_transcript_id = Some("spawn:test".to_string());
         app.reasoning_expanded.insert(0, true);
-        app.focused_reasoning_turn_idx = Some(0);
 
         // Set a sentinel on onboarding_state to verify it is NOT reset.
         app.onboarding_state.first_spawn_seen = Some(Instant::now());
@@ -1448,10 +1443,6 @@ mod tests {
         assert!(
             app.reasoning_expanded.is_empty(),
             "reset_agents must clear reasoning_expanded"
-        );
-        assert!(
-            app.focused_reasoning_turn_idx.is_none(),
-            "reset_agents must clear focused_reasoning_turn_idx"
         );
         // onboarding_state must survive the reset (once-per-session hint).
         assert!(

--- a/crates/wcore-cli/src/tui/app.rs
+++ b/crates/wcore-cli/src/tui/app.rs
@@ -1245,6 +1245,21 @@ pub struct ConfigView {
     /// `[budget] max_wall_time_secs` — the runaway wall-clock guard, or
     /// `None`. Shown on the Safety row alongside the turn ceiling.
     pub budget_max_wall_secs: Option<u64>,
+    /// `[observability] structured_traces` — emit structured trace spans.
+    /// Advanced-tier toggle.
+    pub obs_structured_traces: bool,
+    /// `[observability] online_evolution` — the GEPA online-evolution loop.
+    pub obs_online_evolution: bool,
+    /// `[observability] workflow_live_mode` — live workflow drill-in.
+    pub obs_workflow_live: bool,
+    /// `[storage.credentials] backend` as a lowercase tag (`plaintext` /
+    /// `keyring` / `encrypted-file`). The Advanced radio cycles plaintext↔
+    /// keyring; `encrypted-file` (two configured paths) is shown read-only so
+    /// the radio never clobbers the path layout.
+    pub storage_backend: String,
+    /// `[security] enabled` — the egress network guard. Advanced-tier toggle
+    /// (the `egress_allow` list editor is a later collection slice).
+    pub security_egress_enabled: bool,
 }
 
 /// The four `ProviderCompat` cost-per-token overrides surfaced by the

--- a/crates/wcore-cli/src/tui/app.rs
+++ b/crates/wcore-cli/src/tui/app.rs
@@ -1231,10 +1231,10 @@ pub struct ConfigView {
     /// `[tools] auto_approve` — every tool call is auto-approved without a
     /// per-call prompt. Surfaced by the Essentials Tools row.
     pub tools_auto_approve: bool,
-    /// Number of entries in `[tools] allow_list` (the pre-approved tools).
-    /// Carried as a count (not the Vec) because the Essentials row shows
-    /// "N allowed"; the full editor is an Advanced/collection slice.
-    pub tools_allow_count: usize,
+    /// `[tools] allow_list` — the pre-approved tools. The Essentials Tools
+    /// row shows the count (`.len()`); the Advanced list editor (S7) edits the
+    /// entries directly.
+    pub tools_allow_list: Vec<String>,
     /// `[tools] verify_edits` — re-read files after Write/Edit and feed a
     /// verification-failed note back into the next turn.
     pub tools_verify_edits: bool,
@@ -1257,9 +1257,18 @@ pub struct ConfigView {
     /// keyring; `encrypted-file` (two configured paths) is shown read-only so
     /// the radio never clobbers the path layout.
     pub storage_backend: String,
-    /// `[security] enabled` — the egress network guard. Advanced-tier toggle
-    /// (the `egress_allow` list editor is a later collection slice).
+    /// `[security] enabled` — the egress network guard. Advanced-tier toggle.
     pub security_egress_enabled: bool,
+    /// `[security] egress_allow` — operator-curated extra egress allowlist
+    /// entries. The Advanced list editor (S7) adds/edits/removes domains.
+    pub egress_allow: Vec<String>,
+    /// `[provider_chain] enabled` — wrap the primary provider in the resilient
+    /// circuit-breaker + fallback chain. Advanced-tier toggle (S7).
+    pub failover_enabled: bool,
+    /// `[provider_chain] fallback_models` — ordered fallback model ids tried
+    /// when the primary's circuit opens. The Advanced list editor (S7) edits
+    /// the chain.
+    pub fallback_models: Vec<String>,
 }
 
 /// The four `ProviderCompat` cost-per-token overrides surfaced by the

--- a/crates/wcore-cli/src/tui/commands/mod.rs
+++ b/crates/wcore-cli/src/tui/commands/mod.rs
@@ -282,6 +282,12 @@ impl CommandRegistry {
                 false,
             ),
             Command::new("/config", Workflow, "all settings", false),
+            Command::new(
+                "/connect",
+                Workflow,
+                "paste an API key to connect a provider",
+                false,
+            ),
             Command::new("/setup", Workflow, "re-run the onboarding flow", false),
             // DIAGNOSTICS
             Command::new(
@@ -560,7 +566,8 @@ mod tests {
         // `/voice` is the 26th — toggles voice capture (v0.9.1 W1 E,
         // mirrors the Ctrl+Space chord through the same dispatcher).
         // `/theme` is the 27th — light/dark/auto switch (v0.9.2 W8, §5).
-        assert_eq!(reg.len(), 27);
+        // `/connect` is the 28th — S4b paste-to-detect provider connect.
+        assert_eq!(reg.len(), 28);
         for name in [
             "/resume",
             "/rewind",
@@ -585,6 +592,7 @@ mod tests {
             "/mode",
             "/theme",
             "/config",
+            "/connect",
             "/setup",
             "/doctor",
             "/replay",

--- a/crates/wcore-cli/src/tui/commands/mod.rs
+++ b/crates/wcore-cli/src/tui/commands/mod.rs
@@ -228,6 +228,12 @@ impl CommandRegistry {
                 "tokens and spend this session",
                 false,
             ),
+            Command::new(
+                "/effective",
+                ContextMemory,
+                "view the resolved config (redacted)",
+                false,
+            ),
             // TOOLS & EXTENSIONS
             Command::new(
                 "/tools",
@@ -567,7 +573,8 @@ mod tests {
         // mirrors the Ctrl+Space chord through the same dispatcher).
         // `/theme` is the 27th — light/dark/auto switch (v0.9.2 W8, §5).
         // `/connect` is the 28th — S4b paste-to-detect provider connect.
-        assert_eq!(reg.len(), 28);
+        // `/effective` is the 29th — S9 redacted effective-config preview.
+        assert_eq!(reg.len(), 29);
         for name in [
             "/resume",
             "/rewind",
@@ -581,6 +588,7 @@ mod tests {
             "/repomap",
             "/memory",
             "/cost",
+            "/effective",
             "/tools",
             "/mcp",
             "/auth",

--- a/crates/wcore-cli/src/tui/mod.rs
+++ b/crates/wcore-cli/src/tui/mod.rs
@@ -247,6 +247,17 @@ pub fn config_view_from(config: &wcore_config::config::Config) -> app::ConfigVie
         tools_verify_edits: config.tools.verify_edits,
         budget_max_cost_usd: config.budget.max_cost_usd,
         budget_max_wall_secs: config.budget.max_wall_time_secs,
+        // S6 Advanced: observability toggles, storage backend tag, egress guard.
+        obs_structured_traces: config.observability.structured_traces,
+        obs_online_evolution: config.observability.online_evolution,
+        obs_workflow_live: config.observability.workflow_live_mode,
+        storage_backend: match &config.storage.credentials.backend {
+            wcore_config::credentials::CredentialsBackend::Plaintext => "plaintext",
+            wcore_config::credentials::CredentialsBackend::Keyring => "keyring",
+            wcore_config::credentials::CredentialsBackend::EncryptedFile { .. } => "encrypted-file",
+        }
+        .to_string(),
+        security_egress_enabled: config.security.enabled,
     }
 }
 

--- a/crates/wcore-cli/src/tui/mod.rs
+++ b/crates/wcore-cli/src/tui/mod.rs
@@ -240,6 +240,13 @@ pub fn config_view_from(config: &wcore_config::config::Config) -> app::ConfigVie
             cache_read: config.compat.cost_per_cache_read_token,
             cache_write: config.compat.cost_per_cache_write_token,
         },
+        // S5 Essentials: tools posture + budget cap, read straight from the
+        // resolved config so the home shows the live values.
+        tools_auto_approve: config.tools.auto_approve,
+        tools_allow_count: config.tools.allow_list.len(),
+        tools_verify_edits: config.tools.verify_edits,
+        budget_max_cost_usd: config.budget.max_cost_usd,
+        budget_max_wall_secs: config.budget.max_wall_time_secs,
     }
 }
 

--- a/crates/wcore-cli/src/tui/mod.rs
+++ b/crates/wcore-cli/src/tui/mod.rs
@@ -243,7 +243,7 @@ pub fn config_view_from(config: &wcore_config::config::Config) -> app::ConfigVie
         // S5 Essentials: tools posture + budget cap, read straight from the
         // resolved config so the home shows the live values.
         tools_auto_approve: config.tools.auto_approve,
-        tools_allow_count: config.tools.allow_list.len(),
+        tools_allow_list: config.tools.allow_list.clone(),
         tools_verify_edits: config.tools.verify_edits,
         budget_max_cost_usd: config.budget.max_cost_usd,
         budget_max_wall_secs: config.budget.max_wall_time_secs,
@@ -258,6 +258,11 @@ pub fn config_view_from(config: &wcore_config::config::Config) -> app::ConfigVie
         }
         .to_string(),
         security_egress_enabled: config.security.enabled,
+        // S7 collection editors: the egress allowlist and the provider
+        // failover chain, read straight from the resolved config.
+        egress_allow: config.security.egress_allow.clone(),
+        failover_enabled: config.provider_chain.enabled,
+        fallback_models: config.provider_chain.fallback_models.clone(),
     }
 }
 

--- a/crates/wcore-cli/src/tui/surfaces/agent_nav.rs
+++ b/crates/wcore-cli/src/tui/surfaces/agent_nav.rs
@@ -395,6 +395,12 @@ impl Surface for AgentNavSurface {
         SurfaceId::AgentNav
     }
 
+    /// FIX-2 — AgentNav owns `/` for its own group-filter, so the Router must
+    /// not steal it for the command palette.
+    fn consumes_slash(&self, _app: &App) -> bool {
+        true
+    }
+
     fn on_enter(&mut self, app: &mut App) {
         // Ensure selection is valid against the live agent list.
         let rows = self.build_rows(&app.session.sub_agents);

--- a/crates/wcore-cli/src/tui/surfaces/config.rs
+++ b/crates/wcore-cli/src/tui/surfaces/config.rs
@@ -3014,6 +3014,14 @@ impl ConfigSurface {
                     self.move_providers_focus(1);
                     SurfaceAction::None
                 }
+                // FIX-3 — the headline credential door: `c` opens the
+                // paste-to-detect modal (the same overlay `/connect` opens),
+                // which fingerprints a pasted key, validates it live, and
+                // stores it in the credentials store (applies on rebind — the
+                // legacy env-var write below does NOT). One front door for
+                // connecting an LLM provider; the per-row env-var editor stays
+                // for multi-var / tool credentials (AWS, Vertex, Postgres, …).
+                KeyCode::Char('c') => SurfaceAction::OpenOverlay(SurfaceId::PasteDetect),
                 KeyCode::Enter | KeyCode::Char(' ') => {
                     // Open the credentials modal for the focused entry,
                     // unless it has no env-var-based credentials (e.g.
@@ -3068,10 +3076,19 @@ impl ConfigSurface {
                     "Every tool and provider Wayland can use, with its current status.",
                     Style::default().fg(t.text_dim),
                 )),
-                Line::from(Span::styled(
-                    "Enter on a row → set credentials. `esc` returns to settings.",
-                    Style::default().fg(t.text_muted),
-                )),
+                Line::from(vec![
+                    Span::styled("Press ", Style::default().fg(t.text_muted)),
+                    Span::styled("c", Style::default().fg(t.orange)),
+                    Span::styled(
+                        " to paste an API key (auto-detects the provider) · ",
+                        Style::default().fg(t.text_muted),
+                    ),
+                    Span::styled("⏎", Style::default().fg(t.orange)),
+                    Span::styled(
+                        " edits env vars · esc returns to settings.",
+                        Style::default().fg(t.text_muted),
+                    ),
+                ]),
             ]),
             head_area,
         );
@@ -3150,8 +3167,10 @@ impl ConfigSurface {
             Paragraph::new(Line::from(vec![
                 Span::styled(" ↑↓ ", Style::default().fg(t.orange)),
                 Span::styled("move   ", Style::default().fg(t.text_dim)),
+                Span::styled("c ", Style::default().fg(t.orange)),
+                Span::styled("paste a key   ", Style::default().fg(t.text_dim)),
                 Span::styled("⏎ ", Style::default().fg(t.orange)),
-                Span::styled("set credentials   ", Style::default().fg(t.text_dim)),
+                Span::styled("edit vars   ", Style::default().fg(t.text_dim)),
                 Span::styled("esc ", Style::default().fg(t.orange)),
                 Span::styled("back to settings", Style::default().fg(t.text_dim)),
             ])),
@@ -3393,6 +3412,21 @@ mod tests {
     #[test]
     fn surface_reports_config_id() {
         assert_eq!(ConfigSurface::new().id(), SurfaceId::Config);
+    }
+
+    #[test]
+    fn providers_tier_c_opens_the_paste_detect_modal_fix3() {
+        // FIX-3: in the Tools & Providers tier, `c` opens the paste-to-detect
+        // modal (the superior, live-on-rebind credential door — the same one
+        // `/connect` opens) rather than only the per-row env-var editor.
+        let mut surface = ConfigSurface::new();
+        surface.tier = Tier::Providers;
+        let mut app = App::new();
+        let action = surface.handle_key(key(KeyCode::Char('c')), &mut app);
+        assert!(
+            matches!(action, SurfaceAction::OpenOverlay(SurfaceId::PasteDetect)),
+            "`c` in the Providers tier must open the PasteDetect overlay"
+        );
     }
 
     #[test]

--- a/crates/wcore-cli/src/tui/surfaces/config.rs
+++ b/crates/wcore-cli/src/tui/surfaces/config.rs
@@ -1697,6 +1697,16 @@ impl Surface for ConfigSurface {
         SurfaceId::Config
     }
 
+    /// FIX-2 — own `/` only while an inline text editor is live, so a typed
+    /// `/` lands in the buffer instead of opening the command palette. In every
+    /// navigation tier (no editor active) `/` is free for the global palette.
+    fn consumes_slash(&self, _app: &App) -> bool {
+        self.editor.is_some()
+            || self.expert_editor.is_some()
+            || self.list_editor.is_some()
+            || self.credentials_modal.is_some()
+    }
+
     fn on_enter(&mut self, app: &mut App) {
         // Seed both copies from the live config snapshot so the surface
         // opens reflecting the resolved engine config, and a fresh `esc`
@@ -3383,6 +3393,30 @@ mod tests {
     #[test]
     fn surface_reports_config_id() {
         assert_eq!(ConfigSurface::new().id(), SurfaceId::Config);
+    }
+
+    #[test]
+    fn consumes_slash_only_while_an_inline_editor_is_active() {
+        // FIX-2: in any navigation tier (no editor) `/` is free for the global
+        // command palette; while a text editor is live it must stay literal so
+        // a typed `/` lands in the buffer (e.g. a base_url or fallback model).
+        let app = App::new();
+        let mut surface = ConfigSurface::new();
+        assert!(
+            !surface.consumes_slash(&app),
+            "nav mode must release `/` to the palette"
+        );
+        surface.list_editor = Some(Input::default());
+        assert!(
+            surface.consumes_slash(&app),
+            "an active list editor must keep `/` literal"
+        );
+        surface.list_editor = None;
+        surface.editor = Some((Row::ALL[0], Input::default()));
+        assert!(
+            surface.consumes_slash(&app),
+            "an active field editor must keep `/` literal"
+        );
     }
 
     #[test]

--- a/crates/wcore-cli/src/tui/surfaces/config.rs
+++ b/crates/wcore-cli/src/tui/surfaces/config.rs
@@ -2554,7 +2554,11 @@ impl ConfigSurface {
             };
             let mut spans = vec![
                 Span::styled(marker.to_string(), Style::default().fg(t.orange)),
-                Span::styled(format!("{:<20}", f.label()), label_style),
+                // Pad to 22: the longest label ("Provider cost tuning") is
+                // exactly 20 chars, so a 20-wide pad left its value glued to it
+                // ("Provider cost tuning⏎ open cost tuning"). 22 guarantees a
+                // gap for every label.
+                Span::styled(format!("{:<22}", f.label()), label_style),
             ];
             spans.extend(self.adv_value_spans(f, t));
             lines.push(Line::from(spans));

--- a/crates/wcore-cli/src/tui/surfaces/config.rs
+++ b/crates/wcore-cli/src/tui/surfaces/config.rs
@@ -211,6 +211,22 @@ struct SettingsModel {
     compaction: Compaction,
     /// Whether long-term cross-session memory is on.
     long_term_memory: bool,
+    // TOOLS (`[tools]`) ---------------------------------------------------
+    /// `auto_approve` — approve every tool call without a per-call prompt.
+    /// The Tools row's editable toggle.
+    tools_auto_approve: bool,
+    /// Count of pre-approved tools (`allow_list` length). Read-out only on
+    /// the Tools row; the full list editor is a later collection slice.
+    tools_allow_count: usize,
+    /// `verify_edits` — re-read files after writes. Read-out on the Tools row.
+    tools_verify_edits: bool,
+    // SPENDING (`[budget]`) -----------------------------------------------
+    /// `max_cost_usd` — per-session spend cap. `None` = no cap. The Wallet
+    /// row's editable value; real spend comes from `App::cost`, never here.
+    budget_max_cost_usd: Option<f64>,
+    /// `max_wall_time_secs` — runaway wall-clock guard. Read-out on the
+    /// Safety (Stop after) row alongside the turn ceiling.
+    budget_max_wall_secs: Option<u64>,
     // EXPERT (provider tuning) --------------------------------------------
     /// The four editable `ProviderCompat` cost-per-token overrides for the
     /// active provider (Expert tier). Each `None` = "no override set".
@@ -244,6 +260,11 @@ impl SettingsModel {
             stop_after_turns: cv.max_turns.map(|n| n as u32).unwrap_or(25),
             compaction: Compaction::from_view_str(&cv.compaction),
             long_term_memory: cv.memory_enabled,
+            tools_auto_approve: cv.tools_auto_approve,
+            tools_allow_count: cv.tools_allow_count,
+            tools_verify_edits: cv.tools_verify_edits,
+            budget_max_cost_usd: cv.budget_max_cost_usd,
+            budget_max_wall_secs: cv.budget_max_wall_secs,
             compat_costs: cv.compat_costs,
         }
     }
@@ -265,12 +286,16 @@ enum Row {
     Approval,
     /// HOW WAYLAND ACTS · Plan first.
     PlanFirst,
+    /// HOW WAYLAND ACTS · Tool auto-approval (`[tools]`).
+    Tools,
     /// HOW WAYLAND ACTS · Stop after N turns.
     StopAfter,
     /// MEMORY & CONTEXT · Compaction level.
     Compaction,
     /// MEMORY & CONTEXT · Long-term memory.
     LongTerm,
+    /// SPENDING · per-session budget cap (`[budget]`).
+    Wallet,
     /// The expert-mode entry row below the rule.
     Expert,
 }
@@ -280,26 +305,30 @@ impl Row {
     /// Provider and Model render here as read-only connection read-outs;
     /// they are not in `FOCUSABLE` (you change them with `/provider` and
     /// `/model`), so `↑↓` skip past them and `⏎` never lands on them.
-    const ALL: [Row; 8] = [
+    const ALL: [Row; 10] = [
         Row::Provider,
         Row::Model,
         Row::Approval,
         Row::PlanFirst,
+        Row::Tools,
         Row::StopAfter,
         Row::Compaction,
         Row::LongTerm,
+        Row::Wallet,
         Row::Expert,
     ];
 
     /// The rows the focus ring walks, in display order. Provider and Model
     /// are deliberately excluded: they are read-outs, not editors, so
     /// keeping them out of the ring means `⏎` is never inert on them.
-    const FOCUSABLE: [Row; 6] = [
+    const FOCUSABLE: [Row; 8] = [
         Row::Approval,
         Row::PlanFirst,
+        Row::Tools,
         Row::StopAfter,
         Row::Compaction,
         Row::LongTerm,
+        Row::Wallet,
         Row::Expert,
     ];
 
@@ -308,8 +337,11 @@ impl Row {
     fn section(self) -> Option<&'static str> {
         match self {
             Row::Provider | Row::Model => Some("CONNECTION"),
-            Row::Approval | Row::PlanFirst | Row::StopAfter => Some("HOW WAYLAND ACTS"),
+            Row::Approval | Row::PlanFirst | Row::Tools | Row::StopAfter => {
+                Some("HOW WAYLAND ACTS")
+            }
             Row::Compaction | Row::LongTerm => Some("MEMORY & CONTEXT"),
+            Row::Wallet => Some("SPENDING"),
             Row::Expert => None,
         }
     }
@@ -455,6 +487,8 @@ impl ConfigSurface {
         let memory_enabled = self.current.long_term_memory;
         let approval_mode = self.current.approval.to_config();
         let plan_first = self.current.plan_first;
+        let tools_auto_approve = self.current.tools_auto_approve;
+        let budget_cap = self.current.budget_max_cost_usd;
         wcore_config::config::patch_global_config(|f| {
             f.default.max_turns = max_turns;
             f.default.approval_mode = approval_mode;
@@ -466,6 +500,12 @@ impl ConfigSurface {
                 .get_or_insert_with(wcore_config::config::MemoryConfig::default)
                 .enabled = memory_enabled;
             f.plan.plan_first = plan_first;
+            // S5 Essentials: the Tools auto-approve toggle and the Wallet spend
+            // cap. `[tools]`/`[budget]` are non-Option tables on `ConfigFile`,
+            // so set the fields directly; every other key is preserved by the
+            // partial-merge writer.
+            f.tools.auto_approve = tools_auto_approve;
+            f.budget.max_cost_usd = budget_cap;
         })
         .map(|_| ())
         .map_err(|e| format!("{e:#}"))
@@ -512,6 +552,7 @@ impl ConfigSurface {
                 self.current.approval = ApprovalMode::ALL[next];
             }
             Row::PlanFirst => self.current.plan_first = !self.current.plan_first,
+            Row::Tools => self.current.tools_auto_approve = !self.current.tools_auto_approve,
             Row::Compaction => {
                 let len = Compaction::ALL.len();
                 let idx = Compaction::ALL
@@ -522,9 +563,9 @@ impl ConfigSurface {
                 self.current.compaction = Compaction::ALL[next];
             }
             Row::LongTerm => self.current.long_term_memory = !self.current.long_term_memory,
-            // Text / navigation rows: cycling is inert. Provider/Model are
-            // not in the focus ring, so they never reach this match.
-            Row::Provider | Row::Model | Row::StopAfter | Row::Expert => {}
+            // Text / navigation rows: cycling is inert (StopAfter + Wallet are
+            // ⏎-to-edit). Provider/Model are not in the focus ring.
+            Row::Provider | Row::Model | Row::StopAfter | Row::Wallet | Row::Expert => {}
         }
     }
 
@@ -537,6 +578,23 @@ impl ConfigSurface {
                 // Begin an in-place numeric text edit.
                 let input = Input::new(self.current.stop_after_turns.to_string());
                 self.editor = Some((Row::StopAfter, input));
+            }
+            Row::Wallet => {
+                // Begin an in-place dollar edit, seeded from the current cap
+                // (blank when there is none).
+                let seed = self
+                    .current
+                    .budget_max_cost_usd
+                    .map(|c| format!("{c:.2}"))
+                    .unwrap_or_default();
+                self.editor = Some((Row::Wallet, Input::new(seed)));
+            }
+            // Tools opens the full Tools & Providers tier (the same surface as
+            // `p`) — the headline auto-approve toggle is `space` on the row.
+            Row::Tools => {
+                self.tier = Tier::Providers;
+                self.providers_focus = 0;
+                self.credentials_modal = None;
             }
             // Provider/Model are read-out rows, not editors — you change
             // them with `/provider` and `/model`. They are not in the focus
@@ -552,11 +610,25 @@ impl ConfigSurface {
     /// unparseable / zero value is rejected and the edit is dropped
     /// without changing the setting.
     fn commit_edit(&mut self) {
-        if let Some((Row::StopAfter, input)) = self.editor.take()
-            && let Ok(n) = input.value().trim().parse::<u32>()
-            && n > 0
-        {
-            self.current.stop_after_turns = n;
+        match self.editor.take() {
+            Some((Row::StopAfter, input)) => {
+                if let Ok(n) = input.value().trim().parse::<u32>()
+                    && n > 0
+                {
+                    self.current.stop_after_turns = n;
+                }
+            }
+            Some((Row::Wallet, input)) => {
+                // Dollars; a leading `$` is tolerated. Blank or non-positive
+                // means "no cap"; an unparseable value drops the edit.
+                let raw = input.value().trim().trim_start_matches('$').trim();
+                if raw.is_empty() {
+                    self.current.budget_max_cost_usd = None;
+                } else if let Ok(v) = raw.parse::<f64>() {
+                    self.current.budget_max_cost_usd = (v > 0.0).then_some(v);
+                }
+            }
+            _ => {}
         }
     }
 
@@ -1423,10 +1495,13 @@ impl Surface for ConfigSurface {
         // engine kept its prior binding. The overview context line reads this
         // to show "live apply skipped" instead of a false "now live".
         let apply_failed = app.config_apply_failed;
+        // S5 Essentials: real session spend for the health/cost line — `None`
+        // when no turn has run yet (we show "—", never a fabricated number).
+        let spent = app.cost.as_ref().map(|c| c.total_cost_usd);
         match self.tier {
-            Tier::Overview => self.render_overview(frame, area, theme, apply_failed),
+            Tier::Overview => self.render_overview(frame, area, theme, apply_failed, spent),
             Tier::Detail => {
-                self.render_overview(frame, area, theme, apply_failed);
+                self.render_overview(frame, area, theme, apply_failed, spent);
                 self.render_detail(frame, area, theme);
             }
             Tier::Expert => self.render_expert(frame, area, theme),
@@ -1623,7 +1698,14 @@ impl ConfigSurface {
 
     /// Draw the Tier-1 overview: the four sections, the eight settings,
     /// the expert-entry row, and the footer hint line.
-    fn render_overview(&self, frame: &mut Frame, area: Rect, t: &Theme, apply_failed: bool) {
+    fn render_overview(
+        &self,
+        frame: &mut Frame,
+        area: Rect,
+        t: &Theme,
+        apply_failed: bool,
+        spent_usd: Option<f64>,
+    ) {
         let block = panel("Wayland · Settings", t);
         let inner = block.inner(area);
         frame.render_widget(block, area);
@@ -1631,9 +1713,12 @@ impl ConfigSurface {
             return;
         }
 
-        // Split: a context line, the body, then the two-line footer.
-        let [ctx_area, body_area, footer_area] = Layout::vertical([
+        // Split: a context line, the at-a-glance posture + health strip, the
+        // body, then the two-line footer. The strip is the Essentials "read it
+        // in one glance" summary; the body is the editable rows.
+        let [ctx_area, strip_area, body_area, footer_area] = Layout::vertical([
             Constraint::Length(1),
+            Constraint::Length(2),
             Constraint::Min(1),
             Constraint::Length(2),
         ])
@@ -1683,6 +1768,52 @@ impl ConfigSurface {
             Paragraph::new(Line::from(Span::styled(scope, scope_style))),
             ctx_area,
         );
+
+        // Posture + health strip — the one-glance Essentials summary. Every
+        // value is real: posture from the live settings, health from the
+        // resolved provider/model/key, spend from `App::cost` (or "—").
+        let posture = Line::from(vec![
+            Span::styled("Posture  ", Style::default().fg(t.text_dim)),
+            Span::styled(
+                self.current.approval.label().to_string(),
+                Style::default().fg(t.text),
+            ),
+            Span::styled(" · plan-first ", Style::default().fg(t.text_dim)),
+            Span::styled(
+                if self.current.plan_first { "on" } else { "off" }.to_string(),
+                Style::default().fg(t.text),
+            ),
+            Span::styled(" · tools ", Style::default().fg(t.text_dim)),
+            Span::styled(
+                if self.current.tools_auto_approve {
+                    "auto-approve"
+                } else {
+                    "ask each"
+                }
+                .to_string(),
+                Style::default().fg(t.text),
+            ),
+        ]);
+        let key_span = if self.current.key_set {
+            Span::styled("key ✓", Style::default().fg(t.success))
+        } else {
+            Span::styled("no key", Style::default().fg(t.warning))
+        };
+        let spend = match spent_usd {
+            Some(c) => format!("${c:.2} this session"),
+            None => "— this session".to_string(),
+        };
+        let health = Line::from(vec![
+            Span::styled("Health   ", Style::default().fg(t.text_dim)),
+            Span::styled(self.current.provider.clone(), Style::default().fg(t.text)),
+            Span::styled(" · ", Style::default().fg(t.text_dim)),
+            Span::styled(self.current.model.clone(), Style::default().fg(t.text)),
+            Span::styled("   ", Style::default().fg(t.text_dim)),
+            key_span,
+            Span::styled(" · spent ", Style::default().fg(t.text_dim)),
+            Span::styled(spend, Style::default().fg(t.text)),
+        ]);
+        frame.render_widget(Paragraph::new(vec![posture, health]), strip_area);
 
         // Body — every section + setting row. Provider/Model render here as
         // read-outs but are outside the focus ring, so highlight is keyed on
@@ -1797,6 +1928,29 @@ impl ConfigSurface {
                 t,
             ),
             Row::PlanFirst => toggle_strip(self.current.plan_first, "off", "on for big changes", t),
+            Row::Tools => {
+                // `space` toggles auto-approve (the headline tool-safety switch);
+                // the allowed-tool count + verify-edits are real read-outs.
+                let mut v = toggle_strip(
+                    self.current.tools_auto_approve,
+                    "ask each",
+                    "auto-approve",
+                    t,
+                );
+                v.push(Span::styled(
+                    format!(
+                        "   {} allowed · verify-edits {}",
+                        self.current.tools_allow_count,
+                        if self.current.tools_verify_edits {
+                            "on"
+                        } else {
+                            "off"
+                        }
+                    ),
+                    Style::default().fg(t.text_muted),
+                ));
+                v
+            }
             Row::StopAfter => {
                 // While editing, render the live `tui-input` buffer.
                 if let Some((Row::StopAfter, input)) = &self.editor {
@@ -1811,11 +1965,13 @@ impl ConfigSurface {
                         ),
                     ]
                 } else {
+                    // The turn ceiling, plus the wall-clock guard when one is set.
+                    let value = match self.current.budget_max_wall_secs {
+                        Some(s) => format!("{} turns · {s}s wall", self.current.stop_after_turns),
+                        None => format!("{} turns", self.current.stop_after_turns),
+                    };
                     vec![
-                        Span::styled(
-                            format!("{} turns", self.current.stop_after_turns),
-                            Style::default().fg(t.text),
-                        ),
+                        Span::styled(value, Style::default().fg(t.text)),
                         Span::styled("   ▸ edit  (runaway guard)", disclosure(focused, t)),
                     ]
                 }
@@ -1834,6 +1990,32 @@ impl ConfigSurface {
                 "remembers across sessions",
                 t,
             ),
+            Row::Wallet => {
+                // While editing, render the live dollar buffer; otherwise the
+                // configured cap (real spend is shown on the health line below,
+                // never fabricated here).
+                if let Some((Row::Wallet, input)) = &self.editor {
+                    vec![
+                        Span::styled(
+                            format!("${}_", input.value()),
+                            Style::default().fg(t.orange).add_modifier(Modifier::BOLD),
+                        ),
+                        Span::styled(
+                            "  per session  (⏎ save · esc cancel · blank = no cap)",
+                            Style::default().fg(t.text_muted),
+                        ),
+                    ]
+                } else {
+                    let cap = match self.current.budget_max_cost_usd {
+                        Some(c) => format!("${c:.2} per session"),
+                        None => "no cap".to_string(),
+                    };
+                    vec![
+                        Span::styled(cap, Style::default().fg(t.text)),
+                        Span::styled("   ▸ edit  (spend ceiling)", disclosure(focused, t)),
+                    ]
+                }
+            }
             Row::Expert => vec![Span::styled(
                 "x  expert settings (provider tuning, budgets, traces)",
                 if focused {
@@ -1930,7 +2112,10 @@ impl ConfigSurface {
                     Style::default().fg(t.text_muted),
                 )));
             }
-            Row::StopAfter | Row::Expert => {
+            // StopAfter + Wallet edit in place from the overview; Tools opens
+            // the Providers tier; Expert has its own tier. None reach a radio
+            // detail pane, so this arm only guards the match's exhaustiveness.
+            Row::StopAfter | Row::Wallet | Row::Tools | Row::Expert => {
                 lines.push(Line::from(Span::styled(
                     "  Edit this from the overview.",
                     Style::default().fg(t.text_muted),
@@ -2364,9 +2549,11 @@ fn row_label(row: Row) -> &'static str {
         Row::Model => "Model",
         Row::Approval => "Approval",
         Row::PlanFirst => "Plan first",
+        Row::Tools => "Tools",
         Row::StopAfter => "Stop after",
         Row::Compaction => "Compaction",
         Row::LongTerm => "Long-term",
+        Row::Wallet => "Wallet",
         Row::Expert => "",
     }
 }
@@ -2381,6 +2568,8 @@ fn detail_intro(row: Row) -> &'static str {
         Row::Provider => "The LLM provider Wayland connects to:",
         Row::Model => "The model Wayland uses for this provider:",
         Row::StopAfter => "The runaway guard — how many turns before Wayland halts:",
+        Row::Tools => "What tools Wayland may run without asking:",
+        Row::Wallet => "The per-session spend ceiling:",
         Row::Expert => "",
     }
 }
@@ -3392,8 +3581,9 @@ mod tests {
         assert!(!surface.current.long_term_memory);
         assert!(!surface.is_dirty(), "a fresh seed must be clean");
 
-        // Focus the Long-term row (FOCUSABLE index 4) and toggle it on.
-        for _ in 0..4 {
+        // Focus the Long-term row (FOCUSABLE index 5 after S5 added Tools +
+        // Wallet) and toggle it on.
+        for _ in 0..5 {
             surface.handle_key(key(KeyCode::Down), &mut app);
         }
         assert_eq!(surface.focused_row(), Row::LongTerm);
@@ -3429,6 +3619,134 @@ mod tests {
         assert!(
             written.contains("[memory]") && written.contains("enabled"),
             "the memory toggle must persist to [memory].enabled, got:\n{written}"
+        );
+
+        // SAFETY: restore the prior env under the same lock.
+        unsafe {
+            match prev {
+                Some(v) => std::env::set_var("WAYLAND_HOME", v),
+                None => std::env::remove_var("WAYLAND_HOME"),
+            }
+        }
+    }
+
+    #[test]
+    fn overview_strip_shows_posture_and_real_or_dash_spend() {
+        // S5 Essentials: the at-a-glance strip shows posture from the live
+        // settings and the health line from the resolved provider/model/key.
+        // Spend is real-or-nothing — an em-dash until a turn has actually cost
+        // something, never a fabricated number.
+        let mut app = App::new();
+        app.config.provider = "anthropic".into();
+        app.config.model = "claude-opus-4-8".into();
+        let mut surface = ConfigSurface::new();
+        surface.on_enter(&mut app);
+
+        let text = render_text(&mut surface, &app);
+        assert!(text.contains("Posture"), "posture line missing");
+        assert!(text.contains("Health"), "health line missing");
+        assert!(
+            text.contains("anthropic"),
+            "provider missing from health line"
+        );
+        assert!(
+            text.contains("— this session"),
+            "with no cost the spend must read an em-dash, not $0.00:\n{text}"
+        );
+
+        // With real session cost, the health line shows the actual figure.
+        app.cost = Some(crate::tui::app::SessionCostView {
+            session_id: "s1".into(),
+            total_cost_usd: 0.42,
+            per_turn: vec![],
+        });
+        let text = render_text(&mut surface, &app);
+        assert!(
+            text.contains("$0.42 this session"),
+            "real session spend must surface on the health line:\n{text}"
+        );
+    }
+
+    #[test]
+    fn tools_row_space_toggles_and_persists_auto_approve() {
+        // S5: the Tools row's `space` flips `[tools] auto_approve`; `esc` saves
+        // it to disk. Hermetic via WAYLAND_HOME under the shared env lock.
+        let _guard = EXPERT_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = tempfile::tempdir().expect("tempdir");
+        let prev = std::env::var_os("WAYLAND_HOME");
+        // SAFETY: serialised by EXPERT_ENV_LOCK; restored before unlock.
+        unsafe { std::env::set_var("WAYLAND_HOME", dir.path()) };
+
+        let mut app = App::new();
+        app.config.tools_auto_approve = false;
+        let mut surface = ConfigSurface::new();
+        surface.on_enter(&mut app);
+        // Tools is FOCUSABLE index 2.
+        for _ in 0..2 {
+            surface.handle_key(key(KeyCode::Down), &mut app);
+        }
+        assert_eq!(surface.focused_row(), Row::Tools);
+        surface.handle_key(key(KeyCode::Char(' ')), &mut app);
+        assert!(
+            surface.current.tools_auto_approve,
+            "space must toggle auto-approve on"
+        );
+        assert!(surface.is_dirty(), "the toggle must be a pending edit");
+
+        surface.handle_key(key(KeyCode::Esc), &mut app);
+        assert!(!surface.is_dirty(), "esc must save the toggle");
+        let written = std::fs::read_to_string(dir.path().join("config.toml"))
+            .expect("config.toml should have been written");
+        assert!(
+            written.contains("[tools]") && written.contains("auto_approve"),
+            "the tools toggle must persist to [tools].auto_approve, got:\n{written}"
+        );
+
+        // SAFETY: restore the prior env under the same lock.
+        unsafe {
+            match prev {
+                Some(v) => std::env::set_var("WAYLAND_HOME", v),
+                None => std::env::remove_var("WAYLAND_HOME"),
+            }
+        }
+    }
+
+    #[test]
+    fn wallet_row_edits_and_persists_budget_cap() {
+        // S5: the Wallet row opens a dollar editor on `⏎`; committing then
+        // saving persists `[budget] max_cost_usd`.
+        let _guard = EXPERT_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = tempfile::tempdir().expect("tempdir");
+        let prev = std::env::var_os("WAYLAND_HOME");
+        // SAFETY: serialised by EXPERT_ENV_LOCK; restored before unlock.
+        unsafe { std::env::set_var("WAYLAND_HOME", dir.path()) };
+
+        let mut app = App::new();
+        let mut surface = ConfigSurface::new();
+        surface.on_enter(&mut app);
+        // Wallet is FOCUSABLE index 6.
+        for _ in 0..6 {
+            surface.handle_key(key(KeyCode::Down), &mut app);
+        }
+        assert_eq!(surface.focused_row(), Row::Wallet);
+        surface.handle_key(key(KeyCode::Enter), &mut app); // open the editor
+        for ch in "5.50".chars() {
+            surface.handle_key(key(KeyCode::Char(ch)), &mut app);
+        }
+        surface.handle_key(key(KeyCode::Enter), &mut app); // commit
+        assert_eq!(
+            surface.current.budget_max_cost_usd,
+            Some(5.5),
+            "the dollar edit must parse into the cap"
+        );
+
+        surface.handle_key(key(KeyCode::Esc), &mut app); // save
+        assert!(!surface.is_dirty(), "esc must save the cap");
+        let written = std::fs::read_to_string(dir.path().join("config.toml"))
+            .expect("config.toml should have been written");
+        assert!(
+            written.contains("[budget]") && written.contains("max_cost_usd"),
+            "the cap must persist to [budget].max_cost_usd, got:\n{written}"
         );
 
         // SAFETY: restore the prior env under the same lock.

--- a/crates/wcore-cli/src/tui/surfaces/config.rs
+++ b/crates/wcore-cli/src/tui/surfaces/config.rs
@@ -227,6 +227,19 @@ struct SettingsModel {
     /// `max_wall_time_secs` — runaway wall-clock guard. Read-out on the
     /// Safety (Stop after) row alongside the turn ceiling.
     budget_max_wall_secs: Option<u64>,
+    // ADVANCED (`[observability]`/`[storage]`/`[security]`) ----------------
+    /// `[observability] structured_traces` — emit structured trace spans.
+    obs_structured_traces: bool,
+    /// `[observability] online_evolution` — the GEPA online-evolution loop.
+    obs_online_evolution: bool,
+    /// `[observability] workflow_live_mode` — live workflow drill-in.
+    obs_workflow_live: bool,
+    /// `[storage.credentials] backend` tag (`plaintext`/`keyring`/
+    /// `encrypted-file`). The radio cycles plaintext↔keyring; encrypted-file
+    /// is read-only (its two paths must not be clobbered).
+    storage_backend: String,
+    /// `[security] enabled` — the egress network guard.
+    security_egress_enabled: bool,
     // EXPERT (provider tuning) --------------------------------------------
     /// The four editable `ProviderCompat` cost-per-token overrides for the
     /// active provider (Expert tier). Each `None` = "no override set".
@@ -265,6 +278,17 @@ impl SettingsModel {
             tools_verify_edits: cv.tools_verify_edits,
             budget_max_cost_usd: cv.budget_max_cost_usd,
             budget_max_wall_secs: cv.budget_max_wall_secs,
+            obs_structured_traces: cv.obs_structured_traces,
+            obs_online_evolution: cv.obs_online_evolution,
+            obs_workflow_live: cv.obs_workflow_live,
+            // `CredentialsBackend::default` is Plaintext, so an absent tag (a
+            // bare `ConfigView::default`, pre-resolve) reads as plaintext.
+            storage_backend: if cv.storage_backend.is_empty() {
+                "plaintext".to_string()
+            } else {
+                cv.storage_backend.clone()
+            },
+            security_egress_enabled: cv.security_egress_enabled,
             compat_costs: cv.compat_costs,
         }
     }
@@ -347,6 +371,69 @@ impl Row {
     }
 }
 
+/// A focusable field in the Advanced tier (S6): observability toggles, the
+/// storage credential-backend radio, the egress guard, and a navigation entry
+/// into the Expert provider-cost pane.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AdvField {
+    Traces,
+    OnlineEvolution,
+    WorkflowLive,
+    CredentialBackend,
+    EgressGuard,
+    ProviderCosts,
+}
+
+impl AdvField {
+    /// Every Advanced field in display order; `adv_focus` indexes this list.
+    const ALL: [AdvField; 6] = [
+        AdvField::Traces,
+        AdvField::OnlineEvolution,
+        AdvField::WorkflowLive,
+        AdvField::CredentialBackend,
+        AdvField::EgressGuard,
+        AdvField::ProviderCosts,
+    ];
+
+    /// The section heading this field renders under.
+    fn section(self) -> &'static str {
+        match self {
+            AdvField::Traces | AdvField::OnlineEvolution | AdvField::WorkflowLive => {
+                "OBSERVABILITY"
+            }
+            AdvField::CredentialBackend => "STORAGE",
+            AdvField::EgressGuard => "SECURITY",
+            AdvField::ProviderCosts => "PROVIDER",
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            AdvField::Traces => "Structured traces",
+            AdvField::OnlineEvolution => "Online evolution",
+            AdvField::WorkflowLive => "Workflow live mode",
+            AdvField::CredentialBackend => "Credential store",
+            AdvField::EgressGuard => "Egress guard",
+            AdvField::ProviderCosts => "Provider cost tuning",
+        }
+    }
+
+    fn gloss(self) -> &'static str {
+        match self {
+            AdvField::Traces => "Emit structured trace spans for observability tooling.",
+            AdvField::OnlineEvolution => {
+                "Let Wayland evolve its own prompts in the background (GEPA)."
+            }
+            AdvField::WorkflowLive => "Stream live workflow progress you can drill into.",
+            AdvField::CredentialBackend => {
+                "Where API keys live: the OS keyring or a 0600 plaintext file."
+            }
+            AdvField::EgressGuard => "Restrict outbound network calls to an allowlist.",
+            AdvField::ProviderCosts => "Per-token pricing overrides for the active provider.",
+        }
+    }
+}
+
 // ─────────────────────────────────────────────────────────────────────────
 // The surface
 // ─────────────────────────────────────────────────────────────────────────
@@ -360,6 +447,9 @@ enum Tier {
     Detail,
     /// Tier 3 — the expert pane (the 24 `ProviderCompat` fields).
     Expert,
+    /// Tier A — Advanced: observability / storage / security editors, plus a
+    /// link into the Expert provider-cost pane (S6).
+    Advanced,
     /// Tier P — Tools & Providers list (v0.9.0 W4 E1 Part A).
     Providers,
 }
@@ -382,6 +472,8 @@ pub struct ConfigSurface {
     tier: Tier,
     /// The focused expert field index (Tier 3 only).
     expert_focus: usize,
+    /// The focused Advanced field index (Tier A only); indexes `AdvField::ALL`.
+    adv_focus: usize,
     /// `Some` while a text field is being edited; the edited row plus its
     /// `tui-input` buffer. `None` when no field edit is in flight.
     editor: Option<(Row, Input)>,
@@ -429,6 +521,7 @@ impl ConfigSurface {
             focus: 0,
             tier: Tier::Overview,
             expert_focus: 0,
+            adv_focus: 0,
             editor: None,
             expert_editor: None,
             save_pending: false,
@@ -489,6 +582,11 @@ impl ConfigSurface {
         let plan_first = self.current.plan_first;
         let tools_auto_approve = self.current.tools_auto_approve;
         let budget_cap = self.current.budget_max_cost_usd;
+        let obs_traces = self.current.obs_structured_traces;
+        let obs_evolution = self.current.obs_online_evolution;
+        let obs_workflow_live = self.current.obs_workflow_live;
+        let storage_backend = self.current.storage_backend.clone();
+        let egress_enabled = self.current.security_egress_enabled;
         wcore_config::config::patch_global_config(|f| {
             f.default.max_turns = max_turns;
             f.default.approval_mode = approval_mode;
@@ -506,6 +604,24 @@ impl ConfigSurface {
             // partial-merge writer.
             f.tools.auto_approve = tools_auto_approve;
             f.budget.max_cost_usd = budget_cap;
+            // S6 Advanced: observability toggles, the credential-store backend
+            // (plaintext/keyring only — encrypted-file's paths are left intact),
+            // and the egress guard.
+            f.observability.structured_traces = obs_traces;
+            f.observability.online_evolution = obs_evolution;
+            f.observability.workflow_live_mode = obs_workflow_live;
+            match storage_backend.as_str() {
+                "plaintext" => {
+                    f.storage.credentials.backend =
+                        wcore_config::credentials::CredentialsBackend::Plaintext
+                }
+                "keyring" => {
+                    f.storage.credentials.backend =
+                        wcore_config::credentials::CredentialsBackend::Keyring
+                }
+                _ => {} // encrypted-file or unknown: leave the configured backend
+            }
+            f.security.enabled = egress_enabled;
         })
         .map(|_| ())
         .map_err(|e| format!("{e:#}"))
@@ -573,7 +689,10 @@ impl ConfigSurface {
     /// text edit, depending on the row.
     fn enter_focused(&mut self) {
         match self.focused_row() {
-            Row::Expert => self.tier = Tier::Expert,
+            Row::Expert => {
+                self.tier = Tier::Advanced;
+                self.adv_focus = 0;
+            }
             Row::StopAfter => {
                 // Begin an in-place numeric text edit.
                 let input = Input::new(self.current.stop_after_turns.to_string());
@@ -1482,6 +1601,7 @@ impl Surface for ConfigSurface {
         self.focus = 0;
         self.tier = Tier::Overview;
         self.expert_focus = 0;
+        self.adv_focus = 0;
         self.editor = None;
         self.expert_editor = None;
         self.providers_focus = 0;
@@ -1505,6 +1625,7 @@ impl Surface for ConfigSurface {
                 self.render_detail(frame, area, theme);
             }
             Tier::Expert => self.render_expert(frame, area, theme),
+            Tier::Advanced => self.render_advanced(frame, area, theme),
             Tier::Providers => {
                 self.render_providers(frame, area, theme);
                 if self.credentials_modal.is_some() {
@@ -1564,6 +1685,7 @@ impl Surface for ConfigSurface {
             Tier::Overview => self.handle_overview_key(key),
             Tier::Detail => self.handle_detail_key(key),
             Tier::Expert => self.handle_expert_key(key),
+            Tier::Advanced => self.handle_advanced_key(key),
             Tier::Providers => self.handle_providers_key(key),
         };
         if self.baseline != baseline_before && !self.is_dirty() {
@@ -1604,7 +1726,8 @@ impl ConfigSurface {
                 SurfaceAction::None
             }
             KeyCode::Char('x') => {
-                self.tier = Tier::Expert;
+                self.tier = Tier::Advanced;
+                self.adv_focus = 0;
                 SurfaceAction::None
             }
             KeyCode::Char('p') => {
@@ -1864,7 +1987,7 @@ impl ConfigSurface {
             Span::styled("space ", Style::default().fg(t.orange)),
             Span::styled("toggle  ", Style::default().fg(t.text_dim)),
             Span::styled("x ", Style::default().fg(t.orange)),
-            Span::styled("expert  ", Style::default().fg(t.text_dim)),
+            Span::styled("advanced  ", Style::default().fg(t.text_dim)),
             Span::styled("p ", Style::default().fg(t.orange)),
             Span::styled("providers  ", Style::default().fg(t.text_dim)),
             Span::styled("esc ", Style::default().fg(t.orange)),
@@ -2017,7 +2140,7 @@ impl ConfigSurface {
                 }
             }
             Row::Expert => vec![Span::styled(
-                "x  expert settings (provider tuning, budgets, traces)",
+                "x  advanced settings (traces, storage, egress, provider tuning)",
                 if focused {
                     Style::default().fg(t.orange).add_modifier(Modifier::BOLD)
                 } else {
@@ -2133,6 +2256,179 @@ impl ConfigSurface {
             Span::styled("revert", Style::default().fg(t.text_dim)),
         ]));
         frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), inner);
+    }
+
+    // ── Tier A (Advanced) input + rendering ─────────────────────────────
+
+    /// The focused Advanced field.
+    fn focused_adv(&self) -> AdvField {
+        AdvField::ALL[self.adv_focus.min(AdvField::ALL.len() - 1)]
+    }
+
+    /// Move the Advanced selection up/down, wrapping.
+    fn move_adv(&mut self, delta: isize) {
+        let len = AdvField::ALL.len() as isize;
+        self.adv_focus = (self.adv_focus as isize + delta).rem_euclid(len) as usize;
+    }
+
+    /// Flip / cycle the focused Advanced field's value. Navigation-only fields
+    /// (ProviderCosts) are inert here.
+    fn toggle_adv(&mut self) {
+        match self.focused_adv() {
+            AdvField::Traces => {
+                self.current.obs_structured_traces = !self.current.obs_structured_traces
+            }
+            AdvField::OnlineEvolution => {
+                self.current.obs_online_evolution = !self.current.obs_online_evolution
+            }
+            AdvField::WorkflowLive => {
+                self.current.obs_workflow_live = !self.current.obs_workflow_live
+            }
+            AdvField::EgressGuard => {
+                self.current.security_egress_enabled = !self.current.security_egress_enabled
+            }
+            AdvField::CredentialBackend => {
+                // Cycle plaintext↔keyring. encrypted-file is read-only — never
+                // reconstruct its two paths from a radio.
+                self.current.storage_backend = match self.current.storage_backend.as_str() {
+                    "plaintext" => "keyring".to_string(),
+                    "keyring" => "plaintext".to_string(),
+                    other => other.to_string(),
+                };
+            }
+            AdvField::ProviderCosts => {}
+        }
+    }
+
+    /// Tier-A keys: `↑↓` move, `space`/`←→` toggle, `⏎` opens cost tuning (or
+    /// toggles a setting), `esc` saves and returns to the overview.
+    fn handle_advanced_key(&mut self, key: KeyEvent) -> SurfaceAction {
+        match key.code {
+            KeyCode::Up | KeyCode::Char('k') => {
+                self.move_adv(-1);
+                SurfaceAction::None
+            }
+            KeyCode::Down | KeyCode::Char('j') => {
+                self.move_adv(1);
+                SurfaceAction::None
+            }
+            KeyCode::Char(' ') | KeyCode::Left | KeyCode::Right => {
+                self.toggle_adv();
+                SurfaceAction::None
+            }
+            KeyCode::Enter => {
+                if self.focused_adv() == AdvField::ProviderCosts {
+                    self.tier = Tier::Expert;
+                    self.expert_focus = 0;
+                } else {
+                    self.toggle_adv();
+                }
+                SurfaceAction::None
+            }
+            KeyCode::Esc => {
+                // Save dirty edits (advances baseline → the `handle_key` seam
+                // raises the Tier1Save rebind), then back to the overview.
+                if self.is_dirty() {
+                    self.save();
+                }
+                self.tier = Tier::Overview;
+                SurfaceAction::None
+            }
+            _ => SurfaceAction::None,
+        }
+    }
+
+    /// The value-side spans for one Advanced field.
+    fn adv_value_spans(&self, f: AdvField, t: &Theme) -> Vec<Span<'static>> {
+        match f {
+            AdvField::Traces => toggle_strip(self.current.obs_structured_traces, "off", "on", t),
+            AdvField::OnlineEvolution => {
+                toggle_strip(self.current.obs_online_evolution, "off", "on", t)
+            }
+            AdvField::WorkflowLive => toggle_strip(self.current.obs_workflow_live, "off", "on", t),
+            AdvField::EgressGuard => {
+                toggle_strip(self.current.security_egress_enabled, "off", "allowlist", t)
+            }
+            AdvField::CredentialBackend => match self.current.storage_backend.as_str() {
+                "encrypted-file" => vec![Span::styled(
+                    "encrypted-file (edit paths in config.toml)".to_string(),
+                    Style::default().fg(t.text_muted),
+                )],
+                _ => radio_strip(
+                    &["plaintext", "keyring"],
+                    usize::from(self.current.storage_backend == "keyring"),
+                    t,
+                ),
+            },
+            AdvField::ProviderCosts => vec![Span::styled(
+                "⏎ open cost tuning".to_string(),
+                Style::default().fg(t.text_muted),
+            )],
+        }
+    }
+
+    /// Draw the Tier-A Advanced pane: observability / storage / security
+    /// editors grouped by section, plus the link into the Expert cost pane.
+    fn render_advanced(&self, frame: &mut Frame, area: Rect, t: &Theme) {
+        let block = panel("Wayland · Advanced", t);
+        let inner = block.inner(area);
+        frame.render_widget(block, area);
+        if inner.height < 3 || inner.width < 10 {
+            return;
+        }
+        let [body_area, footer_area] =
+            Layout::vertical([Constraint::Min(1), Constraint::Length(2)]).areas(inner);
+
+        let focused = self.focused_adv();
+        let mut lines: Vec<Line> = Vec::new();
+        let mut last_section: Option<&'static str> = None;
+        for &f in AdvField::ALL.iter() {
+            let sec = f.section();
+            if Some(sec) != last_section {
+                if last_section.is_some() {
+                    lines.push(Line::from(""));
+                }
+                lines.push(Line::from(Span::styled(
+                    sec,
+                    Style::default().fg(t.text_dim).add_modifier(Modifier::BOLD),
+                )));
+                last_section = Some(sec);
+            }
+            let is_focused = f == focused;
+            let marker = if is_focused { "▸ " } else { "  " };
+            let label_style = if is_focused {
+                Style::default().fg(t.orange).add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(t.text)
+            };
+            let mut spans = vec![
+                Span::styled(marker.to_string(), Style::default().fg(t.orange)),
+                Span::styled(format!("{:<20}", f.label()), label_style),
+            ];
+            spans.extend(self.adv_value_spans(f, t));
+            lines.push(Line::from(spans));
+            lines.push(Line::from(Span::styled(
+                format!("    {}", f.gloss()),
+                Style::default().fg(t.text_muted),
+            )));
+        }
+        frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), body_area);
+
+        let hints = Line::from(vec![
+            Span::styled(" ↑↓ ", Style::default().fg(t.orange)),
+            Span::styled("move   ", Style::default().fg(t.text_dim)),
+            Span::styled("space ", Style::default().fg(t.orange)),
+            Span::styled("toggle   ", Style::default().fg(t.text_dim)),
+            Span::styled("⏎ ", Style::default().fg(t.orange)),
+            Span::styled("open/toggle   ", Style::default().fg(t.text_dim)),
+            Span::styled("esc ", Style::default().fg(t.orange)),
+            Span::styled("save & back", Style::default().fg(t.text_dim)),
+        ]);
+        let promise = Line::from(Span::styled(
+            " changes save to your global config.toml and apply live",
+            Style::default().fg(t.text_muted),
+        ));
+        frame.render_widget(Paragraph::new(vec![hints, promise]), footer_area);
     }
 
     // ── Rendering: Tier 3 (expert) ──────────────────────────────────────
@@ -2897,15 +3193,17 @@ mod tests {
             text.contains("MEMORY & CONTEXT"),
             "missing MEMORY & CONTEXT:\n{text}"
         );
+        // S5 added the SPENDING section (Wallet row).
+        assert!(text.contains("SPENDING"), "missing SPENDING:\n{text}");
         // A consequence gloss, not a mechanism, for the approval radio.
         assert!(
             text.contains("Asks before it writes or runs anything"),
             "missing approval gloss:\n{text}"
         );
-        // The expert-entry row.
+        // The advanced-settings entry row (S6 relabel of the expert row).
         assert!(
-            text.contains("expert settings"),
-            "missing expert row:\n{text}"
+            text.contains("advanced settings"),
+            "missing advanced row:\n{text}"
         );
         // The save/undo footer promise.
         assert!(
@@ -2976,7 +3274,11 @@ mod tests {
         let mut app = App::new();
         let mut surface = ConfigSurface::new();
         surface.on_enter(&mut app);
-        surface.handle_key(ch('x'), &mut app);
+        surface.handle_key(ch('x'), &mut app); // → Advanced
+        while surface.focused_adv() != AdvField::ProviderCosts {
+            surface.handle_key(key(KeyCode::Down), &mut app);
+        }
+        surface.handle_key(key(KeyCode::Enter), &mut app); // → Expert cost pane
         assert_eq!(surface.tier, Tier::Expert);
         let text = render_text(&mut surface, &app);
         // The expert pane is titled and grouped.
@@ -3419,10 +3721,16 @@ mod tests {
     /// the theme tests use) to stay hermetic under the concurrent runner.
     static EXPERT_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
-    /// Open the Expert tier and step the selection to the first editable
-    /// Pricing field (`cost_per_input_token`, `EXPERT_FIELDS[15]`).
+    /// Open the Expert cost pane (via the Advanced tier's "Provider cost
+    /// tuning" entry) and step the selection to the first editable Pricing
+    /// field (`cost_per_input_token`, `EXPERT_FIELDS[15]`).
     fn enter_expert_on_first_cost_field(surface: &mut ConfigSurface, app: &mut App) {
-        surface.handle_key(ch('x'), app); // overview → Expert tier
+        surface.handle_key(ch('x'), app); // overview → Advanced tier
+        assert_eq!(surface.tier, Tier::Advanced);
+        while surface.focused_adv() != AdvField::ProviderCosts {
+            surface.handle_key(key(KeyCode::Down), app);
+        }
+        surface.handle_key(key(KeyCode::Enter), app); // Advanced → Expert cost pane
         assert_eq!(surface.tier, Tier::Expert);
         for _ in 0..15 {
             surface.handle_key(key(KeyCode::Down), app);
@@ -3440,7 +3748,7 @@ mod tests {
         let mut app = App::new();
         let mut surface = ConfigSurface::new();
         surface.on_enter(&mut app);
-        surface.handle_key(ch('x'), &mut app);
+        enter_expert_on_first_cost_field(&mut surface, &mut app);
         let frame = render_text(&mut surface, &app);
         assert!(
             frame.contains("edit cost"),
@@ -3831,7 +4139,9 @@ mod tests {
     }
 
     #[test]
-    fn enter_on_expert_row_opens_the_expert_tier() {
+    fn enter_on_advanced_row_opens_the_advanced_tier() {
+        // S6: the home's "Advanced settings" row (formerly "expert") now opens
+        // the Advanced tier; `esc` saves+returns to the overview.
         let mut app = App::new();
         let mut surface = ConfigSurface::new();
         surface.on_enter(&mut app);
@@ -3839,10 +4149,128 @@ mod tests {
             surface.handle_key(key(KeyCode::Down), &mut app);
         }
         surface.handle_key(key(KeyCode::Enter), &mut app);
-        assert_eq!(surface.tier, Tier::Expert);
-        // `esc` from the expert tier returns to the overview.
+        assert_eq!(surface.tier, Tier::Advanced);
+        // `esc` from the advanced tier returns to the overview.
         surface.handle_key(key(KeyCode::Esc), &mut app);
         assert_eq!(surface.tier, Tier::Overview);
+    }
+
+    #[test]
+    fn advanced_pane_renders_its_sections_and_a_radio() {
+        let mut app = App::new();
+        let mut surface = ConfigSurface::new();
+        surface.on_enter(&mut app);
+        surface.handle_key(ch('x'), &mut app);
+        let text = render_text(&mut surface, &app);
+        assert!(text.contains("Advanced"), "missing advanced title:\n{text}");
+        assert!(
+            text.contains("OBSERVABILITY"),
+            "missing OBSERVABILITY:\n{text}"
+        );
+        assert!(text.contains("STORAGE"), "missing STORAGE:\n{text}");
+        assert!(text.contains("SECURITY"), "missing SECURITY:\n{text}");
+        assert!(
+            text.contains("Credential store"),
+            "missing storage radio:\n{text}"
+        );
+        // The radio shows both backends; plaintext is the default selection.
+        assert!(text.contains("plaintext") && text.contains("keyring"));
+    }
+
+    #[test]
+    fn advanced_provider_costs_entry_opens_the_expert_pane() {
+        let mut app = App::new();
+        let mut surface = ConfigSurface::new();
+        surface.on_enter(&mut app);
+        surface.handle_key(ch('x'), &mut app);
+        assert_eq!(surface.tier, Tier::Advanced);
+        while surface.focused_adv() != AdvField::ProviderCosts {
+            surface.handle_key(key(KeyCode::Down), &mut app);
+        }
+        surface.handle_key(key(KeyCode::Enter), &mut app);
+        assert_eq!(
+            surface.tier,
+            Tier::Expert,
+            "⏎ on Provider cost tuning must open the Expert cost pane"
+        );
+    }
+
+    #[test]
+    fn advanced_traces_toggle_persists_to_observability() {
+        // S6: the Advanced Structured-traces toggle flips `[observability]`
+        // and `esc` saves it. Hermetic via WAYLAND_HOME under the env lock.
+        let _guard = EXPERT_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = tempfile::tempdir().expect("tempdir");
+        let prev = std::env::var_os("WAYLAND_HOME");
+        // SAFETY: serialised by EXPERT_ENV_LOCK; restored before unlock.
+        unsafe { std::env::set_var("WAYLAND_HOME", dir.path()) };
+
+        let mut app = App::new();
+        app.config.obs_structured_traces = false;
+        let mut surface = ConfigSurface::new();
+        surface.on_enter(&mut app);
+        surface.handle_key(ch('x'), &mut app); // → Advanced (focus = Traces)
+        assert_eq!(surface.focused_adv(), AdvField::Traces);
+        surface.handle_key(key(KeyCode::Char(' ')), &mut app);
+        assert!(
+            surface.current.obs_structured_traces,
+            "space must flip traces on"
+        );
+        surface.handle_key(key(KeyCode::Esc), &mut app); // save & back
+        assert_eq!(surface.tier, Tier::Overview);
+        assert!(!surface.is_dirty());
+        let written = std::fs::read_to_string(dir.path().join("config.toml"))
+            .expect("config.toml should have been written");
+        assert!(
+            written.contains("[observability]") && written.contains("structured_traces"),
+            "traces must persist to [observability], got:\n{written}"
+        );
+
+        // SAFETY: restore the prior env under the same lock.
+        unsafe {
+            match prev {
+                Some(v) => std::env::set_var("WAYLAND_HOME", v),
+                None => std::env::remove_var("WAYLAND_HOME"),
+            }
+        }
+    }
+
+    #[test]
+    fn advanced_credential_backend_radio_cycles_and_persists() {
+        // S6: the credential-store radio cycles plaintext↔keyring and persists
+        // to `[storage.credentials] backend`.
+        let _guard = EXPERT_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = tempfile::tempdir().expect("tempdir");
+        let prev = std::env::var_os("WAYLAND_HOME");
+        // SAFETY: serialised by EXPERT_ENV_LOCK; restored before unlock.
+        unsafe { std::env::set_var("WAYLAND_HOME", dir.path()) };
+
+        let mut app = App::new();
+        app.config.storage_backend = "plaintext".into();
+        let mut surface = ConfigSurface::new();
+        surface.on_enter(&mut app);
+        surface.handle_key(ch('x'), &mut app); // → Advanced
+        while surface.focused_adv() != AdvField::CredentialBackend {
+            surface.handle_key(key(KeyCode::Down), &mut app);
+        }
+        surface.handle_key(key(KeyCode::Char(' ')), &mut app); // plaintext → keyring
+        assert_eq!(surface.current.storage_backend, "keyring");
+        surface.handle_key(key(KeyCode::Esc), &mut app); // save & back
+        assert!(!surface.is_dirty());
+        let written = std::fs::read_to_string(dir.path().join("config.toml"))
+            .expect("config.toml should have been written");
+        assert!(
+            written.contains("backend") && written.contains("keyring"),
+            "backend must persist to [storage.credentials], got:\n{written}"
+        );
+
+        // SAFETY: restore the prior env under the same lock.
+        unsafe {
+            match prev {
+                Some(v) => std::env::set_var("WAYLAND_HOME", v),
+                None => std::env::remove_var("WAYLAND_HOME"),
+            }
+        }
     }
 
     #[test]
@@ -3853,7 +4281,13 @@ mod tests {
         let mut surface = ConfigSurface::new();
         surface.on_enter(&mut app);
         let theme = Theme::no_color();
-        for tier in [Tier::Overview, Tier::Detail, Tier::Expert, Tier::Providers] {
+        for tier in [
+            Tier::Overview,
+            Tier::Detail,
+            Tier::Expert,
+            Tier::Advanced,
+            Tier::Providers,
+        ] {
             surface.tier = tier;
             for (w, h) in [(1u16, 1u16), (8, 4), (20, 6)] {
                 let mut terminal = Terminal::new(TestBackend::new(w, h)).expect("test terminal");
@@ -3869,7 +4303,11 @@ mod tests {
         let mut app = App::new();
         let mut surface = ConfigSurface::new();
         surface.on_enter(&mut app);
-        surface.handle_key(ch('x'), &mut app);
+        surface.handle_key(ch('x'), &mut app); // → Advanced
+        while surface.focused_adv() != AdvField::ProviderCosts {
+            surface.handle_key(key(KeyCode::Down), &mut app);
+        }
+        surface.handle_key(key(KeyCode::Enter), &mut app); // → Expert cost pane
         assert_eq!(surface.expert_focus, 0);
         surface.handle_key(key(KeyCode::Up), &mut app);
         assert_eq!(

--- a/crates/wcore-cli/src/tui/surfaces/config.rs
+++ b/crates/wcore-cli/src/tui/surfaces/config.rs
@@ -215,9 +215,9 @@ struct SettingsModel {
     /// `auto_approve` — approve every tool call without a per-call prompt.
     /// The Tools row's editable toggle.
     tools_auto_approve: bool,
-    /// Count of pre-approved tools (`allow_list` length). Read-out only on
-    /// the Tools row; the full list editor is a later collection slice.
-    tools_allow_count: usize,
+    /// Pre-approved tools (`allow_list`). The Tools row shows the count; the
+    /// Advanced list editor (S7) edits the entries.
+    tools_allow_list: Vec<String>,
     /// `verify_edits` — re-read files after writes. Read-out on the Tools row.
     tools_verify_edits: bool,
     // SPENDING (`[budget]`) -----------------------------------------------
@@ -240,6 +240,13 @@ struct SettingsModel {
     storage_backend: String,
     /// `[security] enabled` — the egress network guard.
     security_egress_enabled: bool,
+    // COLLECTIONS (`[security]`/`[provider_chain]`) — S7 list editors --------
+    /// `[security] egress_allow` — extra egress allowlist entries.
+    egress_allow: Vec<String>,
+    /// `[provider_chain] enabled` — wrap the primary in the resilient chain.
+    failover_enabled: bool,
+    /// `[provider_chain] fallback_models` — the ordered failover chain.
+    fallback_models: Vec<String>,
     // EXPERT (provider tuning) --------------------------------------------
     /// The four editable `ProviderCompat` cost-per-token overrides for the
     /// active provider (Expert tier). Each `None` = "no override set".
@@ -274,7 +281,7 @@ impl SettingsModel {
             compaction: Compaction::from_view_str(&cv.compaction),
             long_term_memory: cv.memory_enabled,
             tools_auto_approve: cv.tools_auto_approve,
-            tools_allow_count: cv.tools_allow_count,
+            tools_allow_list: cv.tools_allow_list.clone(),
             tools_verify_edits: cv.tools_verify_edits,
             budget_max_cost_usd: cv.budget_max_cost_usd,
             budget_max_wall_secs: cv.budget_max_wall_secs,
@@ -289,6 +296,9 @@ impl SettingsModel {
                 cv.storage_backend.clone()
             },
             security_egress_enabled: cv.security_egress_enabled,
+            egress_allow: cv.egress_allow.clone(),
+            failover_enabled: cv.failover_enabled,
+            fallback_models: cv.fallback_models.clone(),
             compat_costs: cv.compat_costs,
         }
     }
@@ -381,17 +391,61 @@ enum AdvField {
     WorkflowLive,
     CredentialBackend,
     EgressGuard,
+    /// SECURITY · the `egress_allow` list editor (S7).
+    EgressAllowlist,
+    /// TOOLS · the `allow_list` (pre-approved tools) list editor (S7).
+    ToolAllowList,
+    /// FAILOVER · `provider_chain.enabled` toggle (S7).
+    FailoverEnabled,
+    /// FAILOVER · the `fallback_models` chain list editor (S7).
+    FallbackChain,
     ProviderCosts,
+}
+
+/// Which `Vec<String>` config collection the list editor (Tier `ListEdit`) is
+/// editing. Each maps to one `SettingsModel` buffer and one persisted field.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ListKind {
+    /// `[tools] allow_list` — pre-approved tools.
+    ToolsAllow,
+    /// `[security] egress_allow` — extra egress allowlist entries.
+    EgressAllow,
+    /// `[provider_chain] fallback_models` — the failover chain.
+    FallbackModels,
+}
+
+impl ListKind {
+    /// The panel title shown while editing this collection.
+    fn title(self) -> &'static str {
+        match self {
+            ListKind::ToolsAllow => "Pre-approved tools",
+            ListKind::EgressAllow => "Egress allowlist",
+            ListKind::FallbackModels => "Fallback models",
+        }
+    }
+
+    /// The singular noun for one entry (used in hints / empty state).
+    fn item_noun(self) -> &'static str {
+        match self {
+            ListKind::ToolsAllow => "tool",
+            ListKind::EgressAllow => "domain",
+            ListKind::FallbackModels => "model",
+        }
+    }
 }
 
 impl AdvField {
     /// Every Advanced field in display order; `adv_focus` indexes this list.
-    const ALL: [AdvField; 6] = [
+    const ALL: [AdvField; 10] = [
         AdvField::Traces,
         AdvField::OnlineEvolution,
         AdvField::WorkflowLive,
         AdvField::CredentialBackend,
         AdvField::EgressGuard,
+        AdvField::EgressAllowlist,
+        AdvField::ToolAllowList,
+        AdvField::FailoverEnabled,
+        AdvField::FallbackChain,
         AdvField::ProviderCosts,
     ];
 
@@ -402,7 +456,9 @@ impl AdvField {
                 "OBSERVABILITY"
             }
             AdvField::CredentialBackend => "STORAGE",
-            AdvField::EgressGuard => "SECURITY",
+            AdvField::EgressGuard | AdvField::EgressAllowlist => "SECURITY",
+            AdvField::ToolAllowList => "TOOLS",
+            AdvField::FailoverEnabled | AdvField::FallbackChain => "FAILOVER",
             AdvField::ProviderCosts => "PROVIDER",
         }
     }
@@ -414,6 +470,10 @@ impl AdvField {
             AdvField::WorkflowLive => "Workflow live mode",
             AdvField::CredentialBackend => "Credential store",
             AdvField::EgressGuard => "Egress guard",
+            AdvField::EgressAllowlist => "Egress allowlist",
+            AdvField::ToolAllowList => "Pre-approved tools",
+            AdvField::FailoverEnabled => "Provider failover",
+            AdvField::FallbackChain => "Fallback models",
             AdvField::ProviderCosts => "Provider cost tuning",
         }
     }
@@ -429,7 +489,25 @@ impl AdvField {
                 "Where API keys live: the OS keyring or a 0600 plaintext file."
             }
             AdvField::EgressGuard => "Restrict outbound network calls to an allowlist.",
+            AdvField::EgressAllowlist => {
+                "Extra domains/hosts allowed past the egress guard (⏎ to edit)."
+            }
+            AdvField::ToolAllowList => "Tools auto-approved without a per-call prompt (⏎ to edit).",
+            AdvField::FailoverEnabled => {
+                "Wrap the provider in a circuit breaker with a fallback chain."
+            }
+            AdvField::FallbackChain => "Models tried in order when the primary fails (⏎ to edit).",
             AdvField::ProviderCosts => "Per-token pricing overrides for the active provider.",
+        }
+    }
+
+    /// The list collection this field opens, or `None` for non-list fields.
+    fn list_kind(self) -> Option<ListKind> {
+        match self {
+            AdvField::EgressAllowlist => Some(ListKind::EgressAllow),
+            AdvField::ToolAllowList => Some(ListKind::ToolsAllow),
+            AdvField::FallbackChain => Some(ListKind::FallbackModels),
+            _ => None,
         }
     }
 }
@@ -450,6 +528,10 @@ enum Tier {
     /// Tier A — Advanced: observability / storage / security editors, plus a
     /// link into the Expert provider-cost pane (S6).
     Advanced,
+    /// Tier L — a string-list collection editor (S7): the tools allow-list,
+    /// the egress allowlist, or the provider failover chain. The payload says
+    /// which collection is open.
+    ListEdit(ListKind),
     /// Tier P — Tools & Providers list (v0.9.0 W4 E1 Part A).
     Providers,
 }
@@ -474,6 +556,15 @@ pub struct ConfigSurface {
     expert_focus: usize,
     /// The focused Advanced field index (Tier A only); indexes `AdvField::ALL`.
     adv_focus: usize,
+    /// The focused entry index in the open list collection (Tier `ListEdit`).
+    list_focus: usize,
+    /// `Some` while a list entry is being typed (add or edit): the `tui-input`
+    /// buffer. `list_edit_index` says whether it's an add (`None`) or an edit
+    /// of entry `i` (`Some(i)`). `None` when no inline list edit is in flight.
+    list_editor: Option<Input>,
+    /// `Some(i)` when the in-flight list edit replaces entry `i`; `None` when
+    /// it appends a new entry. Meaningless unless `list_editor` is `Some`.
+    list_edit_index: Option<usize>,
     /// `Some` while a text field is being edited; the edited row plus its
     /// `tui-input` buffer. `None` when no field edit is in flight.
     editor: Option<(Row, Input)>,
@@ -522,6 +613,9 @@ impl ConfigSurface {
             tier: Tier::Overview,
             expert_focus: 0,
             adv_focus: 0,
+            list_focus: 0,
+            list_editor: None,
+            list_edit_index: None,
             editor: None,
             expert_editor: None,
             save_pending: false,
@@ -587,6 +681,10 @@ impl ConfigSurface {
         let obs_workflow_live = self.current.obs_workflow_live;
         let storage_backend = self.current.storage_backend.clone();
         let egress_enabled = self.current.security_egress_enabled;
+        let tools_allow_list = self.current.tools_allow_list.clone();
+        let egress_allow = self.current.egress_allow.clone();
+        let failover_enabled = self.current.failover_enabled;
+        let fallback_models = self.current.fallback_models.clone();
         wcore_config::config::patch_global_config(|f| {
             f.default.max_turns = max_turns;
             f.default.approval_mode = approval_mode;
@@ -622,6 +720,14 @@ impl ConfigSurface {
                 _ => {} // encrypted-file or unknown: leave the configured backend
             }
             f.security.enabled = egress_enabled;
+            // S7 collection editors: the tools allow-list, the egress
+            // allowlist, and the provider failover chain (+ its on/off). Each
+            // is a `Vec<String>` / `bool` on a non-Option table, so set it
+            // directly; the partial-merge writer preserves every other key.
+            f.tools.allow_list = tools_allow_list;
+            f.security.egress_allow = egress_allow;
+            f.provider_chain.enabled = failover_enabled;
+            f.provider_chain.fallback_models = fallback_models;
         })
         .map(|_| ())
         .map_err(|e| format!("{e:#}"))
@@ -1602,6 +1708,9 @@ impl Surface for ConfigSurface {
         self.tier = Tier::Overview;
         self.expert_focus = 0;
         self.adv_focus = 0;
+        self.list_focus = 0;
+        self.list_editor = None;
+        self.list_edit_index = None;
         self.editor = None;
         self.expert_editor = None;
         self.providers_focus = 0;
@@ -1626,6 +1735,7 @@ impl Surface for ConfigSurface {
             }
             Tier::Expert => self.render_expert(frame, area, theme),
             Tier::Advanced => self.render_advanced(frame, area, theme),
+            Tier::ListEdit(kind) => self.render_list(frame, area, theme, kind),
             Tier::Providers => {
                 self.render_providers(frame, area, theme);
                 if self.credentials_modal.is_some() {
@@ -1675,6 +1785,26 @@ impl Surface for ConfigSurface {
             return SurfaceAction::None;
         }
 
+        // A list-entry edit (Tier `ListEdit`) captures every key like the other
+        // inline editors. `⏎` commits the typed entry into the buffer (which
+        // makes the surface dirty but does NOT persist — the save happens on
+        // `esc` out of the list tier); `esc` cancels the in-flight entry.
+        if self.list_editor.is_some() {
+            match key.code {
+                KeyCode::Enter => self.commit_list_edit(),
+                KeyCode::Esc => {
+                    self.list_editor = None;
+                    self.list_edit_index = None;
+                }
+                _ => {
+                    if let Some(input) = self.list_editor.as_mut() {
+                        input.handle_event(&ratatui::crossterm::event::Event::Key(key));
+                    }
+                }
+            }
+            return SurfaceAction::None;
+        }
+
         // D007: a Tier-1 save lands deep inside a per-tier key handler with
         // no router/engine access. Snapshot the baseline before dispatch;
         // if the dispatch persisted a change (baseline advanced to current
@@ -1686,6 +1816,7 @@ impl Surface for ConfigSurface {
             Tier::Detail => self.handle_detail_key(key),
             Tier::Expert => self.handle_expert_key(key),
             Tier::Advanced => self.handle_advanced_key(key),
+            Tier::ListEdit(kind) => self.handle_list_key(key, kind),
             Tier::Providers => self.handle_providers_key(key),
         };
         if self.baseline != baseline_before && !self.is_dirty() {
@@ -2063,7 +2194,7 @@ impl ConfigSurface {
                 v.push(Span::styled(
                     format!(
                         "   {} allowed · verify-edits {}",
-                        self.current.tools_allow_count,
+                        self.current.tools_allow_list.len(),
                         if self.current.tools_verify_edits {
                             "on"
                         } else {
@@ -2287,6 +2418,11 @@ impl ConfigSurface {
             AdvField::EgressGuard => {
                 self.current.security_egress_enabled = !self.current.security_egress_enabled
             }
+            AdvField::FailoverEnabled => {
+                self.current.failover_enabled = !self.current.failover_enabled
+            }
+            // List-collection fields are `⏎`-to-open, not `space`-to-toggle.
+            AdvField::EgressAllowlist | AdvField::ToolAllowList | AdvField::FallbackChain => {}
             AdvField::CredentialBackend => {
                 // Cycle plaintext↔keyring. encrypted-file is read-only — never
                 // reconstruct its two paths from a radio.
@@ -2317,9 +2453,12 @@ impl ConfigSurface {
                 SurfaceAction::None
             }
             KeyCode::Enter => {
-                if self.focused_adv() == AdvField::ProviderCosts {
+                let field = self.focused_adv();
+                if field == AdvField::ProviderCosts {
                     self.tier = Tier::Expert;
                     self.expert_focus = 0;
+                } else if let Some(kind) = field.list_kind() {
+                    self.open_list(kind);
                 } else {
                     self.toggle_adv();
                 }
@@ -2348,6 +2487,18 @@ impl ConfigSurface {
             AdvField::WorkflowLive => toggle_strip(self.current.obs_workflow_live, "off", "on", t),
             AdvField::EgressGuard => {
                 toggle_strip(self.current.security_egress_enabled, "off", "allowlist", t)
+            }
+            AdvField::FailoverEnabled => {
+                toggle_strip(self.current.failover_enabled, "off", "on", t)
+            }
+            AdvField::EgressAllowlist => {
+                list_count_spans(self.current.egress_allow.len(), "domain", t)
+            }
+            AdvField::ToolAllowList => {
+                list_count_spans(self.current.tools_allow_list.len(), "tool", t)
+            }
+            AdvField::FallbackChain => {
+                list_count_spans(self.current.fallback_models.len(), "model", t)
             }
             AdvField::CredentialBackend => match self.current.storage_backend.as_str() {
                 "encrypted-file" => vec![Span::styled(
@@ -2424,6 +2575,233 @@ impl ConfigSurface {
             Span::styled("esc ", Style::default().fg(t.orange)),
             Span::styled("save & back", Style::default().fg(t.text_dim)),
         ]);
+        let promise = Line::from(Span::styled(
+            " changes save to your global config.toml and apply live",
+            Style::default().fg(t.text_muted),
+        ));
+        frame.render_widget(Paragraph::new(vec![hints, promise]), footer_area);
+    }
+
+    // ── Tier L (list collection) input + rendering — S7 ─────────────────
+
+    /// The open collection's entries (read-only view).
+    fn list_ref(&self, kind: ListKind) -> &[String] {
+        match kind {
+            ListKind::ToolsAllow => &self.current.tools_allow_list,
+            ListKind::EgressAllow => &self.current.egress_allow,
+            ListKind::FallbackModels => &self.current.fallback_models,
+        }
+    }
+
+    /// The open collection's entries (mutable).
+    fn list_mut(&mut self, kind: ListKind) -> &mut Vec<String> {
+        match kind {
+            ListKind::ToolsAllow => &mut self.current.tools_allow_list,
+            ListKind::EgressAllow => &mut self.current.egress_allow,
+            ListKind::FallbackModels => &mut self.current.fallback_models,
+        }
+    }
+
+    /// Open the list editor for `kind` (from an Advanced list field's `⏎`).
+    fn open_list(&mut self, kind: ListKind) {
+        self.tier = Tier::ListEdit(kind);
+        self.list_focus = 0;
+        self.list_editor = None;
+        self.list_edit_index = None;
+    }
+
+    /// Move the list selection, wrapping. Inert on an empty collection.
+    fn move_list(&mut self, delta: isize, kind: ListKind) {
+        let len = self.list_ref(kind).len();
+        if len == 0 {
+            self.list_focus = 0;
+            return;
+        }
+        self.list_focus =
+            (self.list_focus.min(len - 1) as isize + delta).rem_euclid(len as isize) as usize;
+    }
+
+    /// Remove the focused entry, clamping focus to the new bounds.
+    fn remove_focused_entry(&mut self, kind: ListKind) {
+        self.save_error = None;
+        self.save_pending = false;
+        let len = self.list_ref(kind).len();
+        if len == 0 {
+            return;
+        }
+        let i = self.list_focus.min(len - 1);
+        self.list_mut(kind).remove(i);
+        let new_len = len - 1;
+        self.list_focus = if new_len == 0 { 0 } else { i.min(new_len - 1) };
+    }
+
+    /// Tier-L keys: `↑↓` move, `a` add, `e`/`⏎` edit the focused entry (`⏎` on
+    /// an empty list adds), `d`/`Del` remove, `esc` saves and returns to
+    /// Advanced. The in-flight entry edit itself is captured earlier in
+    /// `handle_key` (the `list_editor` state machine).
+    fn handle_list_key(&mut self, key: KeyEvent, kind: ListKind) -> SurfaceAction {
+        match key.code {
+            KeyCode::Up | KeyCode::Char('k') => {
+                self.move_list(-1, kind);
+                SurfaceAction::None
+            }
+            KeyCode::Down | KeyCode::Char('j') => {
+                self.move_list(1, kind);
+                SurfaceAction::None
+            }
+            KeyCode::Char('a') | KeyCode::Char('+') => {
+                self.save_error = None;
+                self.save_pending = false;
+                self.list_editor = Some(Input::new(String::new()));
+                self.list_edit_index = None;
+                SurfaceAction::None
+            }
+            KeyCode::Enter | KeyCode::Char('e') => {
+                self.save_error = None;
+                self.save_pending = false;
+                let len = self.list_ref(kind).len();
+                if len == 0 {
+                    self.list_editor = Some(Input::new(String::new()));
+                    self.list_edit_index = None;
+                } else {
+                    let i = self.list_focus.min(len - 1);
+                    let seed = self.list_ref(kind)[i].clone();
+                    self.list_editor = Some(Input::new(seed));
+                    self.list_edit_index = Some(i);
+                }
+                SurfaceAction::None
+            }
+            KeyCode::Char('d') | KeyCode::Delete => {
+                self.remove_focused_entry(kind);
+                SurfaceAction::None
+            }
+            KeyCode::Esc => {
+                // Persist the (possibly) changed collection — `save` advances
+                // `baseline`, which the `handle_key` seam detects to raise the
+                // Tier1Save rebind so the change applies live — then back to
+                // the Advanced tier the list field lives on.
+                if self.is_dirty() {
+                    self.save();
+                }
+                self.tier = Tier::Advanced;
+                SurfaceAction::None
+            }
+            _ => SurfaceAction::None,
+        }
+    }
+
+    /// Commit the in-flight list entry (`⏎`). A blank entry is dropped (no
+    /// add, no change to an edited entry). Edits replace in place; adds append
+    /// and move focus to the new entry.
+    fn commit_list_edit(&mut self) {
+        let Some(input) = self.list_editor.take() else {
+            return;
+        };
+        let idx = self.list_edit_index.take();
+        let kind = match self.tier {
+            Tier::ListEdit(k) => k,
+            _ => return,
+        };
+        let val = input.value().trim().to_string();
+        if val.is_empty() {
+            return;
+        }
+        let list = self.list_mut(kind);
+        let new_focus = match idx {
+            Some(i) if i < list.len() => {
+                list[i] = val;
+                i
+            }
+            _ => {
+                list.push(val);
+                list.len() - 1
+            }
+        };
+        self.list_focus = new_focus;
+    }
+
+    /// The live entry-edit buffer line (`▸ typed_`), shown in the entry's slot
+    /// while editing or as a trailing line while adding.
+    fn list_editor_line(&self, t: &Theme) -> Line<'static> {
+        let buf = self
+            .list_editor
+            .as_ref()
+            .map(|i| i.value().to_string())
+            .unwrap_or_default();
+        Line::from(vec![
+            Span::styled("▸ ".to_string(), Style::default().fg(t.orange)),
+            Span::styled(
+                format!("{buf}_"),
+                Style::default().fg(t.orange).add_modifier(Modifier::BOLD),
+            ),
+        ])
+    }
+
+    /// Draw the Tier-L list editor: the collection's entries with a focus
+    /// marker, an inline buffer when adding/editing, and the key hints.
+    fn render_list(&self, frame: &mut Frame, area: Rect, t: &Theme, kind: ListKind) {
+        let block = panel(&format!("Wayland · {}", kind.title()), t);
+        let inner = block.inner(area);
+        frame.render_widget(block, area);
+        if inner.height < 3 || inner.width < 10 {
+            return;
+        }
+        let [body_area, footer_area] =
+            Layout::vertical([Constraint::Min(1), Constraint::Length(2)]).areas(inner);
+
+        let entries = self.list_ref(kind);
+        let editing = self.list_editor.is_some();
+        let mut lines: Vec<Line> = Vec::new();
+        if entries.is_empty() && !editing {
+            lines.push(Line::from(Span::styled(
+                format!("  no {}s yet — press a to add one", kind.item_noun()),
+                Style::default().fg(t.text_muted),
+            )));
+        }
+        for (i, entry) in entries.iter().enumerate() {
+            if editing && self.list_edit_index == Some(i) {
+                lines.push(self.list_editor_line(t));
+                continue;
+            }
+            let focused = i == self.list_focus && !editing;
+            let marker = if focused { "▸ " } else { "  " };
+            let style = if focused {
+                Style::default().fg(t.orange).add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(t.text)
+            };
+            lines.push(Line::from(vec![
+                Span::styled(marker.to_string(), Style::default().fg(t.orange)),
+                Span::styled(entry.clone(), style),
+            ]));
+        }
+        // An add-in-flight (no edit index) renders as a trailing buffer line.
+        if editing && self.list_edit_index.is_none() {
+            lines.push(self.list_editor_line(t));
+        }
+        frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), body_area);
+
+        let hints = if editing {
+            Line::from(vec![
+                Span::styled(" ⏎ ", Style::default().fg(t.orange)),
+                Span::styled("save entry   ", Style::default().fg(t.text_dim)),
+                Span::styled("esc ", Style::default().fg(t.orange)),
+                Span::styled("cancel entry", Style::default().fg(t.text_dim)),
+            ])
+        } else {
+            Line::from(vec![
+                Span::styled(" ↑↓ ", Style::default().fg(t.orange)),
+                Span::styled("move   ", Style::default().fg(t.text_dim)),
+                Span::styled("a ", Style::default().fg(t.orange)),
+                Span::styled("add   ", Style::default().fg(t.text_dim)),
+                Span::styled("e ", Style::default().fg(t.orange)),
+                Span::styled("edit   ", Style::default().fg(t.text_dim)),
+                Span::styled("d ", Style::default().fg(t.orange)),
+                Span::styled("delete   ", Style::default().fg(t.text_dim)),
+                Span::styled("esc ", Style::default().fg(t.orange)),
+                Span::styled("save & back", Style::default().fg(t.text_dim)),
+            ])
+        };
         let promise = Line::from(Span::styled(
             " changes save to your global config.toml and apply live",
             Style::default().fg(t.text_muted),
@@ -2916,6 +3294,21 @@ fn toggle_strip(on: bool, off_label: &str, on_label: &str, t: &Theme) -> Vec<Spa
         Span::styled(format!("{off_label}   "), off_style),
         Span::styled(on_glyph.to_string(), on_style),
         Span::styled(on_label.to_string(), on_style),
+    ]
+}
+
+/// The value-side read-out for an Advanced list field: `N nouns · ⏎ edit`,
+/// or `none · ⏎ add` when the collection is empty. `noun` is the singular.
+fn list_count_spans(count: usize, noun: &str, t: &Theme) -> Vec<Span<'static>> {
+    let summary = if count == 0 {
+        "none".to_string()
+    } else {
+        format!("{count} {noun}{}", if count == 1 { "" } else { "s" })
+    };
+    let action = if count == 0 { "⏎ add" } else { "⏎ edit" };
+    vec![
+        Span::styled(summary, Style::default().fg(t.text)),
+        Span::styled(format!("   {action}"), Style::default().fg(t.text_muted)),
     ]
 }
 
@@ -4066,6 +4459,190 @@ mod tests {
         }
     }
 
+    // ── S7: collection (list) editors ───────────────────────────────────
+
+    /// Open the Tier-L list editor for a given Advanced list field: `x` to
+    /// Advanced, walk to the field, `⏎` to open.
+    fn open_advanced_list(surface: &mut ConfigSurface, app: &mut App, target: AdvField) {
+        surface.handle_key(ch('x'), app);
+        assert_eq!(surface.tier, Tier::Advanced);
+        let mut guard = 0;
+        while surface.focused_adv() != target {
+            surface.handle_key(key(KeyCode::Down), app);
+            guard += 1;
+            assert!(guard < 50, "could not reach {target:?}");
+        }
+        surface.handle_key(key(KeyCode::Enter), app);
+        assert!(
+            matches!(surface.tier, Tier::ListEdit(_)),
+            "⏎ on a list field must open the list editor"
+        );
+    }
+
+    #[test]
+    fn list_editor_add_renders_live_buffer_and_commits() {
+        // Adding an entry shows the live buffer + cursor in the RENDERED frame,
+        // and `⏎` commits it into the collection.
+        let mut app = App::new();
+        let mut surface = ConfigSurface::new();
+        surface.on_enter(&mut app);
+        open_advanced_list(&mut surface, &mut app, AdvField::EgressAllowlist);
+        surface.handle_key(ch('a'), &mut app); // begin add
+        for c in "example.com".chars() {
+            surface.handle_key(ch(c), &mut app);
+        }
+        let frame = render_text(&mut surface, &app);
+        assert!(
+            frame.contains("example.com_"),
+            "the live entry buffer + cursor must render, got:\n{frame}"
+        );
+        surface.handle_key(key(KeyCode::Enter), &mut app); // commit
+        assert!(surface.list_editor.is_none(), "commit clears the buffer");
+        assert_eq!(
+            surface.current.egress_allow,
+            vec!["example.com".to_string()]
+        );
+    }
+
+    #[test]
+    fn list_editor_blank_entry_is_dropped() {
+        // Committing an empty buffer must not add a phantom entry.
+        let mut app = App::new();
+        let mut surface = ConfigSurface::new();
+        surface.on_enter(&mut app);
+        open_advanced_list(&mut surface, &mut app, AdvField::EgressAllowlist);
+        surface.handle_key(ch('a'), &mut app); // begin add
+        surface.handle_key(key(KeyCode::Enter), &mut app); // commit empty
+        assert!(
+            surface.current.egress_allow.is_empty(),
+            "a blank commit must not add an entry"
+        );
+    }
+
+    #[test]
+    fn tools_allow_list_delete_and_add_mutate_the_collection() {
+        // `d` removes the focused entry; `a` + type + `⏎` appends one.
+        let mut app = App::new();
+        app.config.tools_allow_list = vec!["Read".to_string(), "Grep".to_string()];
+        let mut surface = ConfigSurface::new();
+        surface.on_enter(&mut app); // seeds current from the config view
+        assert_eq!(
+            surface.current.tools_allow_list,
+            vec!["Read".to_string(), "Grep".to_string()]
+        );
+        open_advanced_list(&mut surface, &mut app, AdvField::ToolAllowList);
+        surface.handle_key(ch('d'), &mut app); // delete focused (index 0 = Read)
+        assert_eq!(surface.current.tools_allow_list, vec!["Grep".to_string()]);
+        surface.handle_key(ch('a'), &mut app); // begin add
+        for c in "Bash".chars() {
+            surface.handle_key(ch(c), &mut app);
+        }
+        surface.handle_key(key(KeyCode::Enter), &mut app); // commit
+        assert_eq!(
+            surface.current.tools_allow_list,
+            vec!["Grep".to_string(), "Bash".to_string()]
+        );
+    }
+
+    #[test]
+    fn egress_allowlist_add_persists_to_security() {
+        // Add an entry, then `esc` saves the collection to `[security]
+        // egress_allow` on disk. Hermetic via WAYLAND_HOME under the env lock.
+        let _guard = EXPERT_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = tempfile::tempdir().expect("tempdir");
+        let prev = std::env::var_os("WAYLAND_HOME");
+        // SAFETY: serialised by EXPERT_ENV_LOCK; restored before unlock.
+        unsafe { std::env::set_var("WAYLAND_HOME", dir.path()) };
+
+        let mut app = App::new();
+        let mut surface = ConfigSurface::new();
+        surface.on_enter(&mut app);
+        open_advanced_list(&mut surface, &mut app, AdvField::EgressAllowlist);
+        surface.handle_key(ch('a'), &mut app);
+        for c in "myapp.workers.dev".chars() {
+            surface.handle_key(ch(c), &mut app);
+        }
+        surface.handle_key(key(KeyCode::Enter), &mut app); // commit
+        surface.handle_key(key(KeyCode::Esc), &mut app); // save & back to Advanced
+        assert_eq!(surface.tier, Tier::Advanced);
+        assert!(!surface.is_dirty(), "esc must save the collection");
+        let written = std::fs::read_to_string(dir.path().join("config.toml"))
+            .expect("config.toml should have been written");
+        assert!(
+            written.contains("egress_allow") && written.contains("myapp.workers.dev"),
+            "the entry must persist to [security].egress_allow, got:\n{written}"
+        );
+
+        // SAFETY: restore the prior env under the same lock.
+        unsafe {
+            match prev {
+                Some(v) => std::env::set_var("WAYLAND_HOME", v),
+                None => std::env::remove_var("WAYLAND_HOME"),
+            }
+        }
+    }
+
+    #[test]
+    fn failover_toggle_and_fallback_chain_persist_to_provider_chain() {
+        // Enabling failover then adding a fallback model persists both
+        // `[provider_chain] enabled` and `fallback_models` on a single save.
+        let _guard = EXPERT_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = tempfile::tempdir().expect("tempdir");
+        let prev = std::env::var_os("WAYLAND_HOME");
+        // SAFETY: serialised by EXPERT_ENV_LOCK; restored before unlock.
+        unsafe { std::env::set_var("WAYLAND_HOME", dir.path()) };
+
+        let mut app = App::new();
+        let mut surface = ConfigSurface::new();
+        surface.on_enter(&mut app);
+        // Enable failover (a toggle field).
+        surface.handle_key(ch('x'), &mut app);
+        let mut guard = 0;
+        while surface.focused_adv() != AdvField::FailoverEnabled {
+            surface.handle_key(key(KeyCode::Down), &mut app);
+            guard += 1;
+            assert!(guard < 50);
+        }
+        surface.handle_key(key(KeyCode::Char(' ')), &mut app);
+        assert!(
+            surface.current.failover_enabled,
+            "space must enable failover"
+        );
+        // Walk to the chain list and add a model.
+        while surface.focused_adv() != AdvField::FallbackChain {
+            surface.handle_key(key(KeyCode::Down), &mut app);
+        }
+        surface.handle_key(key(KeyCode::Enter), &mut app); // open the (empty) list
+        assert!(matches!(surface.tier, Tier::ListEdit(_)));
+        surface.handle_key(ch('a'), &mut app);
+        for c in "anthropic:haiku".chars() {
+            surface.handle_key(ch(c), &mut app);
+        }
+        surface.handle_key(key(KeyCode::Enter), &mut app); // commit
+        assert_eq!(
+            surface.current.fallback_models,
+            vec!["anthropic:haiku".to_string()]
+        );
+        surface.handle_key(key(KeyCode::Esc), &mut app); // save & back
+        assert!(!surface.is_dirty());
+        let written = std::fs::read_to_string(dir.path().join("config.toml"))
+            .expect("config.toml should have been written");
+        assert!(
+            written.contains("[provider_chain]")
+                && written.contains("fallback_models")
+                && written.contains("anthropic:haiku"),
+            "the chain must persist to [provider_chain].fallback_models, got:\n{written}"
+        );
+
+        // SAFETY: restore the prior env under the same lock.
+        unsafe {
+            match prev {
+                Some(v) => std::env::set_var("WAYLAND_HOME", v),
+                None => std::env::remove_var("WAYLAND_HOME"),
+            }
+        }
+    }
+
     #[test]
     fn overview_esc_closes_when_nothing_is_dirty() {
         // With no pending edits, `esc` closes back to the workspace.
@@ -4286,6 +4863,7 @@ mod tests {
             Tier::Detail,
             Tier::Expert,
             Tier::Advanced,
+            Tier::ListEdit(ListKind::ToolsAllow),
             Tier::Providers,
         ] {
             surface.tier = tier;

--- a/crates/wcore-cli/src/tui/surfaces/diagnostics.rs
+++ b/crates/wcore-cli/src/tui/surfaces/diagnostics.rs
@@ -170,9 +170,8 @@ impl HealthCheck {
 
 /// The `/doctor` report: system dependency + environment health.
 ///
-/// Built from a live [`crate::doctor::collect`] run by [`run_doctor`];
-/// `Default` is the empty report shown for the one frame before the first
-/// `on_enter` collection lands.
+/// Built from a live [`crate::doctor::collect`] run by [`spawn_health_probe`];
+/// `Default` is the empty report shown while the first probe is in flight.
 #[derive(Debug, Clone, Default)]
 pub struct DoctorReport {
     /// The individual check rows, in display order.
@@ -289,47 +288,75 @@ pub struct TokenBudgetView {
     pub last_turn_output: u64,
 }
 
-/// Run the real [`crate::doctor::collect`] probe and convert its result
-/// into a [`DoctorReport`] of [`HealthCheck`] rows.
-///
-/// `doctor::collect` is async (its `which` probes spawn subprocesses),
-/// but the surface's `on_enter` / `handle_key` hooks are synchronous and
-/// run inside the TUI's tokio runtime — so `block_on` cannot be called
-/// here. The probe is therefore driven on a short-lived worker thread
-/// with its own current-thread runtime, and this fn blocks joining it.
-/// The probe is a handful of `which` calls, so the stall is sub-100ms.
-fn run_doctor() -> DoctorReport {
-    let raw = std::thread::spawn(|| {
-        let rt = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .expect("doctor probe runtime");
-        rt.block_on(doctor::collect())
-    })
-    .join()
-    .expect("doctor probe thread");
+/// How long the surface waits for the provider-health probe before it stops
+/// showing "probing…" and reports a timeout. Set above the underlying 5s
+/// per-request cap (plus slack for the concurrent set) so a healthy-but-slow
+/// network still lands normally; only a genuinely stalled probe trips it.
+const HEALTH_PROBE_UI_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(8);
 
-    DoctorReport {
-        checks: raw.checks.iter().map(health_check_from).collect(),
-    }
+/// One result from the off-thread `/doctor` probe. The two probes are
+/// **independent** — the fast system-dependency scan (`which` subprocesses)
+/// is delivered the instant it finishes, without waiting for the slow live
+/// provider-health HTTP probes — so SYSTEM/DISCOVERED fill in immediately
+/// while PROVIDERS is still in flight.
+enum ProbeMsg {
+    /// The converted system-dependency report (`which` checks).
+    Doctor(DoctorReport),
+    /// The live provider-health rows (real HTTP probes).
+    Health(Vec<AgentProviderHealth>),
 }
 
-/// Run the live provider-health probes on a short-lived worker thread,
-/// using the same thread-per-call pattern as [`run_doctor`].
+/// Start the two slow `/doctor` probes on a **detached** worker thread and
+/// return a receiver that delivers each result as it lands.
 ///
-/// The async [`wcore_agent::health::provider_health_check_all`] races
-/// four 5-second-capped HTTP probes in parallel, so the worst-case
-/// stall on the calling (sync) `on_enter` is one timeout, ~5s.
-fn run_provider_health() -> Vec<AgentProviderHealth> {
-    std::thread::spawn(|| {
-        let rt = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .expect("provider-health probe runtime");
-        rt.block_on(health::provider_health_check_all())
-    })
-    .join()
-    .expect("provider-health probe thread")
+/// This is the fix for the `on_enter` UI-thread freeze: `doctor::collect`
+/// (which spawns subprocesses) and `health::provider_health_check_all`
+/// (live HTTP) are async, but the surface's `on_enter`/`handle_key` hooks
+/// are synchronous and run inside the TUI's tokio runtime. The previous
+/// implementation drove them on a worker thread but then **joined** it,
+/// blocking the render loop — and when the HTTP probes stalled (a
+/// restrictive egress layer, or many connected providers exceeding the
+/// per-probe cap), the entire TUI froze and the Diagnostics surface never
+/// painted. Here the thread is left running; the surface renders a
+/// "probing…" state immediately and `tick`→[`DiagnosticsSurface::poll_health`]
+/// fills in SYSTEM/PROVIDERS/DISCOVERED as each result lands (the same
+/// async-poll pattern as the paste-detect modal). The two probes are
+/// dispatched concurrently and each sends on its own, so the fast system
+/// scan is never held hostage by the slow provider HTTP probe.
+fn spawn_health_probe() -> std::sync::mpsc::Receiver<ProbeMsg> {
+    let (tx, rx) = std::sync::mpsc::channel();
+    // If the thread fails to spawn, both senders drop and the receiver
+    // resolves to `Disconnected` — the surface treats that as "no result"
+    // and stops waiting rather than hanging on a perpetual "probing…".
+    let _ = std::thread::Builder::new()
+        .name("wld-doctor-probe".into())
+        .spawn(move || {
+            let rt = match tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+            {
+                Ok(rt) => rt,
+                Err(_) => return,
+            };
+            rt.block_on(async {
+                let tx_doctor = tx.clone();
+                let doctor_task = async move {
+                    let raw = doctor::collect().await;
+                    let report = DoctorReport {
+                        checks: raw.checks.iter().map(health_check_from).collect(),
+                    };
+                    // A dropped receiver (surface left the screen) is an
+                    // expected no-op, not an error.
+                    let _ = tx_doctor.send(ProbeMsg::Doctor(report));
+                };
+                let health_task = async move {
+                    let health = health::provider_health_check_all().await;
+                    let _ = tx.send(ProbeMsg::Health(health));
+                };
+                tokio::join!(doctor_task, health_task);
+            });
+        });
+    rx
 }
 
 /// Build the per-tool backend-status snapshot by walking [`TOOL_GATES`]
@@ -776,6 +803,24 @@ pub struct DiagnosticsSurface {
     /// on this machine (ambient cloud creds, local Ollama, Claude Desktop MCP)
     /// the user could wire up. Rendered as the DISCOVERED section of `/doctor`.
     discovered: Vec<Discovery>,
+    /// In-flight handle for the async system + provider-health probe. `Some`
+    /// while either probe is running (started by `on_enter` / the `r` key);
+    /// `tick` polls it and clears it back to `None` once both results land.
+    /// Keeping the probe off the synchronous `on_enter` path is what stops the
+    /// live HTTP probes from freezing the whole TUI (see [`spawn_health_probe`]).
+    health_pending: Option<std::sync::mpsc::Receiver<ProbeMsg>>,
+    /// Whether the live provider-health rows have landed for the current probe.
+    /// Distinct from `doctor_collected` (the system scan) because the two
+    /// probes resolve independently — the fast system scan should not gate the
+    /// PROVIDERS "probing…" state on the slow HTTP probe, and vice-versa.
+    health_collected: bool,
+    /// When the current probe was started, for the UI-side health timeout.
+    probe_started: Option<std::time::Instant>,
+    /// Set when the provider-health probe exceeded [`HEALTH_PROBE_UI_TIMEOUT`]
+    /// without landing. The HTTP probe carries its own per-request cap, but a
+    /// hostile egress layer can stall it beyond that; rather than show
+    /// "probing…" forever we give up waiting and say so honestly.
+    health_timed_out: bool,
 }
 
 impl Default for DiagnosticsSurface {
@@ -804,6 +849,10 @@ impl DiagnosticsSurface {
             effective_scroll: 0,
             channels: Vec::new(),
             discovered: Vec::new(),
+            health_pending: None,
+            health_collected: false,
+            probe_started: None,
+            health_timed_out: false,
         }
     }
 
@@ -812,25 +861,101 @@ impl DiagnosticsSurface {
         self.mode
     }
 
-    /// Run the live `doctor` probe and store its report. Also refreshes
-    /// the v0.9.0 W4 E2 provider-health probes (real HTTP) + the cheap
-    /// env-driven tool-status snapshot.
+    /// Refresh the `/doctor` data. The cheap, local scans (tool gates, config
+    /// posture, channel configs) run synchronously here; the two slow live
+    /// probes (system `which` checks + provider HTTP health) are started on a
+    /// detached worker thread and filled in later by `tick`→[`Self::poll_health`].
+    ///
+    /// Splitting the work this way is the fix for the `on_enter` freeze: the
+    /// surface paints immediately with the local sections (CONFIG / TOOLS /
+    /// CHANNELS) and a "probing…" placeholder for SYSTEM / PROVIDERS /
+    /// DISCOVERED, instead of blocking the render loop on uncapped HTTP probes.
     fn refresh_doctor(&mut self, app: &App) {
-        self.doctor = run_doctor();
-        self.provider_health = run_provider_health();
+        // Instant, local, non-blocking scans — safe on the UI thread.
         self.tool_status = scan_tool_status();
         self.config_checks = scan_config_health(app);
         // S10: surface the on-disk channel configs (read-only, secret-free).
         self.channels = wcore_channels_registry::scan_user_channels();
-        // S11: "here's what I found" — reuse the just-collected Ollama doctor
-        // signal so we don't re-probe it asynchronously here.
-        let ollama_available = self
-            .doctor
-            .checks
-            .iter()
-            .any(|c| c.label == "ollama" && c.state == HealthState::Ok);
-        self.discovered = scan_environment(ollama_available);
-        self.doctor_collected = true;
+        // Slow live probes run off-thread; DISCOVERED (S11) is computed in
+        // `poll_health` once the doctor report (its Ollama signal) lands.
+        self.start_health_probe();
+    }
+
+    /// Start the async system + provider-health probe (idempotent: replacing
+    /// any in-flight handle). Marks both results not-yet-collected so the
+    /// render shows the "probing…" state until [`Self::poll_health`] applies
+    /// each. The prior rows are kept until then, so a re-run (`r`) updates in
+    /// place rather than flashing to empty.
+    fn start_health_probe(&mut self) {
+        self.doctor_collected = false;
+        self.health_collected = false;
+        self.health_timed_out = false;
+        self.probe_started = Some(std::time::Instant::now());
+        self.health_pending = Some(spawn_health_probe());
+    }
+
+    /// Poll the in-flight health probe; apply any results that have landed.
+    /// Returns `true` when something was applied (so the caller knows a
+    /// repaint is due). Drains every queued message per call so a fast and a
+    /// slow result that arrive together are both picked up. The receiver is
+    /// cleared once both probes have resolved (or the thread dropped without a
+    /// result), so the surface never hangs on a perpetual "probing…". Called
+    /// from `tick` every loop iteration.
+    fn poll_health(&mut self) -> bool {
+        let Some(rx) = self.health_pending.as_ref() else {
+            return false;
+        };
+        let mut changed = false;
+        loop {
+            match rx.try_recv() {
+                Ok(ProbeMsg::Doctor(report)) => {
+                    self.doctor = report;
+                    // S11: "here's what I found" — reuse the just-landed Ollama
+                    // doctor signal rather than re-probing it.
+                    let ollama_available = self
+                        .doctor
+                        .checks
+                        .iter()
+                        .any(|c| c.label == "ollama" && c.state == HealthState::Ok);
+                    self.discovered = scan_environment(ollama_available);
+                    self.doctor_collected = true;
+                    changed = true;
+                }
+                Ok(ProbeMsg::Health(rows)) => {
+                    self.provider_health = rows;
+                    self.health_collected = true;
+                    changed = true;
+                }
+                Err(std::sync::mpsc::TryRecvError::Empty) => break,
+                Err(std::sync::mpsc::TryRecvError::Disconnected) => {
+                    // The probe thread is gone — stop waiting on anything that
+                    // never arrived and render whatever we have.
+                    self.doctor_collected = true;
+                    self.health_collected = true;
+                    changed = true;
+                    break;
+                }
+            }
+        }
+        // UI-side timeout: a stalled provider-health probe (egress layer
+        // holding the connection past its own cap) must not show "probing…"
+        // forever. Give up waiting on it and report a timeout. The detached
+        // probe thread is left to finish on its own; a re-run (`r`) starts a
+        // fresh one.
+        if !self.health_collected
+            && self
+                .probe_started
+                .is_some_and(|t| t.elapsed() >= HEALTH_PROBE_UI_TIMEOUT)
+        {
+            self.health_collected = true;
+            self.health_timed_out = true;
+            changed = true;
+        }
+        // Stop polling once both probes have settled.
+        if self.doctor_collected && self.health_collected {
+            self.health_pending = None;
+        }
+        changed
     }
 
     /// S9: render the redacted effective config into `effective_toml` and reset
@@ -969,6 +1094,14 @@ impl Surface for DiagnosticsSurface {
         self.refresh_doctor(app);
         self.refresh_memory();
         self.refresh_effective();
+    }
+
+    /// Per-tick poll for the async health probe started by `on_enter`/`r`.
+    /// Applies the result when it lands so SYSTEM/PROVIDERS/DISCOVERED fill in
+    /// without blocking the UI thread. Emits no action.
+    fn tick(&mut self, _app: &mut App) -> SurfaceAction {
+        self.poll_health();
+        SurfaceAction::None
     }
 
     fn render(&mut self, frame: &mut Frame, area: Rect, app: &App, theme: &Theme) {
@@ -1162,29 +1295,49 @@ impl DiagnosticsSurface {
             return;
         }
 
-        // The empty report shown for the single frame before the first
-        // `on_enter` probe lands.
-        if !self.doctor_collected && self.doctor.checks.is_empty() {
-            render_empty(frame, inner, t, "Running system checks…");
-            return;
-        }
+        // The two live probes (SYSTEM + PROVIDERS) run off-thread and resolve
+        // independently; until each lands its section (and DISCOVERED, derived
+        // from SYSTEM) shows a "probing…" line. The local sections (CONFIG /
+        // TOOLS / CHANNELS) always render immediately — the whole point of not
+        // blocking `on_enter`.
+        let system_probing = self.health_pending.is_some() && !self.doctor_collected;
+        let providers_probing = self.health_pending.is_some() && !self.health_collected;
+        let probing_line = || {
+            Line::from(Span::styled(
+                "  probing…",
+                Style::default().fg(t.text_muted),
+            ))
+        };
 
         let mut lines: Vec<Line> = Vec::new();
 
         // ── 1. System dependency rows ───────────────────────────────
         push_section_header(&mut lines, t, "SYSTEM");
-        for check in &self.doctor.checks {
-            lines.push(status_row(check.state, &check.label, &check.detail, t));
+        if self.doctor.checks.is_empty() && system_probing {
+            lines.push(probing_line());
+        } else {
+            for check in &self.doctor.checks {
+                lines.push(status_row(check.state, &check.label, &check.detail, t));
+            }
         }
 
         // ── 2. Provider health rows ─────────────────────────────────
         lines.push(Line::from(""));
         push_section_header(&mut lines, t, "PROVIDERS");
         if self.provider_health.is_empty() {
-            lines.push(Line::from(Span::styled(
-                "  no provider probes yet",
-                Style::default().fg(t.text_muted),
-            )));
+            lines.push(if providers_probing {
+                probing_line()
+            } else if self.health_timed_out {
+                Line::from(Span::styled(
+                    "  health probe timed out — check network / egress policy",
+                    Style::default().fg(t.warning),
+                ))
+            } else {
+                Line::from(Span::styled(
+                    "  no provider probes yet",
+                    Style::default().fg(t.text_muted),
+                ))
+            });
         } else {
             for ph in &self.provider_health {
                 lines.push(status_row(
@@ -1304,6 +1457,9 @@ impl DiagnosticsSurface {
         // dim line with the how-to hint (absence is not a problem, so no Warn).
         lines.push(Line::from(""));
         push_section_header(&mut lines, t, "DISCOVERED");
+        if self.discovered.is_empty() && system_probing {
+            lines.push(probing_line());
+        }
         for d in &self.discovered {
             let (glyph, glyph_color, label_color) = if d.available {
                 ("● ", t.success, t.text)
@@ -1635,6 +1791,23 @@ mod tests {
         out
     }
 
+    /// Drive the async health probe (started by `on_enter`/`r`) to full
+    /// settlement by polling `tick`, the way the live render loop does. Both
+    /// the system scan and the provider-health rows must land (the receiver is
+    /// cleared only when both do). Bounded so a hung/slow probe fails the test
+    /// rather than spinning forever. Returns whether it settled in budget.
+    fn drive_health_probe(s: &mut DiagnosticsSurface) -> bool {
+        let mut app = App::new();
+        for _ in 0..400 {
+            s.tick(&mut app);
+            if s.health_pending.is_none() {
+                return true;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(25));
+        }
+        s.health_pending.is_none()
+    }
+
     // -- OSC-9 / bell helpers ----------------------------------------------
 
     #[test]
@@ -1793,14 +1966,15 @@ mod tests {
 
     #[test]
     fn doctor_renders_live_probe_rows_after_on_enter() {
-        // `on_enter` runs the real `doctor::collect` probe. Every doctor
-        // run includes the structural `binary version` row, so the live
+        // `on_enter` starts the real `doctor::collect` probe off-thread; the
+        // render loop's `tick` applies it once it lands. Every doctor run
+        // includes the structural `binary version` row, so the collected
         // report must show it — and no placeholder banner.
         let mut s = DiagnosticsSurface::new();
         s.on_enter(&mut App::new());
         assert!(
-            s.doctor_collected,
-            "on_enter must collect the doctor report"
+            drive_health_probe(&mut s),
+            "the async probe must collect the doctor report"
         );
         assert!(
             !s.doctor.checks.is_empty(),
@@ -1816,16 +1990,77 @@ mod tests {
     }
 
     #[test]
+    fn doctor_on_enter_does_not_block_and_shows_probing() {
+        // The freeze fix: `on_enter` must NOT block on the live probes. It
+        // returns immediately with a probe in flight, and the first render
+        // shows the local sections plus a "probing…" placeholder for the
+        // async ones — never a frozen/blank screen.
+        let mut s = DiagnosticsSurface::new();
+        s.on_enter(&mut App::new());
+        assert!(
+            s.health_pending.is_some(),
+            "on_enter must start the probe without blocking"
+        );
+        assert!(
+            !s.doctor_collected,
+            "the report is still in flight right after on_enter"
+        );
+        let out = render_to_string(&mut s);
+        // Local sections render instantly; the async sections show probing.
+        assert!(out.contains("CONFIG"), "local CONFIG section must render");
+        assert!(
+            out.contains("probing"),
+            "async sections must show a probing state"
+        );
+    }
+
+    #[test]
     fn doctor_re_run_key_refreshes_in_place() {
         let mut s = DiagnosticsSurface::new();
         let mut app = App::new();
-        // `r` runs the probe directly and consumes the key (no command).
+        // `r` starts the probe directly and consumes the key (no command).
         match s.handle_key(key(KeyCode::Char('r')), &mut app) {
             SurfaceAction::None => {}
             other => panic!("expected re-run to be inert, got {other:?}"),
         }
-        assert!(s.doctor_collected, "the `r` key must run the probe");
+        assert!(
+            s.health_pending.is_some(),
+            "the `r` key must start the probe"
+        );
+        assert!(drive_health_probe(&mut s), "the `r` probe must resolve");
         assert!(!s.doctor.checks.is_empty(), "re-run must populate rows");
+    }
+
+    #[test]
+    fn provider_health_probe_times_out_in_the_ui_after_the_cap() {
+        // A stalled provider-health probe (egress layer holding the connection
+        // past its own cap) must not show "probing…" forever. Once the UI
+        // timeout elapses the surface gives up waiting and renders an honest
+        // "timed out" line. Drive it with a never-resolving channel and a
+        // start time pushed past the cap (no real network, fully hermetic).
+        let mut s = DiagnosticsSurface::new();
+        let (_tx, rx) = std::sync::mpsc::channel::<ProbeMsg>();
+        s.health_pending = Some(rx); // _tx kept alive: not Disconnected, just Empty
+        s.doctor_collected = true; // pretend the fast system scan already landed
+        s.health_collected = false;
+        s.probe_started = Some(
+            std::time::Instant::now()
+                - (HEALTH_PROBE_UI_TIMEOUT + std::time::Duration::from_secs(1)),
+        );
+
+        let mut app = App::new();
+        s.tick(&mut app);
+
+        assert!(s.health_timed_out, "the probe must be marked timed out");
+        assert!(
+            s.health_pending.is_none(),
+            "a timed-out probe must stop being polled"
+        );
+        let out = render_to_string(&mut s);
+        assert!(
+            out.contains("timed out"),
+            "PROVIDERS must render the timeout copy:\n{out}"
+        );
     }
 
     // -- /cost screen ------------------------------------------------------
@@ -2545,6 +2780,7 @@ mod tests {
 
         let mut s = DiagnosticsSurface::new();
         s.on_enter(&mut App::new());
+        assert!(drive_health_probe(&mut s), "probe must resolve");
 
         // All four probes must report Yellow.
         assert_eq!(s.provider_health.len(), 4);
@@ -2580,12 +2816,14 @@ mod tests {
 
     #[test]
     fn doctor_provider_health_times_out_at_5s() {
-        // A wedged provider must NOT stall /doctor past the configured
-        // 5s health-check cap. We point `ANTHROPIC_API_BASE` at a TCP
-        // listener that accepts and never replies, set the api key so
-        // the probe is exercised (not skipped as Yellow), then assert
-        // the whole `on_enter` returns inside 10s (5s cap + slack for
-        // CI noise + the other three probes' connect-failures).
+        // A wedged provider must NOT stall /doctor. We point
+        // `ANTHROPIC_API_BASE` at a TCP listener that accepts and never
+        // replies, set the api key so the probe is exercised (not skipped as
+        // Yellow), then assert two things: (1) `on_enter` returns IMMEDIATELY
+        // — the probe runs off-thread, so a wedged provider can never freeze
+        // the UI (the on_enter-freeze fix); (2) once the probe is driven to
+        // completion the Anthropic row is Red/unreachable, proving the
+        // underlying health cap still fired.
         use std::time::Instant;
         use tokio::io::AsyncReadExt;
         use tokio::net::TcpListener;
@@ -2632,10 +2870,18 @@ mod tests {
         s.on_enter(&mut App::new());
         let elapsed = started.elapsed();
 
-        // The 5s cap holds — generous slack for slow CI.
+        // on_enter must NOT block on the (wedged) probe — it only starts the
+        // worker thread and returns. Generous slack for thread-spawn on slow CI.
         assert!(
-            elapsed < std::time::Duration::from_secs(15),
-            "/doctor on_enter must respect the 5s health-probe cap (took {elapsed:?})"
+            elapsed < std::time::Duration::from_secs(2),
+            "/doctor on_enter must not block on the health probe (took {elapsed:?})"
+        );
+
+        // Drive the off-thread probe to completion (the wedged provider hits
+        // the underlying 5s cap), then check the result.
+        assert!(
+            drive_health_probe(&mut s),
+            "probe must resolve within budget"
         );
 
         // The Anthropic row must be Red with an unreachable detail.

--- a/crates/wcore-cli/src/tui/surfaces/diagnostics.rs
+++ b/crates/wcore-cli/src/tui/surfaces/diagnostics.rs
@@ -472,6 +472,108 @@ fn scan_config_health(app: &App) -> Vec<HealthCheck> {
     rows
 }
 
+/// S11: one "here's what I found" discovery row — a latent capability on this
+/// machine the user could wire up (ambient cloud creds, a local Ollama daemon,
+/// an existing Claude Desktop MCP config). Read-only: detection only, never
+/// mutates config.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Discovery {
+    /// Short capability label (e.g. `AWS / Bedrock`).
+    pub label: String,
+    /// Whether the capability was detected on this host.
+    pub available: bool,
+    /// A one-line detail: what was found, or how to enable it.
+    pub detail: String,
+}
+
+/// The Claude Desktop config path on this platform
+/// (`<config-dir>/Claude/claude_desktop_config.json`). Uses the real OS config
+/// dir — Claude Desktop is an external app, so this deliberately does NOT honor
+/// `WAYLAND_HOME` (we are discovering the actual machine).
+fn claude_desktop_config_path() -> std::path::PathBuf {
+    dirs::config_dir()
+        .unwrap_or_default()
+        .join("Claude")
+        .join("claude_desktop_config.json")
+}
+
+/// Count the MCP servers declared in a Claude Desktop config file. Returns
+/// `None` if the file is absent/unreadable/unparseable or has no `mcpServers`
+/// object — the discovery row reads that as "not detected".
+fn count_mcp_servers_in(path: &std::path::Path) -> Option<usize> {
+    let body = std::fs::read_to_string(path).ok()?;
+    let json: serde_json::Value = serde_json::from_str(&body).ok()?;
+    Some(json.get("mcpServers")?.as_object()?.len())
+}
+
+/// S11: probe the machine for latent capabilities Wayland could use. Reuses the
+/// single-source-of-truth ambient/OAuth detection in
+/// [`wcore_config::config::provider_connected`] and the already-collected
+/// Ollama doctor signal; the only fresh probe is the Claude Desktop config scan.
+fn scan_environment(ollama_available: bool) -> Vec<Discovery> {
+    use wcore_config::config::{ProviderType, provider_connected};
+
+    let mut rows = Vec::new();
+
+    rows.push(Discovery {
+        label: "Ollama (local models)".to_string(),
+        available: ollama_available,
+        detail: if ollama_available {
+            "detected — route local models with `ollama:<model>`".to_string()
+        } else {
+            "not found — install ollama or set OLLAMA_BASE_URL".to_string()
+        },
+    });
+
+    let aws = provider_connected(ProviderType::Bedrock);
+    rows.push(Discovery {
+        label: "AWS / Bedrock".to_string(),
+        available: aws,
+        detail: if aws {
+            "ambient AWS credentials detected — Bedrock is ready".to_string()
+        } else {
+            "no AWS credentials (env / ~/.aws / role)".to_string()
+        },
+    });
+
+    let gcp = provider_connected(ProviderType::Vertex);
+    rows.push(Discovery {
+        label: "GCP / Vertex".to_string(),
+        available: gcp,
+        detail: if gcp {
+            "ambient GCP credentials detected — Vertex is ready".to_string()
+        } else {
+            "no GCP credentials (GOOGLE_APPLICATION_CREDENTIALS / ADC)".to_string()
+        },
+    });
+
+    let chatgpt = provider_connected(ProviderType::OpenAIChatGpt);
+    rows.push(Discovery {
+        label: "ChatGPT (OAuth)".to_string(),
+        available: chatgpt,
+        detail: if chatgpt {
+            "stored ChatGPT login detected".to_string()
+        } else {
+            "not signed in — run `wayland auth login chatgpt`".to_string()
+        },
+    });
+
+    let mcp = count_mcp_servers_in(&claude_desktop_config_path());
+    rows.push(Discovery {
+        label: "Claude Desktop MCP".to_string(),
+        available: mcp.is_some_and(|n| n > 0),
+        detail: match mcp {
+            Some(n) if n > 0 => format!(
+                "{n} MCP server{} configured — importable",
+                if n == 1 { "" } else { "s" }
+            ),
+            _ => "no Claude Desktop MCP config found".to_string(),
+        },
+    });
+
+    rows
+}
+
 /// Extract the last 10 engine errors from the session transcript.
 /// The protocol bridge pushes each `ProtocolEvent::Error` as a
 /// `TurnRole::System` turn whose first markdown element starts with
@@ -670,6 +772,10 @@ pub struct DiagnosticsSurface {
     /// `channels_dir()` on `on_enter` + the `r` key, rendered as the CHANNELS
     /// section of `/doctor`.
     channels: Vec<wcore_channels_registry::ChannelSummary>,
+    /// S11 — "here's what I found" environment discovery: latent capabilities
+    /// on this machine (ambient cloud creds, local Ollama, Claude Desktop MCP)
+    /// the user could wire up. Rendered as the DISCOVERED section of `/doctor`.
+    discovered: Vec<Discovery>,
 }
 
 impl Default for DiagnosticsSurface {
@@ -697,6 +803,7 @@ impl DiagnosticsSurface {
             effective_toml: String::new(),
             effective_scroll: 0,
             channels: Vec::new(),
+            discovered: Vec::new(),
         }
     }
 
@@ -715,6 +822,14 @@ impl DiagnosticsSurface {
         self.config_checks = scan_config_health(app);
         // S10: surface the on-disk channel configs (read-only, secret-free).
         self.channels = wcore_channels_registry::scan_user_channels();
+        // S11: "here's what I found" — reuse the just-collected Ollama doctor
+        // signal so we don't re-probe it asynchronously here.
+        let ollama_available = self
+            .doctor
+            .checks
+            .iter()
+            .any(|c| c.label == "ollama" && c.state == HealthState::Ok);
+        self.discovered = scan_environment(ollama_available);
         self.doctor_collected = true;
     }
 
@@ -1183,7 +1298,26 @@ impl DiagnosticsSurface {
             }
         }
 
-        // ── 7. Recent engine errors ─────────────────────────────────
+        // ── 7. Discovered capabilities (S11) ────────────────────────
+        // "Here's what I found" — latent capabilities on this machine the user
+        // could wire up. A found capability paints green; an absent one is a
+        // dim line with the how-to hint (absence is not a problem, so no Warn).
+        lines.push(Line::from(""));
+        push_section_header(&mut lines, t, "DISCOVERED");
+        for d in &self.discovered {
+            let (glyph, glyph_color, label_color) = if d.available {
+                ("● ", t.success, t.text)
+            } else {
+                ("○ ", t.text_dim, t.text_dim)
+            };
+            lines.push(Line::from(vec![
+                Span::styled(glyph.to_string(), Style::default().fg(glyph_color)),
+                Span::styled(format!("{:<22}", d.label), Style::default().fg(label_color)),
+                Span::styled(d.detail.clone(), Style::default().fg(t.text_muted)),
+            ]));
+        }
+
+        // ── 8. Recent engine errors ─────────────────────────────────
         lines.push(Line::from(""));
         push_section_header(&mut lines, t, "RECENT ERRORS");
         let errors = collect_recent_errors(app);
@@ -1204,7 +1338,7 @@ impl DiagnosticsSurface {
             }
         }
 
-        // ── 8. Token budget ─────────────────────────────────────────
+        // ── 9. Token budget ─────────────────────────────────────────
         lines.push(Line::from(""));
         push_section_header(&mut lines, t, "TOKEN BUDGET");
         let budget = token_budget_view(app);
@@ -2311,6 +2445,62 @@ mod tests {
         assert!(
             out.contains("weird") && out.contains("unknown platform"),
             "unknown-platform channel must read 'won't load':\n{out}"
+        );
+    }
+
+    #[test]
+    fn count_mcp_servers_in_parses_claude_desktop_config() {
+        // S11: the only greenfield probe — count `mcpServers` in a Claude
+        // Desktop config; absent file / absent key / bad JSON all read None.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let ok = dir.path().join("claude_desktop_config.json");
+        std::fs::write(&ok, r#"{"mcpServers":{"notion":{},"github":{}}}"#).unwrap();
+        assert_eq!(count_mcp_servers_in(&ok), Some(2));
+
+        assert_eq!(
+            count_mcp_servers_in(&dir.path().join("missing.json")),
+            None,
+            "absent file must read None"
+        );
+
+        let no_key = dir.path().join("empty.json");
+        std::fs::write(&no_key, "{}").unwrap();
+        assert_eq!(
+            count_mcp_servers_in(&no_key),
+            None,
+            "config without mcpServers must read None"
+        );
+    }
+
+    #[test]
+    fn doctor_discovered_section_shows_found_and_absent_rows() {
+        // S11: the DISCOVERED section paints found capabilities prominently and
+        // absent ones as dim how-to hints. Injecting rows keeps the test
+        // hermetic; `doctor_collected` forces the body to render.
+        let mut s = DiagnosticsSurface::new();
+        s.doctor_collected = true;
+        s.discovered = vec![
+            Discovery {
+                label: "Ollama (local models)".to_string(),
+                available: true,
+                detail: "detected — route local models with `ollama:<model>`".to_string(),
+            },
+            Discovery {
+                label: "AWS / Bedrock".to_string(),
+                available: false,
+                detail: "no AWS credentials (env / ~/.aws / role)".to_string(),
+            },
+        ];
+        let app = App::new();
+        let out = render_tall(&mut s, &app);
+        assert!(out.contains("DISCOVERED"), "section header missing:\n{out}");
+        assert!(
+            out.contains("Ollama") && out.contains("detected"),
+            "found capability missing:\n{out}"
+        );
+        assert!(
+            out.contains("AWS / Bedrock") && out.contains("no AWS credentials"),
+            "absent capability + hint missing:\n{out}"
         );
     }
 

--- a/crates/wcore-cli/src/tui/surfaces/diagnostics.rs
+++ b/crates/wcore-cli/src/tui/surfaces/diagnostics.rs
@@ -665,6 +665,11 @@ pub struct DiagnosticsSurface {
     /// Vertical scroll offset for the `/effective` view (the TOML can exceed
     /// the viewport). Clamped on `Up`/`Down`/`PageUp`/`PageDown`.
     effective_scroll: u16,
+    /// S10 — secret-free summaries of the on-disk channel configs (the
+    /// "Integrations ghost" made visible). Scanned from the canonical
+    /// `channels_dir()` on `on_enter` + the `r` key, rendered as the CHANNELS
+    /// section of `/doctor`.
+    channels: Vec<wcore_channels_registry::ChannelSummary>,
 }
 
 impl Default for DiagnosticsSurface {
@@ -691,6 +696,7 @@ impl DiagnosticsSurface {
             config_checks: Vec::new(),
             effective_toml: String::new(),
             effective_scroll: 0,
+            channels: Vec::new(),
         }
     }
 
@@ -707,6 +713,8 @@ impl DiagnosticsSurface {
         self.provider_health = run_provider_health();
         self.tool_status = scan_tool_status();
         self.config_checks = scan_config_health(app);
+        // S10: surface the on-disk channel configs (read-only, secret-free).
+        self.channels = wcore_channels_registry::scan_user_channels();
         self.doctor_collected = true;
     }
 
@@ -1133,7 +1141,49 @@ impl DiagnosticsSurface {
             }
         }
 
-        // ── 6. Recent engine errors ─────────────────────────────────
+        // ── 6. Channels / integrations (S10) ────────────────────────
+        // The on-disk channel configs (`~/.wayland/channels/*.toml`) are
+        // otherwise invisible to the schema-driven `/config` TUI — this is the
+        // "ghost subsystem" made visible. Secret-free: only key names show.
+        lines.push(Line::from(""));
+        push_section_header(&mut lines, t, "CHANNELS");
+        if self.channels.is_empty() {
+            lines.push(Line::from(Span::styled(
+                "  none configured",
+                Style::default().fg(t.text_muted),
+            )));
+        } else {
+            for ch in &self.channels {
+                let (state, detail) = if let Some(err) = &ch.parse_error {
+                    (HealthState::Fail, format!("parse error · {err}"))
+                } else if !ch.known_platform {
+                    (
+                        HealthState::Fail,
+                        format!("unknown platform `{}` · won't load", ch.platform),
+                    )
+                } else if !ch.enabled {
+                    (HealthState::Warn, format!("{} · disabled", ch.platform))
+                } else {
+                    let opts = if ch.option_keys.is_empty() {
+                        String::new()
+                    } else {
+                        format!(" · opts: {}", ch.option_keys.join(", "))
+                    };
+                    let secrets = if ch.secret_keys.is_empty() {
+                        String::new()
+                    } else {
+                        format!(" · secrets: {}", ch.secret_keys.join(", "))
+                    };
+                    (
+                        HealthState::Ok,
+                        format!("{} · enabled{opts}{secrets}", ch.platform),
+                    )
+                };
+                lines.push(status_row(state, &ch.name, &detail, t));
+            }
+        }
+
+        // ── 7. Recent engine errors ─────────────────────────────────
         lines.push(Line::from(""));
         push_section_header(&mut lines, t, "RECENT ERRORS");
         let errors = collect_recent_errors(app);
@@ -1154,7 +1204,7 @@ impl DiagnosticsSurface {
             }
         }
 
-        // ── 7. Token budget ─────────────────────────────────────────
+        // ── 8. Token budget ─────────────────────────────────────────
         lines.push(Line::from(""));
         push_section_header(&mut lines, t, "TOKEN BUDGET");
         let budget = token_budget_view(app);
@@ -2217,6 +2267,50 @@ mod tests {
             egress.detail.contains('1'),
             "egress detail should count the allowlist entry: {}",
             egress.detail
+        );
+    }
+
+    #[test]
+    fn doctor_channels_section_surfaces_status_secret_free() {
+        // S10: the CHANNELS section makes the on-disk channel configs visible —
+        // an enabled known channel shows its option/secret KEY names, an unknown
+        // platform reads "won't load". Injecting summaries keeps the test
+        // hermetic (no FS / no env); `doctor_collected` is forced so the body
+        // renders rather than the "running checks" splash.
+        let mut s = DiagnosticsSurface::new();
+        s.doctor_collected = true;
+        s.channels = vec![
+            wcore_channels_registry::ChannelSummary {
+                name: "myslack".to_string(),
+                platform: "slack".to_string(),
+                enabled: true,
+                known_platform: true,
+                option_keys: vec!["channel".to_string()],
+                secret_keys: vec!["bot_token".to_string()],
+                parse_error: None,
+            },
+            wcore_channels_registry::ChannelSummary {
+                name: "weird".to_string(),
+                platform: "carrierpigeon".to_string(),
+                enabled: true,
+                known_platform: false,
+                option_keys: vec![],
+                secret_keys: vec![],
+                parse_error: None,
+            },
+        ];
+        let app = App::new();
+        let out = render_tall(&mut s, &app);
+        assert!(out.contains("CHANNELS"), "section header missing:\n{out}");
+        assert!(
+            out.contains("myslack") && out.contains("slack"),
+            "known channel missing:\n{out}"
+        );
+        // KEY names are surfaced (never values).
+        assert!(out.contains("bot_token"), "secret key name missing:\n{out}");
+        assert!(
+            out.contains("weird") && out.contains("unknown platform"),
+            "unknown-platform channel must read 'won't load':\n{out}"
         );
     }
 

--- a/crates/wcore-cli/src/tui/surfaces/diagnostics.rs
+++ b/crates/wcore-cli/src/tui/surfaces/diagnostics.rs
@@ -355,6 +355,123 @@ fn env_set_nonempty(name: &str) -> bool {
     matches!(std::env::var(name), Ok(v) if !v.is_empty())
 }
 
+/// S8: build the **config-posture** health rows from the resolved
+/// [`ConfigView`](crate::tui::app::ConfigView) snapshot on `App`.
+///
+/// These are coherence/safety checks on the user's *configuration* — distinct
+/// from the SYSTEM (binaries), PROVIDERS (live HTTP), and TOOLS (env gates)
+/// sections, which probe the runtime environment. Every row reads real config
+/// values plumbed by S5–S7 (egress allowlist, credential backend, spend cap,
+/// failover chain, tool-approval posture) plus one cheap filesystem resolve
+/// for the memory directory. A valid-but-permissive state is surfaced as
+/// `Warn` (never a fake `Fail`); a benign "off" state is an honest `Ok`.
+fn scan_config_health(app: &App) -> Vec<HealthCheck> {
+    let c = &app.config;
+    let mut rows = Vec::new();
+
+    // Egress guard — off means outbound calls are not gated.
+    rows.push(if c.security_egress_enabled {
+        let n = c.egress_allow.len();
+        HealthCheck::new(
+            "egress guard",
+            HealthState::Ok,
+            format!(
+                "on · {n} extra allowlist entr{}",
+                if n == 1 { "y" } else { "ies" }
+            ),
+        )
+    } else {
+        HealthCheck::new(
+            "egress guard",
+            HealthState::Warn,
+            "off — outbound network calls are not restricted",
+        )
+    });
+
+    // Credential storage backend — plaintext is the permissive default.
+    rows.push(match c.storage_backend.as_str() {
+        "keyring" => HealthCheck::new("credential store", HealthState::Ok, "OS keyring"),
+        "encrypted-file" => HealthCheck::new("credential store", HealthState::Ok, "encrypted file"),
+        _ => HealthCheck::new(
+            "credential store",
+            HealthState::Warn,
+            "plaintext file (0600) — Advanced → keyring to harden",
+        ),
+    });
+
+    // Tool approval posture — auto-approve runs every tool call unprompted.
+    rows.push(if c.tools_auto_approve {
+        HealthCheck::new(
+            "tool approval",
+            HealthState::Warn,
+            "auto-approve — every tool call runs without a prompt",
+        )
+    } else {
+        HealthCheck::new(
+            "tool approval",
+            HealthState::Ok,
+            format!("ask each · {} pre-approved", c.tools_allow_list.len()),
+        )
+    });
+
+    // Provider failover chain (S7) — on with no chain does nothing.
+    rows.push(if c.failover_enabled {
+        if c.fallback_models.is_empty() {
+            HealthCheck::new(
+                "provider failover",
+                HealthState::Warn,
+                "on but no fallback models configured",
+            )
+        } else {
+            let n = c.fallback_models.len();
+            HealthCheck::new(
+                "provider failover",
+                HealthState::Ok,
+                format!("on · {n} fallback model{}", if n == 1 { "" } else { "s" }),
+            )
+        }
+    } else {
+        HealthCheck::new(
+            "provider failover",
+            HealthState::Ok,
+            "off — single provider",
+        )
+    });
+
+    // Spend cap (S5) — informational; "no cap" is a valid choice.
+    rows.push(match c.budget_max_cost_usd {
+        Some(cap) => HealthCheck::new(
+            "spend cap",
+            HealthState::Ok,
+            format!("${cap:.2} per session"),
+        ),
+        None => HealthCheck::new("spend cap", HealthState::Ok, "no cap set"),
+    });
+
+    // Long-term memory — when on, the store directory must resolve.
+    rows.push(if c.memory_enabled {
+        match std::env::current_dir()
+            .ok()
+            .and_then(|cwd| wcore_memory::paths::auto_memory_dir(&cwd))
+        {
+            Some(dir) => HealthCheck::new(
+                "long-term memory",
+                HealthState::Ok,
+                format!("on · {}", dir.display()),
+            ),
+            None => HealthCheck::new(
+                "long-term memory",
+                HealthState::Warn,
+                "on · could not resolve the memory directory",
+            ),
+        }
+    } else {
+        HealthCheck::new("long-term memory", HealthState::Ok, "off")
+    });
+
+    rows
+}
+
 /// Extract the last 10 engine errors from the session transcript.
 /// The protocol bridge pushes each `ProtocolEvent::Error` as a
 /// `TurnRole::System` turn whose first markdown element starts with
@@ -529,6 +646,10 @@ pub struct DiagnosticsSurface {
     /// `TOOL_GATES` + a live env-var probe. Cheap to recompute, but
     /// caching it keeps the render path free of `std::env::var` calls.
     tool_status: Vec<ToolStatusRow>,
+    /// S8 — config-posture health rows built from the resolved `ConfigView`
+    /// on `App` (egress / credentials / tool approval / failover / spend cap /
+    /// memory). Refreshed alongside the doctor probe on `on_enter` + `r`.
+    config_checks: Vec<HealthCheck>,
 }
 
 impl Default for DiagnosticsSurface {
@@ -552,6 +673,7 @@ impl DiagnosticsSurface {
             doctor_collected: false,
             provider_health: Vec::new(),
             tool_status: Vec::new(),
+            config_checks: Vec::new(),
         }
     }
 
@@ -563,10 +685,11 @@ impl DiagnosticsSurface {
     /// Run the live `doctor` probe and store its report. Also refreshes
     /// the v0.9.0 W4 E2 provider-health probes (real HTTP) + the cheap
     /// env-driven tool-status snapshot.
-    fn refresh_doctor(&mut self) {
+    fn refresh_doctor(&mut self, app: &App) {
         self.doctor = run_doctor();
         self.provider_health = run_provider_health();
         self.tool_status = scan_tool_status();
+        self.config_checks = scan_config_health(app);
         self.doctor_collected = true;
     }
 
@@ -688,8 +811,8 @@ impl Surface for DiagnosticsSurface {
 
     /// Refresh both the doctor probe and the memory scan when the surface
     /// becomes active, so re-entering the screen always shows live data.
-    fn on_enter(&mut self, _app: &mut App) {
-        self.refresh_doctor();
+    fn on_enter(&mut self, app: &mut App) {
+        self.refresh_doctor(app);
         self.refresh_memory();
     }
 
@@ -753,7 +876,7 @@ impl Surface for DiagnosticsSurface {
             }
             // `/doctor` re-run — re-run the live probe in place.
             KeyCode::Char('r') if self.mode == DiagMode::Doctor => {
-                self.refresh_doctor();
+                self.refresh_doctor(app);
                 SurfaceAction::None
             }
             // `/memory` list navigation.
@@ -853,7 +976,7 @@ impl DiagnosticsSurface {
     ///   5. Token budget for the active model
     fn render_doctor(&self, frame: &mut Frame, area: Rect, app: &App, t: &Theme) {
         let block = panel(
-            " /doctor — system · providers · tools · errors · tokens ",
+            " /doctor — system · providers · config · tools · errors · tokens ",
             t,
         );
         let inner = block.inner(area);
@@ -896,7 +1019,17 @@ impl DiagnosticsSurface {
             }
         }
 
-        // ── 3. Per-tool backend status ──────────────────────────────
+        // ── 3. Config posture rows (S8) ─────────────────────────────
+        // Coherence/safety checks on the resolved config snapshot — the
+        // answer to "is my configuration sane", distinct from the runtime
+        // probes above.
+        lines.push(Line::from(""));
+        push_section_header(&mut lines, t, "CONFIG");
+        for check in &self.config_checks {
+            lines.push(status_row(check.state, &check.label, &check.detail, t));
+        }
+
+        // ── 4. Per-tool backend status ──────────────────────────────
         lines.push(Line::from(""));
         push_section_header(&mut lines, t, "TOOLS");
         for row in &self.tool_status {
@@ -913,7 +1046,7 @@ impl DiagnosticsSurface {
             lines.push(status_row(state, &row.name, &detail, t));
         }
 
-        // ── 4. MCP servers ──────────────────────────────────────────
+        // ── 5. MCP servers ──────────────────────────────────────────
         // Seeded at boot from the connect-health snapshot (tui::run) and
         // updated live by McpReady / McpFailed events. A failed or timed-out
         // server is the answer to "why aren't my plugin's tools showing up".
@@ -946,7 +1079,7 @@ impl DiagnosticsSurface {
             }
         }
 
-        // ── 5. Recent engine errors ─────────────────────────────────
+        // ── 6. Recent engine errors ─────────────────────────────────
         lines.push(Line::from(""));
         push_section_header(&mut lines, t, "RECENT ERRORS");
         let errors = collect_recent_errors(app);
@@ -967,7 +1100,7 @@ impl DiagnosticsSurface {
             }
         }
 
-        // ── 6. Token budget ─────────────────────────────────────────
+        // ── 7. Token budget ─────────────────────────────────────────
         lines.push(Line::from(""));
         push_section_header(&mut lines, t, "TOKEN BUDGET");
         let budget = token_budget_view(app);
@@ -1865,6 +1998,92 @@ mod tests {
         assert!(
             out.contains("none configured"),
             "empty state missing:\n{out}"
+        );
+    }
+
+    #[test]
+    fn doctor_shows_config_section_with_posture_rows() {
+        // S8: the CONFIG section surfaces config-posture health. A permissive
+        // config flags Warn rows the user can act on.
+        let mut s = DiagnosticsSurface::new();
+        let mut app = App::new();
+        app.config.security_egress_enabled = false; // unrestricted egress
+        app.config.tools_auto_approve = true; // every tool unprompted
+        app.config.storage_backend = "plaintext".into();
+        app.config.failover_enabled = true;
+        app.config.fallback_models = Vec::new(); // on but empty
+        s.on_enter(&mut app);
+        let out = render_tall(&mut s, &app);
+        assert!(
+            out.contains("CONFIG"),
+            "CONFIG section header missing:\n{out}"
+        );
+        assert!(out.contains("egress guard"), "egress row missing:\n{out}");
+        assert!(
+            out.contains("credential store"),
+            "creds row missing:\n{out}"
+        );
+        assert!(
+            out.contains("tool approval"),
+            "tool-approval row missing:\n{out}"
+        );
+        assert!(
+            out.contains("provider failover"),
+            "failover row missing:\n{out}"
+        );
+    }
+
+    #[test]
+    fn config_health_flags_permissive_posture_as_warn() {
+        // The risky-but-valid states must be Warn (actionable), never a fake
+        // Fail and never a silent Ok.
+        let mut app = App::new();
+        app.config.security_egress_enabled = false;
+        app.config.tools_auto_approve = true;
+        app.config.storage_backend = "plaintext".into();
+        app.config.failover_enabled = true;
+        app.config.fallback_models = Vec::new();
+        let rows = scan_config_health(&app);
+        let warn = |label: &str| {
+            rows.iter()
+                .find(|r| r.label == label)
+                .unwrap_or_else(|| panic!("missing row {label}"))
+                .state
+        };
+        assert_eq!(warn("egress guard"), HealthState::Warn);
+        assert_eq!(warn("tool approval"), HealthState::Warn);
+        assert_eq!(warn("credential store"), HealthState::Warn);
+        assert_eq!(warn("provider failover"), HealthState::Warn);
+    }
+
+    #[test]
+    fn config_health_marks_hardened_posture_ok() {
+        // A locked-down config reads clean: guard on, keyring, ask-each,
+        // failover with a chain, a spend cap.
+        let mut app = App::new();
+        app.config.security_egress_enabled = true;
+        app.config.egress_allow = vec!["example.com".into()];
+        app.config.tools_auto_approve = false;
+        app.config.tools_allow_list = vec!["Read".into(), "Grep".into()];
+        app.config.storage_backend = "keyring".into();
+        app.config.failover_enabled = true;
+        app.config.fallback_models = vec!["anthropic:haiku".into()];
+        app.config.budget_max_cost_usd = Some(5.0);
+        let rows = scan_config_health(&app);
+        assert!(
+            rows.iter().all(|r| r.state == HealthState::Ok),
+            "a hardened config must have no warnings, got: {:?}",
+            rows.iter()
+                .filter(|r| r.state != HealthState::Ok)
+                .map(|r| (&r.label, &r.detail))
+                .collect::<Vec<_>>()
+        );
+        // The egress row should report the allowlist count.
+        let egress = rows.iter().find(|r| r.label == "egress guard").unwrap();
+        assert!(
+            egress.detail.contains('1'),
+            "egress detail should count the allowlist entry: {}",
+            egress.detail
         );
     }
 

--- a/crates/wcore-cli/src/tui/surfaces/diagnostics.rs
+++ b/crates/wcore-cli/src/tui/surfaces/diagnostics.rs
@@ -585,7 +585,7 @@ pub struct MemoryReport {
 // DiagnosticsSurface
 // ─────────────────────────────────────────────────────────────────────────
 
-/// Which of the three diagnostic screens is in view.
+/// Which diagnostic screen is in view.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DiagMode {
     /// `/doctor` — provider / key / MCP health.
@@ -594,11 +594,18 @@ pub enum DiagMode {
     Cost,
     /// `/memory` — long-term memory contents + delete.
     Memory,
+    /// `/effective` — the resolved effective config, redacted (S9).
+    Effective,
 }
 
 impl DiagMode {
-    /// The three modes in tab order.
-    const ALL: [DiagMode; 3] = [DiagMode::Doctor, DiagMode::Cost, DiagMode::Memory];
+    /// The modes in tab order.
+    const ALL: [DiagMode; 4] = [
+        DiagMode::Doctor,
+        DiagMode::Cost,
+        DiagMode::Memory,
+        DiagMode::Effective,
+    ];
 
     /// The slash-command label for this mode.
     fn label(self) -> &'static str {
@@ -606,6 +613,7 @@ impl DiagMode {
             DiagMode::Doctor => "/doctor",
             DiagMode::Cost => "/cost",
             DiagMode::Memory => "/memory",
+            DiagMode::Effective => "/effective",
         }
     }
 }
@@ -650,6 +658,13 @@ pub struct DiagnosticsSurface {
     /// on `App` (egress / credentials / tool approval / failover / spend cap /
     /// memory). Refreshed alongside the doctor probe on `on_enter` + `r`.
     config_checks: Vec<HealthCheck>,
+    /// S9 — the rendered effective-config TOML (redacted) for the `/effective`
+    /// mode, built on `on_enter` via `wcore_config::config::effective_config_toml`.
+    /// Holds an error message string if the render failed.
+    effective_toml: String,
+    /// Vertical scroll offset for the `/effective` view (the TOML can exceed
+    /// the viewport). Clamped on `Up`/`Down`/`PageUp`/`PageDown`.
+    effective_scroll: u16,
 }
 
 impl Default for DiagnosticsSurface {
@@ -674,6 +689,8 @@ impl DiagnosticsSurface {
             provider_health: Vec::new(),
             tool_status: Vec::new(),
             config_checks: Vec::new(),
+            effective_toml: String::new(),
+            effective_scroll: 0,
         }
     }
 
@@ -691,6 +708,20 @@ impl DiagnosticsSurface {
         self.tool_status = scan_tool_status();
         self.config_checks = scan_config_health(app);
         self.doctor_collected = true;
+    }
+
+    /// S9: render the redacted effective config into `effective_toml` and reset
+    /// the scroll. Uses default CLI args — the file-merged config (global ←
+    /// project ← profile is not threaded yet; a follow-up). A render failure is
+    /// stored as a readable message rather than panicking the read-only screen.
+    fn refresh_effective(&mut self) {
+        self.effective_toml = match wcore_config::config::effective_config_toml(
+            &wcore_config::config::CliArgs::default(),
+        ) {
+            Ok(toml) => toml,
+            Err(e) => format!("could not render the effective config:\n{e:#}"),
+        };
+        self.effective_scroll = 0;
     }
 
     /// Re-scan the project long-term memory directory into the `/memory`
@@ -814,6 +845,7 @@ impl Surface for DiagnosticsSurface {
     fn on_enter(&mut self, app: &mut App) {
         self.refresh_doctor(app);
         self.refresh_memory();
+        self.refresh_effective();
     }
 
     fn render(&mut self, frame: &mut Frame, area: Rect, app: &App, theme: &Theme) {
@@ -831,6 +863,7 @@ impl Surface for DiagnosticsSurface {
             DiagMode::Doctor => self.render_doctor(frame, body_area, app, theme),
             DiagMode::Cost => self.render_cost(frame, body_area, app, theme),
             DiagMode::Memory => self.render_memory(frame, body_area, theme),
+            DiagMode::Effective => self.render_effective(frame, body_area, theme),
         }
     }
 
@@ -855,6 +888,27 @@ impl Surface for DiagnosticsSurface {
             }
             KeyCode::Char('3') => {
                 self.mode = DiagMode::Memory;
+                SurfaceAction::None
+            }
+            KeyCode::Char('4') => {
+                self.mode = DiagMode::Effective;
+                SurfaceAction::None
+            }
+            // `/effective` scroll — the redacted TOML can exceed the viewport.
+            KeyCode::Up | KeyCode::Char('k') if self.mode == DiagMode::Effective => {
+                self.effective_scroll = self.effective_scroll.saturating_sub(1);
+                SurfaceAction::None
+            }
+            KeyCode::Down | KeyCode::Char('j') if self.mode == DiagMode::Effective => {
+                self.effective_scroll = self.effective_scroll.saturating_add(1);
+                SurfaceAction::None
+            }
+            KeyCode::PageUp if self.mode == DiagMode::Effective => {
+                self.effective_scroll = self.effective_scroll.saturating_sub(10);
+                SurfaceAction::None
+            }
+            KeyCode::PageDown if self.mode == DiagMode::Effective => {
+                self.effective_scroll = self.effective_scroll.saturating_add(10);
                 SurfaceAction::None
             }
             KeyCode::Tab => {
@@ -1311,6 +1365,56 @@ impl DiagnosticsSurface {
         let para = Paragraph::new(lines).style(Style::default().bg(t.surface));
         frame.render_widget(para, inner);
     }
+
+    /// Render the `/effective` screen (S9): the redacted, merged effective
+    /// config as scrollable TOML, with a header noting what is and isn't shown.
+    fn render_effective(&self, frame: &mut Frame, area: Rect, t: &Theme) {
+        let block = panel(" /effective — resolved config · redacted ", t);
+        let inner = block.inner(area);
+        frame.render_widget(block, area);
+        if inner.height < 3 || inner.width < 10 {
+            return;
+        }
+        let [note_area, body_area, footer_area] = Layout::vertical([
+            Constraint::Length(2),
+            Constraint::Min(1),
+            Constraint::Length(1),
+        ])
+        .areas(inner);
+
+        frame.render_widget(
+            Paragraph::new(vec![
+                Line::from(Span::styled(
+                    "Merged from global ← project config files. Secrets shown as ***.",
+                    Style::default().fg(t.text_dim),
+                )),
+                Line::from(Span::styled(
+                    "Live env-resolved API keys and session CLI flags are not shown.",
+                    Style::default().fg(t.text_muted),
+                )),
+            ]),
+            note_area,
+        );
+
+        // Clamp the scroll so the view can never run past the end into a blank
+        // screen (the held offset may exceed the content; the display clamps).
+        let total_lines = self.effective_toml.lines().count() as u16;
+        let scroll = self.effective_scroll.min(total_lines.saturating_sub(1));
+        frame.render_widget(
+            Paragraph::new(self.effective_toml.clone())
+                .style(Style::default().fg(t.text))
+                .scroll((scroll, 0)),
+            body_area,
+        );
+
+        frame.render_widget(
+            Paragraph::new(Line::from(Span::styled(
+                "  ↑↓ scroll · 1 doctor · 2 cost · 3 memory · 4 effective · esc workspace",
+                Style::default().fg(t.text_muted),
+            ))),
+            footer_area,
+        );
+    }
 }
 
 #[cfg(test)]
@@ -1414,7 +1518,7 @@ mod tests {
     }
 
     #[test]
-    fn tab_cycles_through_the_three_modes() {
+    fn tab_cycles_through_the_modes() {
         let mut s = DiagnosticsSurface::new();
         let mut app = App::new();
         s.handle_key(key(KeyCode::Tab), &mut app);
@@ -1422,10 +1526,39 @@ mod tests {
         s.handle_key(key(KeyCode::Tab), &mut app);
         assert_eq!(s.mode(), DiagMode::Memory);
         s.handle_key(key(KeyCode::Tab), &mut app);
+        assert_eq!(s.mode(), DiagMode::Effective);
+        s.handle_key(key(KeyCode::Tab), &mut app);
         // Wraps back to the first mode.
         assert_eq!(s.mode(), DiagMode::Doctor);
         s.handle_key(key(KeyCode::BackTab), &mut app);
-        assert_eq!(s.mode(), DiagMode::Memory);
+        assert_eq!(s.mode(), DiagMode::Effective);
+    }
+
+    #[test]
+    fn effective_mode_renders_redaction_note_and_scrolls() {
+        // S9: the `4` key selects the Effective tab; the redacted-config
+        // preview renders with its caveat header and the scroll keys move the
+        // offset. The redaction note is static UI text, so this assertion is
+        // hermetic regardless of the box's real config contents.
+        let mut s = DiagnosticsSurface::new();
+        let mut app = App::new();
+        s.on_enter(&mut app);
+        s.handle_key(key(KeyCode::Char('4')), &mut app);
+        assert_eq!(s.mode(), DiagMode::Effective);
+        let out = render_to_string(&mut s);
+        assert!(out.contains("/effective"), "tab label missing:\n{out}");
+        assert!(
+            out.contains("Secrets shown as"),
+            "redaction note missing:\n{out}"
+        );
+        // Scroll down then up returns to the start; saturating at 0.
+        let before = s.effective_scroll;
+        s.handle_key(key(KeyCode::Down), &mut app);
+        assert_eq!(s.effective_scroll, before + 1);
+        s.handle_key(key(KeyCode::Up), &mut app);
+        assert_eq!(s.effective_scroll, before);
+        s.handle_key(key(KeyCode::Up), &mut app);
+        assert_eq!(s.effective_scroll, 0, "scroll must saturate at the top");
     }
 
     // -- /doctor screen ----------------------------------------------------

--- a/crates/wcore-cli/src/tui/surfaces/mod.rs
+++ b/crates/wcore-cli/src/tui/surfaces/mod.rs
@@ -46,9 +46,8 @@ mod onboarding;
 // `Surface` wiring (draw, async detect spawn, storage write + rebind, slash
 // command) lands in S4b; until then its items are exercised only by unit tests,
 // so allow dead_code on this staged module.
-#[allow(dead_code)]
-mod paste_detect_modal;
 mod palette;
+mod paste_detect_modal;
 mod plan_review;
 mod plugins;
 mod subagents;
@@ -97,6 +96,10 @@ pub enum SurfaceId {
     /// Arrow-key `/provider` picker overlay. Summoned by bare `/provider`,
     /// dismissed with Esc. Not a tab.
     ProviderPicker,
+    /// S4b — the `/connect` paste-to-detect overlay. Paste a key; it
+    /// fingerprints, validates live, and (on accept) stores + makes default.
+    /// Summoned by `/connect`, dismissed with Esc. Not a tab.
+    PasteDetect,
 }
 
 impl SurfaceId {
@@ -133,6 +136,7 @@ impl SurfaceId {
             SurfaceId::Workflows => "Workflows",
             SurfaceId::ModelPicker => "Model",
             SurfaceId::ProviderPicker => "Provider",
+            SurfaceId::PasteDetect => "Connect",
         }
     }
 
@@ -1662,6 +1666,12 @@ impl Router {
                     "/config" => {
                         self.switch(app, SurfaceId::Config);
                     }
+                    "/connect" => {
+                        // S4b: the paste-to-detect overlay — paste a key, it
+                        // fingerprints + validates live, then stores it and
+                        // makes the provider default. Dismissed with Esc.
+                        let _ = self.apply(SurfaceAction::OpenOverlay(SurfaceId::PasteDetect), app);
+                    }
                     "/setup" => {
                         // Re-enter the first-run onboarding flow on demand.
                         self.switch(app, SurfaceId::Onboarding);
@@ -2881,6 +2891,7 @@ fn make_surface(id: SurfaceId) -> Box<dyn Surface> {
         // (make_surface has no `App`), so a bare construction is fine here.
         SurfaceId::ModelPicker => Box::new(model_picker::ModelPickerSurface::new("", "")),
         SurfaceId::ProviderPicker => Box::new(model_picker::ProviderPickerSurface::new("")),
+        SurfaceId::PasteDetect => Box::new(paste_detect_modal::PasteDetectSurface::new()),
     }
 }
 

--- a/crates/wcore-cli/src/tui/surfaces/mod.rs
+++ b/crates/wcore-cli/src/tui/surfaces/mod.rs
@@ -320,6 +320,21 @@ pub trait Surface {
     fn consumes_help_key(&self, _app: &App) -> bool {
         false
     }
+
+    /// FIX-2 — true when this surface owns `/` for its own input and the Router
+    /// must NOT pre-empt it with the global command palette.
+    ///
+    /// Default `false`: most surfaces (Diagnostics, Plugins, SubAgents, …) have
+    /// no `/` binding and no live text field, so the Router opens the command
+    /// palette on `/` there — making slash commands reachable from anywhere,
+    /// not only the Workspace composer. Surfaces that DO capture `/` override
+    /// this: `WorkspaceSurface` (composer-aware `/`), `AgentNav` (filter),
+    /// `Onboarding` (key entry), and `ConfigSurface` while any inline text
+    /// editor is active. When the override returns `true` the key falls through
+    /// to the surface's own `handle_key`.
+    fn consumes_slash(&self, _app: &App) -> bool {
+        false
+    }
 }
 
 /// A placeholder surface used to prove the trait + router wiring.
@@ -1066,6 +1081,20 @@ impl Router {
                 // into the Workspace switch; a returned `None` means the
                 // surface consumed `Esc` for its own state and is left
                 // be.
+                // FIX-2 — `/` opens the command palette from ANY surface, not
+                // only the Workspace composer. Before this, a user inside
+                // Config / Diagnostics / etc. who typed `/doctor` got nothing
+                // (the key was unhandled) and had to Esc home first — yet those
+                // surfaces even advertise `/provider` / `/model` hints. The
+                // Workspace owns its own composer-aware `/` (literal mid-message,
+                // palette on an empty line) so it is excluded; every other
+                // surface gets the global palette door unless it is actively
+                // capturing text (`consumes_slash`), where `/` stays literal.
+                KeyCode::Char('/')
+                    if here != SurfaceId::Workspace && !self.active.consumes_slash(app) =>
+                {
+                    return self.apply(SurfaceAction::OpenOverlay(SurfaceId::Palette), app);
+                }
                 KeyCode::Esc if here == SurfaceId::Diagnostics => {
                     return self.apply(SurfaceAction::Switch(SurfaceId::Workspace), app);
                 }
@@ -3911,6 +3940,24 @@ mod tests {
         let mut router = Router::new(&app);
         router.apply(SurfaceAction::Command("/doctor".into()), &mut app);
         assert_eq!(app.surface, SurfaceId::Diagnostics);
+    }
+
+    #[test]
+    fn slash_opens_the_palette_from_a_non_workspace_surface() {
+        // FIX-2: `/` must reach the command palette from any surface, not just
+        // the Workspace composer. From Diagnostics (no text field, no `/`
+        // binding) pressing `/` opens the palette overlay.
+        let mut app = App::new();
+        let mut router = Router::new(&app);
+        router.apply(SurfaceAction::Switch(SurfaceId::Diagnostics), &mut app);
+        assert_eq!(app.surface, SurfaceId::Diagnostics);
+        assert_eq!(app.overlay, None, "no overlay before `/`");
+        router.handle_key(key(KeyCode::Char('/')), &mut app);
+        assert_eq!(
+            app.overlay,
+            Some(SurfaceId::Palette),
+            "`/` from Diagnostics must open the command palette"
+        );
     }
 
     #[test]

--- a/crates/wcore-cli/src/tui/surfaces/mod.rs
+++ b/crates/wcore-cli/src/tui/surfaces/mod.rs
@@ -1257,6 +1257,15 @@ impl Router {
                         app.config.tools_verify_edits = applied.config_view.tools_verify_edits;
                         app.config.budget_max_cost_usd = applied.config_view.budget_max_cost_usd;
                         app.config.budget_max_wall_secs = applied.config_view.budget_max_wall_secs;
+                        // S6 Advanced: mirror the observability/storage/security
+                        // edits too, same reseed reasoning.
+                        app.config.obs_structured_traces =
+                            applied.config_view.obs_structured_traces;
+                        app.config.obs_online_evolution = applied.config_view.obs_online_evolution;
+                        app.config.obs_workflow_live = applied.config_view.obs_workflow_live;
+                        app.config.storage_backend = applied.config_view.storage_backend.clone();
+                        app.config.security_egress_enabled =
+                            applied.config_view.security_egress_enabled;
                         // The live apply succeeded — clear any prior degraded
                         // flag so `/config` shows the honest "now live" copy.
                         app.config_apply_failed = false;

--- a/crates/wcore-cli/src/tui/surfaces/mod.rs
+++ b/crates/wcore-cli/src/tui/surfaces/mod.rs
@@ -42,6 +42,12 @@ mod diagnostics;
 mod marketplace; // Lane F2 — the /plugins marketplace overlay
 mod model_picker; // arrow-key /model + /provider pickers
 mod onboarding;
+// Paste-to-detect provider setup: state machine + view-model (slice S4a). The
+// `Surface` wiring (draw, async detect spawn, storage write + rebind, slash
+// command) lands in S4b; until then its items are exercised only by unit tests,
+// so allow dead_code on this staged module.
+#[allow(dead_code)]
+mod paste_detect_modal;
 mod palette;
 mod plan_review;
 mod plugins;

--- a/crates/wcore-cli/src/tui/surfaces/mod.rs
+++ b/crates/wcore-cli/src/tui/surfaces/mod.rs
@@ -6059,12 +6059,12 @@ mod tests {
         );
     }
 
-    /// D039/D042: on the Workspace, a bare Tab with a reasoning rail present
-    /// advances the reasoning focus and must NOT switch tabs. Driven through
-    /// the Router; `app.session.turns` carries a Thinking block so the
-    /// Workspace's `owns_tab` reports `true`.
+    /// FIX-7: on the Workspace, a bare Tab switches tabs even when the
+    /// transcript already has a reasoning turn. The old behavior claimed Tab
+    /// for an (invisible) reasoning-focus step whenever any Thinking block
+    /// existed, silently breaking the documented "Tab next tab".
     #[test]
-    fn router_tab_steps_reasoning_rail_does_not_switch_tabs_d042() {
+    fn router_tab_switches_tabs_even_with_a_reasoning_turn_fix7() {
         use crate::tui::app::{TurnRole, TurnView};
         use crate::tui::turn_element::TurnElement;
         let mut app = App::new();
@@ -6078,20 +6078,12 @@ mod tests {
         });
         let mut router = Router::new(&app);
         router.apply(SurfaceAction::Switch(SurfaceId::Workspace), &mut app);
-        assert!(
-            app.focused_reasoning_turn_idx.is_none(),
-            "reasoning focus starts unset"
-        );
+        assert_eq!(app.surface, SurfaceId::Workspace);
         router.handle_key(key(KeyCode::Tab), &mut app);
         assert_eq!(
             app.surface,
-            SurfaceId::Workspace,
-            "Tab with a reasoning rail present must NOT switch tabs"
-        );
-        assert_eq!(
-            app.focused_reasoning_turn_idx,
-            Some(0),
-            "Tab must advance the reasoning focus to the reasoning turn"
+            SurfaceId::TABS[1],
+            "Tab must switch to the next tab even with a reasoning turn present"
         );
     }
 }

--- a/crates/wcore-cli/src/tui/surfaces/mod.rs
+++ b/crates/wcore-cli/src/tui/surfaces/mod.rs
@@ -1241,13 +1241,22 @@ impl Router {
                         // so the next `/config` `on_enter` re-seeds from the
                         // just-saved truth instead of snapping back to the
                         // pre-save values. Provider/model/force are owned by
-                        // other paths (onboarding / CLI), so only the five
-                        // Tier-1 settings are mirrored here.
+                        // other paths (onboarding / CLI), so only the Tier-1
+                        // settings (plus the S5 Tools/Wallet fields below) are
+                        // mirrored here.
                         app.config.max_turns = applied.config_view.max_turns;
                         app.config.approval = applied.config_view.approval;
                         app.config.compaction = applied.config_view.compaction;
                         app.config.memory_enabled = applied.config_view.memory_enabled;
                         app.config.plan_first = applied.config_view.plan_first;
+                        // S5 Essentials: mirror the saved Tools + Wallet fields
+                        // so the next `/config` on_enter reseeds from the just-
+                        // saved truth, same as the five settings above.
+                        app.config.tools_auto_approve = applied.config_view.tools_auto_approve;
+                        app.config.tools_allow_count = applied.config_view.tools_allow_count;
+                        app.config.tools_verify_edits = applied.config_view.tools_verify_edits;
+                        app.config.budget_max_cost_usd = applied.config_view.budget_max_cost_usd;
+                        app.config.budget_max_wall_secs = applied.config_view.budget_max_wall_secs;
                         // The live apply succeeded — clear any prior degraded
                         // flag so `/config` shows the honest "now live" copy.
                         app.config_apply_failed = false;

--- a/crates/wcore-cli/src/tui/surfaces/mod.rs
+++ b/crates/wcore-cli/src/tui/surfaces/mod.rs
@@ -1720,12 +1720,14 @@ impl Router {
                                 self.apply(SurfaceAction::OpenOverlay(SurfaceId::Marketplace), app);
                         }
                     }
-                    "/doctor" | "/memory" | "/tools" => {
+                    "/doctor" | "/memory" | "/tools" | "/effective" => {
                         // `/tools` was a stub forwarded to the LLM. The
                         // diagnostics surface already enumerates every
                         // host-known tool with its backend/enabled status —
                         // route there rather than build a second, divergent
                         // tool list (Krug: one place to see what's loaded).
+                        // `/effective` (S9) lands on the same surface; its
+                        // redacted-config tab is reachable via `4`/Tab.
                         self.switch(app, SurfaceId::Diagnostics);
                     }
                     "/cost" => {

--- a/crates/wcore-cli/src/tui/surfaces/mod.rs
+++ b/crates/wcore-cli/src/tui/surfaces/mod.rs
@@ -1253,7 +1253,7 @@ impl Router {
                         // so the next `/config` on_enter reseeds from the just-
                         // saved truth, same as the five settings above.
                         app.config.tools_auto_approve = applied.config_view.tools_auto_approve;
-                        app.config.tools_allow_count = applied.config_view.tools_allow_count;
+                        app.config.tools_allow_list = applied.config_view.tools_allow_list.clone();
                         app.config.tools_verify_edits = applied.config_view.tools_verify_edits;
                         app.config.budget_max_cost_usd = applied.config_view.budget_max_cost_usd;
                         app.config.budget_max_wall_secs = applied.config_view.budget_max_wall_secs;
@@ -1266,6 +1266,11 @@ impl Router {
                         app.config.storage_backend = applied.config_view.storage_backend.clone();
                         app.config.security_egress_enabled =
                             applied.config_view.security_egress_enabled;
+                        // S7 collection editors: mirror the egress allowlist and
+                        // the failover chain so the next on_enter reseeds truth.
+                        app.config.egress_allow = applied.config_view.egress_allow.clone();
+                        app.config.failover_enabled = applied.config_view.failover_enabled;
+                        app.config.fallback_models = applied.config_view.fallback_models.clone();
                         // The live apply succeeded — clear any prior degraded
                         // flag so `/config` shows the honest "now live" copy.
                         app.config_apply_failed = false;

--- a/crates/wcore-cli/src/tui/surfaces/onboarding.rs
+++ b/crates/wcore-cli/src/tui/surfaces/onboarding.rs
@@ -1568,6 +1568,12 @@ impl Surface for OnboardingSurface {
         SurfaceId::Onboarding
     }
 
+    /// FIX-2 — onboarding is a text-entry flow (API keys, base URLs), so `/` is
+    /// literal here; the Router must not divert it to the command palette.
+    fn consumes_slash(&self, _app: &App) -> bool {
+        true
+    }
+
     fn render(&mut self, frame: &mut Frame, area: Rect, _app: &App, theme: &Theme) {
         // Fold in any validation result that arrived since the last
         // frame *before* drawing, so a resolved validation is reflected

--- a/crates/wcore-cli/src/tui/surfaces/paste_detect_modal.rs
+++ b/crates/wcore-cli/src/tui/surfaces/paste_detect_modal.rs
@@ -19,13 +19,21 @@
 //! [`PasteModal::start_detecting`]; [`PasteModal::poll`] (called each tick)
 //! pulls the [`DetectionResult`] in without ever blocking the render loop.
 
+use ratatui::Frame;
 use ratatui::crossterm::event::{Event, KeyCode, KeyEvent};
+use ratatui::layout::Rect;
+use ratatui::style::{Modifier, Style};
+use ratatui::text::Line;
+use ratatui::widgets::{Block, Clear, Paragraph, Wrap};
 use tokio::sync::oneshot;
 use tui_input::Input;
 use tui_input::backend::crossterm::EventHandler;
 
-use wcore_providers::fingerprint::CredentialKind;
-use wcore_providers::paste_detect::DetectionResult;
+use super::{Surface, SurfaceAction, SurfaceId};
+use crate::tui::app::App;
+use crate::tui::theme::Theme;
+use wcore_providers::fingerprint::{CredentialKind, fingerprint_key};
+use wcore_providers::paste_detect::{DetectionResult, detect_paste};
 
 /// What the host (the `Surface`/router) should do after a key press. Keeps the
 /// modal ignorant of `App`, async runtimes, and storage.
@@ -246,7 +254,10 @@ impl PasteModal {
             }
             PasteState::Guided { kind, provider } => {
                 let what = guided_hint(*kind, provider.as_deref());
-                vec![what, "Press [Esc] to set it up, or paste a different key".to_string()]
+                vec![
+                    what,
+                    "Press [Esc] to set it up, or paste a different key".to_string(),
+                ]
             }
             PasteState::Unresolved {
                 best_guess,
@@ -281,6 +292,211 @@ fn guided_hint(kind: CredentialKind, provider: Option<&str>) -> String {
             Some(p) => format!("{p} needs a bit more to finish setup"),
             None => "This credential needs a bit more to finish setup".to_string(),
         },
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Surface — the thin TUI wrapper over `PasteModal` (S4b).
+// ─────────────────────────────────────────────────────────────────────────
+
+/// The `/connect` overlay surface: an arrow-key-free modal that hosts a
+/// [`PasteModal`], spawns the async `detect_paste` probe, and — on a connected
+/// provider the user accepts — writes the validated key to the credentials
+/// store, makes it the default, and triggers a live engine rebind.
+///
+/// All rendered text comes from the modal's view-model
+/// ([`PasteModal::reveal_lines`] / [`PasteModal::ladder_lines`]); this struct
+/// only owns the spinner tick and the host-side effects the pure modal cannot
+/// perform (async spawn, storage write, rebind signal).
+pub(crate) struct PasteDetectSurface {
+    modal: PasteModal,
+    /// Drives the detection-ladder spinner; advanced once per `tick`.
+    tick: usize,
+}
+
+impl PasteDetectSurface {
+    pub(crate) fn new() -> Self {
+        Self {
+            modal: PasteModal::new(),
+            tick: 0,
+        }
+    }
+
+    /// Persist a validated, accepted credential and request a live rebind.
+    ///
+    /// Returns a human-readable status line for the transcript. The pasted
+    /// value is re-normalized through the fingerprinter so the bytes written
+    /// are exactly the bytes that authenticated (an `export NAME=…` paste is
+    /// stripped to the bare key), and the key is written under the same
+    /// credentials-store slot [`resolve_api_key`](wcore_config) reads — so the
+    /// next rebind resolves it without a restart. On any failure the engine is
+    /// left untouched (no rebind requested).
+    fn save_credential(&self, app: &mut App, slug: &str) -> String {
+        use wcore_config::config::{
+            ProviderType, default_model_for_slug, patch_global_config, provider_type_from_slug,
+            store_provider_api_key,
+        };
+
+        let Some(provider) = provider_type_from_slug(slug) else {
+            return format!("Couldn't map provider \"{slug}\" — nothing saved.");
+        };
+        // Bedrock/Vertex/ChatGPT never reach a Connected state via paste, but
+        // guard anyway: those authenticate out-of-band and have no key slot.
+        if matches!(
+            provider,
+            ProviderType::Bedrock | ProviderType::Vertex | ProviderType::OpenAIChatGpt
+        ) {
+            return format!("{slug} authenticates out-of-band; nothing to store.");
+        }
+
+        let secret = fingerprint_key(self.modal.value()).normalized;
+        if let Err(e) = store_provider_api_key(provider, &secret) {
+            tracing::warn!(target: "wcore_cli::tui::paste_detect", "credential save failed: {e:#}");
+            return format!("Couldn't save the key: {e}");
+        }
+
+        // Make the freshly-connected provider the default so the next prompt
+        // runs against it. Non-destructive: only the `[default]` keys change.
+        let model = default_model_for_slug(slug);
+        let persist = patch_global_config(|f| {
+            f.default.provider = slug.to_string();
+            if !model.is_empty() {
+                f.default.model = Some(model.to_string());
+            }
+        });
+        if let Err(e) = persist {
+            tracing::warn!(target: "wcore_cli::tui::paste_detect", "default-provider write failed: {e:#}");
+            return format!("Key saved, but couldn't set the default: {e}");
+        }
+
+        // The router consumes this on the next tick and rebinds the live
+        // engine, which re-resolves the config (new default + stored key).
+        app.rebind_request = crate::tui::app::RebindRequest::Credential;
+        format!("Connected {slug} — it's now your default. Applying to this session…")
+    }
+
+    /// The lines to draw for the current state: an animated ladder while
+    /// detecting, the masked input while editing, otherwise the settled reveal.
+    fn body_lines(&self) -> Vec<String> {
+        match self.modal.state() {
+            PasteState::Detecting => self.modal.ladder_lines(self.tick),
+            PasteState::Editing => {
+                let mut lines = self.modal.reveal_lines();
+                let echo = self.modal.masked_input();
+                lines.push(String::new());
+                lines.push(format!("  ▸ {echo}"));
+                lines
+            }
+            _ => self.modal.reveal_lines(),
+        }
+    }
+}
+
+impl Surface for PasteDetectSurface {
+    fn id(&self) -> SurfaceId {
+        SurfaceId::PasteDetect
+    }
+
+    fn render(&mut self, frame: &mut Frame, area: Rect, _app: &App, theme: &Theme) {
+        let pane = centered_rect(area, 72, 12);
+        frame.render_widget(Clear, pane);
+        let block = Block::bordered()
+            .title("Connect a provider")
+            .border_style(Style::default().fg(theme.orange))
+            .style(Style::default().bg(theme.surface_elevated).fg(theme.text));
+        let inner = block.inner(pane);
+        frame.render_widget(block, pane);
+        if inner.height == 0 {
+            return;
+        }
+
+        let lines: Vec<Line> = self
+            .body_lines()
+            .into_iter()
+            .map(|s| {
+                // Color by the line's own marker so success/failure read at a
+                // glance; everything else stays in the body text color.
+                let style = if s.starts_with('✓') {
+                    Style::default()
+                        .fg(theme.success)
+                        .add_modifier(Modifier::BOLD)
+                } else if s.starts_with('✗') {
+                    Style::default()
+                        .fg(theme.warning)
+                        .add_modifier(Modifier::BOLD)
+                } else if s.contains("[Enter]") || s.contains("[Esc]") || s.contains("⏎") {
+                    Style::default().fg(theme.text_dim)
+                } else {
+                    Style::default().fg(theme.text)
+                };
+                Line::styled(s, style)
+            })
+            .collect();
+        frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), inner);
+    }
+
+    fn handle_key(&mut self, key: KeyEvent, app: &mut App) -> SurfaceAction {
+        match self.modal.handle_key(key) {
+            PasteModalAction::None => SurfaceAction::None,
+            PasteModalAction::Close => SurfaceAction::CloseOverlay,
+            PasteModalAction::Detect(raw) => {
+                // Spawn the live probe off the render loop; the result lands via
+                // `tick → poll`. Requires a tokio runtime (always present under
+                // the TUI loop). Without one the modal stays in Detecting and
+                // the dropped sender flips it to Unresolved on the next poll.
+                let (tx, rx) = oneshot::channel();
+                if tokio::runtime::Handle::try_current().is_ok() {
+                    tokio::spawn(async move {
+                        let base = wcore_config::config::Config::resolve(
+                            &wcore_config::config::CliArgs::default(),
+                        )
+                        .unwrap_or_default();
+                        let _ = tx.send(detect_paste(&base, &raw).await);
+                    });
+                }
+                self.modal.start_detecting(rx);
+                SurfaceAction::None
+            }
+            PasteModalAction::Save { provider } => {
+                let status = self.save_credential(app, &provider);
+                push_system_line(app, status);
+                SurfaceAction::CloseOverlay
+            }
+        }
+    }
+
+    fn tick(&mut self, _app: &mut App) -> SurfaceAction {
+        self.tick = self.tick.wrapping_add(1);
+        // Drain an in-flight detection result into the modal state. A redraw
+        // happens every frame regardless, so no explicit invalidation needed.
+        self.modal.poll();
+        SurfaceAction::None
+    }
+}
+
+/// Append a one-line System turn so the user sees the outcome of a save without
+/// the modal having to grow a status state. Mirrors the transcript-append shape
+/// used elsewhere in the router (`note_surface_panic`).
+fn push_system_line(app: &mut App, msg: String) {
+    use crate::tui::app::{TurnRole, TurnView};
+    use crate::tui::turn_element::TurnElement;
+    app.session.turns.push(TurnView {
+        role: TurnRole::System,
+        elements: vec![TurnElement::Markdown(msg)],
+    });
+    app.session.trim_history();
+}
+
+/// A centered sub-rect of `area`, clamped to fit. Self-contained so the surface
+/// does not depend on `config.rs`'s private layout helpers.
+fn centered_rect(area: Rect, w: u16, h: u16) -> Rect {
+    let w = w.min(area.width);
+    let h = h.min(area.height);
+    Rect {
+        x: area.x + area.width.saturating_sub(w) / 2,
+        y: area.y + area.height.saturating_sub(h) / 2,
+        width: w,
+        height: h,
     }
 }
 
@@ -433,5 +649,116 @@ mod tests {
         assert!(masked.ends_with("1234"));
         assert!(masked.contains('•'));
         assert!(!masked.contains("secret"));
+    }
+
+    // ── Surface (S4b) ───────────────────────────────────────────────────
+
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+
+    /// Render the surface into an 80×24 `TestBackend` and flatten the buffer.
+    fn render_surface(surface: &mut PasteDetectSurface, app: &App) -> String {
+        let theme = Theme::no_color();
+        let mut terminal = Terminal::new(TestBackend::new(80, 24)).expect("test terminal");
+        terminal
+            .draw(|f| surface.render(f, f.area(), app, &theme))
+            .expect("render paste-detect surface");
+        let buf = terminal.backend().buffer();
+        let mut out = String::new();
+        for y in 0..buf.area.height {
+            for x in 0..buf.area.width {
+                out.push_str(buf[(x, y)].symbol());
+            }
+            out.push('\n');
+        }
+        out
+    }
+
+    #[test]
+    fn surface_reports_paste_detect_id() {
+        assert_eq!(PasteDetectSurface::new().id(), SurfaceId::PasteDetect);
+    }
+
+    #[test]
+    fn editing_state_renders_prompt_framed_with_masked_echo() {
+        let app = App::new();
+        let mut surface = PasteDetectSurface::new();
+        type_str(&mut surface.modal, "sk-ant-api03-bodyXY42");
+        let text = render_surface(&mut surface, &app);
+        assert!(text.contains("Connect a provider"), "framed title missing");
+        assert!(text.contains("Paste an API key"), "editing prompt missing");
+        // The echo masks everything but the last four chars: the tail shows so
+        // the user can confirm the paste, the secret body never reaches screen.
+        assert!(text.contains('•'), "masked dots missing from echo");
+        assert!(text.contains("XY42"), "confirmation tail missing");
+        assert!(!text.contains("api03"), "secret body leaked to screen");
+        assert!(
+            !text.contains("sk-ant-api03-bodyXY42"),
+            "raw secret leaked to screen"
+        );
+    }
+
+    #[test]
+    fn connected_state_renders_real_data_and_default_prompt() {
+        let app = App::new();
+        let mut surface = PasteDetectSurface::new();
+        surface.modal.apply_result(DetectionResult::Connected {
+            provider: "anthropic".to_string(),
+            models: vec![
+                ModelInfo::from_id("claude-opus-4-8"),
+                ModelInfo::from_id("claude-haiku-4-5"),
+            ],
+        });
+        let text = render_surface(&mut surface, &app);
+        assert!(
+            text.contains("anthropic connected"),
+            "provider line missing"
+        );
+        assert!(text.contains("2 models"), "live count missing");
+        assert!(text.contains("claude-opus-4-8"), "flagship id missing");
+        assert!(text.contains("default"), "make-default prompt missing");
+    }
+
+    #[test]
+    fn detecting_state_renders_the_ladder() {
+        let app = App::new();
+        let mut surface = PasteDetectSurface::new();
+        let (_tx, rx) = oneshot::channel();
+        surface.modal.start_detecting(rx);
+        let text = render_surface(&mut surface, &app);
+        assert!(text.contains("Detecting provider"), "ladder not rendered");
+    }
+
+    #[test]
+    fn esc_closes_the_overlay() {
+        let mut app = App::new();
+        let mut surface = PasteDetectSurface::new();
+        type_str(&mut surface.modal, "abc");
+        let action = surface.handle_key(key(KeyCode::Esc), &mut app);
+        assert!(matches!(action, SurfaceAction::CloseOverlay));
+    }
+
+    #[test]
+    fn tick_advances_the_spinner_and_drains_a_result() {
+        let mut app = App::new();
+        let mut surface = PasteDetectSurface::new();
+        let (tx, rx) = oneshot::channel();
+        surface.modal.start_detecting(rx);
+        tx.send(DetectionResult::Connected {
+            provider: "groq".to_string(),
+            models: vec![ModelInfo::from_id("llama-3.1-70b")],
+        })
+        .unwrap();
+        let before = surface.tick;
+        surface.tick(&mut app);
+        assert_eq!(
+            surface.tick,
+            before.wrapping_add(1),
+            "spinner did not advance"
+        );
+        assert!(
+            matches!(surface.modal.state(), PasteState::Connected { .. }),
+            "tick did not drain the detection result into the modal"
+        );
     }
 }

--- a/crates/wcore-cli/src/tui/surfaces/paste_detect_modal.rs
+++ b/crates/wcore-cli/src/tui/surfaces/paste_detect_modal.rs
@@ -1,0 +1,437 @@
+//! Paste-to-detect modal — state machine + view-model.
+//!
+//! The user pastes an API key, token, or credential; the modal fingerprints it,
+//! validates it live against the guessed provider, and reveals what connected —
+//! the headline "you hand it a key and it configures itself" moment.
+//!
+//! This module is the **logic** half: a pure state machine plus a string
+//! view-model. It deliberately holds no ratatui or `App` types so the
+//! transitions and the exact lines that will be drawn are unit-testable without
+//! a terminal. The `Surface` implementation (draw, key routing, the async
+//! `detect_paste` spawn, storage write + live rebind) is a thin wrapper layered
+//! on top — every string it renders comes from [`PasteModal::ladder_lines`] /
+//! [`PasteModal::reveal_lines`] here, so testing this module tests what the user
+//! sees.
+//!
+//! Async is handled the way the rest of the TUI does it: `handle_key` stays
+//! synchronous and, on Enter, returns [`PasteModalAction::Detect`]; the host
+//! spawns `detect_paste` and hands the modal a result channel via
+//! [`PasteModal::start_detecting`]; [`PasteModal::poll`] (called each tick)
+//! pulls the [`DetectionResult`] in without ever blocking the render loop.
+
+use ratatui::crossterm::event::{Event, KeyCode, KeyEvent};
+use tokio::sync::oneshot;
+use tui_input::Input;
+use tui_input::backend::crossterm::EventHandler;
+
+use wcore_providers::fingerprint::CredentialKind;
+use wcore_providers::paste_detect::DetectionResult;
+
+/// What the host (the `Surface`/router) should do after a key press. Keeps the
+/// modal ignorant of `App`, async runtimes, and storage.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum PasteModalAction {
+    /// Nothing to do; the modal absorbed the key.
+    None,
+    /// Begin detecting the pasted credential. The host spawns `detect_paste`
+    /// and calls [`PasteModal::start_detecting`] with the result channel.
+    Detect(String),
+    /// Persist this provider's key (already validated) and set it as default,
+    /// then trigger a live rebind. Carries the provider slug.
+    Save { provider: String },
+    /// Close the modal without saving.
+    Close,
+}
+
+/// The modal's current phase.
+#[derive(Debug)]
+pub(crate) enum PasteState {
+    /// Awaiting input; the user is typing/pasting.
+    Editing,
+    /// A detection is in flight (async). The ladder animates.
+    Detecting,
+    /// A provider connected and the key authenticated.
+    Connected {
+        provider: String,
+        model_count: usize,
+        /// The flagship (first/most-capable) live model id, if any. Only real
+        /// data from the live catalog — never an invented capability.
+        flagship: Option<String>,
+    },
+    /// The credential needs a guided wizard (AWS secret+region, GCP project,
+    /// Azure endpoint, JWT routing) rather than a single validating request.
+    Guided {
+        kind: CredentialKind,
+        provider: Option<String>,
+    },
+    /// Nothing authenticated; show the failures and offer the picker.
+    Unresolved {
+        best_guess: Option<String>,
+        failures: Vec<String>,
+    },
+}
+
+/// The paste-to-detect modal.
+pub(crate) struct PasteModal {
+    input: Input,
+    state: PasteState,
+    /// Result channel for an in-flight detection (set by `start_detecting`).
+    pending: Option<oneshot::Receiver<DetectionResult>>,
+}
+
+impl Default for PasteModal {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PasteModal {
+    pub(crate) fn new() -> Self {
+        Self {
+            input: Input::default(),
+            state: PasteState::Editing,
+            pending: None,
+        }
+    }
+
+    /// The raw text the user has entered so far.
+    pub(crate) fn value(&self) -> &str {
+        self.input.value()
+    }
+
+    pub(crate) fn state(&self) -> &PasteState {
+        &self.state
+    }
+
+    /// Masked echo of the input — credentials are never shown in clear text.
+    pub(crate) fn masked_input(&self) -> String {
+        mask(self.input.value())
+    }
+
+    /// Handle a key. Pure: returns a [`PasteModalAction`] for the host to act on
+    /// and never performs I/O.
+    pub(crate) fn handle_key(&mut self, key: KeyEvent) -> PasteModalAction {
+        match (&self.state, key.code) {
+            // Cancel from anywhere.
+            (_, KeyCode::Esc) => PasteModalAction::Close,
+
+            // Editing: Enter kicks off detection (when there is something to detect).
+            (PasteState::Editing, KeyCode::Enter) => {
+                let value = self.input.value().trim().to_string();
+                if value.is_empty() {
+                    PasteModalAction::None
+                } else {
+                    self.state = PasteState::Detecting;
+                    PasteModalAction::Detect(value)
+                }
+            }
+            (PasteState::Editing, _) => {
+                self.input.handle_event(&Event::Key(key));
+                PasteModalAction::None
+            }
+
+            // Connected: Enter saves + sets default.
+            (PasteState::Connected { provider, .. }, KeyCode::Enter) => PasteModalAction::Save {
+                provider: provider.clone(),
+            },
+
+            // Unresolved: Enter returns to editing for another paste.
+            (PasteState::Unresolved { .. }, KeyCode::Enter) => {
+                self.reset_to_editing();
+                PasteModalAction::None
+            }
+
+            // Detecting / Guided / other keys: absorbed (no-op).
+            _ => PasteModalAction::None,
+        }
+    }
+
+    /// Register the result channel for an in-flight detection. Moves the modal
+    /// into [`PasteState::Detecting`].
+    pub(crate) fn start_detecting(&mut self, rx: oneshot::Receiver<DetectionResult>) {
+        self.state = PasteState::Detecting;
+        self.pending = Some(rx);
+    }
+
+    /// Poll the in-flight detection (call each tick). Returns `true` when a
+    /// result arrived and the state changed.
+    pub(crate) fn poll(&mut self) -> bool {
+        let Some(rx) = self.pending.as_mut() else {
+            return false;
+        };
+        match rx.try_recv() {
+            Ok(result) => {
+                self.pending = None;
+                self.apply_result(result);
+                true
+            }
+            // Sender dropped without a value — treat as a failed detection.
+            Err(oneshot::error::TryRecvError::Closed) => {
+                self.pending = None;
+                self.state = PasteState::Unresolved {
+                    best_guess: None,
+                    failures: vec!["detection was cancelled".to_string()],
+                };
+                true
+            }
+            Err(oneshot::error::TryRecvError::Empty) => false,
+        }
+    }
+
+    /// Fold a [`DetectionResult`] into the modal state. Public to the crate so
+    /// the host can apply a result it obtained synchronously (and so tests can
+    /// drive transitions directly).
+    pub(crate) fn apply_result(&mut self, result: DetectionResult) {
+        self.state = match result {
+            DetectionResult::Connected { provider, models } => PasteState::Connected {
+                provider,
+                model_count: models.len(),
+                flagship: models.first().map(|m| m.id.clone()),
+            },
+            DetectionResult::NeedsGuidedSetup { kind, provider } => {
+                PasteState::Guided { kind, provider }
+            }
+            DetectionResult::Unresolved {
+                best_guess,
+                attempts,
+            } => PasteState::Unresolved {
+                best_guess,
+                failures: attempts
+                    .into_iter()
+                    .filter_map(|a| a.failure.map(|f| format!("{}: {f}", a.provider)))
+                    .collect(),
+            },
+        };
+    }
+
+    fn reset_to_editing(&mut self) {
+        self.input = Input::default();
+        self.state = PasteState::Editing;
+        self.pending = None;
+    }
+
+    /// The animated detection ladder, as drawn lines. `tick` drives the spinner
+    /// glyph on the active rung. Only shown while [`PasteState::Detecting`].
+    pub(crate) fn ladder_lines(&self, tick: usize) -> Vec<String> {
+        const SPINNER: [char; 4] = ['⠋', '⠙', '⠹', '⠸'];
+        let s = SPINNER[tick % SPINNER.len()];
+        vec![
+            format!("{s} Detecting provider…"),
+            format!("{s} Validating key…"),
+            format!("{s} Fetching catalog…"),
+        ]
+    }
+
+    /// The result lines the modal shows once detection settles. Every line is
+    /// backed by real data (provider, live model count, flagship id, or the
+    /// failure reason) — no invented capabilities.
+    pub(crate) fn reveal_lines(&self) -> Vec<String> {
+        match &self.state {
+            PasteState::Editing => vec![
+                "Paste an API key, token, or credential".to_string(),
+                "stored in your keychain · only ever sent to the provider".to_string(),
+            ],
+            PasteState::Detecting => self.ladder_lines(0),
+            PasteState::Connected {
+                provider,
+                model_count,
+                flagship,
+            } => {
+                let mut lines = vec![format!("✓ {provider} connected — {model_count} models")];
+                if let Some(flag) = flagship {
+                    lines.push(format!("  ready: {flag}"));
+                }
+                lines.push("Make this my default? [Enter]   Cancel [Esc]".to_string());
+                lines
+            }
+            PasteState::Guided { kind, provider } => {
+                let what = guided_hint(*kind, provider.as_deref());
+                vec![what, "Press [Esc] to set it up, or paste a different key".to_string()]
+            }
+            PasteState::Unresolved {
+                best_guess,
+                failures,
+            } => {
+                let mut lines = vec!["✗ Couldn't connect with that credential".to_string()];
+                lines.extend(failures.iter().map(|f| format!("  {f}")));
+                if let Some(guess) = best_guess {
+                    lines.push(format!("  looked most like {guess}"));
+                }
+                lines.push("[Enter] try another key   [Esc] close".to_string());
+                lines
+            }
+        }
+    }
+}
+
+/// One-line "what to do next" for a credential that needs a guided wizard.
+fn guided_hint(kind: CredentialKind, provider: Option<&str>) -> String {
+    match kind {
+        CredentialKind::AwsAccessKeyId => {
+            "AWS access key detected — Bedrock also needs the secret key + region".to_string()
+        }
+        CredentialKind::GcpServiceAccount => {
+            "GCP service account detected — Vertex needs the project + location".to_string()
+        }
+        CredentialKind::GcpAccessToken => {
+            "GCP token detected — it's short-lived; let's wire ADC for refresh".to_string()
+        }
+        CredentialKind::Jwt => "Looks like a JWT — which service issues it?".to_string(),
+        _ => match provider {
+            Some(p) => format!("{p} needs a bit more to finish setup"),
+            None => "This credential needs a bit more to finish setup".to_string(),
+        },
+    }
+}
+
+/// Mask a secret for on-screen echo: keep a short visible tail so the user can
+/// confirm they pasted the right thing, hide the rest.
+fn mask(value: &str) -> String {
+    let n = value.chars().count();
+    if n == 0 {
+        return String::new();
+    }
+    let tail: String = value.chars().skip(n.saturating_sub(4)).collect();
+    let dots = "•".repeat(n.saturating_sub(4).min(24));
+    format!("{dots}{tail}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::crossterm::event::KeyModifiers;
+    use wcore_providers::ModelInfo;
+    use wcore_providers::key_validation::ValidationOutcome;
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    fn type_str(m: &mut PasteModal, s: &str) {
+        for ch in s.chars() {
+            m.handle_key(key(KeyCode::Char(ch)));
+        }
+    }
+
+    #[test]
+    fn typing_accumulates_into_the_buffer() {
+        let mut m = PasteModal::new();
+        type_str(&mut m, "sk-ant-xyz");
+        assert_eq!(m.value(), "sk-ant-xyz");
+        assert!(matches!(m.state(), PasteState::Editing));
+    }
+
+    #[test]
+    fn enter_on_nonempty_emits_detect_and_enters_detecting() {
+        let mut m = PasteModal::new();
+        type_str(&mut m, "sk-ant-xyz");
+        let action = m.handle_key(key(KeyCode::Enter));
+        assert_eq!(action, PasteModalAction::Detect("sk-ant-xyz".to_string()));
+        assert!(matches!(m.state(), PasteState::Detecting));
+    }
+
+    #[test]
+    fn enter_on_empty_does_nothing() {
+        let mut m = PasteModal::new();
+        assert_eq!(m.handle_key(key(KeyCode::Enter)), PasteModalAction::None);
+        assert!(matches!(m.state(), PasteState::Editing));
+    }
+
+    #[test]
+    fn esc_always_closes() {
+        let mut m = PasteModal::new();
+        type_str(&mut m, "abc");
+        assert_eq!(m.handle_key(key(KeyCode::Esc)), PasteModalAction::Close);
+    }
+
+    #[test]
+    fn connected_result_reveals_real_data_only() {
+        let mut m = PasteModal::new();
+        m.apply_result(DetectionResult::Connected {
+            provider: "anthropic".to_string(),
+            models: vec![
+                ModelInfo::from_id("claude-opus-4-8"),
+                ModelInfo::from_id("claude-haiku-4-5"),
+            ],
+        });
+        let lines = m.reveal_lines();
+        assert!(lines[0].contains("anthropic connected — 2 models"));
+        assert!(lines.iter().any(|l| l.contains("claude-opus-4-8")));
+        // Enter on a connected modal asks the host to save that provider.
+        assert_eq!(
+            m.handle_key(key(KeyCode::Enter)),
+            PasteModalAction::Save {
+                provider: "anthropic".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn guided_result_shows_the_next_action_not_a_dead_end() {
+        let mut m = PasteModal::new();
+        m.apply_result(DetectionResult::NeedsGuidedSetup {
+            kind: CredentialKind::AwsAccessKeyId,
+            provider: Some("bedrock".to_string()),
+        });
+        let lines = m.reveal_lines();
+        assert!(lines[0].contains("AWS access key"));
+        assert!(lines[0].contains("secret key + region"));
+    }
+
+    #[test]
+    fn unresolved_lists_failures_and_offers_retry() {
+        let mut m = PasteModal::new();
+        m.apply_result(DetectionResult::Unresolved {
+            best_guess: Some("openai".to_string()),
+            attempts: vec![ValidationOutcome {
+                provider: "openai".to_string(),
+                reached: wcore_providers::key_validation::Rung::Detected,
+                models: Vec::new(),
+                failure: Some("401 Unauthorized".to_string()),
+            }],
+        });
+        let lines = m.reveal_lines();
+        assert!(lines.iter().any(|l| l.contains("Couldn't connect")));
+        assert!(lines.iter().any(|l| l.contains("openai: 401 Unauthorized")));
+        assert!(lines.iter().any(|l| l.contains("most like openai")));
+        // Enter retries (back to editing), Esc closes.
+        m.handle_key(key(KeyCode::Enter));
+        assert!(matches!(m.state(), PasteState::Editing));
+    }
+
+    #[test]
+    fn poll_applies_an_async_result() {
+        let mut m = PasteModal::new();
+        let (tx, rx) = oneshot::channel();
+        m.start_detecting(rx);
+        assert!(matches!(m.state(), PasteState::Detecting));
+        assert!(!m.poll(), "nothing sent yet");
+        tx.send(DetectionResult::Connected {
+            provider: "groq".to_string(),
+            models: vec![ModelInfo::from_id("llama-3.1-70b")],
+        })
+        .unwrap();
+        assert!(m.poll(), "result should be applied");
+        assert!(matches!(m.state(), PasteState::Connected { .. }));
+    }
+
+    #[test]
+    fn poll_treats_dropped_sender_as_failure() {
+        let mut m = PasteModal::new();
+        let (tx, rx) = oneshot::channel::<DetectionResult>();
+        m.start_detecting(rx);
+        drop(tx);
+        assert!(m.poll());
+        assert!(matches!(m.state(), PasteState::Unresolved { .. }));
+    }
+
+    #[test]
+    fn masking_keeps_a_short_tail() {
+        let mut m = PasteModal::new();
+        type_str(&mut m, "sk-ant-api03-secret1234");
+        let masked = m.masked_input();
+        assert!(masked.ends_with("1234"));
+        assert!(masked.contains('•'));
+        assert!(!masked.contains("secret"));
+    }
+}

--- a/crates/wcore-cli/src/tui/surfaces/workspace.rs
+++ b/crates/wcore-cli/src/tui/surfaces/workspace.rs
@@ -688,25 +688,10 @@ impl Surface for WorkspaceSurface {
             return action;
         }
 
-        // v0.9.4 W3b.1 — Tab advances `focused_reasoning_turn_idx` to the next
-        // assistant turn that has a `TurnElement::Thinking` block, wrapping around.
-        //
-        // Precedence order (highest → lowest):
-        //   1. `@`-completion popup open → handled above, Tab consumed there.
-        //   2. Tab here → advance reasoning focus (this block).
-        //
-        // The `@`-completion guard already returned early when the popup was
-        // open, so by the time we reach this point the popup is definitely
-        // closed — the bare Tab is safe to claim for focus navigation.
-        // When no turn has a Thinking block the function is a no-op and Tab
-        // falls through to the composer's `_ =>` handler as before.
-        if key.code == KeyCode::Tab && key.modifiers.is_empty() && Self::has_any_reasoning_turn(app)
-        {
-            Self::advance_focused_reasoning(app);
-            return SurfaceAction::None;
-        }
-        // When no turn has a Thinking block, bare Tab falls through to the
-        // composer's `_ =>` handler unchanged.
+        // FIX-7 — a bare Tab here falls through to the Router's global
+        // tab-switch (the documented "Tab next tab"). The `@`-completion
+        // Tab-accept was handled above; the old reasoning-rail Tab-stepping was
+        // removed (it hijacked Tab whenever any reasoning turn existed).
 
         // `Ctrl+B` toggles the right rail (path map · tools · activity).
         // Hiding it gives the transcript the full body width; a chord, so
@@ -904,23 +889,6 @@ impl Surface for WorkspaceSurface {
             // Submit the composer. A `/…` line is a slash command
             // (routed to the registry); anything else is a message.
             KeyCode::Enter => {
-                // v0.9.4 W3b.2 — when a reasoning turn is focused (Tab
-                // placed focus on it) and the composer is empty, Enter
-                // expands/collapses that turn's reasoning block instead of
-                // submitting. The composer wins over focus-expand whenever
-                // the user has typed anything, so normal message sending is
-                // never blocked.
-                if self.composer.value().is_empty()
-                    && let Some(idx) = app.focused_reasoning_turn_idx
-                {
-                    let entry = app.reasoning_expanded.entry(idx).or_insert(false);
-                    *entry = !*entry;
-                    // Clear focus after the expand/collapse so subsequent
-                    // Enter presses submit (don't repeatedly re-toggle).
-                    app.focused_reasoning_turn_idx = None;
-                    return SurfaceAction::None;
-                }
-
                 let text = self.composer.value().trim().to_string();
                 if text.is_empty() {
                     SurfaceAction::None
@@ -1064,15 +1032,15 @@ impl Surface for WorkspaceSurface {
         self.user_has_scrolled_up = offset > 0;
     }
 
-    /// D039 — the Workspace owns a bare Tab only when an in-surface state
-    /// claims it: an open `@`-completion popup (Tab accepts the highlighted
-    /// candidate) or a reasoning rail to step through (Tab advances the
-    /// focused reasoning turn). With neither, Tab falls through to the
-    /// Router's global tab-switch unchanged. Mirrors the precedence in
-    /// `handle_key` (popup first, then reasoning rail) so the Router yields
-    /// exactly when — and only when — `handle_key` would consume the Tab.
-    fn owns_tab(&self, app: &App) -> bool {
-        self.at_completion.is_some() || Self::has_any_reasoning_turn(app)
+    /// D039 — the Workspace owns a bare Tab only when an open `@`-completion
+    /// popup claims it (Tab accepts the highlighted candidate). Otherwise Tab
+    /// falls through to the Router's global tab-switch — the documented
+    /// "Tab next tab" hint, which must always hold (FIX-2/FIX-7). The earlier
+    /// reasoning-rail Tab-stepping was removed: it claimed Tab whenever ANY
+    /// reasoning turn existed, silently breaking tab-switching after the first
+    /// agent "thinking" turn, and it had no visual focus indicator.
+    fn owns_tab(&self, _app: &App) -> bool {
+        self.at_completion.is_some()
     }
 
     /// D038 — the Workspace always owns `?`: its composer either types `?` as
@@ -1097,63 +1065,6 @@ impl WorkspaceSurface {
             .rev()
             .find(|(_, t)| t.role == crate::tui::app::TurnRole::Assistant)
             .map(|(idx, _)| idx)
-    }
-
-    /// v0.9.4 W3b — return `true` if any turn in the session has at least
-    /// one `TurnElement::Thinking` block. Used to decide whether a bare Tab
-    /// should advance the reasoning focus or fall through to the composer.
-    fn has_any_reasoning_turn(app: &App) -> bool {
-        app.session.turns.iter().any(|t| {
-            t.elements
-                .iter()
-                .any(|e| matches!(e, crate::tui::turn_element::TurnElement::Thinking { .. }))
-        })
-    }
-
-    /// v0.9.4 W3b — advance `app.focused_reasoning_turn_idx` to the next
-    /// turn (by index) that has a `TurnElement::Thinking` block, wrapping
-    /// around after the last such turn.
-    ///
-    /// Enumeration approach: collect the indices of all turns that contain a
-    /// Thinking block, then find the successor of the currently-focused index
-    /// in that list (or start at the first entry if focus is `None`). Wrap at
-    /// the end so the user can cycle through all reasoning turns with repeated
-    /// Tab presses. A session with exactly one reasoning turn always focuses
-    /// that turn regardless of how many times Tab is pressed.
-    fn advance_focused_reasoning(app: &mut App) {
-        // Collect indices of all turns that have at least one Thinking element.
-        let reasoning_indices: Vec<usize> = app
-            .session
-            .turns
-            .iter()
-            .enumerate()
-            .filter(|(_, t)| {
-                t.elements
-                    .iter()
-                    .any(|e| matches!(e, crate::tui::turn_element::TurnElement::Thinking { .. }))
-            })
-            .map(|(i, _)| i)
-            .collect();
-
-        if reasoning_indices.is_empty() {
-            // No reasoning turns — leave focus unchanged (caller guards this).
-            return;
-        }
-
-        let next_idx = match app.focused_reasoning_turn_idx {
-            None => reasoning_indices[0],
-            Some(current) => {
-                // Find the position of `current` in the reasoning-index list and
-                // advance by one, wrapping around.
-                match reasoning_indices.iter().position(|&i| i == current) {
-                    Some(pos) => reasoning_indices[(pos + 1) % reasoning_indices.len()],
-                    // Current focus is no longer a reasoning turn (turn was
-                    // removed) — restart at the first one.
-                    None => reasoning_indices[0],
-                }
-            }
-        };
-        app.focused_reasoning_turn_idx = Some(next_idx);
     }
 
     /// v0.9.2 W11-integ (SPEC §2 #10): parse the AskUserQuestion choice
@@ -2251,17 +2162,12 @@ impl WorkspaceSurface {
                     // D038: the `? keys` hint is now truthful — `?` on an
                     // empty composer opens the live help (here it routes to
                     // /help; on every other surface the Router opens the `?`
-                    // overlay). D039: name the Tab the user actually gets here
-                    // — when a reasoning rail exists Tab steps it, otherwise it
-                    // switches tab.
-                    let tab_hint = if Self::has_any_reasoning_turn(app) {
-                        "Tab reasoning"
-                    } else {
-                        "Tab next tab"
-                    };
+                    // overlay). FIX-7: Tab always switches tabs now (the
+                    // reasoning-rail Tab-stepping was removed), so the hint is
+                    // unconditionally honest.
                     (
                         format!(
-                            "{tab_hint}  ⇧Tab mode  {rail_hint}  PgUp/PgDn scroll  End ↓latest  F4 copy/select  ? keys"
+                            "Tab next tab  ⇧Tab mode  {rail_hint}  PgUp/PgDn scroll  End ↓latest  F4 copy/select  ? keys"
                         ),
                         Style::default().fg(theme.text_muted),
                     )
@@ -2380,48 +2286,86 @@ impl WorkspaceSurface {
 fn render_idle_hero(frame: &mut Frame, area: Rect, theme: &Theme) {
     frame.render_widget(Block::default().style(Style::default().bg(theme.bg)), area);
 
-    // The hero copy is 6 rows (subtitle + blank + 3 prompts + blank-lead).
-    // Reserve it only when the pane can spare the rows AFTER the banner has the
-    // headroom it needs (the banner itself degrades to the tagline alone below
-    // BANNER_ROWS + 2). On a short pane the banner takes the whole area and the
-    // hero copy is dropped rather than crammed.
-    const HERO_ROWS: u16 = 6;
-    let show_hero = area.height >= HERO_ROWS + 8;
+    // FIX-5: the boot screen is the first-run concierge moment. Alongside the
+    // starter prompts it surfaces (a) the paste-to-connect door (`/connect`,
+    // the easiest way to add a provider — previously undiscoverable), and (b)
+    // any ambient cloud credentials already on this machine, so the user sees
+    // "you can use these right now" instead of dead space.
+    let detected = detect_boot_providers();
+
+    // Rows: subtitle + blank + [detected?] + 3 prompts + blank-lead. Reserve
+    // them only when the pane can spare the rows after the banner's headroom;
+    // on a short pane the banner takes the whole area and the copy is dropped.
+    let hero_rows: u16 = if detected.is_empty() { 6 } else { 7 };
+    let show_hero = area.height >= hero_rows + 8;
     if !show_hero {
         wayland_banner(frame, area, theme);
         return;
     }
 
     let [banner_area, hero_area] =
-        Layout::vertical([Constraint::Min(1), Constraint::Length(HERO_ROWS)]).areas(area);
+        Layout::vertical([Constraint::Min(1), Constraint::Length(hero_rows)]).areas(area);
     wayland_banner(frame, banner_area, theme);
 
-    // One factual line describing what Wayland is, then concrete starter
-    // prompts. No em-dashes in user-facing copy (project rule) — the bullet is
-    // a middle dot.
-    let lines: Vec<Line> = vec![
+    // No em-dashes in user-facing copy (project rule) — the bullet is a middle
+    // dot.
+    let mut lines: Vec<Line> = vec![
         Line::from(Span::styled(
             "A terminal AI agent that reads, writes, and runs code in your project.",
             Style::default().fg(theme.text_dim),
         )),
         Line::from(""),
-        Line::from(Span::styled(
-            "Try: explain this codebase",
-            Style::default().fg(theme.text_muted),
-        )),
-        Line::from(Span::styled(
-            "Try: add a test for the function I name",
-            Style::default().fg(theme.text_muted),
-        )),
-        Line::from(Span::styled(
-            "Try: /model to pick a model",
-            Style::default().fg(theme.text_muted),
-        )),
     ];
+    if !detected.is_empty() {
+        lines.push(Line::from(vec![
+            Span::styled("Detected: ", Style::default().fg(theme.success)),
+            Span::styled(detected.join(" · "), Style::default().fg(theme.text)),
+            Span::styled(
+                "  ·  /provider to use",
+                Style::default().fg(theme.text_muted),
+            ),
+        ]));
+    }
+    lines.push(Line::from(Span::styled(
+        "Try: explain this codebase",
+        Style::default().fg(theme.text_muted),
+    )));
+    lines.push(Line::from(vec![
+        Span::styled("/connect", Style::default().fg(theme.orange)),
+        Span::styled(
+            " to paste an API key and add a provider",
+            Style::default().fg(theme.text_muted),
+        ),
+    ]));
+    lines.push(Line::from(Span::styled(
+        "Try: /model to pick a model",
+        Style::default().fg(theme.text_muted),
+    )));
+
     let para = Paragraph::new(lines)
         .alignment(Alignment::Center)
         .style(Style::default().bg(theme.bg));
     frame.render_widget(para, hero_area);
+}
+
+/// FIX-5: ambient LLM-provider credentials already present on this machine —
+/// the ones a user can route to immediately without entering a key. Reuses the
+/// single source of truth `provider_connected` (sync, no network): AWS for
+/// Bedrock, GCP ADC for Vertex, and a stored ChatGPT OAuth login. Returns the
+/// human labels of the connected ones, in a stable order.
+fn detect_boot_providers() -> Vec<&'static str> {
+    use wcore_config::config::{ProviderType, provider_connected};
+    let mut found = Vec::new();
+    if provider_connected(ProviderType::Bedrock) {
+        found.push("AWS Bedrock");
+    }
+    if provider_connected(ProviderType::Vertex) {
+        found.push("Google Vertex");
+    }
+    if provider_connected(ProviderType::OpenAIChatGpt) {
+        found.push("ChatGPT login");
+    }
+    found
 }
 
 /// D009: the SETTLED half of the transcript — the completed turns and their
@@ -3923,9 +3867,10 @@ mod tests {
             out.contains("Try: explain this codebase"),
             "idle hero example prompt 1 missing:\n{out}"
         );
+        // FIX-5: the boot screen advertises the paste-to-connect door.
         assert!(
-            out.contains("Try: add a test"),
-            "idle hero example prompt 2 missing:\n{out}"
+            out.contains("/connect") && out.contains("paste an API key"),
+            "idle hero must surface the /connect provider door:\n{out}"
         );
         assert!(
             out.contains("Try: /model"),
@@ -7541,94 +7486,23 @@ mod tests {
         t
     }
 
-    /// Tab advances `focused_reasoning_turn_idx` to the next turn with a
-    /// Thinking block, wrapping around after the last reasoning turn.
+    /// FIX-7 — a reasoning turn in the transcript must NOT make the Workspace
+    /// claim Tab. The old behavior hijacked Tab whenever any Thinking block
+    /// existed (with no visual focus indicator), silently breaking the
+    /// documented "Tab next tab" after the first agent turn. `owns_tab` must
+    /// now be false so the Router's global tab-switch fires.
     #[test]
-    fn tab_advances_focused_reasoning_idx_v094() {
+    fn tab_does_not_get_stolen_by_a_reasoning_turn_fix7() {
         use crate::tui::app::TurnRole;
         let mut app = App::new();
-        // Three turns: user (idx 0, no thinking), assistant with reasoning
-        // (idx 1), assistant with reasoning (idx 2). Only indices 1 and 2
-        // are reasoning turns; Tab must cycle through them.
         app.session.turns.push(plain_turn(TurnRole::User));
         app.session.turns.push(reasoning_turn(TurnRole::Assistant));
-        app.session.turns.push(reasoning_turn(TurnRole::Assistant));
 
-        let mut surface = WorkspaceSurface::new();
-        assert_eq!(
-            app.focused_reasoning_turn_idx, None,
-            "no focus before first Tab"
-        );
-
-        // First Tab → focus lands on the first reasoning turn (idx 1).
-        surface.handle_key(key(KeyCode::Tab), &mut app);
-        assert_eq!(
-            app.focused_reasoning_turn_idx,
-            Some(1),
-            "first Tab must focus the first reasoning turn"
-        );
-
-        // Second Tab → advances to the next reasoning turn (idx 2).
-        surface.handle_key(key(KeyCode::Tab), &mut app);
-        assert_eq!(
-            app.focused_reasoning_turn_idx,
-            Some(2),
-            "second Tab must advance to the second reasoning turn"
-        );
-
-        // Third Tab → wraps around to idx 1.
-        surface.handle_key(key(KeyCode::Tab), &mut app);
-        assert_eq!(
-            app.focused_reasoning_turn_idx,
-            Some(1),
-            "Tab must wrap around to the first reasoning turn after the last"
-        );
-
-        // User turn (idx 0) must never become the focus.
-        assert_ne!(app.focused_reasoning_turn_idx, Some(0));
-    }
-
-    /// Enter with `focused_reasoning_turn_idx == Some(idx)` and an empty
-    /// composer flips `reasoning_expanded[idx]` and clears the focus.
-    #[test]
-    fn enter_expands_focused_reasoning_block_v094() {
-        use crate::tui::app::TurnRole;
-        let mut app = App::new();
-        app.session.turns.push(reasoning_turn(TurnRole::Assistant));
-
-        let mut surface = WorkspaceSurface::new();
-        // Set focus to turn 0 manually (simulating a prior Tab press).
-        app.focused_reasoning_turn_idx = Some(0);
-
-        // Default: absent ⇒ collapsed.
+        let surface = WorkspaceSurface::new();
         assert!(
-            !app.reasoning_expanded.get(&0).copied().unwrap_or(false),
-            "reasoning block must start collapsed"
+            !surface.owns_tab(&app),
+            "a reasoning turn must not make the Workspace claim Tab (FIX-7)"
         );
-
-        // Enter with empty composer + active focus → expand.
-        let action = surface.handle_key(key(KeyCode::Enter), &mut app);
-        assert!(
-            matches!(action, SurfaceAction::None),
-            "expand action must return SurfaceAction::None"
-        );
-        assert_eq!(
-            app.reasoning_expanded.get(&0).copied(),
-            Some(true),
-            "Enter must expand the focused reasoning turn"
-        );
-        // Focus must be cleared after the expand.
-        assert_eq!(
-            app.focused_reasoning_turn_idx, None,
-            "focus must clear after Enter expand"
-        );
-
-        // A second Enter on an empty composer with no focus is a plain
-        // empty-submit no-op (not a toggle).
-        let action2 = surface.handle_key(key(KeyCode::Enter), &mut app);
-        assert!(matches!(action2, SurfaceAction::None));
-        // The map entry is unchanged (no second toggle without focus).
-        assert_eq!(app.reasoning_expanded.get(&0).copied(), Some(true));
     }
 
     /// Ctrl+R still toggles the most-recent assistant turn's reasoning when
@@ -7641,8 +7515,6 @@ mod tests {
         app.session.turns.push(reasoning_turn(TurnRole::Assistant));
 
         let mut surface = WorkspaceSurface::new();
-        // No reasoning focus set.
-        assert_eq!(app.focused_reasoning_turn_idx, None);
 
         // Ctrl+R must flip the most-recent assistant turn (idx 1).
         surface.handle_key(ctrl(KeyCode::Char('r')), &mut app);
@@ -7655,25 +7527,14 @@ mod tests {
         // Second Ctrl+R collapses it.
         surface.handle_key(ctrl(KeyCode::Char('r')), &mut app);
         assert_eq!(app.reasoning_expanded.get(&1).copied(), Some(false));
-
-        // Ctrl+R must not interact with focused_reasoning_turn_idx.
-        assert_eq!(
-            app.focused_reasoning_turn_idx, None,
-            "Ctrl+R must not set focused_reasoning_turn_idx"
-        );
     }
 
-    /// Tab while the `@`-completion popup is open accepts the completion
-    /// candidate — it does NOT advance the reasoning focus.
+    /// Tab while the `@`-completion popup is open accepts the highlighted
+    /// candidate — the one in-surface state that still owns Tab (FIX-7).
     #[test]
     fn tab_still_accepts_slash_completion_v094() {
         let mut app = App::new();
         let mut surface = WorkspaceSurface::new();
-
-        // Seed a reasoning turn so advance_focused_reasoning would normally fire.
-        app.session
-            .turns
-            .push(reasoning_turn(crate::tui::app::TurnRole::Assistant));
 
         // Type `@di` to open the @-completion popup.
         for c in "@di".chars() {
@@ -7683,8 +7544,12 @@ mod tests {
             surface.at_completion.is_some(),
             "typing `@di` must open the @-completion popup"
         );
+        assert!(
+            surface.owns_tab(&app),
+            "an open @-completion popup must claim Tab"
+        );
 
-        // Tab must accept the completion, NOT advance reasoning focus.
+        // Tab must accept the completion.
         surface.handle_key(key(KeyCode::Tab), &mut app);
 
         assert!(
@@ -7695,10 +7560,6 @@ mod tests {
             surface.composer.value(),
             "@diff",
             "Tab must accept the highlighted candidate"
-        );
-        assert_eq!(
-            app.focused_reasoning_turn_idx, None,
-            "Tab must NOT advance reasoning focus when the @-completion popup is open"
         );
     }
 

--- a/crates/wcore-cli/src/tui/widgets/statusbar.rs
+++ b/crates/wcore-cli/src/tui/widgets/statusbar.rs
@@ -218,9 +218,16 @@ pub fn status_bar(f: &mut Frame, area: Rect, app: &App, t: &Theme, _sample: Syst
     // heuristic) — IJFW discipline: the user always sees the spend.
     if area.width >= COST_SEGMENT_MIN_WIDTH {
         spans.push(divider(t));
-        let cost = app.cost.as_ref().map(|c| c.total_cost_usd).unwrap_or(0.0);
+        // Real-or-nothing: before any spend is recorded `app.cost` is `None` —
+        // show an em-dash, never a fabricated `$0.00` (matches the `/config`
+        // health line and Sean's cost = real-or-nothing rule). A recorded zero
+        // (Some(0.0)) is honest data and still prints `$0.00`.
+        let cost_str = match app.cost.as_ref() {
+            Some(c) => format_cost(c.total_cost_usd),
+            None => "—".to_string(),
+        };
         spans.push(Span::styled(
-            format!(" {} ", format_cost(cost)),
+            format!(" {cost_str} "),
             Style::default().bg(t.bg).fg(t.text_dim),
         ));
         spans.push(divider(t));
@@ -506,6 +513,23 @@ mod tests {
         assert!(line.contains("$1.23"), "session cost missing: {line:?}");
         assert!(!line.contains("cpu"), "cpu leaked: {line:?}");
         assert!(!line.contains("ram"), "ram leaked: {line:?}");
+    }
+
+    #[test]
+    fn status_bar_shows_em_dash_when_no_cost_recorded() {
+        // Real-or-nothing: at boot `app.cost` is None — the status bar must
+        // show an em-dash, never a fabricated `$0.00`.
+        let app = App::new();
+        assert!(app.cost.is_none(), "precondition: no cost at boot");
+        let line = render(&app, &Theme::hearth(), 120);
+        assert!(
+            !line.contains("$0.00"),
+            "must not fabricate $0.00 with no spend: {line:?}"
+        );
+        assert!(
+            line.contains('—'),
+            "spend must read an em-dash when unrecorded: {line:?}"
+        );
     }
 
     #[test]

--- a/crates/wcore-config/src/config.rs
+++ b/crates/wcore-config/src/config.rs
@@ -1937,10 +1937,15 @@ fn resolve_api_key(
 )]
 pub struct MissingApiKey;
 
-fn lookup_store_api_key(
-    store: &dyn crate::credentials::CredentialsStore,
-    provider: ProviderType,
-) -> Option<String> {
+/// The credentials-store key under which `provider`'s API key is stored, or
+/// `None` for providers that authenticate out-of-band (Bedrock/Vertex via cloud
+/// credentials, ChatGPT Codex via OAuth) and therefore have no store slot.
+///
+/// This is the single source of truth for the mapping: both the read path
+/// ([`lookup_store_api_key`], consumed by [`resolve_api_key`]) and the write
+/// path ([`store_provider_api_key`]) go through it, so a key written here is
+/// guaranteed to be the key resolution later reads back.
+pub fn credentials_store_key(provider: ProviderType) -> Option<String> {
     let key = match provider {
         ProviderType::Anthropic => "providers.anthropic.api_key",
         ProviderType::OpenAI => "providers.openai.api_key",
@@ -1967,7 +1972,56 @@ fn lookup_store_api_key(
         ProviderType::Mistral => "providers.mistral.api_key",
         ProviderType::Cohere => "providers.cohere.api_key",
     };
-    store.get(key).ok().flatten()
+    Some(key.to_string())
+}
+
+fn lookup_store_api_key(
+    store: &dyn crate::credentials::CredentialsStore,
+    provider: ProviderType,
+) -> Option<String> {
+    let key = credentials_store_key(provider)?;
+    store.get(&key).ok().flatten()
+}
+
+/// Persist a validated API key for `provider` into the configured credentials
+/// store — the same store [`resolve_api_key`] reads from — so a subsequent
+/// [`Config::resolve`] (e.g. a live engine rebind) picks it up without a
+/// restart and without mutating process environment variables.
+///
+/// The storage backend (keyring / plaintext-0600 / encrypted-file) is read
+/// from the on-disk `[storage.credentials]` block, exactly as resolution will
+/// read it. Returns an error for providers with no store slot
+/// ([`credentials_store_key`] returns `None`) or on a store write failure. The
+/// value is never logged.
+pub fn store_provider_api_key(provider: ProviderType, api_key: &str) -> anyhow::Result<()> {
+    let Some(store_key) = credentials_store_key(provider) else {
+        anyhow::bail!(
+            "provider {} authenticates out-of-band and has no credentials-store API key",
+            provider_type_slug(provider)
+        );
+    };
+
+    // Resolve the SAME storage backend resolution will later read from: the
+    // on-disk `[storage.credentials]` block (defaulted when the file or the
+    // block is absent).
+    let storage = load_global_config_file()
+        .map(|f| f.storage.credentials)
+        .unwrap_or_default();
+
+    let store = crate::credentials::open_store(&storage, &credentials_storage_path())?;
+    store
+        .put(&store_key, api_key)
+        .map_err(|e| anyhow::anyhow!("writing {store_key} to credentials store: {e}"))?;
+    Ok(())
+}
+
+/// Load and parse the global `config.toml` into a [`ConfigFile`], or `None`
+/// when the file does not exist. Mirrors the load half of
+/// [`patch_global_config`] without mutating or rewriting the file.
+fn load_global_config_file() -> Option<ConfigFile> {
+    let path = global_config_path();
+    let raw = std::fs::read_to_string(&path).ok()?;
+    toml::from_str(&raw).ok()
 }
 
 // --- App directories ---
@@ -3540,6 +3594,49 @@ mod tests {
         let storage = crate::credentials::CredentialsStorageConfig::default();
         let result = resolve_api_key(None, None, ProviderType::Vertex, &storage).unwrap();
         assert_eq!(result, "");
+    }
+
+    #[test]
+    fn credentials_store_key_maps_bearer_providers_and_excludes_oob() {
+        // Out-of-band auth (cloud creds / OAuth) has no store slot.
+        assert_eq!(credentials_store_key(ProviderType::Bedrock), None);
+        assert_eq!(credentials_store_key(ProviderType::Vertex), None);
+        assert_eq!(credentials_store_key(ProviderType::OpenAIChatGpt), None);
+        // Bearer-key providers map to `providers.<slug>.api_key`, including the
+        // hyphenated slugs that are easy to get wrong by hand.
+        assert_eq!(
+            credentials_store_key(ProviderType::Anthropic).as_deref(),
+            Some("providers.anthropic.api_key")
+        );
+        assert_eq!(
+            credentials_store_key(ProviderType::AzureOpenAI).as_deref(),
+            Some("providers.azure-openai.api_key")
+        );
+        assert_eq!(
+            credentials_store_key(ProviderType::FluxRouter).as_deref(),
+            Some("providers.flux-router.api_key")
+        );
+    }
+
+    #[test]
+    fn stored_key_is_read_back_by_resolution() {
+        // The contract paste-to-detect depends on: a key written under
+        // `credentials_store_key` is the exact key resolution reads back, so a
+        // saved credential resolves live on the next rebind. Exercised through
+        // the real read path (`lookup_store_api_key`) against a plaintext store,
+        // with no process-env mutation.
+        use crate::credentials::CredentialsStore;
+        let dir = tempfile::tempdir().unwrap();
+        let store =
+            crate::credentials::PlaintextCredentialsStore::new(dir.path().join("creds.toml"));
+        let write_key = credentials_store_key(ProviderType::Deepseek).unwrap();
+        store.put(&write_key, "sk-deepseek-secret").unwrap();
+
+        let read = lookup_store_api_key(&store, ProviderType::Deepseek);
+        assert_eq!(read.as_deref(), Some("sk-deepseek-secret"));
+
+        // A provider with no slot resolves to nothing from the store.
+        assert_eq!(lookup_store_api_key(&store, ProviderType::Bedrock), None);
     }
 
     // -------------------------------------------------------------------------

--- a/crates/wcore-config/src/config.rs
+++ b/crates/wcore-config/src/config.rs
@@ -1330,6 +1330,24 @@ impl Config {
             ..self.clone()
         }
     }
+
+    /// Like [`for_provider_discovery`](Self::for_provider_discovery), but binds
+    /// an explicitly-supplied `api_key` instead of resolving one from storage or
+    /// the environment. This is the seam for the `/config` paste-to-detect flow:
+    /// it lets the engine probe a *just-pasted* key against a candidate provider
+    /// (via `list_models`) before the key is ever written to disk. The provider
+    /// identity, base URL, and compat preset are stamped from `provider`; the
+    /// model is irrelevant to `list_models` and is left as `self.model`.
+    pub fn for_key_validation(&self, provider: ProviderType, api_key: &str) -> Self {
+        Self {
+            provider,
+            provider_label: provider_type_slug(provider).to_string(),
+            api_key: api_key.to_string(),
+            base_url: default_base_url_for(provider),
+            compat: compat_defaults_for(provider),
+            ..self.clone()
+        }
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/crates/wcore-config/src/config.rs
+++ b/crates/wcore-config/src/config.rs
@@ -2488,6 +2488,119 @@ pub fn migrate_legacy_yaml_if_needed() {
     );
 }
 
+/// Render the **effective configuration** as a redacted, pretty-printed TOML
+/// string: the values the engine resolves from disk, merged in cascade order
+/// (global ← project ← `--profile`) with the headline CLI overrides stamped on.
+///
+/// This is the data layer behind the `/doctor` Effective-config preview. It
+/// repeats the file-merge phase of [`Config::resolve`] (steps 1–4) — the same
+/// `try_load_config_file` / `merge_config_files` / `apply_profile` path — so the
+/// preview never drifts from what `resolve` actually loads.
+///
+/// **Secrets are redacted.** Every string value whose key name looks like a
+/// credential (`api_key`, `token`, `secret`, `password`, `credential`,
+/// `private_key`, or anything containing `auth`) is replaced with `***` via a
+/// recursive walk of the serialized value tree — robust to new secret-bearing
+/// fields (a new key under `[providers.*]` / `[channels.*]` / MCP headers is
+/// masked without a code change). Over-redaction is the safe direction.
+///
+/// Caveats surfaced to the user by the caller's header: live env-resolved API
+/// keys never appear here (the file never holds them), and `WAYLAND_HOME`
+/// sandboxing is honored through [`global_config_path`].
+pub fn effective_config_toml(cli: &CliArgs) -> anyhow::Result<String> {
+    use anyhow::Context;
+
+    // Steps 1–4 of `resolve`: load + merge + optional profile overlay.
+    let global = try_load_config_file(&global_config_path())
+        .context("loading global config for the effective-config preview")?;
+    let project_path = cli
+        .project_dir
+        .as_ref()
+        .map(|d| d.join(".wayland-core.toml"))
+        .unwrap_or_else(project_config_path);
+    let project = try_load_config_file(&project_path)
+        .context("loading project config for the effective-config preview")?;
+    let mut merged = merge_config_files(global, project);
+    if let Some(profile_name) = &cli.profile {
+        merged = apply_profile(merged, profile_name)?;
+    }
+
+    // Stamp the headline CLI overrides so the preview reflects launch flags
+    // (the rest of the CLI surface is provider-resolution detail that does not
+    // belong in a config-file preview).
+    if let Some(provider) = &cli.provider {
+        merged.default.provider = provider.clone();
+    }
+    if let Some(model) = &cli.model {
+        merged.default.model = Some(model.clone());
+    }
+    if cli.max_turns.is_some() {
+        merged.default.max_turns = cli.max_turns;
+    }
+
+    let mut value =
+        toml::Value::try_from(&merged).context("serializing the merged config for redaction")?;
+    redact_secrets_in_place(&mut value);
+    toml::to_string_pretty(&value).context("rendering the effective config as TOML")
+}
+
+/// True if a TOML key name designates a secret value that must be redacted.
+/// Matched case-insensitively as a substring so compound names
+/// (`webhook_secret`, `bot_token`, `Authorization`) are covered.
+fn is_secret_key(key: &str) -> bool {
+    const NEEDLES: [&str; 9] = [
+        "api_key",
+        "apikey",
+        "token",
+        "secret",
+        "password",
+        "passwd",
+        "credential",
+        "private_key",
+        "auth",
+    ];
+    let lowered = key.to_ascii_lowercase();
+    NEEDLES.iter().any(|n| lowered.contains(n))
+}
+
+/// Recursively replace every secret-keyed string value in `value` with `***`.
+fn redact_secrets_in_place(value: &mut toml::Value) {
+    match value {
+        toml::Value::Table(table) => {
+            for (key, child) in table.iter_mut() {
+                if is_secret_key(key) {
+                    mask_value(child);
+                } else {
+                    redact_secrets_in_place(child);
+                }
+            }
+        }
+        toml::Value::Array(items) => {
+            for child in items.iter_mut() {
+                redact_secrets_in_place(child);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Mask every string reachable from a secret-keyed value (a bare string, an
+/// array of strings, or a nested table of strings). Non-string leaves
+/// (numbers/bools) under a secret key are left as-is — they are not secrets to
+/// leak, and masking them would corrupt the rendered types.
+fn mask_value(value: &mut toml::Value) {
+    match value {
+        toml::Value::String(s) => *s = "***".to_string(),
+        toml::Value::Array(items) => items.iter_mut().for_each(mask_value),
+        toml::Value::Table(table) => {
+            for (_, child) in table.iter_mut() {
+                mask_value(child);
+            }
+        }
+        _ => {}
+    }
+}
+
 /// Merge two config files. Project overrides global.
 fn merge_config_files(global: ConfigFile, project: ConfigFile) -> ConfigFile {
     let default = DefaultConfig {
@@ -4691,6 +4804,128 @@ skills_lifecycle = true
              contents:\n{toml_contents}\n\
              (this means the migration read yaml from somewhere other than \
              WAYLAND_HOME — hermeticity bug)"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // S9: effective-config preview (`effective_config_toml`) + secret redaction.
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn redact_masks_secret_named_keys_at_any_depth() {
+        // The redaction walk must mask credential-shaped keys wherever they
+        // appear — top-level, nested tables, and inside header tables — while
+        // leaving non-secret values (and non-string secret leaves) intact.
+        let mut value: toml::Value = toml::from_str(
+            r#"
+            [default]
+            provider = "anthropic"
+
+            [providers.anthropic]
+            api_key = "sk-ant-SECRET"
+            base_url = "https://api.anthropic.com"
+
+            [channels.telegram]
+            bot_token = "12345:SECRET"
+            chat_id = 99
+
+            [mcp.servers.notion.headers]
+            Authorization = "Bearer SECRET"
+            "#,
+        )
+        .expect("parse fixture");
+
+        redact_secrets_in_place(&mut value);
+        let out = toml::to_string_pretty(&value).expect("serialize");
+
+        assert!(!out.contains("SECRET"), "a secret leaked:\n{out}");
+        assert!(
+            out.contains("api_key = \"***\""),
+            "api_key not masked:\n{out}"
+        );
+        assert!(
+            out.contains("bot_token = \"***\""),
+            "token not masked:\n{out}"
+        );
+        assert!(
+            out.contains("Authorization = \"***\""),
+            "auth header not masked:\n{out}"
+        );
+        // Non-secret values survive.
+        assert!(
+            out.contains("provider = \"anthropic\""),
+            "provider lost:\n{out}"
+        );
+        assert!(out.contains("api.anthropic.com"), "base_url lost:\n{out}");
+        assert!(out.contains("chat_id = 99"), "non-secret int lost:\n{out}");
+    }
+
+    #[test]
+    #[serial_test::serial(wayland_home_env)]
+    fn effective_config_toml_merges_and_redacts_from_disk() {
+        let wh_key = "WAYLAND_HOME";
+        let prev_wh = std::env::var_os(wh_key);
+        let sandbox = tempfile::tempdir().expect("tempdir sandbox");
+        // SAFETY: serialized by the `wayland_home_env` serial group.
+        unsafe { std::env::set_var(wh_key, sandbox.path()) };
+
+        std::fs::write(
+            sandbox.path().join("config.toml"),
+            "[default]\nprovider = \"anthropic\"\n\n\
+             [providers.anthropic]\napi_key = \"sk-ant-LIVE-SECRET\"\n",
+        )
+        .expect("seed config.toml");
+
+        let rendered = effective_config_toml(&CliArgs::default());
+
+        // Restore env BEFORE asserting so a failure can't leak state.
+        match prev_wh {
+            Some(v) => unsafe { std::env::set_var(wh_key, v) },
+            None => unsafe { std::env::remove_var(wh_key) },
+        }
+
+        let out = rendered.expect("effective config should render");
+        assert!(
+            out.contains("provider = \"anthropic\""),
+            "merged provider missing:\n{out}"
+        );
+        assert!(
+            !out.contains("sk-ant-LIVE-SECRET") && out.contains("***"),
+            "the api key must be redacted in the preview:\n{out}"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial(wayland_home_env)]
+    fn effective_config_toml_stamps_cli_overrides() {
+        let wh_key = "WAYLAND_HOME";
+        let prev_wh = std::env::var_os(wh_key);
+        // Empty sandbox (no config.toml) so the merge starts from defaults and
+        // never reads the host's real config.
+        let sandbox = tempfile::tempdir().expect("tempdir sandbox");
+        // SAFETY: serialized by the `wayland_home_env` serial group.
+        unsafe { std::env::set_var(wh_key, sandbox.path()) };
+
+        let cli = CliArgs {
+            provider: Some("openai".to_string()),
+            model: Some("gpt-sentinel".to_string()),
+            ..CliArgs::default()
+        };
+        let rendered = effective_config_toml(&cli);
+
+        match prev_wh {
+            Some(v) => unsafe { std::env::set_var(wh_key, v) },
+            None => unsafe { std::env::remove_var(wh_key) },
+        }
+
+        let out = rendered.expect("effective config should render");
+        assert!(
+            out.contains("provider = \"openai\""),
+            "CLI provider override not stamped:\n{out}"
+        );
+        assert!(
+            out.contains("gpt-sentinel"),
+            "CLI model override not stamped:\n{out}"
         );
     }
 

--- a/crates/wcore-config/tests/hermeticity_audit_test.rs
+++ b/crates/wcore-config/tests/hermeticity_audit_test.rs
@@ -31,6 +31,13 @@ const ALLOWLIST: &[&str] = &[
     // The canonical helper — this is the one legitimate call site, the
     // platform-native fallback inside `wayland_config_dir()` itself.
     "crates/wcore-config/src/config.rs",
+    // S11 self-configure discovery (`/doctor` DISCOVERED): counts MCP servers
+    // in the REAL machine's Claude-Desktop config at
+    // `<config_dir>/Claude/claude_desktop_config.json`. This deliberately
+    // probes the actual OS config dir (not `WAYLAND_HOME`) — routing it through
+    // `wayland_config_dir()` would make it look in the sandbox and never find
+    // the user's real Claude install. Read-only; writes no Wayland state.
+    "crates/wcore-cli/src/tui/surfaces/diagnostics.rs",
 ];
 
 fn workspace_root() -> PathBuf {

--- a/crates/wcore-providers/src/cerebras.rs
+++ b/crates/wcore-providers/src/cerebras.rs
@@ -56,6 +56,10 @@ impl LlmProvider for CerebrasProvider {
     ) -> Result<mpsc::Receiver<LlmEvent>, ProviderError> {
         self.inner.stream(request).await
     }
+
+    async fn list_models(&self) -> anyhow::Result<Vec<crate::ModelInfo>> {
+        self.inner.list_models().await
+    }
 }
 
 /// Register a Cerebras factory in the given registry under the lowercased id

--- a/crates/wcore-providers/src/deepseek.rs
+++ b/crates/wcore-providers/src/deepseek.rs
@@ -55,6 +55,10 @@ impl LlmProvider for DeepSeekProvider {
     ) -> Result<mpsc::Receiver<LlmEvent>, ProviderError> {
         self.inner.stream(request).await
     }
+
+    async fn list_models(&self) -> anyhow::Result<Vec<crate::ModelInfo>> {
+        self.inner.list_models().await
+    }
 }
 
 /// Register a DeepSeek factory in the given registry under the lowercased id

--- a/crates/wcore-providers/src/fingerprint.rs
+++ b/crates/wcore-providers/src/fingerprint.rs
@@ -1,0 +1,551 @@
+//! Key fingerprinting — guess the provider from a pasted credential's *shape*.
+//!
+//! This is the first step of the `/config` "paste-to-detect" flow: the user
+//! pastes an API key, token, or credential blob, and we narrow it to a ranked
+//! set of provider candidates **before** making any network call. The live
+//! probe (`list_models` against the guessed provider) is the source of truth;
+//! a fingerprint is only a hypothesis. A unique prefix (`sk-ant-`) yields one
+//! high-confidence candidate; a shared prefix (bare `sk-`) yields an ambiguous
+//! set to validate in parallel; an unknown shape yields nothing (fall back to a
+//! provider picker).
+//!
+//! Pure and side-effect-free by design, so the whole table is unit-testable
+//! without a network. Prefixes are drawn from each provider's published key
+//! format (see the config-redesign research synthesis); they are matched
+//! **longest-first** so that `sk-ant-` wins over the bare `sk-` bucket.
+
+/// What kind of credential the pasted string appears to be. Most providers use
+/// a simple bearer key; AWS and GCP do not, and need a guided completion path
+/// rather than a single validating GET.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CredentialKind {
+    /// A bearer-style API key, validated by one authenticated `GET /models`.
+    BearerKey,
+    /// An AWS access-key id (`AKIA…`/`ASIA…`). NOT a complete credential on its
+    /// own — needs the secret access key + region. Branch to the AWS wizard.
+    AwsAccessKeyId,
+    /// An AWS Bedrock bearer API key (`ABSK…` / `bedrock-api-key-…`). Unlike a
+    /// classic access key this *is* a usable bearer, no SigV4 required.
+    BedrockApiKey,
+    /// A GCP service-account JSON blob. Long-term signing material, not a token;
+    /// needs `project_id` + a minted OAuth token before Vertex can be reached.
+    GcpServiceAccount,
+    /// A GCP OAuth access token (`ya29.…`). A valid but ephemeral opaque bearer.
+    GcpAccessToken,
+    /// A JSON Web Token (`eyJ…`). Decode the header to route (Azure AD, etc.).
+    Jwt,
+    /// Shape not recognized — fall back to a provider picker.
+    Unknown,
+}
+
+/// How sure the prefix match is. Drives the validation strategy: a single
+/// [`Confidence::High`] candidate is validated alone; [`Confidence::Ambiguous`]
+/// or [`Confidence::Low`] candidates are validated in parallel, first 2xx wins.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Confidence {
+    /// No prefix; a shape-only heuristic (e.g. a bare 32-hex string → Azure).
+    Low,
+    /// A shared/ambiguous prefix (bare `sk-` → OpenAI *or* DeepSeek).
+    Ambiguous,
+    /// A unique, unambiguous prefix (`sk-ant-`, `xai-`, `gsk_`).
+    High,
+}
+
+/// A single ranked provider candidate. `slug` matches the provider-catalog id.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProviderGuess {
+    pub slug: &'static str,
+    pub confidence: Confidence,
+}
+
+impl ProviderGuess {
+    const fn new(slug: &'static str, confidence: Confidence) -> Self {
+        Self { slug, confidence }
+    }
+}
+
+/// The result of fingerprinting a pasted credential.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Fingerprint {
+    /// The cleaned credential: surrounding quotes, an `export NAME=` wrapper,
+    /// and a trailing `# comment` are all stripped. This is what gets validated
+    /// and stored — never the raw paste.
+    pub normalized: String,
+    /// What kind of credential the shape indicates.
+    pub kind: CredentialKind,
+    /// Ranked provider candidates, most-specific first. Empty ⇒ unknown shape.
+    pub candidates: Vec<ProviderGuess>,
+    /// A provider slug inferred from an `export NAME=…` variable name, if the
+    /// paste was an env-var line (e.g. `ANTHROPIC_API_KEY` ⇒ `anthropic`). Used
+    /// to break ties in the ambiguous bucket.
+    pub env_var_hint: Option<&'static str>,
+    /// True when the shape alone cannot be validated and a guided form is
+    /// required: AWS (secret + region), Azure (resource endpoint), GCP (project).
+    pub needs_completion: bool,
+}
+
+impl Fingerprint {
+    /// `true` when exactly one high-confidence candidate exists — validate it
+    /// alone. Otherwise the caller should probe the candidates in parallel.
+    pub fn is_unambiguous(&self) -> bool {
+        self.candidates.len() == 1 && self.candidates[0].confidence == Confidence::High
+    }
+
+    /// The best single guess, if any (candidates are kept in rank order).
+    pub fn best(&self) -> Option<&ProviderGuess> {
+        self.candidates.first()
+    }
+}
+
+/// Longest-prefix-first table of unambiguous credential prefixes. Order matters:
+/// `sk-ant-` must be tested before `sk-`, `sk-or-` before `sk-`, etc. Each entry
+/// is `(prefix, slug)` and yields a [`Confidence::High`] bearer candidate.
+const UNIQUE_PREFIXES: &[(&str, &str)] = &[
+    ("sk-ant-", "anthropic"),
+    ("sk-proj-", "openai"),
+    ("sk-svcacct-", "openai"),
+    ("sk-admin-", "openai"),
+    ("sk-or-v1-", "openrouter"),
+    ("sk-or-", "openrouter"),
+    ("csk-", "cerebras"),
+    ("gsk_", "groq"),
+    ("xai-", "xai"),
+    ("pplx-", "perplexity"),
+    ("r8_", "replicate"),
+    ("hf_", "huggingface"),
+    ("AIza", "gemini"),
+];
+
+/// Map a recognised credential env-var name to a provider slug. Used both as a
+/// tie-breaker hint and (for `export FOO=bar` pastes) to bias ranking.
+fn slug_for_env_var(name: &str) -> Option<&'static str> {
+    let slug = match name {
+        "ANTHROPIC_API_KEY" => "anthropic",
+        "OPENAI_API_KEY" => "openai",
+        "OPENROUTER_API_KEY" => "openrouter",
+        "GROQ_API_KEY" => "groq",
+        "XAI_API_KEY" => "xai",
+        "DEEPSEEK_API_KEY" => "deepseek",
+        "MISTRAL_API_KEY" => "mistral",
+        "PERPLEXITY_API_KEY" => "perplexity",
+        "CEREBRAS_API_KEY" => "cerebras",
+        "TOGETHER_API_KEY" => "together",
+        "FIREWORKS_API_KEY" => "fireworks-ai",
+        "COHERE_API_KEY" => "cohere",
+        "REPLICATE_API_TOKEN" => "replicate",
+        "GEMINI_API_KEY" | "GOOGLE_API_KEY" => "gemini",
+        "HF_TOKEN" | "HUGGINGFACE_API_KEY" | "HUGGING_FACE_HUB_TOKEN" => "huggingface",
+        _ => return None,
+    };
+    Some(slug)
+}
+
+/// Fingerprint a pasted credential into ranked provider candidates.
+///
+/// Never makes a network call. The returned [`Fingerprint::candidates`] are a
+/// hypothesis to be confirmed by a live probe; an empty list means "unknown
+/// shape — show the provider picker".
+pub fn fingerprint_key(raw: &str) -> Fingerprint {
+    let (normalized, env_var_hint) = normalize(raw);
+
+    // 1. Structured credential: a GCP service-account JSON blob.
+    if let Some(kind) = json_credential_kind(&normalized) {
+        let needs_completion = kind == CredentialKind::GcpServiceAccount;
+        return Fingerprint {
+            normalized,
+            kind,
+            candidates: vec![ProviderGuess::new("vertex", Confidence::High)],
+            env_var_hint,
+            needs_completion,
+        };
+    }
+
+    // 2. Non-bearer / opaque token shapes that short-circuit to a guided path.
+    if let Some(fp) = non_bearer_shape(&normalized, env_var_hint) {
+        return fp;
+    }
+
+    // 3. Unique bearer prefixes (longest-first).
+    for (prefix, slug) in UNIQUE_PREFIXES {
+        if normalized.starts_with(prefix) {
+            return Fingerprint {
+                normalized,
+                kind: CredentialKind::BearerKey,
+                candidates: vec![ProviderGuess::new(slug, Confidence::High)],
+                env_var_hint,
+                needs_completion: false,
+            };
+        }
+    }
+
+    // 4. Ambiguous bare `sk-` bucket: OpenAI legacy vs DeepSeek (and other
+    //    OpenAI-compatible relays). Rank by the env-var hint when present.
+    if normalized.starts_with("sk-") {
+        let mut candidates = vec![
+            ProviderGuess::new("openai", Confidence::Ambiguous),
+            ProviderGuess::new("deepseek", Confidence::Ambiguous),
+        ];
+        rank_by_hint(&mut candidates, env_var_hint);
+        return Fingerprint {
+            normalized,
+            kind: CredentialKind::BearerKey,
+            candidates,
+            env_var_hint,
+            needs_completion: false,
+        };
+    }
+
+    // 5. No-prefix shapes: trust the env-var hint if we have one, else low-
+    //    confidence heuristics (a bare 32-hex string is Azure-shaped).
+    if let Some(hint) = env_var_hint {
+        return Fingerprint {
+            normalized,
+            kind: CredentialKind::BearerKey,
+            candidates: vec![ProviderGuess::new(hint, Confidence::Ambiguous)],
+            env_var_hint,
+            needs_completion: false,
+        };
+    }
+
+    if is_hex(&normalized) && normalized.len() == 32 {
+        // Azure OpenAI keys are 32-hex; they still need a resource endpoint.
+        return Fingerprint {
+            normalized,
+            kind: CredentialKind::BearerKey,
+            candidates: vec![ProviderGuess::new("azure-openai", Confidence::Low)],
+            env_var_hint,
+            needs_completion: true,
+        };
+    }
+
+    // 6. Unknown shape — caller shows the provider picker.
+    Fingerprint {
+        normalized,
+        kind: CredentialKind::Unknown,
+        candidates: Vec::new(),
+        env_var_hint,
+        needs_completion: false,
+    }
+}
+
+/// Detect opaque-token / non-bearer shapes that can't be validated from the
+/// pasted string alone.
+fn non_bearer_shape(s: &str, env_var_hint: Option<&'static str>) -> Option<Fingerprint> {
+    // AWS Bedrock bearer API key — a usable bearer, no SigV4 needed.
+    if s.starts_with("ABSK") || s.starts_with("bedrock-api-key-") {
+        return Some(Fingerprint {
+            normalized: s.to_string(),
+            kind: CredentialKind::BedrockApiKey,
+            candidates: vec![ProviderGuess::new("bedrock", Confidence::High)],
+            env_var_hint,
+            needs_completion: false,
+        });
+    }
+    // AWS classic access-key id — incomplete credential (needs secret + region).
+    if let Some(rest) = strip_aws_access_key_prefix(s) {
+        // AKIA/ASIA/... + 16 base32-ish chars = 20 total.
+        if rest.len() == 16 && rest.chars().all(|c| c.is_ascii_alphanumeric()) {
+            return Some(Fingerprint {
+                normalized: s.to_string(),
+                kind: CredentialKind::AwsAccessKeyId,
+                candidates: vec![ProviderGuess::new("bedrock", Confidence::High)],
+                env_var_hint,
+                needs_completion: true,
+            });
+        }
+    }
+    // GCP OAuth access token — ephemeral opaque bearer (NOT a JWT, don't decode).
+    if s.starts_with("ya29.") {
+        return Some(Fingerprint {
+            normalized: s.to_string(),
+            kind: CredentialKind::GcpAccessToken,
+            candidates: vec![ProviderGuess::new("vertex", Confidence::High)],
+            env_var_hint,
+            needs_completion: true,
+        });
+    }
+    // JWT — decode the header to route (Azure AD / GCP id-token). Routing is the
+    // caller's job; here we just classify the kind and leave candidates empty.
+    if s.starts_with("eyJ") && s.matches('.').count() == 2 {
+        return Some(Fingerprint {
+            normalized: s.to_string(),
+            kind: CredentialKind::Jwt,
+            candidates: Vec::new(),
+            env_var_hint,
+            needs_completion: true,
+        });
+    }
+    None
+}
+
+/// AWS access-key id prefixes (`AKIA` long-term, `ASIA` temporary session, plus
+/// the rarer `ABIA`/`ACCA`). Returns the remainder after the 4-char prefix.
+fn strip_aws_access_key_prefix(s: &str) -> Option<&str> {
+    for p in ["AKIA", "ASIA", "ABIA", "ACCA"] {
+        if let Some(rest) = s.strip_prefix(p) {
+            return Some(rest);
+        }
+    }
+    None
+}
+
+/// Classify a JSON credential blob. Currently recognises GCP service-account
+/// JSON; returns `None` for non-JSON input.
+fn json_credential_kind(s: &str) -> Option<CredentialKind> {
+    let t = s.trim_start();
+    if !t.starts_with('{') {
+        return None;
+    }
+    // Cheap structural check — avoid a full parse on a hot paste path.
+    if t.contains("\"type\"") && t.contains("\"service_account\"") {
+        return Some(CredentialKind::GcpServiceAccount);
+    }
+    None
+}
+
+/// Move the candidate whose slug matches the env-var hint to the front.
+fn rank_by_hint(candidates: &mut [ProviderGuess], hint: Option<&'static str>) {
+    if let Some(hint) = hint
+        && let Some(pos) = candidates.iter().position(|c| c.slug == hint)
+    {
+        candidates.swap(0, pos);
+    }
+}
+
+fn is_hex(s: &str) -> bool {
+    !s.is_empty() && s.chars().all(|c| c.is_ascii_hexdigit())
+}
+
+/// Clean a pasted credential. Handles the messy reality of what people paste:
+/// surrounding whitespace, wrapping quotes, a full `export NAME="value"` shell
+/// line (the variable name becomes a provider hint), and a trailing `# comment`.
+fn normalize(raw: &str) -> (String, Option<&'static str>) {
+    let mut s = raw.trim();
+
+    // `export NAME=value` or `NAME=value` — extract the value, keep the hint.
+    let mut hint = None;
+    if let Some((name, value)) = split_assignment(s) {
+        hint = slug_for_env_var(name);
+        s = value;
+    }
+
+    let s = strip_quotes_and_comment(s);
+    (s.to_string(), hint)
+}
+
+/// Parse a `[export ]NAME=VALUE` line. Returns `(name, value)` only when the
+/// left-hand side is a syntactically valid shell variable name.
+fn split_assignment(s: &str) -> Option<(&str, &str)> {
+    let body = s.strip_prefix("export ").map(str::trim_start).unwrap_or(s);
+    let (name, value) = body.split_once('=')?;
+    let name = name.trim_end();
+    if is_valid_env_name(name) {
+        Some((name, value.trim()))
+    } else {
+        None
+    }
+}
+
+fn is_valid_env_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_alphabetic() || c == '_' => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+/// Strip matched surrounding quotes, then a trailing whitespace-delimited
+/// `# comment`. If the value is quoted, the comment outside the quotes is
+/// dropped and quote contents are taken verbatim.
+fn strip_quotes_and_comment(s: &str) -> &str {
+    let s = s.trim();
+    for q in ['"', '\''] {
+        if let Some(rest) = s.strip_prefix(q)
+            && let Some(end) = rest.find(q)
+        {
+            return &rest[..end];
+        }
+    }
+    // Unquoted: drop a trailing ` # comment` (space-delimited so we never eat a
+    // '#' that is part of the value).
+    match s.split_once(" #") {
+        Some((before, _)) => before.trim_end(),
+        None => s,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn slugs(fp: &Fingerprint) -> Vec<&str> {
+        fp.candidates.iter().map(|c| c.slug).collect()
+    }
+
+    #[test]
+    fn unique_prefixes_resolve_to_one_high_candidate() {
+        let cases = [
+            ("sk-ant-api03-AAbb1234567890", "anthropic"),
+            ("sk-proj-abcDEF123", "openai"),
+            ("sk-svcacct-xyz", "openai"),
+            ("sk-or-v1-deadbeef", "openrouter"),
+            ("csk-1234567890", "cerebras"),
+            ("gsk_abcd1234", "groq"),
+            ("xai-abcd1234", "xai"),
+            ("pplx-abcd1234", "perplexity"),
+            ("r8_abcd1234", "replicate"),
+            ("hf_abcd1234", "huggingface"),
+            ("AIzaSyA1234567890abcdefghijklmnopqrst", "gemini"),
+        ];
+        for (key, want) in cases {
+            let fp = fingerprint_key(key);
+            assert!(
+                fp.is_unambiguous(),
+                "{key} should be unambiguous, got {:?}",
+                fp.candidates
+            );
+            assert_eq!(fp.best().unwrap().slug, want, "wrong provider for {key}");
+            assert_eq!(fp.kind, CredentialKind::BearerKey);
+            assert!(!fp.needs_completion);
+        }
+    }
+
+    #[test]
+    fn anthropic_wins_over_bare_sk_bucket() {
+        // The longest-prefix rule must put sk-ant- ahead of the sk- fallback.
+        let fp = fingerprint_key("sk-ant-api03-zzz");
+        assert_eq!(slugs(&fp), vec!["anthropic"]);
+    }
+
+    #[test]
+    fn bare_sk_is_ambiguous_openai_and_deepseek() {
+        let fp = fingerprint_key("sk-0123456789abcdef0123456789abcdef");
+        assert_eq!(fp.kind, CredentialKind::BearerKey);
+        assert_eq!(slugs(&fp), vec!["openai", "deepseek"]);
+        assert!(!fp.is_unambiguous());
+        assert!(fp.candidates.iter().all(|c| c.confidence == Confidence::Ambiguous));
+    }
+
+    #[test]
+    fn env_var_line_is_unwrapped_and_hints_ranking() {
+        let fp = fingerprint_key("export DEEPSEEK_API_KEY=\"sk-abcdef123456\"");
+        assert_eq!(fp.normalized, "sk-abcdef123456");
+        assert_eq!(fp.env_var_hint, Some("deepseek"));
+        // The hint pulls deepseek ahead of openai in the ambiguous bucket.
+        assert_eq!(slugs(&fp), vec!["deepseek", "openai"]);
+    }
+
+    #[test]
+    fn plain_assignment_without_export_is_unwrapped() {
+        let fp = fingerprint_key("ANTHROPIC_API_KEY=sk-ant-api03-xyz");
+        assert_eq!(fp.normalized, "sk-ant-api03-xyz");
+        assert_eq!(fp.env_var_hint, Some("anthropic"));
+        assert_eq!(slugs(&fp), vec!["anthropic"]);
+    }
+
+    #[test]
+    fn surrounding_quotes_and_whitespace_are_stripped() {
+        assert_eq!(fingerprint_key("  'sk-ant-api03-xyz'  ").normalized, "sk-ant-api03-xyz");
+        assert_eq!(fingerprint_key("\"xai-abc\"").normalized, "xai-abc");
+    }
+
+    #[test]
+    fn trailing_comment_is_dropped() {
+        let fp = fingerprint_key("gsk_livekey123  # my groq key");
+        assert_eq!(fp.normalized, "gsk_livekey123");
+        assert_eq!(slugs(&fp), vec!["groq"]);
+    }
+
+    #[test]
+    fn hash_inside_value_is_preserved() {
+        // No space before '#', so it is part of the value, not a comment.
+        let fp = fingerprint_key("sk-ant-api03-ab#cd");
+        assert_eq!(fp.normalized, "sk-ant-api03-ab#cd");
+    }
+
+    #[test]
+    fn aws_access_key_needs_completion() {
+        let fp = fingerprint_key("AKIAIOSFODNN7EXAMPLE");
+        assert_eq!(fp.kind, CredentialKind::AwsAccessKeyId);
+        assert_eq!(slugs(&fp), vec!["bedrock"]);
+        assert!(fp.needs_completion, "a lone access-key id can't be validated alone");
+    }
+
+    #[test]
+    fn aws_session_key_prefix_recognised() {
+        let fp = fingerprint_key("ASIAIOSFODNN7EXAMPLE");
+        assert_eq!(fp.kind, CredentialKind::AwsAccessKeyId);
+    }
+
+    #[test]
+    fn bedrock_bearer_key_is_complete() {
+        let fp = fingerprint_key("ABSKabcdef0123456789");
+        assert_eq!(fp.kind, CredentialKind::BedrockApiKey);
+        assert_eq!(slugs(&fp), vec!["bedrock"]);
+        assert!(!fp.needs_completion);
+    }
+
+    #[test]
+    fn gcp_service_account_json_detected() {
+        let blob = r#"{ "type": "service_account", "project_id": "demo", "private_key": "x" }"#;
+        let fp = fingerprint_key(blob);
+        assert_eq!(fp.kind, CredentialKind::GcpServiceAccount);
+        assert_eq!(slugs(&fp), vec!["vertex"]);
+        assert!(fp.needs_completion);
+    }
+
+    #[test]
+    fn gcp_access_token_is_opaque_not_jwt() {
+        let fp = fingerprint_key("ya29.a0ARrdaM-opaque-token");
+        assert_eq!(fp.kind, CredentialKind::GcpAccessToken);
+        assert_eq!(slugs(&fp), vec!["vertex"]);
+    }
+
+    #[test]
+    fn jwt_is_classified_without_candidates() {
+        let fp = fingerprint_key("eyJhbGciOiJI.eyJzdWIiOiIx.sigpart");
+        assert_eq!(fp.kind, CredentialKind::Jwt);
+        assert!(fp.candidates.is_empty(), "JWT routing is decided by the caller");
+        assert!(fp.needs_completion);
+    }
+
+    #[test]
+    fn bare_32_hex_is_low_confidence_azure_needing_endpoint() {
+        let fp = fingerprint_key("0123456789abcdef0123456789abcdef");
+        assert_eq!(slugs(&fp), vec!["azure-openai"]);
+        assert_eq!(fp.best().unwrap().confidence, Confidence::Low);
+        assert!(fp.needs_completion);
+    }
+
+    #[test]
+    fn no_prefix_with_env_hint_uses_the_hint() {
+        let fp = fingerprint_key("MISTRAL_API_KEY=abcdef0123456789ABCDEF0123");
+        assert_eq!(fp.env_var_hint, Some("mistral"));
+        assert_eq!(slugs(&fp), vec!["mistral"]);
+    }
+
+    #[test]
+    fn unknown_shape_yields_no_candidates() {
+        let fp = fingerprint_key("just-some-random-text");
+        assert_eq!(fp.kind, CredentialKind::Unknown);
+        assert!(fp.candidates.is_empty());
+        assert!(fp.best().is_none());
+    }
+
+    #[test]
+    fn empty_input_is_unknown_not_a_panic() {
+        let fp = fingerprint_key("   ");
+        assert_eq!(fp.normalized, "");
+        assert_eq!(fp.kind, CredentialKind::Unknown);
+        assert!(fp.candidates.is_empty());
+    }
+
+    #[test]
+    fn google_api_key_env_alias_maps_to_gemini() {
+        let fp = fingerprint_key("GOOGLE_API_KEY=AIzaSyXXXX");
+        // Both the env hint and the AIza prefix agree.
+        assert_eq!(fp.env_var_hint, Some("gemini"));
+        assert_eq!(slugs(&fp), vec!["gemini"]);
+    }
+}

--- a/crates/wcore-providers/src/fingerprint.rs
+++ b/crates/wcore-providers/src/fingerprint.rs
@@ -424,7 +424,11 @@ mod tests {
         assert_eq!(fp.kind, CredentialKind::BearerKey);
         assert_eq!(slugs(&fp), vec!["openai", "deepseek"]);
         assert!(!fp.is_unambiguous());
-        assert!(fp.candidates.iter().all(|c| c.confidence == Confidence::Ambiguous));
+        assert!(
+            fp.candidates
+                .iter()
+                .all(|c| c.confidence == Confidence::Ambiguous)
+        );
     }
 
     #[test]
@@ -446,7 +450,10 @@ mod tests {
 
     #[test]
     fn surrounding_quotes_and_whitespace_are_stripped() {
-        assert_eq!(fingerprint_key("  'sk-ant-api03-xyz'  ").normalized, "sk-ant-api03-xyz");
+        assert_eq!(
+            fingerprint_key("  'sk-ant-api03-xyz'  ").normalized,
+            "sk-ant-api03-xyz"
+        );
         assert_eq!(fingerprint_key("\"xai-abc\"").normalized, "xai-abc");
     }
 
@@ -469,7 +476,10 @@ mod tests {
         let fp = fingerprint_key("AKIAIOSFODNN7EXAMPLE");
         assert_eq!(fp.kind, CredentialKind::AwsAccessKeyId);
         assert_eq!(slugs(&fp), vec!["bedrock"]);
-        assert!(fp.needs_completion, "a lone access-key id can't be validated alone");
+        assert!(
+            fp.needs_completion,
+            "a lone access-key id can't be validated alone"
+        );
     }
 
     #[test]
@@ -506,7 +516,10 @@ mod tests {
     fn jwt_is_classified_without_candidates() {
         let fp = fingerprint_key("eyJhbGciOiJI.eyJzdWIiOiIx.sigpart");
         assert_eq!(fp.kind, CredentialKind::Jwt);
-        assert!(fp.candidates.is_empty(), "JWT routing is decided by the caller");
+        assert!(
+            fp.candidates.is_empty(),
+            "JWT routing is decided by the caller"
+        );
         assert!(fp.needs_completion);
     }
 

--- a/crates/wcore-providers/src/fireworks.rs
+++ b/crates/wcore-providers/src/fireworks.rs
@@ -62,6 +62,10 @@ impl LlmProvider for FireworksProvider {
     ) -> Result<mpsc::Receiver<LlmEvent>, ProviderError> {
         self.inner.stream(request).await
     }
+
+    async fn list_models(&self) -> anyhow::Result<Vec<crate::ModelInfo>> {
+        self.inner.list_models().await
+    }
 }
 
 /// Register a Fireworks factory in the given registry under the lowercased id

--- a/crates/wcore-providers/src/flux_router.rs
+++ b/crates/wcore-providers/src/flux_router.rs
@@ -60,6 +60,10 @@ impl LlmProvider for FluxRouterProvider {
     ) -> Result<mpsc::Receiver<LlmEvent>, ProviderError> {
         self.inner.stream(request).await
     }
+
+    async fn list_models(&self) -> anyhow::Result<Vec<crate::ModelInfo>> {
+        self.inner.list_models().await
+    }
 }
 
 /// Register a Flux Router factory in the given registry under the lowercased

--- a/crates/wcore-providers/src/groq.rs
+++ b/crates/wcore-providers/src/groq.rs
@@ -55,6 +55,10 @@ impl LlmProvider for GroqProvider {
     ) -> Result<mpsc::Receiver<LlmEvent>, ProviderError> {
         self.inner.stream(request).await
     }
+
+    async fn list_models(&self) -> anyhow::Result<Vec<crate::ModelInfo>> {
+        self.inner.list_models().await
+    }
 }
 
 /// Register a Groq factory in the given registry under the lowercased id
@@ -172,6 +176,41 @@ mod tests {
             DebugConfig::default(),
         );
         assert!(matches!(second, Err(RegistryError::DuplicateId(_))));
+    }
+
+    #[tokio::test]
+    async fn list_models_does_a_live_fetch_not_the_alias_floor() {
+        // Regression (E2E-found): the OpenAI-compat newtypes must forward
+        // `list_models` to their inner `OpenAIProvider` (a live `GET /v1/models`),
+        // NOT inherit the trait-default alias catalog. Before the fix, Groq's
+        // `list_models` returned the (empty) alias floor, so paste-to-connect
+        // validation could never authenticate Groq/OpenRouter/Cerebras/Deepseek
+        // even with valid keys — they all fell through to the picker.
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/models"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(
+                r#"{"data":[{"id":"llama-3.3-70b-versatile"},{"id":"mixtral-8x7b"}]}"#,
+            ))
+            .mount(&server)
+            .await;
+
+        let p = GroqProvider::new(
+            "gsk_test",
+            &server.uri(),
+            ProviderCompat::default(),
+            DebugConfig::default(),
+        );
+        let models = p.list_models().await.expect("list_models");
+        assert_eq!(
+            models.len(),
+            2,
+            "Groq must surface the live model catalog, not the empty alias floor"
+        );
+        assert!(models.iter().any(|m| m.id == "llama-3.3-70b-versatile"));
     }
 
     #[test]

--- a/crates/wcore-providers/src/key_validation.rs
+++ b/crates/wcore-providers/src/key_validation.rs
@@ -89,9 +89,15 @@ pub async fn validate_key(base: &Config, slug: &str, api_key: &str) -> Validatio
     validate_with(base, slug, api_key, create_provider).await
 }
 
-/// Core of [`validate_key`], generic over how the provider is built so tests can
-/// inject a fake provider without a network call.
-async fn validate_with<F>(base: &Config, slug: &str, api_key: &str, build: F) -> ValidationOutcome
+/// Core of [`validate_key`], generic over how the provider is built so the
+/// paste-detect orchestrator and tests can inject a fake provider without a
+/// network call.
+pub(crate) async fn validate_with<F>(
+    base: &Config,
+    slug: &str,
+    api_key: &str,
+    build: F,
+) -> ValidationOutcome
 where
     F: FnOnce(&Config) -> Arc<dyn LlmProvider>,
 {

--- a/crates/wcore-providers/src/key_validation.rs
+++ b/crates/wcore-providers/src/key_validation.rs
@@ -1,0 +1,239 @@
+//! Key validation — drive a live `list_models` probe against a just-pasted key.
+//!
+//! Step 2 of the `/config` paste-to-detect flow. Given a provider slug (from
+//! [`fingerprint`](crate::fingerprint)) and the pasted key, build a one-off
+//! provider bound to that key and ask it to list models. The result places the
+//! key on a small confidence ladder:
+//!
+//! - [`Rung::Detected`]      — shape recognised; the probe did not authenticate.
+//! - [`Rung::CanListModels`] — the live model endpoint returned a real catalog:
+//!   the key authenticated and the account can enumerate models.
+//!
+//! A higher [`Rung::Ready`] (a billed one-token test request that proves the
+//! account can actually *run* a model — catching credit-empty / access-blocked
+//! keys) is modelled here but driven by the flow layer, which decides when to
+//! spend. `validate_key` itself never spends tokens.
+//!
+//! Every provider's `list_models` floors to its static alias catalog on any
+//! failure, so "the returned list equals the alias catalog" is read as "the live
+//! fetch did not succeed" — the same Live-vs-BuiltIn discrimination
+//! [`model_catalog`](crate::model_catalog) uses. Caveat: a provider whose
+//! `/models` endpoint is unauthenticated (e.g. OpenRouter) returns a live list
+//! even for a bad key; such providers need a key-specific validation endpoint,
+//! a follow-up refinement tracked in the config-cockpit build plan.
+
+use std::sync::Arc;
+
+use wcore_config::config::{Config, provider_type_from_slug};
+
+use crate::{LlmProvider, ModelInfo, alias_models, create_provider};
+
+/// How far up the validation ladder a pasted key reached. Each rung implies the
+/// ones below it, so the variants are ordered for comparison.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Rung {
+    /// Shape recognised and a provider guessed, but the live probe did not
+    /// authenticate (or the provider has no live catalog).
+    Detected,
+    /// The live model endpoint returned a real (non-fallback) catalog: the key
+    /// authenticated and can list models.
+    CanListModels,
+    /// A minimal test request succeeded — the account can actually run a model.
+    /// Set by the flow layer after an opt-in billed probe; never reached by
+    /// [`validate_key`] alone.
+    Ready,
+}
+
+/// The outcome of probing a pasted key against a candidate provider.
+#[derive(Debug, Clone)]
+pub struct ValidationOutcome {
+    /// The provider slug that was probed.
+    pub provider: String,
+    /// The highest rung reached.
+    pub reached: Rung,
+    /// The live model catalog, when [`Rung::CanListModels`] was reached
+    /// (otherwise empty).
+    pub models: Vec<ModelInfo>,
+    /// A human-readable reason the key did not authenticate, when it didn't.
+    pub failure: Option<String>,
+}
+
+impl ValidationOutcome {
+    /// `true` when the key authenticated and can list models.
+    pub fn is_usable(&self) -> bool {
+        self.reached >= Rung::CanListModels
+    }
+
+    /// Number of models the live catalog returned (0 when not usable).
+    pub fn model_count(&self) -> usize {
+        self.models.len()
+    }
+
+    fn detected(slug: &str, failure: impl Into<String>) -> Self {
+        Self {
+            provider: slug.to_string(),
+            reached: Rung::Detected,
+            models: Vec::new(),
+            failure: Some(failure.into()),
+        }
+    }
+}
+
+/// Probe a pasted `api_key` against the provider named by `slug`, returning how
+/// far up the validation ladder it got. Reuses the provider's live
+/// `list_models` (timeout-bounded, alias-floored) — the same path that warms the
+/// model picker — so a successful probe doubles as a warm catalog fetch.
+///
+/// Makes one network call (the model-list request). Never writes the key.
+pub async fn validate_key(base: &Config, slug: &str, api_key: &str) -> ValidationOutcome {
+    validate_with(base, slug, api_key, create_provider).await
+}
+
+/// Core of [`validate_key`], generic over how the provider is built so tests can
+/// inject a fake provider without a network call.
+async fn validate_with<F>(base: &Config, slug: &str, api_key: &str, build: F) -> ValidationOutcome
+where
+    F: FnOnce(&Config) -> Arc<dyn LlmProvider>,
+{
+    let Some(provider_type) = provider_type_from_slug(slug) else {
+        return ValidationOutcome::detected(slug, format!("unknown provider '{slug}'"));
+    };
+
+    let cfg = base.for_key_validation(provider_type, api_key);
+    let provider = build(&cfg);
+
+    match provider.list_models().await {
+        Ok(models) if is_live_catalog(&models, slug) => ValidationOutcome {
+            provider: slug.to_string(),
+            reached: Rung::CanListModels,
+            models,
+            failure: None,
+        },
+        Ok(_) => ValidationOutcome::detected(
+            slug,
+            "key not accepted, or this provider has no live model catalog",
+        ),
+        Err(e) => ValidationOutcome::detected(slug, e.to_string()),
+    }
+}
+
+/// A `list_models` result is a *live* catalog when it is non-empty and differs
+/// from the provider's static alias fallback. An equal result means the live
+/// fetch floored (auth/HTTP/parse failure) and is not proof the key works.
+fn is_live_catalog(models: &[ModelInfo], slug: &str) -> bool {
+    !models.is_empty() && models != alias_models(slug).as_slice()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use tokio::sync::mpsc;
+    use wcore_config::config::Config;
+    use wcore_types::llm::{LlmEvent, LlmRequest};
+
+    use crate::ProviderError;
+
+    enum Behavior {
+        Models(Vec<ModelInfo>),
+        Error(String),
+    }
+
+    struct FakeProvider {
+        behavior: Behavior,
+    }
+
+    #[async_trait]
+    impl LlmProvider for FakeProvider {
+        async fn stream(
+            &self,
+            _request: &LlmRequest,
+        ) -> Result<mpsc::Receiver<LlmEvent>, ProviderError> {
+            unreachable!("validate_key only calls list_models")
+        }
+        async fn list_models(&self) -> anyhow::Result<Vec<ModelInfo>> {
+            match &self.behavior {
+                Behavior::Models(m) => Ok(m.clone()),
+                Behavior::Error(e) => Err(anyhow::anyhow!(e.clone())),
+            }
+        }
+    }
+
+    fn fake(behavior: Behavior) -> impl FnOnce(&Config) -> Arc<dyn LlmProvider> {
+        move |_cfg| Arc::new(FakeProvider { behavior })
+    }
+
+    #[tokio::test]
+    async fn live_catalog_reaches_can_list_models() {
+        let live = vec![ModelInfo {
+            id: "claude-opus-4-8".into(),
+            display: "Opus 4.8".into(),
+        }];
+        let out = validate_with(
+            &Config::default(),
+            "anthropic",
+            "sk-ant-xxx",
+            fake(Behavior::Models(live)),
+        )
+        .await;
+        assert_eq!(out.reached, Rung::CanListModels);
+        assert!(out.is_usable());
+        assert_eq!(out.model_count(), 1);
+        assert!(out.failure.is_none());
+    }
+
+    #[tokio::test]
+    async fn floored_to_alias_catalog_is_only_detected() {
+        // A result equal to the alias catalog means the live fetch failed (the
+        // provider floored), so the key is NOT proven to work.
+        let aliases = alias_models("anthropic");
+        assert!(!aliases.is_empty(), "anthropic needs an alias catalog here");
+        let out = validate_with(
+            &Config::default(),
+            "anthropic",
+            "sk-ant-bad",
+            fake(Behavior::Models(aliases)),
+        )
+        .await;
+        assert_eq!(out.reached, Rung::Detected);
+        assert!(!out.is_usable());
+        assert!(out.failure.is_some());
+    }
+
+    #[tokio::test]
+    async fn empty_catalog_is_only_detected() {
+        let out = validate_with(
+            &Config::default(),
+            "anthropic",
+            "x",
+            fake(Behavior::Models(Vec::new())),
+        )
+        .await;
+        assert_eq!(out.reached, Rung::Detected);
+        assert!(!out.is_usable());
+    }
+
+    #[tokio::test]
+    async fn error_surfaces_as_detected_with_failure_message() {
+        let out = validate_with(
+            &Config::default(),
+            "openai",
+            "x",
+            fake(Behavior::Error("401 Unauthorized".into())),
+        )
+        .await;
+        assert_eq!(out.reached, Rung::Detected);
+        assert_eq!(out.failure.as_deref(), Some("401 Unauthorized"));
+    }
+
+    #[tokio::test]
+    async fn unknown_slug_fails_fast_without_building() {
+        // The build closure must never run for an unknown slug.
+        let out = validate_with(&Config::default(), "not-a-provider", "x", |_cfg| {
+            panic!("must not build a provider for an unknown slug")
+        })
+        .await;
+        assert_eq!(out.reached, Rung::Detected);
+        assert!(out.failure.unwrap().contains("unknown provider"));
+    }
+}

--- a/crates/wcore-providers/src/lib.rs
+++ b/crates/wcore-providers/src/lib.rs
@@ -12,6 +12,7 @@ pub mod cohere;
 pub mod cooldown;
 pub mod deepseek;
 pub mod failover;
+pub mod fingerprint;
 pub mod fireworks;
 pub mod flux_router;
 pub mod gemini;

--- a/crates/wcore-providers/src/lib.rs
+++ b/crates/wcore-providers/src/lib.rs
@@ -19,6 +19,7 @@ pub mod gemini;
 pub mod groq;
 pub mod http_client;
 pub mod key_rotation;
+pub mod key_validation;
 // litellm, lmstudio, vllm: deleted per DECISIONS.md §D3 (Sean, 2026-05-23).
 // These were framework-shaped local-inference adapters shipped as code but
 // never wired to ProviderType arms. Revivable as plugins if needed.

--- a/crates/wcore-providers/src/lib.rs
+++ b/crates/wcore-providers/src/lib.rs
@@ -33,6 +33,7 @@ pub mod openai_compat;
 pub mod openai_compatible;
 pub mod openai_responses;
 pub mod openrouter;
+pub mod paste_detect;
 pub mod perplexity;
 pub mod qwen;
 pub mod registry;

--- a/crates/wcore-providers/src/mistral.rs
+++ b/crates/wcore-providers/src/mistral.rs
@@ -54,6 +54,10 @@ impl LlmProvider for MistralProvider {
     ) -> Result<mpsc::Receiver<LlmEvent>, ProviderError> {
         self.inner.stream(request).await
     }
+
+    async fn list_models(&self) -> anyhow::Result<Vec<crate::ModelInfo>> {
+        self.inner.list_models().await
+    }
 }
 
 /// Register a Mistral factory in the given registry under the lowercased id

--- a/crates/wcore-providers/src/moonshot.rs
+++ b/crates/wcore-providers/src/moonshot.rs
@@ -58,6 +58,10 @@ impl LlmProvider for MoonshotProvider {
     ) -> Result<mpsc::Receiver<LlmEvent>, ProviderError> {
         self.inner.stream(request).await
     }
+
+    async fn list_models(&self) -> anyhow::Result<Vec<crate::ModelInfo>> {
+        self.inner.list_models().await
+    }
 }
 
 /// Register a Moonshot factory in the given registry under the lowercased id

--- a/crates/wcore-providers/src/nvidia.rs
+++ b/crates/wcore-providers/src/nvidia.rs
@@ -58,6 +58,10 @@ impl LlmProvider for NvidiaProvider {
     ) -> Result<mpsc::Receiver<LlmEvent>, ProviderError> {
         self.inner.stream(request).await
     }
+
+    async fn list_models(&self) -> anyhow::Result<Vec<crate::ModelInfo>> {
+        self.inner.list_models().await
+    }
 }
 
 /// Register an NVIDIA NIM factory in the given registry under the lowercased id

--- a/crates/wcore-providers/src/openai_compatible.rs
+++ b/crates/wcore-providers/src/openai_compatible.rs
@@ -65,6 +65,10 @@ impl LlmProvider for OpenAICompatibleProvider {
     ) -> Result<mpsc::Receiver<LlmEvent>, ProviderError> {
         self.inner.stream(request).await
     }
+
+    async fn list_models(&self) -> anyhow::Result<Vec<crate::ModelInfo>> {
+        self.inner.list_models().await
+    }
 }
 
 /// Register an OpenAI-compatible factory in the given registry under the

--- a/crates/wcore-providers/src/openrouter.rs
+++ b/crates/wcore-providers/src/openrouter.rs
@@ -73,6 +73,10 @@ impl LlmProvider for OpenRouterProvider {
     ) -> Result<mpsc::Receiver<LlmEvent>, ProviderError> {
         self.inner.stream(request).await
     }
+
+    async fn list_models(&self) -> anyhow::Result<Vec<crate::ModelInfo>> {
+        self.inner.list_models().await
+    }
 }
 
 /// Register an OpenRouter factory in the given registry under the lowercased

--- a/crates/wcore-providers/src/paste_detect.rs
+++ b/crates/wcore-providers/src/paste_detect.rs
@@ -1,0 +1,262 @@
+//! Paste-to-detect orchestration: raw paste → fingerprint → live validation.
+//!
+//! This is the brain of the `/config` paste flow, composing the two foundation
+//! pieces ([`fingerprint`](crate::fingerprint) + [`key_validation`]) into a
+//! single call the TUI can render without any logic of its own. Given whatever
+//! the user actually pasted, it returns one [`DetectionResult`]:
+//!
+//! - [`DetectionResult::Connected`] — a provider was detected and the key
+//!   authenticated (can list models). The headline success path.
+//! - [`DetectionResult::NeedsGuidedSetup`] — the shape needs more than the
+//!   pasted string (AWS secret + region, GCP project, an Azure endpoint, a JWT
+//!   to route). We deliberately do **not** fire a blind network call here — that
+//!   would leak the credential to the wrong endpoint and can't succeed anyway.
+//! - [`DetectionResult::Unresolved`] — an ambiguous/unknown shape where no
+//!   candidate authenticated. Carries the per-candidate failures and a best
+//!   guess to prefill the provider picker.
+//!
+//! Candidates are probed most-specific-first with early return on the first
+//! usable one (the fingerprint already ranks the likely provider first, biased
+//! by any `export NAME=` hint), so the common ambiguous case (`sk-` → OpenAI
+//! vs DeepSeek) resolves in one probe when the hint is present. A latency
+//! optimization — probing the ambiguous bucket concurrently — is a documented
+//! follow-up; correctness does not depend on it.
+
+use std::sync::Arc;
+
+use wcore_config::config::Config;
+
+use crate::create_provider;
+use crate::fingerprint::{CredentialKind, fingerprint_key};
+use crate::key_validation::{ValidationOutcome, validate_with};
+use crate::{LlmProvider, ModelInfo};
+
+/// The single outcome of detecting and validating a pasted credential.
+#[derive(Debug, Clone)]
+pub enum DetectionResult {
+    /// A provider was detected and the key authenticated.
+    Connected {
+        /// Provider slug (e.g. `"anthropic"`).
+        provider: String,
+        /// The live model catalog the probe fetched.
+        models: Vec<ModelInfo>,
+    },
+    /// The credential shape is valid but needs a guided completion flow rather
+    /// than a single validating request.
+    NeedsGuidedSetup {
+        kind: CredentialKind,
+        /// The provider the wizard should target, if known (`"bedrock"`/`"vertex"`).
+        provider: Option<String>,
+    },
+    /// Nothing authenticated. `attempts` records what was tried and why each
+    /// failed; `best_guess` prefills the provider picker.
+    Unresolved {
+        attempts: Vec<ValidationOutcome>,
+        best_guess: Option<String>,
+    },
+}
+
+/// Detect and validate whatever the user pasted, using real providers.
+///
+/// Makes at most one network call per candidate (most-specific first, early
+/// return on success). Never writes the key.
+pub async fn detect_paste(base: &Config, raw: &str) -> DetectionResult {
+    detect_with(base, raw, create_provider).await
+}
+
+/// Core of [`detect_paste`], generic over how providers are built so tests can
+/// inject fakes. `build` is called once per probed candidate.
+pub(crate) async fn detect_with<F>(base: &Config, raw: &str, build: F) -> DetectionResult
+where
+    F: Fn(&Config) -> Arc<dyn LlmProvider>,
+{
+    let fp = fingerprint_key(raw);
+
+    // A shape that needs secret+region / project / endpoint / JWT routing must
+    // not be blind-probed — branch to the guided wizard instead.
+    if fp.needs_completion {
+        return DetectionResult::NeedsGuidedSetup {
+            kind: fp.kind,
+            provider: fp.best().map(|g| g.slug.to_string()),
+        };
+    }
+
+    // Unknown shape — straight to the picker.
+    if fp.candidates.is_empty() {
+        return DetectionResult::Unresolved {
+            attempts: Vec::new(),
+            best_guess: None,
+        };
+    }
+
+    // Probe candidates in rank order; first usable one wins.
+    let mut attempts = Vec::new();
+    for guess in &fp.candidates {
+        let outcome = validate_with(base, guess.slug, &fp.normalized, |cfg| build(cfg)).await;
+        if outcome.is_usable() {
+            return DetectionResult::Connected {
+                provider: outcome.provider,
+                models: outcome.models,
+            };
+        }
+        attempts.push(outcome);
+    }
+
+    DetectionResult::Unresolved {
+        best_guess: fp.best().map(|g| g.slug.to_string()),
+        attempts,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use tokio::sync::mpsc;
+    use wcore_config::config::{Config, ProviderType, provider_type_slug};
+    use wcore_types::llm::{LlmEvent, LlmRequest};
+
+    use crate::{ProviderError, alias_models};
+
+    struct FakeProvider {
+        models: Vec<ModelInfo>,
+    }
+
+    #[async_trait]
+    impl LlmProvider for FakeProvider {
+        async fn stream(
+            &self,
+            _request: &LlmRequest,
+        ) -> Result<mpsc::Receiver<LlmEvent>, ProviderError> {
+            unreachable!("detect only calls list_models")
+        }
+        async fn list_models(&self) -> anyhow::Result<Vec<ModelInfo>> {
+            Ok(self.models.clone())
+        }
+    }
+
+    /// Build a provider factory where exactly `live_provider` returns a real
+    /// (non-alias) catalog and every other provider floors to its alias list
+    /// (i.e. authentication "failed" for everyone else).
+    fn only_live(live_provider: ProviderType) -> impl Fn(&Config) -> Arc<dyn LlmProvider> {
+        move |cfg: &Config| {
+            let slug = provider_type_slug(cfg.provider);
+            let models = if cfg.provider == live_provider {
+                vec![ModelInfo {
+                    id: format!("{slug}-flagship-live"),
+                    display: "Flagship (live)".into(),
+                }]
+            } else {
+                alias_models(slug) // floored == auth failed
+            };
+            Arc::new(FakeProvider { models })
+        }
+    }
+
+    /// A factory where no provider authenticates (everyone floors).
+    fn all_floored() -> impl Fn(&Config) -> Arc<dyn LlmProvider> {
+        move |cfg: &Config| {
+            let slug = provider_type_slug(cfg.provider);
+            Arc::new(FakeProvider {
+                models: alias_models(slug),
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn unique_prefix_connects_directly() {
+        let r = detect_with(
+            &Config::default(),
+            "sk-ant-api03-xyz",
+            only_live(ProviderType::Anthropic),
+        )
+        .await;
+        match r {
+            DetectionResult::Connected { provider, models } => {
+                assert_eq!(provider, "anthropic");
+                assert_eq!(models.len(), 1);
+            }
+            other => panic!("expected Connected, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn ambiguous_bucket_resolves_to_the_live_one() {
+        // Bare `sk-` ranks [openai, deepseek]; only DeepSeek authenticates, so
+        // the orchestrator tries openai (floors), then deepseek (connects).
+        let r = detect_with(
+            &Config::default(),
+            "sk-0123456789abcdef0123456789abcdef",
+            only_live(ProviderType::Deepseek),
+        )
+        .await;
+        match r {
+            DetectionResult::Connected { provider, .. } => assert_eq!(provider, "deepseek"),
+            other => panic!("expected Connected deepseek, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn env_hint_orders_the_live_candidate_first() {
+        // The hint pulls deepseek to the front; it connects on the first probe.
+        let r = detect_with(
+            &Config::default(),
+            "export DEEPSEEK_API_KEY=sk-abcdef0123456789",
+            only_live(ProviderType::Deepseek),
+        )
+        .await;
+        assert!(matches!(r, DetectionResult::Connected { provider, .. } if provider == "deepseek"));
+    }
+
+    #[tokio::test]
+    async fn aws_access_key_needs_guided_setup_without_probing() {
+        // The build closure must never run for a non-bearer shape.
+        let r = detect_with(&Config::default(), "AKIAIOSFODNN7EXAMPLE", |_cfg| {
+            panic!("must not probe a non-bearer shape")
+        })
+        .await;
+        match r {
+            DetectionResult::NeedsGuidedSetup { kind, provider } => {
+                assert_eq!(kind, CredentialKind::AwsAccessKeyId);
+                assert_eq!(provider.as_deref(), Some("bedrock"));
+            }
+            other => panic!("expected NeedsGuidedSetup, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn unknown_shape_is_unresolved_without_probing() {
+        let r = detect_with(&Config::default(), "just-random-text", |_cfg| {
+            panic!("must not probe an unknown shape")
+        })
+        .await;
+        assert!(matches!(
+            r,
+            DetectionResult::Unresolved {
+                attempts,
+                best_guess: None
+            } if attempts.is_empty()
+        ));
+    }
+
+    #[tokio::test]
+    async fn all_rejected_is_unresolved_with_attempts_and_guess() {
+        let r = detect_with(
+            &Config::default(),
+            "sk-0123456789abcdef0123456789abcdef",
+            all_floored(),
+        )
+        .await;
+        match r {
+            DetectionResult::Unresolved {
+                attempts,
+                best_guess,
+            } => {
+                assert_eq!(attempts.len(), 2, "both ambiguous candidates were tried");
+                assert!(attempts.iter().all(|a| !a.is_usable()));
+                assert_eq!(best_guess.as_deref(), Some("openai"));
+            }
+            other => panic!("expected Unresolved, got {other:?}"),
+        }
+    }
+}

--- a/crates/wcore-providers/src/perplexity.rs
+++ b/crates/wcore-providers/src/perplexity.rs
@@ -60,6 +60,10 @@ impl LlmProvider for PerplexityProvider {
     ) -> Result<mpsc::Receiver<LlmEvent>, ProviderError> {
         self.inner.stream(request).await
     }
+
+    async fn list_models(&self) -> anyhow::Result<Vec<crate::ModelInfo>> {
+        self.inner.list_models().await
+    }
 }
 
 /// Register a Perplexity factory in the given registry under the lowercased id

--- a/crates/wcore-providers/src/qwen.rs
+++ b/crates/wcore-providers/src/qwen.rs
@@ -64,6 +64,10 @@ impl LlmProvider for QwenProvider {
     ) -> Result<mpsc::Receiver<LlmEvent>, ProviderError> {
         self.inner.stream(request).await
     }
+
+    async fn list_models(&self) -> anyhow::Result<Vec<crate::ModelInfo>> {
+        self.inner.list_models().await
+    }
 }
 
 /// Register a Qwen factory in the given registry under the lowercased id

--- a/crates/wcore-providers/src/together.rs
+++ b/crates/wcore-providers/src/together.rs
@@ -54,6 +54,10 @@ impl LlmProvider for TogetherProvider {
     ) -> Result<mpsc::Receiver<LlmEvent>, ProviderError> {
         self.inner.stream(request).await
     }
+
+    async fn list_models(&self) -> anyhow::Result<Vec<crate::ModelInfo>> {
+        self.inner.list_models().await
+    }
 }
 
 /// Register a Together AI factory in the given registry under the lowercased

--- a/crates/wcore-providers/src/xai.rs
+++ b/crates/wcore-providers/src/xai.rs
@@ -54,6 +54,10 @@ impl LlmProvider for XaiProvider {
     ) -> Result<mpsc::Receiver<LlmEvent>, ProviderError> {
         self.inner.stream(request).await
     }
+
+    async fn list_models(&self) -> anyhow::Result<Vec<crate::ModelInfo>> {
+        self.inner.list_models().await
+    }
 }
 
 /// Register an xAI factory in the given registry under the lowercased id


### PR DESCRIPTION
## Config Cockpit — operational-topology `/config` + `/doctor`

Turns the config surface from a ~5-field editor into a full operational cockpit, built as 13 box-gated slices. Every change is non-destructive (`patch_global_config` preserves all other keys) and applies live via the existing `RebindRequest` seam — no restarts.

### What's in it

- **Paste-to-connect (`/connect`)** — paste an API key → fingerprint the provider → live-validate (list-models / test-fire ladder) → store in the credentials store → set as default, all live. The credentials-store path applies on rebind; the legacy `.env` write did not.
- **Essentials `/config` home** — real Tools (`auto_approve` + allow-list count) and Wallet (`[budget] max_cost_usd`) rows, plus a posture + health/cost strip (real session spend or em-dash, never fabricated).
- **Advanced tier** — observability toggles, credential-store backend radio (plaintext↔keyring; encrypted-file read-only), egress guard, and a link into the Expert cost-tuning pane.
- **Collection list editors** — a shared string-list editor for `[tools] allow_list`, `[security] egress_allow`, and `[provider_chain] fallback_models` (+ the failover on/off toggle).
- **`/doctor` config-posture health** — egress, credential storage, tool-approval posture, failover chain, spend cap, memory dir; permissive-but-valid states warn, never a fake fail.
- **Effective-config preview (`/effective`)** — the resolved, merged config as redacted TOML (every secret-named key masked via a recursive value walk).
- **Channels / Integrations visibility** — the on-disk channel configs (previously invisible to the schema TUI) listed read-only and secret-free, **plus the F-019 fix**: the channel loader now honors `WAYLAND_HOME` instead of `dirs::home_dir()` (a sandboxed process no longer reads the host's real channel configs).
- **Self-configure discovery** — a `/doctor` "here's what I found" section: ambient AWS/GCP creds, local Ollama, stored ChatGPT login, and importable Claude Desktop MCP servers — reusing existing detection (`provider_connected`, the doctor probe) rather than duplicating it.

### Verification

Box-gated per slice on Hetzner (Mac can't compile this workspace): `cargo clippy --all-targets -- -D warnings` clean, `cargo fmt --all -- --check` clean, and the targeted crate suites green — **1643 wcore-cli + 283 wcore-config + 11 channels-registry tests pass** (33 new across the slices). CI runs the full cross-platform matrix as the authoritative gate.

### Deferred (optional polish, no coverage gaps)

S7b HashMap collection editors (MCP/profiles/hooks), S9b effective-config `[source]` provenance + `--profile` threading + export, S10b editable per-connector channel forms, S11b first-run onboarding placement + one-click "connect this".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
