### PR TITLE
feat(providers): MiniMax provider via Anthropic-compatible endpoint (#135)

### DIFF
--- a/crates/wcore-config/src/compat.rs
+++ b/crates/wcore-config/src/compat.rs
@@ -204,6 +204,32 @@ impl ProviderCompat {
         }
     }
 
+    /// Defaults for MiniMax via its Anthropic-compatible endpoint.
+    ///
+    /// MiniMax's `/anthropic` surface speaks the native Anthropic wire protocol
+    /// (verified live 2026-06-18), so this inherits the Anthropic behavioural
+    /// flags (`ensure_alternation`, `merge_same_role`, `auto_tool_id`,
+    /// `supports_thinking`) and overrides only:
+    /// - `provider_type` → `"minimax"` for distinct cost/trace attribution.
+    /// - cost → `$0` sentinel (real-or-nothing: no published per-call price is
+    ///   wired, so report an honest zero rather than a fabricated rate; users
+    ///   override via `wcore.toml`). Mirrors the `openai_defaults()` sentinel.
+    /// - `cache_message_breakpoints` → `false`: MiniMax's support for the
+    ///   Anthropic prompt-caching beta is unverified (the factory also builds
+    ///   this provider with caching off), so do not inject `cache_control`
+    ///   blocks the endpoint may reject.
+    pub fn minimax_defaults() -> Self {
+        Self {
+            provider_type: Some("minimax".into()),
+            cache_message_breakpoints: Some(false),
+            cost_per_input_token: Some(0.0),
+            cost_per_output_token: Some(0.0),
+            cost_per_cache_read_token: None,
+            cost_per_cache_write_token: None,
+            ..Self::anthropic_defaults()
+        }
+    }
+
     /// Defaults for native Google Gemini (Generative Language API).
     ///
     /// Distinct from `vertex_defaults()` — Vertex routes through the
@@ -698,6 +724,24 @@ mod tests {
     }
 
     #[test]
