### PR TITLE
feat(mcp): Forge zero-config local-MCP discovery — keystone + reader + grant client + connect flow (Slice 3, headless)

### DIFF
--- a/crates/wcore-agent/src/bootstrap.rs
+++ b/crates/wcore-agent/src/bootstrap.rs
@@ -934,14 +934,27 @@ impl AgentBootstrap {
 
         let mut mcp_managers: Vec<Arc<McpManager>> = Vec::new();
         let mcp_manager = if !self.config.mcp.servers.is_empty() {
-            match McpManager::connect_all(&self.config.mcp.servers).await {
+            // Slice 3, Piece 2 — resolve any `${cred:KEY}` header references
+            // against the credentials store at the connect boundary, on a clone.
+            // The long-lived `self.config` keeps the literal `${cred:...}` so the
+            // token never round-trips back to config.toml. If the store can't be
+            // opened, connect with the literals (each referencing server then
+            // fails its own connect, in isolation).
+            let resolved_servers = match self.config.open_credentials_store() {
+                Ok(store) => wcore_config::mcp_cred_refs::resolve_servers_for_connect(
+                    &self.config.mcp.servers,
+                    &*store,
+                ),
+                Err(_) => self.config.mcp.servers.clone(),
+            };
+            match McpManager::connect_all(&resolved_servers).await {
                 Ok(mgr) => {
                     let mgr = Arc::new(mgr);
                     wcore_mcp::tool_proxy::register_mcp_tools(
                         &mut registry,
                         &mgr,
                         &builtin_names,
-                        &self.config.mcp.servers,
+                        &resolved_servers,
                     );
                     mcp_managers.push(mgr.clone());
                     Some(mgr)

--- a/crates/wcore-agent/src/plugins/mcp_delivery.rs
+++ b/crates/wcore-agent/src/plugins/mcp_delivery.rs
@@ -52,6 +52,7 @@ pub fn translate_mcp_server_spec(spec: &McpServerSpec) -> McpServerConfig {
             url: None,
             headers: None,
             deferred: None,
+            allow_local: false,
         },
         McpTransport::Sse { url } => McpServerConfig {
             transport: TransportType::Sse,
@@ -61,6 +62,7 @@ pub fn translate_mcp_server_spec(spec: &McpServerSpec) -> McpServerConfig {
             url: Some(url.clone()),
             headers: None,
             deferred: None,
+            allow_local: false,
         },
         McpTransport::Http { url } => McpServerConfig {
             transport: TransportType::StreamableHttp,
@@ -70,6 +72,7 @@ pub fn translate_mcp_server_spec(spec: &McpServerSpec) -> McpServerConfig {
             url: Some(url.clone()),
             headers: None,
             deferred: None,
+            allow_local: false,
         },
     }
 }

--- a/crates/wcore-cli/src/main.rs
+++ b/crates/wcore-cli/src/main.rs
@@ -2153,6 +2153,7 @@ fn to_mcp_server_config(
         url,
         headers,
         deferred: Some(false),
+        allow_local: false,
     })
 }
 

--- a/crates/wcore-cli/src/tui/engine_bridge.rs
+++ b/crates/wcore-cli/src/tui/engine_bridge.rs
@@ -1545,65 +1545,197 @@ impl TuiEngine {
     /// connected + registered live (no restart). The TUI (Piece 3) calls this
     /// once [`wcore_mcp::forge_grant::request_grant`] returns `Granted`.
     pub fn connect_forge_server(&self, name: String, url: String, token: String) {
-        let send_err = |msg: String| {
-            let _ = self.tx.send(ProtocolEvent::Error {
-                msg_id: None,
-                error: ErrorInfo {
-                    code: "mcp_connect".to_string(),
-                    message: msg,
-                    retryable: false,
-                },
+        match Self::store_and_persist_forge(&name, &url, &token) {
+            Ok(server) => {
+                // Connect + register live (the `${cred:}` header is resolved inside).
+                tokio::spawn(Self::connect_and_register_mcp(
+                    self.engine.clone(),
+                    self.tx.clone(),
+                    name,
+                    server,
+                ));
+            }
+            Err(e) => {
+                let _ = self.tx.send(ProtocolEvent::Error {
+                    msg_id: None,
+                    error: ErrorInfo {
+                        code: "mcp_connect".to_string(),
+                        message: e,
+                        retryable: false,
+                    },
+                });
+            }
+        }
+    }
+
+    /// Slice 3, Piece 3 — the full one-command Forge connect: discover → live
+    /// probe → grant → connect. `name` selects among discovered servers (or
+    /// picks the sole one). The grant `POST` triggers the human **Approve**
+    /// prompt in the producer's GUI, so this runs entirely off-thread and
+    /// reports progress/outcome as turns on the bridge channel. Recoverable
+    /// grant outcomes (denied / rate-limited / bad-scopes) are surfaced as
+    /// guidance, not hard errors.
+    pub fn connect_forge_discovered(&self, name: Option<String>) {
+        let tx = self.tx.clone();
+        let info = |msg: String| {
+            let _ = tx.send(ProtocolEvent::Info {
+                msg_id: String::new(),
+                message: msg,
             });
         };
 
-        // 1. Store the token in the secret store, keyed per server. Resolving a
-        //    config snapshot picks up the configured credentials backend.
-        let cred_key = wcore_config::mcp_cred_refs::mcp_token_cred_key(&name);
-        let cfg = match wcore_config::config::Config::resolve(
-            &wcore_config::config::CliArgs::default(),
-        ) {
-            Ok(c) => c,
-            Err(e) => {
-                send_err(format!(
-                    "Couldn't load config to store the grant token: {e}"
-                ));
+        // Pick the target server synchronously (a cheap local file read).
+        let servers = wcore_config::forge_discovery::read_discovered_servers();
+        let server = match Self::pick_forge_server(servers, name.as_deref()) {
+            Ok(s) => s,
+            Err(msg) => {
+                info(msg);
                 return;
             }
         };
-        match cfg.open_credentials_store() {
-            Ok(store) => {
-                if let Err(e) = store.put(&cred_key, &token) {
-                    send_err(format!("Couldn't store the grant token securely: {e}"));
-                    return;
-                }
-            }
-            Err(e) => {
-                send_err(format!("Credentials store unavailable: {e}"));
+        let Some(grant_url) = server.auth.grant_url.clone() else {
+            info(format!(
+                "'{}' doesn't use the loopback-grant flow — nothing to authorize.",
+                server.label()
+            ));
+            return;
+        };
+
+        let engine = self.engine.clone();
+        let tx2 = self.tx.clone();
+        let label = server.label().to_string();
+        tokio::spawn(async move {
+            let report_info = |msg: String| {
+                let _ = tx2.send(ProtocolEvent::Info {
+                    msg_id: String::new(),
+                    message: msg,
+                });
+            };
+            let report_err = |msg: String| {
+                let _ = tx2.send(ProtocolEvent::Error {
+                    msg_id: None,
+                    error: ErrorInfo {
+                        code: "mcp_connect".to_string(),
+                        message: msg,
+                        retryable: false,
+                    },
+                });
+            };
+
+            let client = wcore_mcp::forge_grant::loopback_http_client();
+
+            // 1. Liveness: a stale discovery entry must not prompt a grant.
+            if wcore_mcp::forge_grant::probe_metadata(&client, &server.metadata_url, &server.name)
+                .await
+                .is_none()
+            {
+                report_err(format!(
+                    "'{label}' is listed but not responding — it may not be running. \
+                     Start it and try /mcp connect again."
+                ));
                 return;
             }
-        }
 
-        // 2. Build + persist `[mcp.servers.<name>]` with the `${cred:}` header.
-        //    Only the reference lands on disk — the token stays in the store.
-        let server = wcore_config::mcp_cred_refs::build_forge_mcp_server_config(&url, &cred_key);
-        if let Err(e) = wcore_config::config::patch_global_config({
-            let name = name.clone();
+            // 2. Grant — this triggers the Approve prompt in the producer's GUI.
+            report_info(format!(
+                "Requesting access to '{label}' — approve the request in its window…"
+            ));
+            match wcore_mcp::forge_grant::request_grant(
+                &client,
+                &grant_url,
+                "Wayland Core",
+                &["read", "write"],
+            )
+            .await
+            {
+                wcore_mcp::forge_grant::GrantOutcome::Granted { token, .. } => {
+                    match Self::store_and_persist_forge(&server.name, &server.url, &token) {
+                        Ok(cfg) => {
+                            Self::connect_and_register_mcp(engine, tx2, server.name, cfg).await
+                        }
+                        Err(e) => report_err(e),
+                    }
+                }
+                wcore_mcp::forge_grant::GrantOutcome::Denied => report_err(format!(
+                    "Access to '{label}' was not approved. Run /mcp connect to try again."
+                )),
+                wcore_mcp::forge_grant::GrantOutcome::RateLimited => report_err(format!(
+                    "'{label}' is rate-limiting grant requests — wait a moment and retry."
+                )),
+                wcore_mcp::forge_grant::GrantOutcome::BadScopes(m) => {
+                    report_err(format!("'{label}' rejected the requested scopes: {m}"))
+                }
+                wcore_mcp::forge_grant::GrantOutcome::Error(m) => {
+                    report_err(format!("Couldn't get access to '{label}': {m}"))
+                }
+            }
+        });
+    }
+
+    /// Pick a discovered Forge server by `name`, or the sole one when no name is
+    /// given. Returns a user-facing message (Err) when the choice is ambiguous,
+    /// absent, or unnamed-but-plural.
+    fn pick_forge_server(
+        servers: Vec<wcore_config::forge_discovery::DiscoveredMcpServer>,
+        name: Option<&str>,
+    ) -> Result<wcore_config::forge_discovery::DiscoveredMcpServer, String> {
+        if servers.is_empty() {
+            return Err(
+                "No Forge MCP servers found. (Looked in the Forge discovery file under your OS \
+                 config dir — start Agent Vault, then try /mcp connect.)"
+                    .to_string(),
+            );
+        }
+        match name {
+            Some(n) => servers
+                .into_iter()
+                .find(|s| s.name == n)
+                .ok_or_else(|| format!("No discovered Forge server named '{n}'.")),
+            None => {
+                if servers.len() == 1 {
+                    Ok(servers.into_iter().next().expect("len == 1"))
+                } else {
+                    let names: Vec<&str> = servers.iter().map(|s| s.name.as_str()).collect();
+                    Err(format!(
+                        "Multiple Forge servers discovered ({}). Pick one: /mcp connect <name>.",
+                        names.join(", ")
+                    ))
+                }
+            }
+        }
+    }
+
+    /// Store a granted bearer `token` in the credentials store and persist a
+    /// `[mcp.servers.<name>]` entry whose `Authorization` header is a `${cred:}`
+    /// reference (so the token never lands in `config.toml`). Returns the built
+    /// server config (ready to connect), or a user-facing error string. Shared
+    /// by [`Self::connect_forge_server`] and [`Self::connect_forge_discovered`].
+    fn store_and_persist_forge(
+        name: &str,
+        url: &str,
+        token: &str,
+    ) -> Result<wcore_config::config::McpServerConfig, String> {
+        let cred_key = wcore_config::mcp_cred_refs::mcp_token_cred_key(name);
+        let cfg = wcore_config::config::Config::resolve(&wcore_config::config::CliArgs::default())
+            .map_err(|e| format!("Couldn't load config to store the grant token: {e}"))?;
+        let store = cfg
+            .open_credentials_store()
+            .map_err(|e| format!("Credentials store unavailable: {e}"))?;
+        store
+            .put(&cred_key, token)
+            .map_err(|e| format!("Couldn't store the grant token securely: {e}"))?;
+
+        let server = wcore_config::mcp_cred_refs::build_forge_mcp_server_config(url, &cred_key);
+        wcore_config::config::patch_global_config({
+            let name = name.to_string();
             let server = server.clone();
             move |f| {
                 f.mcp.servers.insert(name, server);
             }
-        }) {
-            send_err(format!("Couldn't persist the MCP server config: {e}"));
-            return;
-        }
+        })
+        .map_err(|e| format!("Couldn't persist the MCP server config: {e}"))?;
 
-        // 3. Connect + register live (the header `${cred:}` is resolved inside).
-        tokio::spawn(Self::connect_and_register_mcp(
-            self.engine.clone(),
-            self.tx.clone(),
-            name,
-            server,
-        ));
+        Ok(server)
     }
 
     /// Connect a single MCP server and register its tools onto the live engine
@@ -2188,6 +2320,51 @@ mod tests {
             ProtocolEvent::StreamStart { msg_id } => assert_eq!(msg_id, "m1"),
             other => panic!("expected StreamStart, got {other:?}"),
         }
+    }
+
+    fn disc(name: &str) -> wcore_config::forge_discovery::DiscoveredMcpServer {
+        wcore_config::forge_discovery::DiscoveredMcpServer {
+            name: name.to_string(),
+            display_name: None,
+            transport: "streamable-http".to_string(),
+            url: format!("http://127.0.0.1:3456/{name}"),
+            auth: wcore_config::forge_discovery::DiscoveredAuth {
+                scheme: "loopback-grant".to_string(),
+                grant_url: Some("http://127.0.0.1:3456/grant".to_string()),
+            },
+            metadata_url: "http://127.0.0.1:3456/.well-known/mcp".to_string(),
+        }
+    }
+
+    #[test]
+    fn pick_forge_server_errors_when_none_discovered() {
+        let got = TuiEngine::pick_forge_server(vec![], None);
+        assert!(got.unwrap_err().contains("No Forge MCP servers"));
+    }
+
+    #[test]
+    fn pick_forge_server_returns_sole_server_without_a_name() {
+        let got = TuiEngine::pick_forge_server(vec![disc("agent-vault")], None).unwrap();
+        assert_eq!(got.name, "agent-vault");
+    }
+
+    #[test]
+    fn pick_forge_server_requires_a_name_when_plural() {
+        let err = TuiEngine::pick_forge_server(vec![disc("a"), disc("b")], None).unwrap_err();
+        assert!(err.contains("Multiple Forge servers"));
+        assert!(err.contains("a") && err.contains("b"));
+    }
+
+    #[test]
+    fn pick_forge_server_selects_by_name() {
+        let got = TuiEngine::pick_forge_server(vec![disc("a"), disc("b")], Some("b")).unwrap();
+        assert_eq!(got.name, "b");
+    }
+
+    #[test]
+    fn pick_forge_server_reports_unknown_name() {
+        let err = TuiEngine::pick_forge_server(vec![disc("a")], Some("nope")).unwrap_err();
+        assert!(err.contains("nope"));
     }
 
     #[test]

--- a/crates/wcore-cli/src/tui/engine_bridge.rs
+++ b/crates/wcore-cli/src/tui/engine_bridge.rs
@@ -1528,115 +1528,211 @@ impl TuiEngine {
                 return;
             }
         };
-        let engine = self.engine.clone();
-        let tx = self.tx.clone();
-        tokio::spawn(async move {
-            let mut single = std::collections::HashMap::new();
-            single.insert(name.clone(), config.clone());
-            let manager = match wcore_mcp::manager::McpManager::connect_all(&single).await {
-                Ok(mgr) => std::sync::Arc::new(mgr),
-                Err(e) => {
-                    let reason = format!("{e}");
-                    let _ = tx.send(ProtocolEvent::McpFailed {
-                        name: name.clone(),
-                        reason: reason.clone(),
-                    });
-                    let _ = tx.send(ProtocolEvent::Error {
-                        msg_id: None,
-                        error: ErrorInfo {
-                            code: "mcp_add".to_string(),
-                            message: format!("Couldn't connect MCP server '{name}': {reason}"),
-                            retryable: false,
-                        },
-                    });
-                    return;
-                }
-            };
-            // `connect_all` is non-fatal per-server: a server that failed or
-            // timed out still returns `Ok` with the cause recorded in
-            // `health()`, not `Err`. Surface that honestly instead of falling
-            // through and reporting "connected, 0 tools".
-            use wcore_mcp::manager::McpServerHealth;
-            match manager.health().get(&name) {
-                Some(McpServerHealth::Ready { .. }) => {}
-                other => {
-                    let reason = match other {
-                        Some(McpServerHealth::Failed { reason }) => reason.clone(),
-                        Some(McpServerHealth::TimedOut { after }) => {
-                            format!("connect timed out after {after:?}")
-                        }
-                        _ => "server did not connect".to_string(),
-                    };
-                    let _ = tx.send(ProtocolEvent::McpFailed {
-                        name: name.clone(),
-                        reason: reason.clone(),
-                    });
-                    let _ = tx.send(ProtocolEvent::Error {
-                        msg_id: None,
-                        error: ErrorInfo {
-                            code: "mcp_add".to_string(),
-                            message: format!("MCP server '{name}' failed to connect: {reason}"),
-                            retryable: false,
-                        },
-                    });
+        tokio::spawn(Self::connect_and_register_mcp(
+            self.engine.clone(),
+            self.tx.clone(),
+            name,
+            config,
+        ));
+    }
+
+    /// Slice 3, Piece 2 — connect a discovered Forge MCP server after a
+    /// successful loopback grant. The bearer `token` is stored in the
+    /// credentials store (NEVER `config.toml`); the persisted
+    /// `[mcp.servers.<name>]` entry carries only a `${cred:KEY}` reference in
+    /// its `Authorization` header, which is resolved back to the real token at
+    /// connect time by [`Self::connect_and_register_mcp`]. The server is then
+    /// connected + registered live (no restart). The TUI (Piece 3) calls this
+    /// once [`wcore_mcp::forge_grant::request_grant`] returns `Granted`.
+    pub fn connect_forge_server(&self, name: String, url: String, token: String) {
+        let send_err = |msg: String| {
+            let _ = self.tx.send(ProtocolEvent::Error {
+                msg_id: None,
+                error: ErrorInfo {
+                    code: "mcp_connect".to_string(),
+                    message: msg,
+                    retryable: false,
+                },
+            });
+        };
+
+        // 1. Store the token in the secret store, keyed per server. Resolving a
+        //    config snapshot picks up the configured credentials backend.
+        let cred_key = wcore_config::mcp_cred_refs::mcp_token_cred_key(&name);
+        let cfg = match wcore_config::config::Config::resolve(
+            &wcore_config::config::CliArgs::default(),
+        ) {
+            Ok(c) => c,
+            Err(e) => {
+                send_err(format!(
+                    "Couldn't load config to store the grant token: {e}"
+                ));
+                return;
+            }
+        };
+        match cfg.open_credentials_store() {
+            Ok(store) => {
+                if let Err(e) = store.put(&cred_key, &token) {
+                    send_err(format!("Couldn't store the grant token securely: {e}"));
                     return;
                 }
             }
-            // Register the freshly discovered tools onto the LIVE registry.
-            // `registry_mut` only hands out a `&mut` when the registry Arc is
-            // uncontended — a turn in flight holds a clone, so we report busy
-            // instead of dropping the add. The MCP proxies clone the manager
-            // Arc internally, so it stays alive after this scope.
-            let mut guard = engine.lock().await;
-            let builtin_names = guard.tool_names();
-            let message = match guard.registry_mut() {
-                Some(reg) => {
-                    wcore_mcp::tool_proxy::register_single_server_tools(
-                        reg,
-                        &manager,
-                        &name,
-                        &builtin_names,
-                        config.deferred.unwrap_or(true),
-                    );
-                    let tool_names: Vec<String> = manager
-                        .all_tools()
-                        .iter()
-                        .filter(|(sn, _)| *sn == name.as_str())
-                        .map(|(_, t)| t.name.clone())
-                        .collect();
-                    let tool_count = tool_names.len();
-                    // Update the TUI's live mcp_status (so /doctor reflects the
-                    // add) — the bridge's McpReady arm records Ready{tool_count}.
-                    // Previously this path emitted only Info, leaving mcp_status
-                    // stale after a live `/mcp add`.
-                    let _ = tx.send(ProtocolEvent::McpReady {
-                        name: name.clone(),
-                        tools: tool_names,
-                    });
-                    format!(
-                        "MCP server '{name}' connected. {tool_count} tool(s) available now. \
-                         Type /mcp to see all servers."
-                    )
-                }
-                None => {
-                    let _ = tx.send(ProtocolEvent::Error {
-                        msg_id: None,
-                        error: ErrorInfo {
-                            code: "mcp_add".to_string(),
-                            message: format!(
-                                "Can't add '{name}' while a turn is running. Try /mcp add again \
-                                 once it's idle."
-                            ),
-                            retryable: true,
-                        },
-                    });
-                    return;
-                }
-            };
-            let _ = tx.send(ProtocolEvent::Info {
-                msg_id: String::new(),
-                message,
-            });
+            Err(e) => {
+                send_err(format!("Credentials store unavailable: {e}"));
+                return;
+            }
+        }
+
+        // 2. Build + persist `[mcp.servers.<name>]` with the `${cred:}` header.
+        //    Only the reference lands on disk — the token stays in the store.
+        let server = wcore_config::mcp_cred_refs::build_forge_mcp_server_config(&url, &cred_key);
+        if let Err(e) = wcore_config::config::patch_global_config({
+            let name = name.clone();
+            let server = server.clone();
+            move |f| {
+                f.mcp.servers.insert(name, server);
+            }
+        }) {
+            send_err(format!("Couldn't persist the MCP server config: {e}"));
+            return;
+        }
+
+        // 3. Connect + register live (the header `${cred:}` is resolved inside).
+        tokio::spawn(Self::connect_and_register_mcp(
+            self.engine.clone(),
+            self.tx.clone(),
+            name,
+            server,
+        ));
+    }
+
+    /// Connect a single MCP server and register its tools onto the live engine
+    /// registry, reporting progress/failure on the bridge channel. Shared by the
+    /// `/mcp add` path and the Forge connect flow. `${cred:KEY}` references in
+    /// the server's headers are resolved against the credentials store here, at
+    /// the connect boundary — `config.toml` keeps the literal reference.
+    async fn connect_and_register_mcp(
+        engine: Arc<tokio::sync::Mutex<wcore_agent::engine::AgentEngine>>,
+        tx: UnboundedSender<ProtocolEvent>,
+        name: String,
+        mut config: wcore_config::config::McpServerConfig,
+    ) {
+        // Resolve `${cred:KEY}` header references just before connecting.
+        // Best-effort: if the store can't be opened, the literal header is left
+        // in place and the connect fails honestly below (no silent empty bearer).
+        // A no-reference header (the plain `/mcp add` path) never touches the store.
+        if let Ok(cfg) =
+            wcore_config::config::Config::resolve(&wcore_config::config::CliArgs::default())
+            && let Ok(store) = cfg.open_credentials_store()
+        {
+            let _ = wcore_config::mcp_cred_refs::resolve_server_headers(&mut config, &*store);
+        }
+
+        let mut single = std::collections::HashMap::new();
+        single.insert(name.clone(), config.clone());
+        let manager = match wcore_mcp::manager::McpManager::connect_all(&single).await {
+            Ok(mgr) => std::sync::Arc::new(mgr),
+            Err(e) => {
+                let reason = format!("{e}");
+                let _ = tx.send(ProtocolEvent::McpFailed {
+                    name: name.clone(),
+                    reason: reason.clone(),
+                });
+                let _ = tx.send(ProtocolEvent::Error {
+                    msg_id: None,
+                    error: ErrorInfo {
+                        code: "mcp_add".to_string(),
+                        message: format!("Couldn't connect MCP server '{name}': {reason}"),
+                        retryable: false,
+                    },
+                });
+                return;
+            }
+        };
+        // `connect_all` is non-fatal per-server: a server that failed or
+        // timed out still returns `Ok` with the cause recorded in
+        // `health()`, not `Err`. Surface that honestly instead of falling
+        // through and reporting "connected, 0 tools".
+        use wcore_mcp::manager::McpServerHealth;
+        match manager.health().get(&name) {
+            Some(McpServerHealth::Ready { .. }) => {}
+            other => {
+                let reason = match other {
+                    Some(McpServerHealth::Failed { reason }) => reason.clone(),
+                    Some(McpServerHealth::TimedOut { after }) => {
+                        format!("connect timed out after {after:?}")
+                    }
+                    _ => "server did not connect".to_string(),
+                };
+                let _ = tx.send(ProtocolEvent::McpFailed {
+                    name: name.clone(),
+                    reason: reason.clone(),
+                });
+                let _ = tx.send(ProtocolEvent::Error {
+                    msg_id: None,
+                    error: ErrorInfo {
+                        code: "mcp_add".to_string(),
+                        message: format!("MCP server '{name}' failed to connect: {reason}"),
+                        retryable: false,
+                    },
+                });
+                return;
+            }
+        }
+        // Register the freshly discovered tools onto the LIVE registry.
+        // `registry_mut` only hands out a `&mut` when the registry Arc is
+        // uncontended — a turn in flight holds a clone, so we report busy
+        // instead of dropping the add. The MCP proxies clone the manager
+        // Arc internally, so it stays alive after this scope.
+        let mut guard = engine.lock().await;
+        let builtin_names = guard.tool_names();
+        let message = match guard.registry_mut() {
+            Some(reg) => {
+                wcore_mcp::tool_proxy::register_single_server_tools(
+                    reg,
+                    &manager,
+                    &name,
+                    &builtin_names,
+                    config.deferred.unwrap_or(true),
+                );
+                let tool_names: Vec<String> = manager
+                    .all_tools()
+                    .iter()
+                    .filter(|(sn, _)| *sn == name.as_str())
+                    .map(|(_, t)| t.name.clone())
+                    .collect();
+                let tool_count = tool_names.len();
+                // Update the TUI's live mcp_status (so /doctor reflects the
+                // add) — the bridge's McpReady arm records Ready{tool_count}.
+                // Previously this path emitted only Info, leaving mcp_status
+                // stale after a live `/mcp add`.
+                let _ = tx.send(ProtocolEvent::McpReady {
+                    name: name.clone(),
+                    tools: tool_names,
+                });
+                format!(
+                    "MCP server '{name}' connected. {tool_count} tool(s) available now. \
+                     Type /mcp to see all servers."
+                )
+            }
+            None => {
+                let _ = tx.send(ProtocolEvent::Error {
+                    msg_id: None,
+                    error: ErrorInfo {
+                        code: "mcp_add".to_string(),
+                        message: format!(
+                            "Can't add '{name}' while a turn is running. Try /mcp add again \
+                             once it's idle."
+                        ),
+                        retryable: true,
+                    },
+                });
+                return;
+            }
+        };
+        let _ = tx.send(ProtocolEvent::Info {
+            msg_id: String::new(),
+            message,
         });
     }
 

--- a/crates/wcore-cli/src/tui/engine_bridge.rs
+++ b/crates/wcore-cli/src/tui/engine_bridge.rs
@@ -652,6 +652,7 @@ fn mcp_config_from_target(target: &str) -> Result<wcore_config::config::McpServe
             url: Some(target.to_string()),
             headers: None,
             deferred: Some(false),
+            allow_local: false,
         });
     }
     let mut parts = target.split_whitespace();
@@ -669,6 +670,7 @@ fn mcp_config_from_target(target: &str) -> Result<wcore_config::config::McpServe
         url: None,
         headers: None,
         deferred: Some(false),
+        allow_local: false,
     })
 }
 

--- a/crates/wcore-cli/src/tui/surfaces/diagnostics.rs
+++ b/crates/wcore-cli/src/tui/surfaces/diagnostics.rs
@@ -598,6 +598,18 @@ fn scan_environment(ollama_available: bool) -> Vec<Discovery> {
         },
     });
 
+    // Slice 3 — Forge-suite local MCP servers advertised in the cross-app
+    // discovery file (e.g. Agent Vault). These are hints, not liveness — the
+    // live probe + grant happen on `/mcp connect`, so this row just surfaces
+    // that one is available to link. One row per discovered server.
+    for s in wcore_config::forge_discovery::read_discovered_servers() {
+        rows.push(Discovery {
+            label: format!("Forge MCP: {}", s.label()),
+            available: true,
+            detail: format!("discovered at {} — run /mcp connect to link", s.url),
+        });
+    }
+
     rows
 }
 

--- a/crates/wcore-cli/src/tui/surfaces/mod.rs
+++ b/crates/wcore-cli/src/tui/surfaces/mod.rs
@@ -1816,6 +1816,31 @@ impl Router {
                                     ),
                                 }
                             }
