### PR TITLE
fix(forge-mcp): close token-exfil SSRF + 4 reliability defects (deep-sweep Wave 1b)

### DIFF
--- a/crates/wcore-cli/src/tui/engine_bridge.rs
+++ b/crates/wcore-cli/src/tui/engine_bridge.rs
@@ -1649,6 +1649,18 @@ impl TuiEngine {
             .await
             {
                 wcore_mcp::forge_grant::GrantOutcome::Granted { token, .. } => {
+                    // F12: the granted bearer token must never be sent off-box.
+                    // Refuse to store/persist/connect unless the server URL is
+                    // strictly loopback (SSRF guard) — a tampered discovery file
+                    // could otherwise point url at an attacker host.
+                    if !wcore_tools::url_safety::is_loopback_url(&server.url) {
+                        report_err(format!(
+                            "refusing to connect Forge server '{}': its url '{}' is not loopback \
+                             — the granted token must not be sent off-box (SSRF guard)",
+                            server.name, server.url
+                        ));
+                        return;
+                    }
                     match Self::store_and_persist_forge(&server.name, &server.url, &token) {
                         Ok(cfg) => {
                             Self::connect_and_register_mcp(engine, tx2, server.name, cfg).await

--- a/crates/wcore-config/src/forge_discovery.rs
+++ b/crates/wcore-config/src/forge_discovery.rs
@@ -96,9 +96,16 @@ pub fn read_discovered_servers() -> Vec<DiscoveredMcpServer> {
 
 /// [`read_discovered_servers`] against an explicit path (testable).
 pub fn read_discovered_servers_at(path: &std::path::Path) -> Vec<DiscoveredMcpServer> {
-    let Ok(raw) = std::fs::read_to_string(path) else {
+    use std::io::Read;
+    // F31: this file is cross-application and writable by any local app, so cap
+    // the read to defend against an oversized/garbage file exhausting memory.
+    const MAX_DISCOVERY_FILE_BYTES: u64 = 256 * 1024;
+    let mut raw = String::new();
+    let read = std::fs::File::open(path)
+        .and_then(|f| f.take(MAX_DISCOVERY_FILE_BYTES).read_to_string(&mut raw));
+    if read.is_err() {
         return Vec::new();
-    };
+    }
     match serde_json::from_str::<DiscoveryFile>(&raw) {
         Ok(file) => file.servers,
         Err(_) => Vec::new(),

--- a/crates/wcore-mcp/src/forge_grant.rs
+++ b/crates/wcore-mcp/src/forge_grant.rs
@@ -148,7 +148,16 @@ pub async fn request_grant(
     }
 
     let body = serde_json::json!({ "client_name": client_name, "scopes": scopes });
-    let resp = match client.post(grant_url).json(&body).send().await {
+    // F29: the producer holds the grant POST open until the human clicks Approve,
+    // which routinely takes longer than the client's 10s metadata-probe timeout.
+    // Override the per-request timeout so a slow human approval doesn't fail.
+    let resp = match client
+        .post(grant_url)
+        .json(&body)
+        .timeout(std::time::Duration::from_secs(120))
+        .send()
+        .await
+    {
         Ok(r) => r,
         Err(e) => return GrantOutcome::Error(format!("grant request failed: {e}")),
     };
@@ -156,6 +165,11 @@ pub async fn request_grant(
     let status = resp.status().as_u16();
     match status {
         200 => match resp.json::<GrantBody>().await {
+            // F30: a 200 with an empty token is unusable — reject it rather than
+            // storing/sending a blank bearer.
+            Ok(g) if g.token.trim().is_empty() => {
+                GrantOutcome::Error("grant returned a 200 but an empty token".to_string())
+            }
             Ok(g) => GrantOutcome::Granted {
                 token: g.token,
                 scopes: g.scopes,

--- a/crates/wcore-mcp/src/transport/sse.rs
+++ b/crates/wcore-mcp/src/transport/sse.rs
@@ -198,7 +198,7 @@ impl SseTransport {
                     // configured url's origin — for absolute and relative
                     // payloads alike. The resolved URL is then re-checked
                     // through the SSRF guard before we ever attach headers.
-                    let endpoint = resolve_endpoint(url, &event_data)?;
+                    let endpoint = resolve_endpoint(url, &event_data, allow_local)?;
                     post_url = Some(endpoint);
                     break;
                 }
@@ -429,7 +429,11 @@ fn whatwg_tuple_origin(url: &str) -> Option<reqwest::Url> {
 /// `https://vendor` + `@attacker/x` parses to host `attacker`.) The resolved
 /// URL is then re-checked through the SSRF guard (M-13) before it is
 /// returned.
-fn resolve_endpoint(configured_url: &str, event_data: &str) -> Result<String, McpError> {
+fn resolve_endpoint(
+    configured_url: &str,
+    event_data: &str,
+    allow_local: bool,
+) -> Result<String, McpError> {
     // Parse the configured base with the SAME WHATWG parser reqwest dials
     // with (`reqwest::Url` is `url::Url`); fail closed on a hostless/opaque
     // configured url.
@@ -458,7 +462,17 @@ fn resolve_endpoint(configured_url: &str, event_data: &str) -> Result<String, Mc
     let endpoint = resolved.to_string();
 
     // Defense-in-depth: re-run the SSRF guard on the resolved POST URL.
-    if !wcore_tools::url_safety::is_safe_url(&endpoint) {
+    // F28 — mirror `connect()`'s predicate choice: a trusted local SSE server
+    // (allow_local) is same-origin with the configured loopback url, so the
+    // resolved endpoint must pass the loopback-permitting guard rather than the
+    // loopback-BLOCKING `is_safe_url`. The same-origin gate above already pins
+    // the endpoint to the configured (loopback) origin.
+    let endpoint_ok = if allow_local {
+        wcore_tools::url_safety::is_safe_url_allow_loopback(&endpoint)
+    } else {
+        wcore_tools::url_safety::is_safe_url(&endpoint)
+    };
+    if !endpoint_ok {
         return Err(McpError::Transport(format!(
             "SSE endpoint rejected — resolves to a private or internal \
              network address (SSRF guard): {endpoint}"
@@ -746,6 +760,7 @@ mod tests {
         let err = resolve_endpoint(
             "https://vendor.example/mcp",
             r"https://attacker.example\@vendor.example/collect",
+            false,
         )
         .expect_err("backslash-@ host smuggle must be rejected cross-origin");
         let msg = err.to_string();
@@ -758,7 +773,7 @@ mod tests {
     /// H-5 — a same-origin relative endpoint joins onto the base.
     #[test]
     fn resolve_endpoint_relative_same_origin_ok() {
-        let resolved = resolve_endpoint("https://example.com/mcp/sse", "/messages")
+        let resolved = resolve_endpoint("https://example.com/mcp/sse", "/messages", false)
             .expect("relative endpoint should resolve");
         assert_eq!(resolved, "https://example.com/messages");
     }
@@ -769,6 +784,7 @@ mod tests {
         let resolved = resolve_endpoint(
             "https://example.com/mcp/sse",
             "https://example.com/messages/abc",
+            false,
         )
         .expect("same-origin absolute endpoint should resolve");
         assert_eq!(resolved, "https://example.com/messages/abc");
@@ -782,6 +798,7 @@ mod tests {
         let err = resolve_endpoint(
             "https://vendor.example/mcp",
             "https://attacker.example/collect",
+            false,
         )
         .expect_err("cross-origin endpoint must be rejected");
         let msg = err.to_string();
@@ -805,7 +822,7 @@ mod tests {
         // what rejects — this isolates the join-vs-concat behavior. Under
         // the old concat resolver the host became `attacker.evil.test`; the
         // join resolver keeps it on `8.8.8.8`.
-        let resolved = resolve_endpoint("http://8.8.8.8/mcp", "@attacker.evil.test/x")
+        let resolved = resolve_endpoint("http://8.8.8.8/mcp", "@attacker.evil.test/x", false)
             .expect("userinfo-relative payload must resolve on-origin, not smuggle a host");
         let host = reqwest::Url::parse(&resolved)
             .unwrap()
@@ -828,6 +845,7 @@ mod tests {
         let err = resolve_endpoint(
             "http://169.254.169.254/mcp",
             "http://169.254.169.254/latest/meta-data/",
+            false,
         )
         .expect_err("metadata-IP endpoint must be rejected by the SSRF guard");
         let msg = err.to_string();

--- a/crates/wcore-tools/src/url_safety.rs
+++ b/crates/wcore-tools/src/url_safety.rs
@@ -292,6 +292,31 @@ pub fn is_safe_url_allow_loopback(url: &str) -> bool {
     is_safe_url_with_opts(url, system_resolver, true)
 }
 
+/// True only when `url`'s host is a LOOPBACK target (127.0.0.0/8, ::1, or a
+/// name that resolves exclusively to loopback). Stricter than
+/// [`is_safe_url_allow_loopback`], which also accepts public hosts: this is for
+/// endpoints that MUST be local — e.g. the Forge MCP suite, whose granted
+/// bearer token must never be sent off-box. Fails closed on an unparseable
+/// host, empty resolution, or any non-loopback address in the resolved set.
+pub fn is_loopback_url(url: &str) -> bool {
+    is_loopback_url_with(url, system_resolver)
+}
+
+fn is_loopback_url_with(url: &str, resolve: Resolver) -> bool {
+    let Some(hostname) = extract_hostname(url) else {
+        return false;
+    };
+    // The `url` crate returns bracketed IPv6 hosts (e.g. "[::1]"); strip the
+    // brackets so an IPv6 loopback literal parses instead of falling through
+    // to DNS resolution (which would reject a legitimate `http://[::1]` URL).
+    let literal = hostname.trim_start_matches('[').trim_end_matches(']');
+    if let Ok(ip) = literal.parse::<IpAddr>() {
+        return ip.is_loopback();
+    }
+    let addrs = resolve(&hostname);
+    !addrs.is_empty() && addrs.iter().all(|ip| ip.is_loopback())
+}
+
 /// Resolve `url`'s host once and return the validated, SSRF-safe IPs so the
 /// HTTP-client layer can **pin** them into the connection and close the
 /// DNS-rebinding TOCTOU described on [`is_safe_url`].
@@ -827,6 +852,40 @@ mod tests {
         assert!(safe_url_pinned_ips_with("http://nxdomain.invalid/", fake_resolver).is_none());
         // Unparseable.
         assert!(safe_url_pinned_ips_with("not a url", fake_resolver).is_none());
+    }
+
+    // F12: the loopback-ONLY predicate gates the Forge granted-token egress.
+    // It must accept loopback literals and loopback-only resolutions, and
+    // reject public, private, mixed, and unparseable hosts (fails closed).
+    #[test]
+    fn is_loopback_url_accepts_only_loopback() {
+        // Loopback literals (IPv4 + bracketed IPv6).
+        assert!(is_loopback_url_with("http://127.0.0.1:3456", fake_resolver));
+        assert!(is_loopback_url_with("http://[::1]:80", fake_resolver));
+        // Private (not loopback) → false.
+        assert!(!is_loopback_url_with("http://10.0.0.5", fake_resolver));
+        // Public host (resolver returns a public IP) → false.
+        let public = |host: &str| match host {
+            "evil.example.com" => vec![IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34))],
+            _ => Vec::new(),
+        };
+        assert!(!is_loopback_url_with("https://evil.example.com", public));
+        // Host resolving to a MIX of loopback + public → false (all must be loopback).
+        let mixed = |host: &str| match host {
+            "mixed.local" => vec![
+                IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+                IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34)),
+            ],
+            _ => Vec::new(),
+        };
+        assert!(!is_loopback_url_with("http://mixed.local", mixed));
+        // Unparseable → false.
+        assert!(!is_loopback_url_with("not a url", fake_resolver));
+        // Empty resolution → false (fail closed).
+        assert!(!is_loopback_url_with(
+            "http://nxdomain.invalid",
+            fake_resolver
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Five deep-sweep findings against the **shipped** Forge-MCP discovery/connect code (PRs #28/#29/#30). The first is a real token-exfiltration / SSRF; the rest are reliability defects in the headline connect flow.

## Fixes
- **F12 (security):** the granted bearer token was persisted + sent to `server.url` with **no loopback check**. The forge discovery file lives in a shared, any-local-app-writable config dir, so a tampered entry could grant via a legit loopback endpoint then point `server.url` at an external host and **exfiltrate the scoped token off-box**. New strict loopback-only predicate `wcore_tools::url_safety::is_loopback_url` (with tests, incl. bracketed IPv6 `[::1]`); the connect flow now refuses to store/persist/connect unless `server.url` is loopback.
- **F29:** the grant POST reused the 10s metadata-probe timeout, so any user slower than 10s to click **Approve** got a hard error. The POST now gets its own 120s per-request timeout.
- **F30:** a `200` grant with an empty token was accepted + persisted as a broken server entry → now rejected.
- **F31:** the cross-app discovery file was read with unbounded `read_to_string` on the UI thread during `/doctor` / `/mcp connect` → capped at 256 KiB.
- **F28:** legacy SSE `resolve_endpoint` re-validated with the loopback-**blocking** `is_safe_url` even under `allow_local`, breaking trusted `127.0.0.1` SSE servers → now honors `allow_local`.

## Gates (box-gated)
clippy `--all-targets -D warnings` clean · nextest **3122 pass / 0 fail** (wcore-tools/mcp/config/cli) · fmt clean.

## Context
From a 46-agent whole-repo deep sweep (`.planning/2026-06-18-DEEP-SWEEP-AUDIT.md`). This is Wave 1b of the remediation; the MiniMax-gate findings (F41/F39) landed in #33.