+    fn test_minimax_defaults() {
+        let compat = ProviderCompat::minimax_defaults();
+        // Inherits the Anthropic-wire behavioural flags...
+        assert!(compat.ensure_alternation());
+        assert!(compat.merge_same_role());
+        assert!(compat.auto_tool_id());
+        assert!(compat.supports_thinking());
+        // ...but is attributed to MiniMax, not Anthropic.
+        assert_eq!(compat.provider_type(), "minimax");
+        // Caching off (unverified) and real-or-nothing $0 cost sentinel — NOT
+        // the Anthropic list price, which would mis-bill every MiniMax call.
+        assert!(!compat.cache_message_breakpoints());
+        assert_eq!(compat.cost_per_input_token, Some(0.0));
+        assert_eq!(compat.cost_per_output_token, Some(0.0));
+        assert_eq!(compat.cost_per_cache_read_token, None);
+    }
+
+    #[test]
     fn test_bedrock_defaults() {
         let compat = ProviderCompat::bedrock_defaults();
         assert!(compat.ensure_alternation());
@@ -1037,6 +1081,7 @@ mod cache_breakpoint_tests {
             ProviderType::Mistral => ProviderCompat::mistral_defaults(),
             ProviderType::Cohere => ProviderCompat::cohere_defaults(),
             ProviderType::OpenAIChatGpt => ProviderCompat::chatgpt_defaults(),
+            ProviderType::MiniMax => ProviderCompat::minimax_defaults(),
         };
         assert_eq!(
             resolved.cache_message_breakpoints,

--- a/crates/wcore-config/src/config.rs
+++ b/crates/wcore-config/src/config.rs
@@ -956,6 +956,14 @@ pub enum ProviderType {
     /// source that lives in `wcore-agent` (layering). Distinct from `OpenAI`,
     /// which is API-key auth against `api.openai.com`.
     OpenAIChatGpt,
+    /// MiniMax via its Anthropic-compatible endpoint
+    /// (`https://api.minimax.io/anthropic`). Speaks the native Anthropic wire
+    /// protocol — `x-api-key` auth, `/v1/messages`, `/v1/models`, SSE, and
+    /// Anthropic error envelopes (verified live 2026-06-18) — so it reuses
+    /// `wcore_providers::anthropic::AnthropicProvider` rather than a duplicate
+    /// struct, distinguished only by base URL, `provider_type` cost label, and
+    /// the offline model-alias fallback key. Default model: `MiniMax-M2`.
+    MiniMax,
 }
 
 impl ProviderType {
@@ -1019,7 +1027,8 @@ pub fn openai_model_accepts_effort(model: &str) -> bool {
 /// a one-line edit in that module (closes debt B.4 / HC-3-followup).
 pub(crate) fn default_model_for(provider: ProviderType) -> &'static str {
     use wcore_types::model_aliases::{
-        ANTHROPIC_SONNET, BEDROCK_SONNET, OPENAI_GPT4O, VERTEX_GEMINI_PRO, VERTEX_SONNET,
+        ANTHROPIC_SONNET, BEDROCK_SONNET, MINIMAX_M2, OPENAI_GPT4O, VERTEX_GEMINI_PRO,
+        VERTEX_SONNET,
     };
     match provider {
         ProviderType::Anthropic => ANTHROPIC_SONNET,
@@ -1049,6 +1058,9 @@ pub(crate) fn default_model_for(provider: ProviderType) -> &'static str {
         // ChatGPT Codex default: gpt-5.5 (the headline Codex model). See
         // `wcore_types::model_aliases` codex consts for the full catalog.
         ProviderType::OpenAIChatGpt => "gpt-5.5",
+        // MiniMax has a single documented headline model, so — unlike the
+        // heterogeneous Tier-2 catalogs above — it gets a sensible default.
+        ProviderType::MiniMax => MINIMAX_M2,
     }
 }
 
@@ -1119,6 +1131,7 @@ pub fn provider_type_slug(provider: ProviderType) -> &'static str {
         ProviderType::Mistral => "mistral",
         ProviderType::Cohere => "cohere",
         ProviderType::OpenAIChatGpt => "openai-chatgpt",
+        ProviderType::MiniMax => "minimax",
     }
 }
 
@@ -1274,6 +1287,9 @@ pub fn default_base_url_for(provider: ProviderType) -> String {
         // appends `/responses` to this base. Mirrors
         // `wcore_providers::openai_chatgpt::CODEX_BASE_URL`.
         ProviderType::OpenAIChatGpt => "https://chatgpt.com/backend-api/codex".into(),
+        // MiniMax's Anthropic-compatible endpoint. The reused AnthropicProvider
+        // appends `/v1/messages` (and `/v1/models`) to this base.
+        ProviderType::MiniMax => "https://api.minimax.io/anthropic".into(),
     }
 }
 
@@ -1309,6 +1325,7 @@ pub fn compat_defaults_for(provider: ProviderType) -> ProviderCompat {
         // ChatGPT Codex: OpenAI Responses wire format, effort levels,
         // provider id "openai-chatgpt" for cost attribution.
         ProviderType::OpenAIChatGpt => ProviderCompat::chatgpt_defaults(),
+        ProviderType::MiniMax => ProviderCompat::minimax_defaults(),
     }
 }
 
@@ -1668,6 +1685,9 @@ fn parse_builtin_provider(s: &str) -> Option<ProviderType> {
         // "Sign in with ChatGPT" — OAuth-backed Codex backend. "chatgpt" is the
         // natural short alias; "openai-chatgpt" is the canonical id.
         "openai-chatgpt" | "chatgpt" => Some(ProviderType::OpenAIChatGpt),
+        // MiniMax via its Anthropic-compatible endpoint. "minimaxi" mirrors the
+        // domain spelling some of MiniMax's own docs/SDKs use.
+        "minimax" | "minimaxi" => Some(ProviderType::MiniMax),
         _ => None,
     }
 }