+                            Some("connect") => {
+                                // Slice 3: zero-config connect to a discovered
+                                // Forge MCP server (Agent Vault). Reads the Forge
+                                // discovery file → live-probe → grant (triggers
+                                // the Approve prompt in the producer's window) →
+                                // connect, all off-thread; progress arrives as
+                                // Info/Error turns. `connect <name>` disambiguates
+                                // when more than one server is discovered.
+                                let target = parts.next().map(str::to_string);
+                                match self.engine.as_ref() {
+                                    Some(engine) => {
+                                        engine.connect_forge_discovered(target);
+                                        push_system(
+                                            app,
+                                            "Looking for a Forge MCP server to connect…"
+                                                .to_string(),
+                                        );
+                                    }
+                                    None => push_system(
+                                        app,
+                                        "No engine attached. /mcp connect needs a live session."
+                                            .to_string(),
+                                    ),
+                                }
+                            }
                             _ => {
                                 let inv = self.engine.as_ref().map(|e| e.inventory());
                                 push_system(app, render_mcp_list(inv));

--- a/crates/wcore-config/src/config.rs
+++ b/crates/wcore-config/src/config.rs
@@ -84,6 +84,14 @@ pub struct McpServerConfig {
     /// Defaults to true when omitted — MCP tools are deferred by default to reduce
     /// input token usage. Set to `false` to send full schemas eagerly.
     pub deferred: Option<bool>,
+    /// Allow this MCP server's URL to resolve to a loopback address
+    /// (127.0.0.0/8, ::1, localhost). MCP endpoints are trusted user config,
+    /// not model-driven URLs, so the SSRF guard should not block a user's own
+    /// local MCP server. Off by default. Other private/LAN/link-local/CGNAT/
+    /// cloud-metadata ranges and internal hostnames remain blocked even when
+    /// enabled. No effect on stdio transport.
+    #[serde(default)]
+    pub allow_local: bool,
 }
 
 /// Collection of MCP server configurations

--- a/crates/wcore-config/src/forge_discovery.rs
+++ b/crates/wcore-config/src/forge_discovery.rs
@@ -1,0 +1,197 @@
+//! Forge local-MCP discovery — consumer side (read-only).
+//!
+//! Forge-suite desktop apps (Agent Vault, future Foundry tools) advertise their
+//! local MCP server by writing a shared file at
+//! `<dirs::config_dir()>/forge/mcp-servers.json`. This module reads that file so
+//! Wayland Core can auto-detect those servers instead of requiring hand-config.
+//!
+//! The path deliberately uses the real OS config dir (`dirs::config_dir()`), NOT
+//! the WAYLAND_HOME-honoring [`wayland_config_dir`](crate::config::wayland_config_dir):
+//! it is a cross-application convention written by *other* apps about the actual
+//! machine, exactly like the Claude-Desktop MCP discovery.
+//!
+//! Per the contract (`.audit/waylandcore-mcp-fix/FORGE-MCP-DISCOVERY-SPEC.md`),
+//! entries are **hints, not liveness** — a producer crash leaves a stale entry,
+//! so a consumer MUST liveness-probe `metadata_url` before offering to connect,
+//! and must never auto-connect silently. This module only parses; the probe +
+//! grant + connect live in `wcore-mcp`.
+
+use std::path::PathBuf;
+
+use serde::Deserialize;
+
+/// Schema version this consumer understands.
+pub const DISCOVERY_VERSION: u32 = 1;
+
+/// How a consumer obtains a bearer token for a discovered server.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct DiscoveredAuth {
+    /// `loopback-grant` (ask `grant_url` for a scoped token) or `none`.
+    pub scheme: String,
+    /// The `POST` endpoint that mints a scoped token (present for `loopback-grant`).
+    #[serde(default)]
+    pub grant_url: Option<String>,
+}
+
+/// One advertised local MCP server. Carries handles only — never a secret.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct DiscoveredMcpServer {
+    /// Stable machine id, unique per producing app (e.g. `agent-vault`).
+    pub name: String,
+    /// Human label for the "X detected — connect?" prompt.
+    #[serde(default)]
+    pub display_name: Option<String>,
+    /// Transport string as written by the producer (e.g. `streamable-http`).
+    pub transport: String,
+    /// The MCP endpoint, e.g. `http://127.0.0.1:3456/mcp`.
+    pub url: String,
+    /// How to authenticate.
+    pub auth: DiscoveredAuth,
+    /// Unauthenticated liveness/metadata endpoint to probe before connecting.
+    pub metadata_url: String,
+}
+
+impl DiscoveredMcpServer {
+    /// The label to show the user (falls back to `name` when no display name).
+    pub fn label(&self) -> &str {
+        self.display_name.as_deref().unwrap_or(&self.name)
+    }
+
+    /// Whether this server uses the loopback-grant handshake (vs. `none`).
+    pub fn uses_loopback_grant(&self) -> bool {
+        self.auth.scheme == "loopback-grant" && self.auth.grant_url.is_some()
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct DiscoveryFile {
+    // The file's `version` key is intentionally not modelled: we parse
+    // best-effort across versions (unknown fields ignored, bad entries
+    // dropped), so a newer producer never breaks an older consumer. The
+    // version this consumer targets is [`DISCOVERY_VERSION`].
+    #[serde(default)]
+    servers: Vec<DiscoveredMcpServer>,
+}
+
+/// The shared Forge discovery file path: `<config_dir>/forge/mcp-servers.json`.
+///
+/// Returns `None` only when the OS has no resolvable config dir (rare; e.g. a
+/// stripped environment with no `HOME`/`APPDATA`).
+pub fn forge_discovery_path() -> Option<PathBuf> {
+    Some(dirs::config_dir()?.join("forge").join("mcp-servers.json"))
+}
+
+/// Read and parse the discovery file. Tolerant of a missing or malformed file
+/// (→ empty list) — discovery is a best-effort convenience, never an error.
+///
+/// A file whose `version` is newer than [`DISCOVERY_VERSION`] is still parsed
+/// best-effort: unknown fields are ignored and entries that fail to deserialize
+/// are dropped, so a forward-compatible producer never breaks an older consumer.
+pub fn read_discovered_servers() -> Vec<DiscoveredMcpServer> {
+    match forge_discovery_path() {
+        Some(path) => read_discovered_servers_at(&path),
+        None => Vec::new(),
+    }
+}
+
+/// [`read_discovered_servers`] against an explicit path (testable).
+pub fn read_discovered_servers_at(path: &std::path::Path) -> Vec<DiscoveredMcpServer> {
+    let Ok(raw) = std::fs::read_to_string(path) else {
+        return Vec::new();
+    };
+    match serde_json::from_str::<DiscoveryFile>(&raw) {
+        Ok(file) => file.servers,
+        Err(_) => Vec::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    /// The exact file content the live Agent Vault producer writes (from the
+    /// frozen contract) must parse into one usable entry.
+    const LIVE_CONTRACT_JSON: &str = r#"{
+      "version": 1,
+      "servers": [{
+        "name": "agent-vault",
+        "display_name": "Agent Vault",
+        "transport": "streamable-http",
+        "url": "http://127.0.0.1:3456/mcp",
+        "auth": { "scheme": "loopback-grant", "grant_url": "http://127.0.0.1:3456/grant" },
+        "metadata_url": "http://127.0.0.1:3456/.well-known/mcp"
+      }]
+    }"#;
+
+    fn write_tmp(content: &str) -> tempfile::NamedTempFile {
+        let mut f = tempfile::NamedTempFile::new().expect("temp file");
+        f.write_all(content.as_bytes()).expect("write");
+        f.flush().expect("flush");
+        f
+    }
+
+    #[test]
+    fn parses_the_frozen_live_contract() {
+        let f = write_tmp(LIVE_CONTRACT_JSON);
+        let servers = read_discovered_servers_at(f.path());
+        assert_eq!(servers.len(), 1);
+        let s = &servers[0];
+        assert_eq!(s.name, "agent-vault");
+        assert_eq!(s.label(), "Agent Vault");
+        assert_eq!(s.url, "http://127.0.0.1:3456/mcp");
+        assert_eq!(s.metadata_url, "http://127.0.0.1:3456/.well-known/mcp");
+        assert!(s.uses_loopback_grant());
+        assert_eq!(
+            s.auth.grant_url.as_deref(),
+            Some("http://127.0.0.1:3456/grant")
+        );
+    }
+
+    #[test]
+    fn missing_file_yields_no_servers_not_an_error() {
+        let servers =
+            read_discovered_servers_at(std::path::Path::new("/nonexistent/forge/mcp-servers.json"));
+        assert!(servers.is_empty());
+    }
+
+    #[test]
+    fn corrupt_file_yields_no_servers() {
+        let f = write_tmp("{ not valid json …");
+        assert!(read_discovered_servers_at(f.path()).is_empty());
+    }
+
+    #[test]
+    fn label_falls_back_to_name_without_display_name() {
+        let f = write_tmp(
+            r#"{"version":1,"servers":[{"name":"foundry-x","transport":"streamable-http",
+              "url":"http://127.0.0.1:9/mcp","auth":{"scheme":"none"},
+              "metadata_url":"http://127.0.0.1:9/.well-known/mcp"}]}"#,
+        );
+        let servers = read_discovered_servers_at(f.path());
+        assert_eq!(servers.len(), 1);
+        assert_eq!(servers[0].label(), "foundry-x");
+        // `auth.scheme = none` is not a loopback-grant server.
+        assert!(!servers[0].uses_loopback_grant());
+    }
+
+    #[test]
+    fn preserves_multiple_servers_and_ignores_unknown_fields() {
+        // Forward-compat: a newer producer may add fields/versions; we ignore
+        // unknowns and still read every well-formed entry.
+        let f = write_tmp(
+            r#"{"version":2,"extra":"ignored","servers":[
+              {"name":"a","transport":"streamable-http","url":"http://127.0.0.1:1/mcp",
+               "auth":{"scheme":"loopback-grant","grant_url":"http://127.0.0.1:1/grant"},
+               "metadata_url":"http://127.0.0.1:1/.well-known/mcp","future":true},
+              {"name":"b","transport":"streamable-http","url":"http://127.0.0.1:2/mcp",
+               "auth":{"scheme":"none"},"metadata_url":"http://127.0.0.1:2/.well-known/mcp"}
+            ]}"#,
+        );
+        let servers = read_discovered_servers_at(f.path());
+        assert_eq!(
+            servers.iter().map(|s| s.name.as_str()).collect::<Vec<_>>(),
+            ["a", "b"]
+        );
+    }
+}

