### PR TITLE
fix(core): Windows MCP stdio launch (#164) + Anthropic unrecoverable-conversation (#161)

### DIFF
--- a/crates/wcore-mcp/src/transport/stdio.rs
+++ b/crates/wcore-mcp/src/transport/stdio.rs
@@ -190,6 +190,24 @@ fn windows_cmd_quote(arg: &str) -> String {
     out
 }
 
+/// The executable token for a `cmd /C <line>` command line on Windows.
+///
+/// Unlike an argument, a program name must NOT be caret-escaped: cmd.exe
+/// resolves it against PATH/PATHEXT itself (`node` → `node.exe`/`node.cmd`).
+/// Running it through [`windows_cmd_quote`] produced `^"node^"`, which cmd read
+/// as a literal-quoted name and failed to resolve, so the MCP server never
+/// started (wayland#164). A bare name passes through unchanged; a path with
+/// whitespace is wrapped in the plain double quotes `cmd /C` expects for the
+/// executable token (no caret-escaping). Pure + platform-independent so it is
+/// unit-testable on any host.
+fn windows_program_token(command: &str) -> String {
+    if command.chars().any(char::is_whitespace) {
+        format!("\"{command}\"")
+    } else {
+        command.to_string()
+    }
+}
+
 /// SIGKILL the child's entire process group (Rank 24, unix-only).
 ///
 /// The child is spawned with `process_group(0)`, so its PGID equals its own
@@ -281,6 +299,35 @@ mod cmd_quote_tests {
         // caret-escape quotes: ^"a\\^"
         assert_eq!(out, "^\"a\\\\^\"");
     }
+
+    // wayland#164: a PROGRAM name (vs an argument) must not be caret-escaped —
+    // cmd resolves it via PATH/PATHEXT. These pin the regression where
+    // `node` was turned into `^"node^"` and failed to launch.
+    use super::windows_program_token;
+
+    #[test]
+    fn program_token_passes_bare_names_through_unquoted() {
+        // The exact production cases: cmd must see `node`, not `^"node^"`.
+        assert_eq!(windows_program_token("node"), "node");
+        assert_eq!(windows_program_token("npx"), "npx");
+        assert_eq!(windows_program_token("python"), "python");
+        // A path without spaces also passes through (cmd resolves it directly).
+        assert_eq!(
+            windows_program_token("C:\\nodejs\\node.exe"),
+            "C:\\nodejs\\node.exe"
+        );
+    }
+
+    #[test]
+    fn program_token_quotes_a_path_with_spaces_without_carets() {
+        let out = windows_program_token("C:\\Program Files\\nodejs\\node.exe");
+        assert_eq!(out, "\"C:\\Program Files\\nodejs\\node.exe\"");
+        // Critically: no caret-escaping on the executable token.
+        assert!(
+            !out.contains('^'),
+            "program token must never be caret-escaped: {out:?}"
+        );
+    }
 }
 
 impl StdioTransport {
@@ -336,7 +383,16 @@ impl StdioTransport {
             c
         } else {
             let mut parts = Vec::with_capacity(1 + args.len());
-            parts.push(shell_quote(command));
+            // wayland#164: the PROGRAM name must not go through `shell_quote`
+            // on Windows — that caret-escapes it to `^"node^"`, which cmd reads
+            // as a literal-quoted name and fails to resolve. cmd resolves the
+            // executable token against PATH/PATHEXT itself; only the ARGS need
+            // metacharacter-escaping.
+            parts.push(if cfg!(windows) {
+                windows_program_token(command)
+            } else {
+                shell_quote(command)
+            });
             for a in args {
                 parts.push(shell_quote(a));
             }

--- a/crates/wcore-providers/src/anthropic_shared.rs
+++ b/crates/wcore-providers/src/anthropic_shared.rs
@@ -28,11 +28,11 @@ pub fn build_messages(messages: &[Message], compat: &ProviderCompat) -> Vec<Valu
         let mut content: Vec<Value> = msg
             .content
             .iter()
-            .map(|block| match block {
-                ContentBlock::Text { text } => json!({
+            .filter_map(|block| match block {
+                ContentBlock::Text { text } => Some(json!({
                     "type": "text",
                     "text": text
-                }),
+                })),
                 ContentBlock::ToolUse {
                     id, name, input, ..
                 } => {
@@ -41,27 +41,31 @@ pub fn build_messages(messages: &[Message], compat: &ProviderCompat) -> Vec<Valu
                     } else {
                         id.clone()
                     };
-                    json!({
+                    Some(json!({
                         "type": "tool_use",
                         "id": tool_id,
                         "name": name,
                         "input": input
-                    })
+                    }))
                 }
                 ContentBlock::ToolResult {
                     tool_use_id,
                     content,
                     is_error,
-                } => json!({
+                } => Some(json!({
                     "type": "tool_result",
                     "tool_use_id": tool_use_id,
                     "content": content,
                     "is_error": is_error
-                }),
-                ContentBlock::Thinking { thinking } => json!({
-                    "type": "thinking",
-                    "thinking": thinking
-                }),
+                })),
+                // wayland#161: a `thinking` block replayed in message history
+                // must carry a valid `signature` — which we never capture, and
+                // which a model switch would invalidate anyway. Anthropic 400s
+                // on an unsigned thinking block
+                // (`messages[n].content[m].thinking.signature`), stranding the
+                // whole conversation as unrecoverable. Omitting thinking on
+                // replay is always accepted, so drop it.
+                ContentBlock::Thinking { .. } => None,
             })
             .collect();
 
@@ -78,6 +82,14 @@ pub fn build_messages(messages: &[Message], compat: &ProviderCompat) -> Vec<Valu
                     item["text"] = json!(cleaned);
                 }
             }