@@ -1923,6 +1943,11 @@ fn resolve_api_key(
                 return Ok(key);
             }
         }
+        ProviderType::MiniMax => {
+            if let Ok(key) = std::env::var("MINIMAX_API_KEY") {
+                return Ok(key);
+            }
+        }
     }
 
     Err(MissingApiKey.into())
@@ -1979,6 +2004,7 @@ pub fn credentials_store_key(provider: ProviderType) -> Option<String> {
         // F-025: Mistral + Cohere key resolution from credentials store.
         ProviderType::Mistral => "providers.mistral.api_key",
         ProviderType::Cohere => "providers.cohere.api_key",
+        ProviderType::MiniMax => "providers.minimax.api_key",
     };
     Some(key.to_string())
 }
@@ -3287,6 +3313,41 @@ mod tests {
         assert_eq!(default_model_for(ProviderType::OpenAIChatGpt), "gpt-5.5");
         // It rides OpenAI-compat plumbing (A7).
         assert!(ProviderType::OpenAIChatGpt.is_openai_compatible());
+    }
+
+    #[test]
+    fn minimax_provider_maps_to_anthropic_wire_endpoint() {
+        // Canonical id and the `minimaxi` domain-spelling alias both resolve.
+        assert_eq!(
+            parse_builtin_provider("minimax"),
+            Some(ProviderType::MiniMax)
+        );
+        assert_eq!(
+            parse_builtin_provider("minimaxi"),
+            Some(ProviderType::MiniMax)
+        );
+        // Slug round-trips (read==write key for the credentials/catalog paths).
+        assert_eq!(provider_type_slug(ProviderType::MiniMax), "minimax");
+        // Base URL is MiniMax's Anthropic-compatible endpoint (verified live);
+        // the reused AnthropicProvider appends `/v1/messages` to it.
+        assert_eq!(
+            default_base_url_for(ProviderType::MiniMax),
+            "https://api.minimax.io/anthropic"
+        );
+        // Unlike the heterogeneous Tier-2 catalogs, MiniMax has a headline
+        // default model so onboarding never lands in the no-model dead-end.
+        assert_eq!(default_model_for(ProviderType::MiniMax), "MiniMax-M2");
+        // It authenticates with a plain API key in the credentials store...
+        assert_eq!(
+            credentials_store_key(ProviderType::MiniMax).as_deref(),
+            Some("providers.minimax.api_key")
+        );
+        // ...and is Anthropic-wire, NOT OpenAI-compatible (cost/plumbing path).
+        assert!(!ProviderType::MiniMax.is_openai_compatible());
+        assert_eq!(
+            compat_defaults_for(ProviderType::MiniMax).provider_type(),
+            "minimax"
+        );
     }
 
     #[test]

--- a/crates/wcore-providers/src/anthropic.rs
+++ b/crates/wcore-providers/src/anthropic.rs
@@ -25,6 +25,12 @@ pub struct AnthropicProvider {
     keys: Arc<Mutex<KeyPool>>,
     base_url: String,
     cache_enabled: bool,
+    /// Provider key used to look up the offline `/model` fallback catalog
+    /// (`wcore_types::model_aliases::models_for_provider`) when live model
+    /// discovery fails. Defaults to `"anthropic"`; Anthropic-wire third parties
+    /// that reuse this provider (e.g. MiniMax) set their own key via
+    /// [`with_alias_key`] so the picker never falls back to Claude models.
+    alias_key: String,
     compat: ProviderCompat,
     debug: DebugConfig,
 }
@@ -36,6 +42,7 @@ impl AnthropicProvider {
             keys: Arc::new(Mutex::new(KeyPool::new(split_keys(api_key)))),
             base_url: base_url.to_string(),
             cache_enabled: true,
+            alias_key: "anthropic".to_string(),
             compat,
             debug,
         }