--- a/crates/wcore-config/src/lib.rs
+++ b/crates/wcore-config/src/lib.rs
@@ -28,6 +28,7 @@ pub mod debug;
 // v0.9.0 W4 E1 / S-H3: atomic .env writer with strict key/value validation.
 pub mod env_file;
 pub mod file_cache;
+pub mod forge_discovery;
 pub mod hooks;
 // v0.7.0 Task 1.B.1: convenience facade over `keyring` for `wayland init` + channels.
 pub mod keychain;

--- a/crates/wcore-config/src/lib.rs
+++ b/crates/wcore-config/src/lib.rs
@@ -32,6 +32,7 @@ pub mod forge_discovery;
 pub mod hooks;
 // v0.7.0 Task 1.B.1: convenience facade over `keyring` for `wayland init` + channels.
 pub mod keychain;
+pub mod mcp_cred_refs;
 pub mod plan;
 pub mod plugins_config;
 pub mod shell;

--- a/crates/wcore-config/src/mcp_cred_refs.rs
+++ b/crates/wcore-config/src/mcp_cred_refs.rs
@@ -1,0 +1,320 @@
+//! `${cred:KEY}` credential-reference resolution for MCP server headers
+//! (Slice 3, Piece 2).
+//!
+//! MCP `[mcp.servers.*]` `headers` in `config.toml` are literal strings. To keep
+//! a bearer token OUT of `config.toml`, a header value may embed a reference of
+//! the form `${cred:KEY}`, e.g.
+//!
+//! ```toml
+//! [mcp.servers.agent-vault]
+//! transport = "streamable-http"
+//! url = "http://127.0.0.1:3456/mcp"
+//! allow_local = true
+//! [mcp.servers.agent-vault.headers]
+//! Authorization = "Bearer ${cred:mcp:agent-vault:token}"
+//! ```
+//!
+//! The literal `${cred:...}` stays on disk; the real secret is looked up from
+//! the [`CredentialsStore`] and substituted in **at the connect boundary, on a
+//! clone** of the server map — never written back into the long-lived in-memory
+//! `Config`, so an accidental re-serialize can't leak the token to disk. `KEY`
+//! is everything between `${cred:` and the next `}` (so it may itself contain
+//! `:`, as the `mcp:<server>:token` convention does).
+//!
+//! A server whose header carries no `${cred:` reference is passed through
+//! untouched and never touches the store — existing literal-header MCP servers
+//! are unaffected even when the store is empty or locked.
+
+use std::collections::HashMap;
+
+use crate::config::McpServerConfig;
+use crate::credentials::{CredentialsError, CredentialsStore};
+
+/// Marker that opens a credential reference: `${cred:KEY}`.
+const CRED_PREFIX: &str = "${cred:";
+
+/// The recommended credentials-store key for a Forge MCP server's bearer token.
+/// Namespaced per server so two discovered servers never collide.
+pub fn mcp_token_cred_key(server_name: &str) -> String {
+    format!("mcp:{server_name}:token")
+}
+
+/// Build the `[mcp.servers.<name>]` config for a Forge loopback server: a
+/// `streamable-http` server at `url`, `allow_local = true` (it lives on
+/// 127.0.0.1), and an `Authorization` header whose value is a `${cred:KEY}`
+/// reference — so the bearer token is stored in the credentials store and the
+/// config file only ever carries the reference, never the secret.
+pub fn build_forge_mcp_server_config(url: &str, cred_key: &str) -> McpServerConfig {
+    let mut headers = HashMap::new();
+    headers.insert(
+        "Authorization".to_string(),
+        format!("Bearer ${{cred:{cred_key}}}"),
+    );
+    McpServerConfig {
+        transport: crate::config::TransportType::StreamableHttp,
+        command: None,
+        args: None,
+        env: None,
+        url: Some(url.to_string()),
+        headers: Some(headers),
+        deferred: None,
+        allow_local: true,
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum CredRefError {
+    /// The referenced key is not present in the credentials store.
+    #[error("credential reference ${{cred:{key}}} not found in the credentials store")]
+    Missing { key: String },
+    /// The store itself errored (e.g. keyring locked) while looking the key up.
+    #[error("credentials store error resolving ${{cred:{key}}}: {source}")]
+    Store {
+        key: String,
+        #[source]
+        source: CredentialsError,
+    },
+    /// A `${cred:` opener with no closing `}`.
+    #[error("malformed credential reference (unterminated `${{cred:...}}`) in header value")]
+    Malformed,
+}
+
+/// Substitute every `${cred:KEY}` occurrence in `value` with the secret stored
+/// under `KEY`. A value with no reference is returned unchanged (the store is
+/// never consulted). Fails closed: a missing key or store error aborts the whole
+/// value rather than emitting a half-resolved or empty bearer.
+pub fn resolve_cred_refs(
+    value: &str,
+    store: &dyn CredentialsStore,
+) -> Result<String, CredRefError> {
+    if !value.contains(CRED_PREFIX) {
+        return Ok(value.to_string());
+    }
+    let mut out = String::with_capacity(value.len());
+    let mut rest = value;
+    while let Some(start) = rest.find(CRED_PREFIX) {
+        out.push_str(&rest[..start]);
+        let after = &rest[start + CRED_PREFIX.len()..];
+        let end = after.find('}').ok_or(CredRefError::Malformed)?;
+        let key = &after[..end];
+        let secret = store
+            .get(key)
+            .map_err(|source| CredRefError::Store {
+                key: key.to_string(),
+                source,
+            })?
+            .ok_or_else(|| CredRefError::Missing {
+                key: key.to_string(),
+            })?;
+        out.push_str(&secret);
+        rest = &after[end + 1..];
+    }
+    out.push_str(rest);
+    Ok(out)
+}
+
+/// Resolve `${cred:KEY}` references in every header value of one server, in
+/// place. Used by the single-server live-add path where a resolution failure is
+/// a hard error the user sees (they just asked to connect this server).
+pub fn resolve_server_headers(
+    server: &mut McpServerConfig,
+    store: &dyn CredentialsStore,
+) -> Result<(), CredRefError> {
+    if let Some(headers) = server.headers.as_mut() {
+        for v in headers.values_mut() {
+            if v.contains(CRED_PREFIX) {
+                *v = resolve_cred_refs(v, store)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Build a connect-ready clone of a server map with all `${cred:KEY}` header
+/// references resolved. Best-effort per server: a server whose reference cannot
+/// be resolved is left with its literal header (a warning is logged) so it fails
+/// its own connect in isolation instead of blocking every other server at boot.
+/// The input map (the long-lived `Config`) is never mutated.
+pub fn resolve_servers_for_connect(
+    servers: &HashMap<String, McpServerConfig>,
+    store: &dyn CredentialsStore,
+) -> HashMap<String, McpServerConfig> {
+    let mut out = servers.clone();
+    for (name, server) in out.iter_mut() {
+        if let Err(e) = resolve_server_headers(server, store) {
+            tracing::warn!(
+                server = %name,
+                error = %e,
+                "MCP server credential reference did not resolve; \
+                 connecting with the literal header (its own connect will fail \
+                 if the header is required)"
+            );
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::TransportType;
+
+    /// A trivial in-memory store so resolution is testable without a backend.
+    #[derive(Default)]
+    struct MapStore(HashMap<String, String>);
+    impl MapStore {
+        fn with(key: &str, val: &str) -> Self {
+            let mut m = HashMap::new();
+            m.insert(key.to_string(), val.to_string());
+            Self(m)
+        }
+    }
+    impl CredentialsStore for MapStore {
+        fn get(&self, key: &str) -> Result<Option<String>, CredentialsError> {
+            Ok(self.0.get(key).cloned())
+        }
+        fn put(&self, _: &str, _: &str) -> Result<(), CredentialsError> {
+            Ok(())
+        }
+        fn delete(&self, _: &str) -> Result<(), CredentialsError> {
+            Ok(())
+        }
+    }
+
+    fn http_server(header_val: &str) -> McpServerConfig {
+        let mut headers = HashMap::new();
+        headers.insert("Authorization".to_string(), header_val.to_string());
+        McpServerConfig {
+            transport: TransportType::StreamableHttp,
+            command: None,
+            args: None,
+            env: None,
+            url: Some("http://127.0.0.1:3456/mcp".to_string()),
+            headers: Some(headers),
+            deferred: None,
+            allow_local: true,
+        }
+    }
+
+    #[test]
+    fn resolves_a_single_reference_inside_a_bearer() {
+        let store = MapStore::with("mcp:agent-vault:token", "secret-xyz");
+        let got = resolve_cred_refs("Bearer ${cred:mcp:agent-vault:token}", &store).unwrap();
+        assert_eq!(got, "Bearer secret-xyz");
+    }
+
+    #[test]
+    fn key_may_contain_colons() {
+        // The `mcp:<server>:token` convention puts colons inside KEY; resolution
+        // must stop at `}`, not at the first `:`.
+        let store = MapStore::with("mcp:a:b:c:token", "deep");
+        assert_eq!(
+            resolve_cred_refs("${cred:mcp:a:b:c:token}", &store).unwrap(),
+            "deep"
+        );
+    }
+
+    #[test]
+    fn resolves_multiple_references_in_one_value() {
+        let mut m = HashMap::new();
+        m.insert("k1".to_string(), "A".to_string());
+        m.insert("k2".to_string(), "B".to_string());
+        let store = MapStore(m);
+        assert_eq!(
+            resolve_cred_refs("${cred:k1}-${cred:k2}", &store).unwrap(),
+            "A-B"
+        );
+    }
+
+    #[test]
+    fn value_without_reference_is_passed_through_without_touching_store() {
+        // Empty store: a literal header must still resolve fine (no lookup).
+        let store = MapStore::default();
+        assert_eq!(
+            resolve_cred_refs("Bearer static-token", &store).unwrap(),
+            "Bearer static-token"
+        );
+    }
+
+    #[test]
+    fn missing_key_fails_closed() {
+        let store = MapStore::default();
+        match resolve_cred_refs("Bearer ${cred:absent}", &store) {
+            Err(CredRefError::Missing { key }) => assert_eq!(key, "absent"),
+            other => panic!("expected Missing, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unterminated_reference_is_malformed() {
+        let store = MapStore::with("k", "v");
+        assert!(matches!(
+            resolve_cred_refs("Bearer ${cred:k", &store),
+            Err(CredRefError::Malformed)
+        ));
+    }
+
+    #[test]
+    fn resolve_server_headers_rewrites_in_place() {
+        let store = MapStore::with("mcp:agent-vault:token", "tok");
+        let mut server = http_server("Bearer ${cred:mcp:agent-vault:token}");
+        resolve_server_headers(&mut server, &store).unwrap();
+        assert_eq!(
+            server.headers.unwrap().get("Authorization").unwrap(),
+            "Bearer tok"
+        );
+    }
+
+    #[test]
+    fn map_resolver_is_best_effort_and_leaves_input_untouched() {
+        let store = MapStore::with("mcp:ok:token", "good");
+        let mut servers = HashMap::new();
+        servers.insert("ok".to_string(), http_server("Bearer ${cred:mcp:ok:token}"));
+        servers.insert(
+            "broken".to_string(),
+            http_server("Bearer ${cred:mcp:broken:token}"),
+        );
+
+        let resolved = resolve_servers_for_connect(&servers, &store);
+
+        // The resolvable server is concrete...
+        assert_eq!(
+            resolved["ok"].headers.as_ref().unwrap()["Authorization"],
+            "Bearer good"
+        );
+        // ...the broken one keeps its literal (fails its own connect later)...
+        assert_eq!(
+            resolved["broken"].headers.as_ref().unwrap()["Authorization"],
+            "Bearer ${cred:mcp:broken:token}"
+        );
+        // ...and the input map was never mutated.
+        assert_eq!(
+            servers["ok"].headers.as_ref().unwrap()["Authorization"],
+            "Bearer ${cred:mcp:ok:token}"
+        );
+    }
+
+    #[test]
+    fn token_cred_key_is_namespaced_per_server() {
+        assert_eq!(mcp_token_cred_key("agent-vault"), "mcp:agent-vault:token");
+    }
+
+    #[test]
+    fn forge_server_config_carries_a_cred_ref_not_a_secret() {
+        let key = mcp_token_cred_key("agent-vault");
+        let cfg = build_forge_mcp_server_config("http://127.0.0.1:3456/mcp", &key);
+        assert_eq!(cfg.transport, TransportType::StreamableHttp);
+        assert!(cfg.allow_local);
+        assert_eq!(cfg.url.as_deref(), Some("http://127.0.0.1:3456/mcp"));
+        let auth = &cfg.headers.as_ref().unwrap()["Authorization"];
+        assert_eq!(auth, "Bearer ${cred:mcp:agent-vault:token}");
+        // The on-disk value must be a reference, never a literal token.
+        assert!(auth.contains("${cred:"));
+
+        // And it round-trips back through the resolver with the real token.
+        let store = MapStore::with(&key, "live-token");
+        let mut cfg2 = cfg;
+        resolve_server_headers(&mut cfg2, &store).unwrap();
+        assert_eq!(cfg2.headers.unwrap()["Authorization"], "Bearer live-token");
+    }
+}

--- a/crates/wcore-config/tests/hermeticity_audit_test.rs
+++ b/crates/wcore-config/tests/hermeticity_audit_test.rs
@@ -38,6 +38,13 @@ const ALLOWLIST: &[&str] = &[
     // `wayland_config_dir()` would make it look in the sandbox and never find
     // the user's real Claude install. Read-only; writes no Wayland state.
     "crates/wcore-cli/src/tui/surfaces/diagnostics.rs",
+    // Forge cross-app MCP discovery: the `<config_dir>/forge/mcp-servers.json`
+    // file is a convention written by *other* Forge-suite apps (Agent Vault,
+    // future Foundry tools) about the REAL machine — deliberately NOT
+    // `WAYLAND_HOME`-scoped, exactly like the Claude-Desktop MCP discovery. It
+    // is read-only and never writes Wayland state, so it does not break
+    // hermeticity. See the module doc in `forge_discovery.rs` for the rationale.
+    "crates/wcore-config/src/forge_discovery.rs",
 ];
 
 fn workspace_root() -> PathBuf {

--- a/crates/wcore-mcp/Cargo.toml
+++ b/crates/wcore-mcp/Cargo.toml
@@ -42,3 +42,6 @@ wcore-mcp = { path = ".", features = ["test-utils"] }
 tokio-util.workspace = true
 tempfile.workspace = true
 serial_test.workspace = true
+# Slice 3 — forge_grant.rs mocks the producer's /.well-known/mcp + /grant
+# endpoints to verify the liveness probe + grant status mapping.
+wiremock.workspace = true

--- a/crates/wcore-mcp/src/forge_grant.rs
+++ b/crates/wcore-mcp/src/forge_grant.rs
@@ -1,0 +1,364 @@
+//! Forge local-MCP grant client — consumer side (Slice 3, Piece 1).
+//!
+//! Once [`wcore_config::forge_discovery`] has surfaced a discovered Forge server,
+//! this module performs the two unauthenticated bootstrap HTTP calls that turn a
+//! *hint* into a *connectable, authorized* server:
+//!
+//! 1. [`probe_metadata`] — `GET <metadata_url>` liveness check. A discovery
+//!    entry is only a hint (a producer crash leaves a stale entry), so we never
+//!    offer to connect until a `200` whose `name` matches the entry proves the
+//!    server is alive and is who it claims to be.
+//! 2. [`request_grant`] — `POST <grant_url>` to mint a scoped bearer token. The
+//!    `200` path only returns *after the user clicks Approve* in the producer's
+//!    GUI; everything else (deny / bad scopes / rate-limit) is mapped to a
+//!    structured [`GrantOutcome`] the caller surfaces without treating it as a
+//!    hard crash.
+//!
+//! Wire contract is frozen + live-verified by the producer (Agent Vault):
+//! `.audit/waylandcore-mcp-fix/FORGE-MCP-DISCOVERY-SPEC.md` §2 (metadata) / §3
+//! (grant). Do NOT change the shapes here.
+//!
+//! ## Network boundary
+//! Every request goes through an [`wcore_egress::EgressClient`] built with the
+//! **loopback-permitting** SSRF policy ([`loopback_http_client`]), mirroring
+//! [`crate::transport::streamable_http`]'s `allow_local` branch: the resolver +
+//! redirect policy dial `127.0.0.1`/`::1` but keep every other private / LAN /
+//! link-local / CGNAT / cloud-metadata range blocked. We additionally gate each
+//! URL through [`is_safe_url_allow_loopback`](wcore_tools::url_safety::is_safe_url_allow_loopback)
+//! *before* sending, failing closed on a non-loopback private target — a Forge
+//! server is always on loopback, so a discovery file pointing anywhere else is
+//! rejected, not dialed.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde::Deserialize;
+
+use wcore_tools::url_safety::{
+    LoopbackOkResolver, is_safe_url_allow_loopback, ssrf_safe_redirect_policy_allow_loopback,
+};
+
+/// Liveness/metadata response from `GET <metadata_url>` (spec §2).
+///
+/// Tolerant: only `name` is required (it is what we name-match against the
+/// discovery entry). Unknown fields are ignored so a newer producer never
+/// breaks an older consumer.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct Metadata {
+    /// Stable machine id — must equal the discovery entry's `name`.
+    pub name: String,
+    /// Human label (producer may localize/rename).
+    #[serde(default)]
+    pub display_name: Option<String>,
+    /// Number of tools the server currently exposes (display-only).
+    #[serde(default)]
+    pub tool_count: Option<u32>,
+}
+
+/// Outcome of a `POST <grant_url>` token request (spec §3).
+///
+/// Every non-200 is a *recoverable* outcome the UI surfaces as guidance, not a
+/// transport crash — a denied grant means "ask again with Approve", a 400 means
+/// "fix the scopes", a 429 means "back off".
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GrantOutcome {
+    /// `200` — user clicked Approve. Carries the bearer token + granted scopes
+    /// (server-clamped to a subset of `read`/`write`).
+    Granted { token: String, scopes: Vec<String> },
+    /// `403` — denied, timed out, or no UI present (deny-by-default).
+    Denied,
+    /// `400` — empty/invalid scopes. Carries the server's human message.
+    BadScopes(String),
+    /// `429` — grant rate-limit (~10/min/peer). Back off; do not hammer.
+    RateLimited,
+    /// Any other status, a non-loopback/SSRF-rejected URL, a transport failure,
+    /// or an unparseable success body. Carries a diagnostic string.
+    Error(String),
+}
+
+/// Error envelope shape the producer returns on 4xx (`{"error": "..."}`).
+#[derive(Debug, Deserialize)]
+struct ErrorBody {
+    #[serde(default)]
+    error: Option<String>,
+}
+
+/// Successful grant body (`{"token": "...", "scopes": ["read","write"]}`).
+#[derive(Debug, Deserialize)]
+struct GrantBody {
+    token: String,
+    #[serde(default)]
+    scopes: Vec<String>,
+}
+
+/// Build the loopback-permitting HTTP client used for the metadata + grant
+/// calls. Short timeouts (a local server answers in milliseconds; a stale entry
+/// must fail fast, not hang the connect flow). Mirrors the `allow_local` branch
+/// of [`crate::transport::streamable_http::StreamableHttpTransport::connect`].
+pub fn loopback_http_client() -> wcore_egress::EgressClient {
+    wcore_egress::EgressClient::builder()
+        .connect_timeout(Duration::from_secs(5))
+        .timeout(Duration::from_secs(10))
+        .redirect(ssrf_safe_redirect_policy_allow_loopback())
+        .dns_resolver(Arc::new(LoopbackOkResolver))
+        .build()
+        .unwrap_or_else(|_| wcore_egress::EgressClient::new())
+}
+
+/// `GET <metadata_url>` and confirm the server is alive AND is the server the
+/// discovery entry named.
+///
+/// Returns `Some(metadata)` only on a `200` whose `name` equals `expected_name`.
+/// Any non-200, a name mismatch, a non-loopback URL, a transport failure, or an
+/// unparseable body → `None` (treat the discovery entry as stale; do not offer
+/// to connect).
+pub async fn probe_metadata(
+    client: &wcore_egress::EgressClient,
+    metadata_url: &str,
+    expected_name: &str,
+) -> Option<Metadata> {
+    if !is_safe_url_allow_loopback(metadata_url) {
+        return None;
+    }
+    let resp = client.get(metadata_url).send().await.ok()?;
+    if !resp.status().is_success() {
+        return None;
+    }
+    let meta = resp.json::<Metadata>().await.ok()?;
+    (meta.name == expected_name).then_some(meta)
+}
+
+/// `POST <grant_url>` with `{client_name, scopes}` and map the response to a
+/// [`GrantOutcome`] (spec §3).
+///
+/// `client_name` is displayed-but-untrusted by the producer — it is shown to the
+/// user verbatim in the Approve modal. `scopes` is clamped server-side to a
+/// subset of `read`/`write`.
+pub async fn request_grant(
+    client: &wcore_egress::EgressClient,
+    grant_url: &str,
+    client_name: &str,
+    scopes: &[&str],
+) -> GrantOutcome {
+    if !is_safe_url_allow_loopback(grant_url) {
+        return GrantOutcome::Error(format!(
+            "grant url rejected — resolves to a non-loopback/internal address \
+             (SSRF guard): {grant_url}"
+        ));
+    }
+
+    let body = serde_json::json!({ "client_name": client_name, "scopes": scopes });
+    let resp = match client.post(grant_url).json(&body).send().await {
+        Ok(r) => r,
+        Err(e) => return GrantOutcome::Error(format!("grant request failed: {e}")),
+    };
+
+    let status = resp.status().as_u16();
+    match status {
+        200 => match resp.json::<GrantBody>().await {
+            Ok(g) => GrantOutcome::Granted {
+                token: g.token,
+                scopes: g.scopes,
+            },
+            Err(e) => GrantOutcome::Error(format!("grant 200 but unparseable body: {e}")),
+        },
+        403 => GrantOutcome::Denied,
+        400 => {
+            let msg = resp
+                .json::<ErrorBody>()
+                .await
+                .ok()
+                .and_then(|b| b.error)
+                .unwrap_or_else(|| "invalid scopes".to_string());
+            GrantOutcome::BadScopes(msg)
+        }
+        429 => GrantOutcome::RateLimited,
+        other => GrantOutcome::Error(format!("unexpected grant status {other}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::matchers::{body_partial_json, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    /// The frozen `GET /.well-known/mcp` shape (spec §2) with a matching name is
+    /// accepted and its display fields are surfaced.
+    #[tokio::test]
+    async fn probe_accepts_live_matching_server() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/.well-known/mcp"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "name": "agent-vault",
+                "display_name": "Agent Vault",
+                "version": "1.0.0",
+                "transport": "streamable-http",
+                "url": "http://127.0.0.1:3456/mcp",
+                "auth": { "scheme": "loopback-grant", "grant_url": "http://127.0.0.1:3456/grant" },
+                "tool_count": 13
+            })))
+            .mount(&server)
+            .await;
+
+        let client = loopback_http_client();
+        let url = format!("{}/.well-known/mcp", server.uri());
+        let meta = probe_metadata(&client, &url, "agent-vault").await;
+
+        let meta = meta.expect("a live matching server must probe Some");
+        assert_eq!(meta.name, "agent-vault");
+        assert_eq!(meta.display_name.as_deref(), Some("Agent Vault"));
+        assert_eq!(meta.tool_count, Some(13));
+    }
+
+    /// A live server whose `name` does NOT match the discovery entry is treated
+    /// as stale/impostor — `None`, never offered for connect.
+    #[tokio::test]
+    async fn probe_rejects_name_mismatch() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/.well-known/mcp"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "name": "some-other-app",
+                "tool_count": 1
+            })))
+            .mount(&server)
+            .await;
+
+        let client = loopback_http_client();
+        let url = format!("{}/.well-known/mcp", server.uri());
+        assert!(probe_metadata(&client, &url, "agent-vault").await.is_none());
+    }
+
+    /// A non-200 (server up but unhealthy / wrong route) → stale → `None`.
+    #[tokio::test]
+    async fn probe_rejects_non_200() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/.well-known/mcp"))
+            .respond_with(ResponseTemplate::new(503))
+            .mount(&server)
+            .await;
+
+        let client = loopback_http_client();
+        let url = format!("{}/.well-known/mcp", server.uri());
+        assert!(probe_metadata(&client, &url, "agent-vault").await.is_none());
+    }
+
+    /// A metadata URL that resolves off-loopback is rejected before any I/O —
+    /// the SSRF gate fails closed (no request is even attempted).
+    #[tokio::test]
+    async fn probe_rejects_non_loopback_url() {
+        let client = loopback_http_client();
+        let got = probe_metadata(
+            &client,
+            "http://169.254.169.254/.well-known/mcp",
+            "agent-vault",
+        )
+        .await;
+        assert!(got.is_none());
+    }
+
+    /// `200` after Approve → `Granted` with the token + clamped scopes, and the
+    /// request carries the frozen `{client_name, scopes}` body (spec §3).
+    #[tokio::test]
+    async fn grant_200_yields_token_and_sends_contract_body() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/grant"))
+            .and(body_partial_json(
+                json!({ "client_name": "Wayland Core", "scopes": ["read", "write"] }),
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "token": "abc123.base64url.bearer",
+                "scopes": ["read", "write"]
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = loopback_http_client();
+        let url = format!("{}/grant", server.uri());
+        let outcome = request_grant(&client, &url, "Wayland Core", &["read", "write"]).await;
+
+        assert_eq!(
+            outcome,
+            GrantOutcome::Granted {
+                token: "abc123.base64url.bearer".to_string(),
+                scopes: vec!["read".to_string(), "write".to_string()],
+            }
+        );
+    }
+
+    /// `403` (user denied / no UI / timeout) → `Denied`, not an error.
+    #[tokio::test]
+    async fn grant_403_is_denied() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/grant"))
+            .respond_with(
+                ResponseTemplate::new(403).set_body_json(json!({ "error": "Grant denied." })),
+            )
+            .mount(&server)
+            .await;
+
+        let client = loopback_http_client();
+        let url = format!("{}/grant", server.uri());
+        assert_eq!(
+            request_grant(&client, &url, "Wayland Core", &["read", "write"]).await,
+            GrantOutcome::Denied
+        );
+    }
+
+    /// `400` → `BadScopes` carrying the server's human message.
+    #[tokio::test]
+    async fn grant_400_is_bad_scopes_with_message() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/grant"))
+            .respond_with(ResponseTemplate::new(400).set_body_json(json!({
+                "error": "No valid scopes requested. Valid scopes: read, write."
+            })))
+            .mount(&server)
+            .await;
+
+        let client = loopback_http_client();
+        let url = format!("{}/grant", server.uri());
+        match request_grant(&client, &url, "Wayland Core", &[]).await {
+            GrantOutcome::BadScopes(msg) => assert!(msg.contains("Valid scopes")),
+            other => panic!("expected BadScopes, got {other:?}"),
+        }
+    }
+
+    /// `429` → `RateLimited` (caller backs off).
+    #[tokio::test]
+    async fn grant_429_is_rate_limited() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/grant"))
+            .respond_with(ResponseTemplate::new(429).set_body_json(json!({
+                "error": "Too many grant requests. Try again shortly."
+            })))
+            .mount(&server)
+            .await;
+
+        let client = loopback_http_client();
+        let url = format!("{}/grant", server.uri());
+        assert_eq!(
+            request_grant(&client, &url, "Wayland Core", &["read", "write"]).await,
+            GrantOutcome::RateLimited
+        );
+    }
+
+    /// An off-loopback grant URL is SSRF-rejected before any request.
+    #[tokio::test]
+    async fn grant_rejects_non_loopback_url() {
+        let client = loopback_http_client();
+        match request_grant(&client, "http://10.0.0.5/grant", "Wayland Core", &["read"]).await {
+            GrantOutcome::Error(msg) => assert!(msg.contains("SSRF") || msg.contains("loopback")),
+            other => panic!("expected SSRF Error, got {other:?}"),
+        }
+    }
+}