+        }
+
+        // wayland#161: an assistant turn truncated mid-thinking (or one that
+        // held only a thinking block) is now empty after the drop above.
+        // Anthropic rejects a message with empty `content`, so skip the turn
+        // rather than emit `content: []` and 400 the request.
+        if content.is_empty() {
+            continue;
         }
 
         // W1 Task 4: translate MessageCacheHint::Breakpoint into Anthropic
@@ -587,20 +599,56 @@ mod tests {
         assert_eq!(content[0]["is_error"], false);
     }
 
+    /// wayland#161: thinking blocks must NOT be replayed — they lack the
+    /// `signature` Anthropic requires (we never capture it, and a model switch
+    /// would invalidate it), so replaying one 400s and strands the conversation.
     #[test]
-    fn test_build_messages_with_thinking() {
+    fn test_build_messages_drops_thinking_blocks() {
+        // A turn with text + thinking keeps only the text.
         let messages = vec![Message::new(
             Role::Assistant,
-            vec![ContentBlock::Thinking {
-                thinking: "Let me think...".to_string(),
-            }],
+            vec![
+                ContentBlock::Thinking {
+                    thinking: "Let me think...".to_string(),
+                },
+                ContentBlock::Text {
+                    text: "Here is the answer.".to_string(),
+                },
+            ],
         )];
         let result = build_messages(&messages, &default_compat());
         assert_eq!(result.len(), 1);
-        assert_eq!(result[0]["role"], "assistant");
         let content = result[0]["content"].as_array().unwrap();
-        assert_eq!(content[0]["type"], "thinking");
-        assert_eq!(content[0]["thinking"], "Let me think...");
+        assert_eq!(content.len(), 1, "thinking block must be dropped");
+        assert_eq!(content[0]["type"], "text");
+        assert_eq!(content[0]["text"], "Here is the answer.");
+        // No thinking block may survive into the request.
+        assert!(content.iter().all(|b| b["type"] != "thinking"));
+    }
+
+    /// A turn truncated mid-thinking (only a thinking block) becomes empty and
+    /// must be skipped entirely — Anthropic rejects empty `content`. This is the
+    /// exact wayland#161 reproduction (truncation then continue/model-switch).
+    #[test]
+    fn test_build_messages_skips_thinking_only_turn() {
+        let messages = vec![
+            Message::new(
+                Role::User,
+                vec![ContentBlock::Text {
+                    text: "hi".to_string(),
+                }],
+            ),
+            Message::new(
+                Role::Assistant,
+                vec![ContentBlock::Thinking {
+                    thinking: "interrupted...".to_string(),
+                }],
+            ),
+        ];
+        let result = build_messages(&messages, &default_compat());
+        // Only the user turn survives; the thinking-only assistant turn is gone.
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0]["role"], "user");
     }
 
     // --- compat-driven behavior tests ---


### PR DESCRIPTION
Two confirmed wayland-core bugs filed against the desktop app (FerroxLabs/wayland), fixed in the engine.

### wayland#164 — Windows MCP stdio launches `"node^"` instead of `node`
The `cmd /C` launch path ran the **program name** through `windows_cmd_quote`, which wraps it in quotes then caret-escapes them (`node` → `^"node^"`). cmd reads that as a literal-quoted name and can't resolve it, so the stdio MCP server (e.g. `wayland-team-guide`) exits before responding. A program name must never be caret-escaped — cmd resolves it via PATH/PATHEXT. New `windows_program_token` passes bare names through and quotes only a path with whitespace (plain double quotes, no carets); args still get full escaping. 2 platform-independent tests.

### wayland#161 — conversation unrecoverable after truncation + model switch
After a token-budget truncation, continuing (especially with a model switch) replayed a prior assistant turn's `thinking` block to Anthropic. We never capture the thinking `signature` (only Gemini does), and a model switch invalidates any signature anyway, so the replayed block is unsigned — Anthropic 400s on `messages[n].content[m].thinking.signature` and the conversation is stranded. `build_messages` now drops thinking blocks (omitting them on replay is always accepted) and skips a turn that becomes empty as a result (the exact truncated-mid-thinking case). Shared by Anthropic/Bedrock/Vertex. 2 new tests.

### Verification (box-gated)
clippy clean; 671 wcore-providers + the wcore-mcp stdio tests pass; fmt clean.

Part of a triage of the app's issue tracker — see the linked issues for the findings on the others (several turned out to be features, upstream/external, or app/host-layer rather than core).