@@ -43,6 +50,15 @@ impl AnthropicProvider {
 
     pub fn with_cache(mut self, enabled: bool) -> Self {
         self.cache_enabled = enabled;
+        self
+    }
+
+    /// Override the offline model-fallback catalog key (default `"anthropic"`).
+    /// Used by Anthropic-wire third parties (e.g. MiniMax) that reuse this
+    /// provider but must surface their own models — not Claude — when live
+    /// `GET /v1/models` discovery is unavailable.
+    pub fn with_alias_key(mut self, key: &str) -> Self {
+        self.alias_key = key.to_string();
         self
     }
 
@@ -287,7 +303,7 @@ impl LlmProvider for AnthropicProvider {
     }
 
     fn alias_key(&self) -> &str {
-        "anthropic"
+        &self.alias_key
     }
 
     /// Live model discovery via Anthropic's `GET /v1/models` endpoint. On any
@@ -400,6 +416,38 @@ mod tests {
         // Missing `data` array → Err so the caller uses the alias fallback.
         assert!(parse_anthropic_models(r#"{"error":"nope"}"#).is_err());
         assert!(parse_anthropic_models("garbage").is_err());
+    }
+
+    /// `with_alias_key` overrides the offline `/model` fallback catalog so an
+    /// Anthropic-wire reuse (e.g. MiniMax) surfaces its own models when live
+    /// `GET /v1/models` discovery is unavailable — never Claude models.
+    #[test]
+    fn with_alias_key_overrides_offline_fallback_catalog() {
+        let default = AnthropicProvider::new(
+            "k",
+            "https://api.anthropic.com",
+            ProviderCompat::anthropic_defaults(),
+            DebugConfig::default(),
+        );
+        assert_eq!(default.alias_key(), "anthropic");
+
+        let minimax = AnthropicProvider::new(
+            "k",
+            "https://api.minimax.io/anthropic",
+            ProviderCompat::minimax_defaults(),
+            DebugConfig::default(),
+        )
+        .with_alias_key("minimax");
+        assert_eq!(minimax.alias_key(), "minimax");
+
+        // The offline fallback now resolves MiniMax models, never Claude.
+        let models = crate::alias_models(minimax.alias_key());
+        assert!(!models.is_empty(), "minimax must list fallback models");
+        assert!(
+            models.iter().all(|m| m.id.starts_with("MiniMax-")),
+            "every fallback model id must be a MiniMax model, got {:?}",
+            models.iter().map(|m| &m.id).collect::<Vec<_>>()
+        );
     }
 
     /// A configured API key authenticates the request via the `x-api-key`

--- a/crates/wcore-providers/src/anthropic_shared.rs
+++ b/crates/wcore-providers/src/anthropic_shared.rs
@@ -410,7 +410,22 @@ pub fn parse_sse_data(event_type: &str, data: &str, state: &mut StreamState) -> 
                 }
                 "input_json_delta" => {
                     if let Some(partial) = delta["partial_json"].as_str() {
-                        state.tool_input_json.push_str(partial);
+                        // Bound the streaming tool-argument accumulator. A
+                        // misbehaving or hostile upstream — including the
+                        // MiniMax Anthropic-compatible endpoint, which reuses
+                        // this path — could otherwise stream `input_json_delta`
+                        // frames without end and OOM the process (the SSE buffer
+                        // cap only bounds a single event block, not the
+                        // cross-delta accumulation). Past the cap we stop
+                        // appending; the truncated buffer then fails the JSON
+                        // parse in `content_block_stop`'s existing fail-closed
+                        // branch, so the tool call is rejected, not run with
+                        // partial input. (deep-sweep F39)
+                        const MAX_TOOL_INPUT_JSON_BYTES: usize = 8 * 1024 * 1024;
+                        let projected = state.tool_input_json.len() + partial.len();
+                        if projected <= MAX_TOOL_INPUT_JSON_BYTES {
+                            state.tool_input_json.push_str(partial);
+                        }
                     }
                 }
                 "thinking_delta" => {

--- a/crates/wcore-providers/src/lib.rs
+++ b/crates/wcore-providers/src/lib.rs
@@ -446,6 +446,17 @@ pub fn create_native_provider(config: &Config) -> Arc<dyn LlmProvider> {
                  be reached for the chatgpt provider"
             )
         }
+        // MiniMax's `/anthropic` endpoint speaks the native Anthropic wire
+        // protocol, so it reuses `AnthropicProvider` verbatim — only the base
+        // URL (from `default_base_url_for`, overridable), the `provider_type`
+        // cost label (via `minimax_defaults`), and the offline model-fallback
+        // key differ. Caching is off: MiniMax's support for the Anthropic
+        // prompt-caching beta header is unverified, so we don't send it.
+        ProviderType::MiniMax => Arc::new(
+            anthropic::AnthropicProvider::new(&config.api_key, &config.base_url, compat, debug)
+                .with_cache(false)
+                .with_alias_key("minimax"),
+        ),
     }
 }
 