--- a/crates/wcore-mcp/src/lib.rs
+++ b/crates/wcore-mcp/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod config;
+pub mod forge_grant;
 pub mod manager;
 pub mod protocol;
 pub mod server;

--- a/crates/wcore-mcp/src/manager.rs
+++ b/crates/wcore-mcp/src/manager.rs
@@ -232,14 +232,14 @@ impl McpManager {
                     .as_deref()
                     .ok_or_else(|| McpError::InitFailed("SSE transport requires 'url'".into()))?;
                 let headers = config.headers.as_ref().unwrap_or(&empty_map);
-                Box::new(SseTransport::connect(url, headers).await?)
+                Box::new(SseTransport::connect(url, headers, config.allow_local).await?)
             }
             TransportType::StreamableHttp => {
                 let url = config.url.as_deref().ok_or_else(|| {
                     McpError::InitFailed("streamable-http transport requires 'url'".into())
                 })?;
                 let headers = config.headers.as_ref().unwrap_or(&empty_map);
-                Box::new(StreamableHttpTransport::connect(url, headers).await?)
+                Box::new(StreamableHttpTransport::connect(url, headers, config.allow_local).await?)
             }
         };
 
@@ -916,6 +916,7 @@ mod tests {
             url: None,
             headers: None,
             deferred: None,
+            allow_local: false,
         };
         let mut configs = HashMap::new();
         configs.insert("hung-server".to_string(), hung);