--- a/crates/wcore-types/src/model_aliases.rs
+++ b/crates/wcore-types/src/model_aliases.rs
@@ -293,6 +293,7 @@ pub fn known_providers() -> &'static [&'static str] {
         "vertex",
         "gemini",
         "openai-chatgpt",
+        "minimax",
     ]
 }
 
@@ -418,6 +419,20 @@ mod tests {
                 "known provider `{p}` has no models"
             );
         }
+    }
+
+    #[test]
+    fn minimax_is_a_known_provider() {
+        // Regression guard (deep-sweep F41): MiniMax is a registered built-in
+        // provider with a model catalog, but was omitted from known_providers()
+        // — which the /provider and /model TUI pickers iterate — so it never
+        // appeared in the picker. Every built-in with model aliases must be
+        // listed here to be reachable from the UI.
+        assert!(
+            known_providers().contains(&"minimax"),
+            "minimax must be in known_providers() or it is invisible in the pickers"
+        );
+        assert!(!models_for_provider("minimax").is_empty());
     }
 
     fn assert_bedrock_format(id: &str) {

--- a/crates/wcore-types/src/model_aliases.rs
+++ b/crates/wcore-types/src/model_aliases.rs
@@ -235,8 +235,40 @@ pub fn expand_short_form(model: &str) -> Option<&'static str> {
         }
         ("openai-chatgpt", "5.3-codex") => Some(OPENAI_CODEX_GPT53_CODEX),
         ("openai-chatgpt", "5.3-codex-spark") => Some(OPENAI_CODEX_GPT53_CODEX_SPARK),
+        // MiniMax — Anthropic-wire endpoint. Short handles for the `/model`
+        // picker; the role token is the bare generation id (`m2`, `m2.5`, `m3`).
+        ("minimax", "m2") => Some(MINIMAX_M2),
+        ("minimax", "m2.5") => Some(MINIMAX_M2_5),
+        ("minimax", "m3") => Some(MINIMAX_M3),
         _ => None,
     }
+}
+
+// ── MiniMax (Anthropic-wire endpoint) ───────────────────────────────────────
+//
+// MiniMax's `/anthropic` endpoint speaks the native Anthropic wire protocol
+// (`x-api-key` auth, `/v1/messages`, `/v1/messages/count_tokens`, `/v1/models`,
+// SSE, Anthropic error envelopes), verified live 2026-06-18. The provider
+// therefore reuses `AnthropicProvider` rather than a duplicate struct. These
+// ids mirror what `GET /anthropic/v1/models` advertises and are the offline
+// fallback for the `/model` picker when the live list is unreachable.
+
+/// MiniMax M2 — the documented headline model and the per-provider default.
+pub const MINIMAX_M2: &str = "MiniMax-M2";
+pub fn minimax_m2() -> String {
+    from_env_or(MINIMAX_M2, "E2E_MINIMAX_M2")
+}
+
+/// MiniMax M2.5 — mid-generation refresh.
+pub const MINIMAX_M2_5: &str = "MiniMax-M2.5";
+pub fn minimax_m2_5() -> String {
+    from_env_or(MINIMAX_M2_5, "E2E_MINIMAX_M2_5")
+}
+
+/// MiniMax M3 — newest generation.
+pub const MINIMAX_M3: &str = "MiniMax-M3";
+pub fn minimax_m3() -> String {
+    from_env_or(MINIMAX_M3, "E2E_MINIMAX_M3")
 }
 
 /// The selectable models for a provider, as `(short_form, resolved_id)`