@@ -953,6 +954,7 @@ mod tests {
             url: None,
             headers: None,
             deferred: None,
+            allow_local: false,
         };
         // A real MCP handshake fixture: answer initialize + tools/list.
         let healthy_script = r#"
@@ -971,6 +973,7 @@ mod tests {
             url: None,
             headers: None,
             deferred: None,
+            allow_local: false,
         };
         let mut configs = HashMap::new();
         configs.insert("hung".to_string(), hung);
@@ -1004,6 +1007,7 @@ mod tests {
             url: None,
             headers: None,
             deferred: None,
+            allow_local: false,
         };
         let mut configs = HashMap::new();
         configs.insert("hung".to_string(), hung);
@@ -1037,6 +1041,7 @@ mod tests {
             url: None,
             headers: None,
             deferred: None,
+            allow_local: false,
         };
         let mut configs = HashMap::new();
         configs.insert("broken".to_string(), broken);
@@ -1077,6 +1082,7 @@ mod tests {
             url: None,
             headers: None,
             deferred: None,
+            allow_local: false,
         };
         let hung = McpServerConfig {
             transport: TransportType::Stdio,
@@ -1086,6 +1092,7 @@ mod tests {
             url: None,
             headers: None,
             deferred: None,
+            allow_local: false,
         };
         let mut configs = HashMap::new();
         configs.insert("healthy".to_string(), healthy);

--- a/crates/wcore-mcp/src/tool_proxy.rs
+++ b/crates/wcore-mcp/src/tool_proxy.rs
@@ -289,6 +289,7 @@ mod tests {
             url: None,
             headers: None,
             deferred,
+            allow_local: false,
         }
     }
 