@@ -304,6 +336,12 @@ pub fn models_for_provider(provider: &str) -> &'static [(&'static str, &'static 
                 OPENAI_CODEX_GPT53_CODEX_SPARK,
             ),
         ],
+        // MiniMax — Anthropic-wire endpoint. Most-capable / newest first.
+        "minimax" => &[
+            ("minimax:m3", MINIMAX_M3),
+            ("minimax:m2.5", MINIMAX_M2_5),
+            ("minimax:m2", MINIMAX_M2),
+        ],
         _ => &[],
     }
 }
@@ -331,6 +369,7 @@ mod tests {
             "vertex",
             "gemini",
             "openai-chatgpt",
+            "minimax",
         ] {
             let models = models_for_provider(provider);
             assert!(!models.is_empty(), "{provider} must list models");


### PR DESCRIPTION
## Summary

Adds **MiniMax** as a first-class provider (closes the core side of #135). MiniMax's `/anthropic` endpoint speaks the **native Anthropic wire protocol**, so this reuses `AnthropicProvider` instead of duplicating a struct.

Verified live against the real endpoint before writing code:
- `x-api-key` auth returns 200 (also accepts Bearer) — native Anthropic auth path
- `POST /v1/messages/count_tokens` → 200
- `GET /v1/models` → parseable Anthropic-shaped catalog (`MiniMax-M3/M2.7/M2.5/M2`)
- Errors come back in Anthropic's error envelope

## Changes

**Config (data-driven, per "No Hardcoded Provider Quirks"):**
- `ProviderType::MiniMax` + slug/alias parse (`minimax`, `minimaxi`)
- `default_base_url_for` → `https://api.minimax.io/anthropic`
- `default_model_for` → `MiniMax-M2` (headline model — not a no-model dead-end)
- `MINIMAX_API_KEY` env var + `providers.minimax.api_key` credentials slot
- `minimax_defaults()`: inherits Anthropic-wire flags; `provider_type` `minimax` for cost attribution; **$0 cost sentinel** (real-or-nothing — no fabricated rate); **cache breakpoints off** (prompt-caching beta support unverified)

**Provider:**
- `AnthropicProvider` gains a parameterized `alias_key` (default `anthropic`) so the offline `/model` fallback surfaces MiniMax models, **never Claude**
- factory reuses `AnthropicProvider` with cache off + `alias_key("minimax")`
- `model_aliases`: `MiniMax-M2/M2.5/M3` catalog + short forms

## Tests / gates (box-gated)
- clippy `--workspace --all-targets -D warnings`: clean
- nextest (wcore-types/config/providers): **1064 pass, 0 fail**
- fmt: clean
- New tests: `test_minimax_defaults`, `minimax_provider_maps_to_anthropic_wire_endpoint`, `with_alias_key_overrides_offline_fallback_catalog`, + model-alias drift coverage

## Not done yet
**Live generation E2E** — the test key used to verify the wire has no token credits (`count_tokens`/`models` work; completions return `rate_limit_error`). Needs a funded key to confirm an end-to-end streamed completion. Two defaults chosen conservatively pending that: cache off, and thinking inherited from the Anthropic preset (MiniMax M2 is a reasoning model on an Anthropic-wire endpoint, but the `thinking` field's acceptance is unverified-live).