--- a/crates/wcore-mcp/src/transport/sse.rs
+++ b/crates/wcore-mcp/src/transport/sse.rs
@@ -39,8 +39,12 @@ pub struct SseTransport {
 
 impl SseTransport {
     /// Connect to an SSE MCP server.
-    pub async fn connect(url: &str, headers: &HashMap<String, String>) -> Result<Self, McpError> {
-        Self::connect_with_timeout(url, headers, SSE_REQUEST_TIMEOUT).await
+    pub async fn connect(
+        url: &str,
+        headers: &HashMap<String, String>,
+        allow_local: bool,
+    ) -> Result<Self, McpError> {
+        Self::connect_with_timeout(url, headers, SSE_REQUEST_TIMEOUT, allow_local).await
     }
 
     /// [`connect`](Self::connect) with an explicit per-request timeout.
@@ -50,6 +54,7 @@ impl SseTransport {
         url: &str,
         headers: &HashMap<String, String>,
         request_timeout: std::time::Duration,
+        allow_local: bool,
     ) -> Result<Self, McpError> {
         // M-13 (SSRF) — validate the configured URL before we attach any
         // secret-bearing header and open a connection to it. `is_safe_url`
@@ -57,7 +62,16 @@ impl SseTransport {
         // failure, so a server configured at `http://169.254.169.254/...`
         // (or a hostname that resolves there) is rejected at connect time
         // rather than becoming an SSRF primitive.
-        if !wcore_tools::url_safety::is_safe_url(url) {
+        //
+        // `allow_local` (per-server config) relaxes the LOOPBACK block only,
+        // for trusted user-configured local MCP servers. Every other private/
+        // internal/metadata range stays blocked.
+        let url_ok = if allow_local {
+            wcore_tools::url_safety::is_safe_url_allow_loopback(url)
+        } else {
+            wcore_tools::url_safety::is_safe_url(url)
+        };
+        if !url_ok {
             return Err(McpError::Transport(format!(
                 "SSE MCP url rejected — resolves to a private or internal \
                  network address (SSRF guard): {url}"
@@ -97,13 +111,26 @@ impl SseTransport {
         // re-resolves the host at connect time; `SsrfSafeResolver` makes
         // reqwest dial only validated public IPs (no check→connect rebind
         // window) for the initial GET and every redirect hop.
-        let client = wcore_egress::EgressClient::builder()
+        // allow_local swaps in the loopback-permitting redirect policy +
+        // resolver so reqwest can dial 127.0.0.1/::1 for a trusted local SSE
+        // server; both variants keep every non-loopback SSRF protection.
+        let builder = wcore_egress::EgressClient::builder()
             .pool_idle_timeout(std::time::Duration::from_secs(5))
-            .connect_timeout(std::time::Duration::from_secs(15))
-            .redirect(wcore_tools::url_safety::ssrf_safe_redirect_policy())
-            .dns_resolver(std::sync::Arc::new(
-                wcore_tools::url_safety::SsrfSafeResolver,
-            ))
+            .connect_timeout(std::time::Duration::from_secs(15));
+        let builder = if allow_local {
+            builder
+                .redirect(wcore_tools::url_safety::ssrf_safe_redirect_policy_allow_loopback())
+                .dns_resolver(std::sync::Arc::new(
+                    wcore_tools::url_safety::LoopbackOkResolver,
+                ))
+        } else {
+            builder
+                .redirect(wcore_tools::url_safety::ssrf_safe_redirect_policy())
+                .dns_resolver(std::sync::Arc::new(
+                    wcore_tools::url_safety::SsrfSafeResolver,
+                ))
+        };
+        let client = builder
             .build()
             .unwrap_or_else(|_| wcore_egress::EgressClient::new());
 

--- a/crates/wcore-mcp/src/transport/streamable_http.rs
+++ b/crates/wcore-mcp/src/transport/streamable_http.rs
@@ -28,11 +28,25 @@ pub struct StreamableHttpTransport {
 
 impl StreamableHttpTransport {
     /// Create a new Streamable HTTP transport
-    pub async fn connect(url: &str, headers: &HashMap<String, String>) -> Result<Self, McpError> {
+    pub async fn connect(
+        url: &str,
+        headers: &HashMap<String, String>,
+        allow_local: bool,
+    ) -> Result<Self, McpError> {
         // M-13 (SSRF) — validate the configured URL before attaching any
         // secret-bearing header. `is_safe_url` fails closed on
         // private/internal/metadata targets and on DNS failure.
-        if !wcore_tools::url_safety::is_safe_url(url) {
+        //
+        // `allow_local` (per-server config) relaxes the LOOPBACK block only,
+        // for trusted user-configured local MCP servers — an MCP endpoint is
+        // trusted configuration, not a model-driven URL. Every other private/
+        // internal/metadata range stays blocked.
+        let url_ok = if allow_local {
+            wcore_tools::url_safety::is_safe_url_allow_loopback(url)
+        } else {
+            wcore_tools::url_safety::is_safe_url(url)
+        };
+        if !url_ok {
             return Err(McpError::Transport(format!(
                 "Streamable-HTTP MCP url rejected — resolves to a private or \
                  internal network address (SSRF guard): {url}"
@@ -70,14 +84,28 @@ impl StreamableHttpTransport {
         // re-resolves the host at connect time; `SsrfSafeResolver` makes
         // reqwest dial only validated public IPs (no check→connect rebind
         // window) for the initial request and every redirect hop.
-        let client = wcore_egress::EgressClient::builder()
+        // When allow_local is set, use the loopback-permitting redirect policy
+        // and resolver so reqwest can actually dial 127.0.0.1/::1 (the default
+        // SsrfSafeResolver drops loopback at connect time). Both variants keep
+        // every non-loopback SSRF protection intact.
+        let builder = wcore_egress::EgressClient::builder()
             .pool_idle_timeout(std::time::Duration::from_secs(5))
             .connect_timeout(std::time::Duration::from_secs(15))
-            .timeout(std::time::Duration::from_secs(120))
-            .redirect(wcore_tools::url_safety::ssrf_safe_redirect_policy())
-            .dns_resolver(std::sync::Arc::new(
-                wcore_tools::url_safety::SsrfSafeResolver,
-            ))
+            .timeout(std::time::Duration::from_secs(120));
+        let builder = if allow_local {
+            builder
+                .redirect(wcore_tools::url_safety::ssrf_safe_redirect_policy_allow_loopback())
+                .dns_resolver(std::sync::Arc::new(
+                    wcore_tools::url_safety::LoopbackOkResolver,
+                ))
+        } else {
+            builder
+                .redirect(wcore_tools::url_safety::ssrf_safe_redirect_policy())
+                .dns_resolver(std::sync::Arc::new(
+                    wcore_tools::url_safety::SsrfSafeResolver,
+                ))
+        };
+        let client = builder
             .build()
             .unwrap_or_else(|_| wcore_egress::EgressClient::new());
 
@@ -307,7 +335,7 @@ mod tests {
     #[tokio::test]
     async fn connect_rejects_metadata_ip_url() {
         let headers = HashMap::new();
-        let err = StreamableHttpTransport::connect("http://169.254.169.254/mcp", &headers)
+        let err = StreamableHttpTransport::connect("http://169.254.169.254/mcp", &headers, false)
             .await
             .expect_err("metadata-IP url must be rejected at connect");
         let msg = err.to_string();
@@ -317,14 +345,32 @@ mod tests {
         );
     }
 
-    /// M-13 — a loopback URL is likewise rejected (SSRF to localhost
-    /// services).
+    /// M-13 — a loopback URL is rejected by default (allow_local = false).
     #[tokio::test]
     async fn connect_rejects_loopback_url() {
         let headers = HashMap::new();
-        let err = StreamableHttpTransport::connect("http://127.0.0.1:8080/mcp", &headers)
+        let err = StreamableHttpTransport::connect("http://127.0.0.1:8080/mcp", &headers, false)
             .await
-            .expect_err("loopback url must be rejected at connect");
+            .expect_err("loopback url must be rejected at connect when allow_local=false");
+        assert!(
+            err.to_string().contains("private or internal") || err.to_string().contains("SSRF")
+        );
+    }
+
+    /// allow_local = true: a loopback URL passes the SSRF gate (connect does no
+    /// network I/O, so it returns Ok), enabling trusted local MCP servers like
+    /// Agent Vault on 127.0.0.1. A metadata/private IP must STILL be rejected
+    /// even with allow_local set.
+    #[tokio::test]
+    async fn connect_allows_loopback_when_allow_local() {
+        let headers = HashMap::new();
+        StreamableHttpTransport::connect("http://127.0.0.1:3456/mcp", &headers, true)
+            .await
+            .expect("loopback url must be accepted at connect when allow_local=true");
+
+        let err = StreamableHttpTransport::connect("http://169.254.169.254/mcp", &headers, true)
+            .await
+            .expect_err("metadata IP must stay blocked even when allow_local=true");
         assert!(
             err.to_string().contains("private or internal") || err.to_string().contains("SSRF")
         );

--- a/crates/wcore-mcp/tests/mcp_integration.rs
+++ b/crates/wcore-mcp/tests/mcp_integration.rs
@@ -196,6 +196,7 @@ async fn handshake_success_discovers_tools() {
             url: None,
             headers: None,
             deferred: None,
+            allow_local: false,
         },
     );
 
@@ -245,6 +246,7 @@ async fn handshake_init_transport_error_propagates() {
             url: None,
             headers: None,
             deferred: None,
+            allow_local: false,
         },
     );
 

--- a/crates/wcore-tools/src/url_safety.rs
+++ b/crates/wcore-tools/src/url_safety.rs
@@ -370,7 +370,9 @@ fn is_safe_url_with_opts(url: &str, resolve: Resolver, allow_loopback: bool) -> 
         return false;
     }
 
-    !addrs.into_iter().any(|ip| is_blocked_ip_with(ip, allow_loopback))
+    !addrs
+        .into_iter()
+        .any(|ip| is_blocked_ip_with(ip, allow_loopback))
 }
 
 /// Build the SSRF-resistant `reqwest` redirect policy shared by every
@@ -461,7 +463,12 @@ fn ssrf_safe_socket_addrs_with_opts(
         };
     }
     let addrs = resolve(host);
-    if addrs.is_empty() || addrs.iter().copied().any(|ip| is_blocked_ip_with(ip, allow_loopback)) {
+    if addrs.is_empty()
+        || addrs
+            .iter()
+            .copied()
+            .any(|ip| is_blocked_ip_with(ip, allow_loopback))
+    {
         return Vec::new();
     }
     addrs.into_iter().map(|ip| SocketAddr::new(ip, 0)).collect()
@@ -569,25 +576,61 @@ mod tests {
             fake_resolver,
             true
         ));
-        assert!(is_safe_url_with_opts("http://127.0.0.1/", fake_resolver, true));
+        assert!(is_safe_url_with_opts(
+            "http://127.0.0.1/",
+            fake_resolver,
+            true
+        ));
         // A hostname that resolves to loopback is allowed too (covers localhost
         // and IPv6 `::1` via the resolver path). `myhost.local` -> 127.0.0.1.
-        assert!(is_safe_url_with_opts("http://myhost.local/", fake_resolver, true));
+        assert!(is_safe_url_with_opts(
+            "http://myhost.local/",
+            fake_resolver,
+            true
+        ));
         // Note: a *bracketed* IPv6 literal (`http://[::1]/`) is parsed with the
         // brackets retained and so routes through the resolver rather than the
         // literal-IP fast path — a pre-existing behavior of `extract_hostname`,
         // unchanged here. Use a hostname (e.g. `localhost`) for IPv6 loopback.
 
         // Non-loopback ranges remain blocked even with allow_loopback=true.
-        assert!(!is_safe_url_with_opts("http://169.254.169.254/", fake_resolver, true));
-        assert!(!is_safe_url_with_opts("http://10.0.0.5/", fake_resolver, true));
-        assert!(!is_safe_url_with_opts("http://192.168.1.1/", fake_resolver, true));
-        assert!(!is_safe_url_with_opts("http://172.16.0.1/", fake_resolver, true));
-        assert!(!is_safe_url_with_opts("http://100.64.0.1/", fake_resolver, true));
+        assert!(!is_safe_url_with_opts(
+            "http://169.254.169.254/",
+            fake_resolver,
+            true
+        ));
+        assert!(!is_safe_url_with_opts(
+            "http://10.0.0.5/",
+            fake_resolver,
+            true
+        ));
+        assert!(!is_safe_url_with_opts(
+            "http://192.168.1.1/",
+            fake_resolver,
+            true
+        ));
+        assert!(!is_safe_url_with_opts(
+            "http://172.16.0.1/",
+            fake_resolver,
+            true
+        ));
+        assert!(!is_safe_url_with_opts(
+            "http://100.64.0.1/",
+            fake_resolver,
+            true
+        ));
         // intranet.local resolves to 10.0.0.5 — still blocked.
-        assert!(!is_safe_url_with_opts("http://intranet.local/", fake_resolver, true));
+        assert!(!is_safe_url_with_opts(
+            "http://intranet.local/",
+            fake_resolver,
+            true
+        ));
         // Public still fine.
-        assert!(is_safe_url_with_opts("https://example.com/", fake_resolver, true));
+        assert!(is_safe_url_with_opts(
+            "https://example.com/",
+            fake_resolver,
+            true
+        ));
 
         // The DEFAULT path (allow_loopback=false) still blocks loopback.
         assert!(!is_safe_url_with("http://127.0.0.1/", fake_resolver));

--- a/crates/wcore-tools/src/url_safety.rs
+++ b/crates/wcore-tools/src/url_safety.rs
@@ -126,10 +126,23 @@ fn ip_is_cloud_metadata(ip: IpAddr) -> bool {
 
 /// Return true if the IP should be blocked for SSRF protection.
 fn is_blocked_ip(ip: IpAddr) -> bool {
+    is_blocked_ip_with(ip, false)
+}
+
+/// Return true if the IP should be blocked for SSRF protection.
+///
+/// `allow_loopback` relaxes the loopback block ONLY (IPv4 127.0.0.0/8, IPv6
+/// `::1`, and IPv4-mapped/compatible loopback). It is used for trusted,
+/// user-configured *local* targets (e.g. a local MCP server the user added by
+/// hand) where a connection to the user's own machine is not the SSRF threat
+/// the guard exists to stop. Every other range — private LAN, link-local,
+/// CGNAT, multicast, unspecified, documentation, IPv6 ULA, cloud-metadata —
+/// stays blocked regardless.
+fn is_blocked_ip_with(ip: IpAddr, allow_loopback: bool) -> bool {
     match ip {
         IpAddr::V4(v4) => {
-            if v4.is_private()
-                || v4.is_loopback()
+            if (!allow_loopback && v4.is_loopback())
+                || v4.is_private()
                 || v4.is_link_local()
                 || v4.is_broadcast()
                 || v4.is_multicast()
@@ -144,7 +157,7 @@ fn is_blocked_ip(ip: IpAddr) -> bool {
             false
         }
         IpAddr::V6(v6) => {
-            if v6.is_loopback() || v6.is_multicast() || v6.is_unspecified() {
+            if (!allow_loopback && v6.is_loopback()) || v6.is_multicast() || v6.is_unspecified() {
                 return true;
             }
             // Unique local fc00::/7
@@ -158,13 +171,13 @@ fn is_blocked_ip(ip: IpAddr) -> bool {
             }
             // IPv4-mapped IPv6 — unwrap and re-check using IPv4 rules.
             if let Some(mapped) = v6.to_ipv4_mapped() {
-                return is_blocked_ip(IpAddr::V4(mapped));
+                return is_blocked_ip_with(IpAddr::V4(mapped), allow_loopback);
             }
             // IPv4-compatible (deprecated): ::a.b.c.d
             if let Some(compat) = v6.to_ipv4() {
-                // Reject the all-zeros and loopback aliases at minimum; the
-                // mapping path above already handles the modern form.
-                if compat.is_unspecified() || compat.is_loopback() {
+                // Reject the all-zeros (and loopback aliases unless explicitly
+                // allowed); the mapping path above handles the modern form.
+                if compat.is_unspecified() || (!allow_loopback && compat.is_loopback()) {
                     return true;
                 }
             }
@@ -269,6 +282,16 @@ pub fn is_safe_url(url: &str) -> bool {
     is_safe_url_with(url, system_resolver)
 }
 
+/// Like [`is_safe_url`] but permits LOOPBACK targets (127.0.0.0/8, `::1`,
+/// `localhost`). For trusted, user-configured local endpoints only — e.g. a
+/// local MCP server the user added by hand. Every other private/internal/
+/// metadata range stays blocked. An MCP server URL is trusted configuration,
+/// not a model-driven fetch, so the SSRF guard's loopback block (meant for
+/// untrusted URLs) should not apply to it.
+pub fn is_safe_url_allow_loopback(url: &str) -> bool {
+    is_safe_url_with_opts(url, system_resolver, true)
+}
+
 /// Resolve `url`'s host once and return the validated, SSRF-safe IPs so the
 /// HTTP-client layer can **pin** them into the connection and close the
 /// DNS-rebinding TOCTOU described on [`is_safe_url`].
@@ -315,6 +338,10 @@ fn safe_url_pinned_ips_with(url: &str, resolve: Resolver) -> Option<Vec<IpAddr>>
 }
 
 fn is_safe_url_with(url: &str, resolve: Resolver) -> bool {
+    is_safe_url_with_opts(url, resolve, false)
+}
+
+fn is_safe_url_with_opts(url: &str, resolve: Resolver, allow_loopback: bool) -> bool {
     let Some(hostname) = extract_hostname(url) else {
         return false;
     };
@@ -325,14 +352,15 @@ fn is_safe_url_with(url: &str, resolve: Resolver) -> bool {
     }
 
     // Explicit cloud-metadata check — reject before falling through to the
-    // general private-IP block so the log line names the threat.
+    // general private-IP block so the log line names the threat. (Loopback is
+    // never a metadata endpoint, so this gate is unaffected by allow_loopback.)
     if is_cloud_metadata_url_with(url, resolve) {
         return false;
     }
 
     // Literal IP — skip DNS.
     if let Ok(ip) = hostname.parse::<IpAddr>() {
-        return !is_blocked_ip(ip);
+        return !is_blocked_ip_with(ip, allow_loopback);
     }
 
     let addrs = resolve(&hostname);
@@ -342,7 +370,7 @@ fn is_safe_url_with(url: &str, resolve: Resolver) -> bool {
         return false;
     }
 
-    !addrs.into_iter().any(is_blocked_ip)
+    !addrs.into_iter().any(|ip| is_blocked_ip_with(ip, allow_loopback))
 }
 
 /// Build the SSRF-resistant `reqwest` redirect policy shared by every
@@ -386,6 +414,27 @@ pub fn ssrf_safe_redirect_policy() -> Policy {
     })
 }
 
+/// Loopback-permitting variant of [`ssrf_safe_redirect_policy`] for trusted
+/// local endpoints. Re-validates every hop with [`is_safe_url_allow_loopback`],
+/// so loopback hops are followed but all other private/internal/metadata
+/// redirect targets are still blocked. Pair with [`LoopbackOkResolver`].
+pub fn ssrf_safe_redirect_policy_allow_loopback() -> Policy {
+    Policy::custom(|attempt| {
+        if attempt.previous().len() >= 10 {
+            return attempt.error("too many redirects");
+        }
+        let url = attempt.url().to_string();
+        if is_safe_url_allow_loopback(&url) {
+            attempt.follow()
+        } else {
+            attempt.error(format!(
+                "redirect blocked — target URL is a private or internal \
+                 network address: {url}"
+            ))
+        }
+    })
+}
+
 /// Resolve `host` and return the SSRF-safe socket addresses to dial (port `0`;
 /// reqwest sets the real port per the URL/scheme). Returns empty — i.e. "do
 /// not connect", failing closed — for a cloud-metadata hostname, a literal
@@ -393,18 +442,26 @@ pub fn ssrf_safe_redirect_policy() -> Policy {
 /// is private/internal (no split-horizon). Mirrors [`safe_url_pinned_ips`] but
 /// keyed on the bare hostname, which is all a [`Resolve`] impl receives.
 fn ssrf_safe_socket_addrs_with(host: &str, resolve: Resolver) -> Vec<SocketAddr> {
+    ssrf_safe_socket_addrs_with_opts(host, resolve, false)
+}
+
+fn ssrf_safe_socket_addrs_with_opts(
+    host: &str,
+    resolve: Resolver,
+    allow_loopback: bool,
+) -> Vec<SocketAddr> {
     if CLOUD_METADATA_HOSTNAMES.contains(&host) {
         return Vec::new();
     }
     if let Ok(ip) = host.parse::<IpAddr>() {
-        return if is_blocked_ip(ip) {
+        return if is_blocked_ip_with(ip, allow_loopback) {
             Vec::new()
         } else {
             vec![SocketAddr::new(ip, 0)]
         };
     }
     let addrs = resolve(host);
-    if addrs.is_empty() || addrs.iter().copied().any(is_blocked_ip) {
+    if addrs.is_empty() || addrs.iter().copied().any(|ip| is_blocked_ip_with(ip, allow_loopback)) {
         return Vec::new();
     }
     addrs.into_iter().map(|ip| SocketAddr::new(ip, 0)).collect()
@@ -450,6 +507,33 @@ impl Resolve for SsrfSafeResolver {
     }
 }
 
+/// Loopback-permitting counterpart to [`SsrfSafeResolver`]. Returns loopback
+/// IPs (in addition to safe public IPs) so reqwest can dial a trusted local
+/// endpoint, while still dropping every other private/internal/metadata
+/// address. Use ONLY for user-configured local targets (e.g. local MCP
+/// servers), paired with [`ssrf_safe_redirect_policy_allow_loopback`].
+#[derive(Debug, Clone, Copy, Default)]
+pub struct LoopbackOkResolver;
+
+impl Resolve for LoopbackOkResolver {
+    fn resolve(&self, name: Name) -> Resolving {
+        let host = name.as_str().to_string();
+        Box::pin(async move {
+            let safe = tokio::task::spawn_blocking(move || {
+                ssrf_safe_socket_addrs_with_opts(&host, system_resolver, true)
+            })
+            .await
+            .unwrap_or_default();
+            if safe.is_empty() {
+                return Err(Box::<dyn std::error::Error + Send + Sync>::from(
+                    "SSRF guard: host has no safe address to dial (loopback allowed)",
+                ));
+            }
+            Ok(Box::new(safe.into_iter()) as Addrs)
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -472,6 +556,42 @@ mod tests {
         assert!(is_safe_url_with("https://example.com/path", fake_resolver));
         assert!(is_safe_url_with("http://example.com:8080/", fake_resolver));
         assert!(is_safe_url_with("https://ipv6-pub.example/", fake_resolver));
+    }
+
+    // allow_local / loopback opt-in: a trusted user-configured local MCP server
+    // (e.g. Agent Vault at http://127.0.0.1:3456/mcp) must be reachable, while
+    // EVERY other private/internal/metadata range stays blocked.
+    #[test]
+    fn allow_loopback_permits_loopback_but_still_blocks_others() {
+        // Loopback now allowed (literal IPs skip the resolver).
+        assert!(is_safe_url_with_opts(
+            "http://127.0.0.1:3456/mcp",
+            fake_resolver,
+            true
+        ));
+        assert!(is_safe_url_with_opts("http://127.0.0.1/", fake_resolver, true));
+        // A hostname that resolves to loopback is allowed too (covers localhost
+        // and IPv6 `::1` via the resolver path). `myhost.local` -> 127.0.0.1.
+        assert!(is_safe_url_with_opts("http://myhost.local/", fake_resolver, true));
+        // Note: a *bracketed* IPv6 literal (`http://[::1]/`) is parsed with the
+        // brackets retained and so routes through the resolver rather than the
+        // literal-IP fast path — a pre-existing behavior of `extract_hostname`,
+        // unchanged here. Use a hostname (e.g. `localhost`) for IPv6 loopback.
+
+        // Non-loopback ranges remain blocked even with allow_loopback=true.
+        assert!(!is_safe_url_with_opts("http://169.254.169.254/", fake_resolver, true));
+        assert!(!is_safe_url_with_opts("http://10.0.0.5/", fake_resolver, true));
+        assert!(!is_safe_url_with_opts("http://192.168.1.1/", fake_resolver, true));
+        assert!(!is_safe_url_with_opts("http://172.16.0.1/", fake_resolver, true));
+        assert!(!is_safe_url_with_opts("http://100.64.0.1/", fake_resolver, true));
+        // intranet.local resolves to 10.0.0.5 — still blocked.
+        assert!(!is_safe_url_with_opts("http://intranet.local/", fake_resolver, true));
+        // Public still fine.
+        assert!(is_safe_url_with_opts("https://example.com/", fake_resolver, true));
+
+        // The DEFAULT path (allow_loopback=false) still blocks loopback.
+        assert!(!is_safe_url_with("http://127.0.0.1/", fake_resolver));
+        assert!(is_safe_url_allow_loopback("http://127.0.0.1:3456/mcp"));
     }
 
     // H-1-broad — the SSRF-safe DNS resolver is the connect-time half that

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -60,6 +60,33 @@ deferred = true    # Don't load tool schemas at startup
 
 Use `deferred = true` for MCP servers with many tools to keep the initial system prompt small.
 
+## Local (loopback) MCP servers — `allow_local`
+
+For safety, the HTTP transports (`sse`, `streamable-http`) refuse to connect to
+URLs that resolve to private/internal addresses — an SSRF guard that stops a
+compromised or model-driven URL from reaching `169.254.169.254`, your LAN, etc.
+By default this also blocks **loopback** (`127.0.0.1`, `::1`, `localhost`).
+
+An MCP server you configure by hand is *trusted configuration*, not a
+model-supplied URL, so to connect to a local MCP server (e.g. a desktop app
+exposing tools on `127.0.0.1`) set `allow_local = true`. This relaxes the
+**loopback block only** — every other private/LAN/link-local/CGNAT/cloud-metadata
+range stays blocked even when enabled.
+
+```toml
+# Example: connect to Agent Vault (desktop) running a local MCP server.
+[mcp.servers.agent-vault]
+transport = "streamable-http"
+url = "http://127.0.0.1:3456/mcp"
+allow_local = true
+headers = { Authorization = "Bearer <AGENT_VAULT_MCP_TOKEN>" }
+```
+
+| `allow_local` | Behavior |
+|---------------|----------|
+| `false` (default) | Loopback and all private/internal targets are rejected at connect time |
+| `true` | Loopback (`127.0.0.0/8`, `::1`, `localhost`) is permitted; all other private/internal/metadata ranges remain blocked |
+
 ## Tool Naming
 
 - MCP tool names are used directly when there's no conflict


### PR DESCRIPTION
Zero-config interop so Wayland Core can **discover, liveness-check, one-click-grant, and connect** to a Forge-suite local MCP server (Agent Vault) with no copy-paste. This PR is the **headless half** (everything box-gated; CI is the authoritative cross-platform gate). The TUI one-click surface is a follow-up gated on #28.

### What's here
- **Keystone — `allow_local` SSRF relaxation** (`59437fec`, +fmt `ae154f42`): opt-in `McpServerConfig.allow_local` relaxes the loopback block only; every other private/LAN/link-local/CGNAT/metadata range stays blocked. `LoopbackOkResolver` + `ssrf_safe_redirect_policy_allow_loopback`.
- **Discovery reader** (`7e94246a`): `wcore_config::forge_discovery` reads `<config_dir>/forge/mcp-servers.json` (tolerant parse, entries are hints not liveness). 5 tests.
- **Piece 1 — grant client** (`8668764b`): `wcore_mcp::forge_grant` — `probe_metadata` (200 + name-match only) and `request_grant` (200→Granted / 403→Denied / 400→BadScopes / 429→RateLimited / else→Error) over a loopback-permitting, SSRF-gated egress client. 9 wiremock tests.
- **Piece 2 — connect flow + `${cred:KEY}`** (`20b94c2a`): `wcore_config::mcp_cred_refs` resolves `${cred:KEY}` header refs **at the config→manager boundary, on a clone** — the bearer token lives in the credentials store, `config.toml` only ever holds the reference, and the long-lived in-memory `Config` keeps the literal (an accidental re-serialize can't leak it). Boot wiring resolves before `connect_all`; `engine_bridge::connect_forge_server` stores the token → persists `[mcp.servers.<name>]` → connects+registers live, sharing a refactored `connect_and_register_mcp` with `/mcp add`. 11 unit tests.

### Verification (box-gated; Mac never compiles locally)
clippy clean (tools/config/mcp/agent/cli, `-D warnings`); **2237 tests pass** (incl. 9 forge_grant + 11 mcp_cred_refs); fmt clean.

### Not in this PR (follow-ups)
- **Piece 3 — TUI one-click** (probe → grant → `connect_forge_server`). Reuses `/doctor` DISCOVERED + boot hero from #28, so it stacks after #28 merges.
- **Live E2E** needs a signed Agent Vault build running + a human clicking Approve (the 200-grant path cannot be obtained headless). Producer side (Agent Vault Slices 1+2) is already merged.

Draft until #28 lands and the live E2E is run.