### PR TITLE
fix(audit): 7 high-severity defects (deep-sweep Wave 2)

### DIFF
--- a/crates/wcore-acp/src/client.rs
+++ b/crates/wcore-acp/src/client.rs
@@ -28,6 +28,13 @@ use crate::protocol::{
 /// the open SSE connection.
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// Hard cap on the SSE reassembly buffer in [`parse_sse_events`]. The streaming
+/// endpoint uses an effectively-infinite (24h) read timeout, so a hostile
+/// server could stream delimiter-free bytes forever; bound the accumulator so
+/// it fails the stream instead of OOMing. 4 MiB matches the MCP streamable-HTTP
+/// SSE cap and exceeds any legitimate single ACP event frame.
+const MAX_ACP_SSE_BUFFER_BYTES: usize = 4 * 1024 * 1024;
+
 /// ACP client over HTTP/SSE. Construct one per base URL + bearer
 /// token; reuse it across requests so connection pooling kicks in.
 #[derive(Debug, Clone)]
@@ -187,6 +194,21 @@ where
                     }
                     // Empty heartbeat — keep looping.
                     continue;
+                }
+                // Bound the reassembly buffer. The HTTP/SSE endpoint sets a 24h
+                // read timeout, so a hostile server streaming delimiter-free
+                // bytes would otherwise accumulate without bound until the host
+                // OOMs. Once the buffer exceeds the cap with no `\n\n` event
+                // boundary in sight, fail the stream. Matches the MCP
+                // streamable-HTTP SSE cap (`MAX_SSE_BUFFER_BYTES`, 4 MiB).
+                if buf.len() > MAX_ACP_SSE_BUFFER_BYTES {
+                    return Some((
+                        Err(AcpError::Transport(format!(
+                            "SSE reassembly buffer exceeded {MAX_ACP_SSE_BUFFER_BYTES} bytes \
+                             without an event boundary — server is misbehaving"
+                        ))),
+                        (stream, buf),
+                    ));
                 }
                 match stream.next().await {
                     Some(Ok(b)) => buf.extend_from_slice(&b),
@@ -352,5 +374,32 @@ mod tests {
             .expect("at least one event")
             .expect("event ok");
         assert!(matches!(first, MessageEvent::Done { .. }), "got {first:?}");
+    }
+
+    /// F8 — a server streaming delimiter-free bytes past the reassembly cap
+    /// must fail the stream with a Transport error rather than accumulating
+    /// without bound (24h read timeout would otherwise OOM the process).
+    #[tokio::test]
+    async fn sse_parser_fails_on_unbounded_delimiterless_stream() {
+        // Each chunk is 64 KiB of non-`\n` bytes; feed enough to exceed the cap.
+        let chunk = bytes::Bytes::from(vec![b'x'; 64 * 1024]);
+        let n = (MAX_ACP_SSE_BUFFER_BYTES / chunk.len()) + 2;
+        let upstream =
+            futures::stream::iter(std::iter::repeat_with(move || Ok(chunk.clone())).take(n));
+
+        let mut events = Box::pin(parse_sse_events(upstream));
+        let item = events
+            .next()
+            .await
+            .expect("the parser must yield a terminal error item");
+        match item {
+            Err(AcpError::Transport(msg)) => {
+                assert!(
+                    msg.contains("reassembly buffer exceeded"),
+                    "expected buffer-cap error, got: {msg}"
+                );
+            }
+            other => panic!("expected a Transport buffer-cap error, got {other:?}"),
+        }
     }
 }

--- a/crates/wcore-channel-matrix/src/rest.rs
+++ b/crates/wcore-channel-matrix/src/rest.rs
@@ -4,12 +4,23 @@
 //! Transaction IDs use a process-local counter (monotonic u64) to make retries idempotent.
 
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 
 use crate::error::MatrixError;
 
 static TXN_COUNTER: AtomicU64 = AtomicU64::new(1);
+
+/// Hard cap on a single media download. The `mxc://` URI is attacker-controlled
+/// (it arrives on an inbound message), so the body is streamed with a byte cap
+/// to prevent an OOM-DoS from a homeserver that omits/lies about
+/// `Content-Length`. Matches the 100 MiB cap used by the Discord/Slack/Telegram
+/// media paths.
+const MAX_MEDIA_BYTES: usize = 100 * 1024 * 1024;
+
+/// Wall-clock timeout for a media download request (including the body read).
+const MEDIA_DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(60);
 
 #[derive(Serialize)]
 struct TextMessageBody<'a> {
@@ -180,6 +191,7 @@ pub async fn download_media(
     let resp = http
         .get(&url)
         .bearer_auth(access_token)
+        .timeout(MEDIA_DOWNLOAD_TIMEOUT)
         .send()
         .await
         .map_err(|e| MatrixError::Network(e.to_string()))?;
@@ -188,11 +200,12 @@ pub async fn download_media(
         let body = resp.text().await.unwrap_or_default();
         return Err(MatrixError::Http { status, body });
     }
-    let bytes = resp
-        .bytes()
+    // Stream the body with a hard cap so a homeserver that omits/lies about
+    // Content-Length on an attacker-supplied mxc:// URI cannot OOM the host.
+    let bytes = wcore_egress::read_body_capped(resp, MAX_MEDIA_BYTES)
         .await
         .map_err(|e| MatrixError::Network(format!("media body read: {e}")))?;
-    Ok(bytes.to_vec())
+    Ok(bytes)
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/wcore-channel-matrix/src/sync.rs
+++ b/crates/wcore-channel-matrix/src/sync.rs
@@ -26,6 +26,16 @@ use crate::error::MatrixError;
 /// timeout is this plus a buffer so a wedged proxy can't park us forever.
 const SYNC_TIMEOUT_MS: u64 = 30_000;
 
+/// Hard cap on a single `/sync` response body. The body is buffered fully to
+/// parse `SyncResponse`, so without a cap a homeserver (or a wedged proxy)
+/// streaming an unbounded body inside this infinite long-poll loop could OOM
+/// the host. 32 MiB comfortably exceeds any legitimate `/sync` payload.
+const MAX_SYNC_BODY_BYTES: usize = 32 * 1024 * 1024;
+
+/// Max length of a homeserver error body we retain in `MatrixError::Http`.
+/// Truncated so a large error payload can't bloat the error/log path.
+const MAX_ERROR_BODY_BYTES: usize = 4 * 1024;
+
 /// Constructor arguments — flatter than a struct, easier to spawn.
 pub(crate) struct SyncArgs {
     pub http: wcore_egress::EgressClient,
@@ -273,13 +283,27 @@ async fn sync_once(
         .map_err(|e| MatrixError::Network(e.to_string()))?;
 
     let status = resp.status().as_u16();
-    if !resp.status().is_success() {
-        let body = resp.text().await.unwrap_or_default();
+    // Read the body through a capped helper so neither the error nor the
+    // success path can buffer an unbounded body inside this long-poll loop.
+    let body_bytes = wcore_egress::read_body_capped(resp, MAX_SYNC_BODY_BYTES)
+        .await
+        .map_err(|e| MatrixError::Network(format!("sync body read: {e}")))?;
+
+    if !(200..300).contains(&status) {
+        // Truncate the retained error body so a large payload can't bloat the
+        // error/log path. Slice on a char boundary to keep the string valid.
+        let mut body = String::from_utf8_lossy(&body_bytes).into_owned();
+        if body.len() > MAX_ERROR_BODY_BYTES {
+            let mut end = MAX_ERROR_BODY_BYTES;
+            while !body.is_char_boundary(end) {
+                end -= 1;
+            }
+            body.truncate(end);
+        }
         return Err(MatrixError::Http { status, body });
     }
 
-    resp.json::<SyncResponse>()
-        .await
+    serde_json::from_slice::<SyncResponse>(&body_bytes)
         .map_err(|e| MatrixError::Parse(e.to_string()))
 }
 

--- a/crates/wcore-mcp/src/transport/streamable_http.rs
+++ b/crates/wcore-mcp/src/transport/streamable_http.rs
@@ -15,6 +15,26 @@ use crate::protocol::{JsonRpcRequest, JsonRpcResponse};
 /// single JSON-RPC response frame.
 const MAX_SSE_BUFFER_BYTES: usize = 4 * 1024 * 1024;
 
+/// Max length of a response-body preview surfaced in a parse-error message.
+const MAX_BODY_PREVIEW_BYTES: usize = 256;
+
+/// Render a bounded, redacted preview of a response body for inclusion in a
+/// parse-error message. The full body is never logged: it may be arbitrarily
+/// large (the cap is megabytes) and may carry secrets. Truncates to
+/// [`MAX_BODY_PREVIEW_BYTES`] on a char boundary and appends an ellipsis when
+/// the body was longer.
+fn redacted_body_preview(body: &[u8]) -> String {
+    let text = String::from_utf8_lossy(body);
+    if text.len() <= MAX_BODY_PREVIEW_BYTES {
+        return text.into_owned();
+    }
+    let mut end = MAX_BODY_PREVIEW_BYTES;
+    while !text.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}… ({} bytes total, truncated)", &text[..end], body.len())
+}
+
 /// Streamable HTTP transport: uses HTTP POST for both requests and responses
 /// Supports optional SSE streaming for server responses
 #[derive(Debug)]
@@ -161,13 +181,21 @@ impl StreamableHttpTransport {
             // SSE response: parse events to find the JSON-RPC response
             self.parse_sse_response(response).await
         } else {
-            // Direct JSON response
-            let text = response
-                .text()
+            // Direct JSON response. Read with the same hard cap the SSE branch
+            // uses (mcp-40) so a server answering `application/json` with an
+            // unbounded body cannot OOM the host.
+            let body = wcore_egress::read_body_capped(response, MAX_SSE_BUFFER_BYTES)
                 .await
                 .map_err(|e| McpError::Transport(format!("Read response body failed: {}", e)))?;
-            serde_json::from_str(&text).map_err(|e| {
-                McpError::Transport(format!("Parse JSON response failed: {} — raw: {}", e, text))
+            serde_json::from_slice(&body).map_err(|e| {
+                // On parse error include only a bounded, redacted preview of the
+                // body — never the full raw payload (which may carry secrets or
+                // be arbitrarily large).
+                McpError::Transport(format!(
+                    "Parse JSON response failed: {} — preview: {}",
+                    e,
+                    redacted_body_preview(&body)
+                ))
             })
         }
     }
@@ -416,5 +444,22 @@ mod tests {
     fn unrelated_json_frame_is_skipped() {
         let frame = r#"{"notification":"progress"}"#;
         assert!(matches!(classify_sse_frame(frame), SseFrame::Skip));
+    }
+
+    /// A short body is previewed verbatim; an oversize body is truncated to a
+    /// bounded preview and never surfaced in full (mcp-40 direct-JSON branch).
+    #[test]
+    fn redacted_body_preview_bounds_oversize_body() {
+        let short = b"{\"ok\":true}";
+        assert_eq!(redacted_body_preview(short), "{\"ok\":true}");
+
+        let big = vec![b'x'; MAX_BODY_PREVIEW_BYTES * 4];
+        let preview = redacted_body_preview(&big);
+        assert!(
+            preview.len() < big.len(),
+            "preview must be shorter than the full body"
+        );
+        assert!(preview.contains("truncated"));
+        assert!(preview.contains(&big.len().to_string()));
     }
 }

--- a/crates/wcore-providers/src/openai_responses.rs
+++ b/crates/wcore-providers/src/openai_responses.rs
@@ -130,7 +130,43 @@ fn build_input(messages: &[Message]) -> Vec<Value> {
         }
     }
 
+    // Drop orphaned `function_call_output` items. The Responses API 400s with
+    // "No tool call found for function call output" on any function_call_output
+    // whose `call_id` has no matching `function_call` item in the same input
+    // set — the same failure the Chat Completions path closes via
+    // `clean_orphaned_tool_results` (FerroxLabs/wayland#85). An orphan arises
+    // when history trimming drops the parent assistant `function_call` while
+    // keeping its result. Stripping it is strictly correct; an orphaned output
+    // is unconditionally invalid to send.
+    clean_orphaned_function_call_outputs(&mut input);
+
     input
+}
+
+/// Remove `function_call_output` items whose `call_id` matches no
+/// `function_call` item in the same input set — the Responses-shape
+/// counterpart to `openai.rs::clean_orphaned_tool_results`.
+fn clean_orphaned_function_call_outputs(input: &mut Vec<Value>) {
+    use std::collections::HashSet;
+
+    let called_ids: HashSet<String> = input
+        .iter()
+        .filter(|item| item["type"].as_str() == Some("function_call"))
+        .filter_map(|item| item["call_id"].as_str().map(String::from))
+        .collect();
+
+    input.retain(|item| {
+        if item["type"].as_str() == Some("function_call_output")
+            && let Some(id) = item["call_id"].as_str()
+        {
+            // Keep only outputs whose call survives in the input set.
+            called_ids.contains(id)
+        } else {
+            // Non-output items, and any malformed output without a call_id,
+            // are out of scope for this pass.
+            true
+        }
+    });
 }
 
 /// A user message becomes either a `message` item with `input_text` content,
@@ -746,6 +782,56 @@ mod tests {
         assert_eq!(input[1]["type"], json!("function_call_output"));
         assert_eq!(input[1]["call_id"], json!("call_abc"));
         assert_eq!(input[1]["output"], json!("file contents"));
+    }
+
+    #[test]
+    fn build_input_drops_orphaned_function_call_output() {
+        // A tool result whose parent assistant function_call was trimmed from
+        // history is an orphan: the Responses API 400s on it. It must be
+        // dropped, while a matched call/output pair is preserved.
+        let orphan_result = Message::new(
+            Role::Tool,
+            vec![ContentBlock::ToolResult {
+                tool_use_id: "call_orphan".into(),
+                content: "stale result".into(),
+                is_error: false,
+            }],
+        );
+        let assistant = Message::new(
+            Role::Assistant,
+            vec![ContentBlock::ToolUse {
+                id: "call_live".into(),
+                name: "read".into(),
+                input: json!({ "path": "x.txt" }),
+                extra: None,
+            }],
+        );
+        let matched_result = Message::new(
+            Role::Tool,
+            vec![ContentBlock::ToolResult {
+                tool_use_id: "call_live".into(),
+                content: "file contents".into(),
+                is_error: false,
+            }],
+        );
+
+        let input = build_input(&[orphan_result, assistant, matched_result]);
+
+        // The orphaned function_call_output (call_orphan) is gone.
+        assert!(
+            !input.iter().any(|item| {
+                item["type"] == json!("function_call_output")
+                    && item["call_id"] == json!("call_orphan")
+            }),
+            "orphaned function_call_output must be dropped, got {input:?}"
+        );
+        // The matched function_call + function_call_output pair survives.
+        assert!(input.iter().any(|item| {
+            item["type"] == json!("function_call") && item["call_id"] == json!("call_live")
+        }));
+        assert!(input.iter().any(|item| {
+            item["type"] == json!("function_call_output") && item["call_id"] == json!("call_live")
+        }));
     }
 
     #[test]

--- a/crates/wcore-tools/src/glob.rs
+++ b/crates/wcore-tools/src/glob.rs
@@ -128,6 +128,29 @@ impl Tool for GlobTool {
     /// through `ctx.vfs.exists()` first. Top-level RealFs is a no-op;
     /// sandboxed sub-agents are clamped to their root.
     async fn execute_with_ctx(&self, input: Value, ctx: &ToolContext) -> ToolResult {
+        // The sandboxed path validates `path` via the VFS, but `execute()`
+        // builds the glob from `pattern` directly against the real filesystem.
+        // An absolute pattern (`/etc/**`) or one containing `..` escapes the
+        // jail and enumerates paths outside it, so reject those shapes here —
+        // only on the sandboxed entry, leaving the direct `execute()` path
+        // unchanged.
+        if let Some(pattern) = input["pattern"].as_str() {
+            let pattern_path = Path::new(pattern);
+            if pattern_path.is_absolute()
+                || pattern_path
+                    .components()
+                    .any(|c| matches!(c, std::path::Component::ParentDir))
+            {
+                return ToolResult {
+                    content: format!(
+                        "Glob refused: pattern {pattern:?} is absolute or contains `..` traversal, \
+                         which would escape the sandbox"
+                    ),
+                    is_error: true,
+                };
+            }
+        }
+
         let path_arg = input["path"].as_str().unwrap_or(".");
         let path = Path::new(path_arg);
         if let Err(e) = ctx.vfs.exists(path).await {
@@ -228,6 +251,50 @@ mod tests {
         assert!(!result.is_error, "glob should succeed");
         let lines: Vec<&str> = result.content.lines().collect();
         assert_eq!(lines.len(), 5, "all 5 files should be returned");
+    }
+
+    #[tokio::test]
+    async fn test_glob_rejects_absolute_and_traversal_patterns_under_sandbox() {
+        use std::sync::Arc;
+        use tokio_util::sync::CancellationToken;
+
+        use crate::context::ToolContext;
+        use crate::vfs::{RealFs, SandboxedFs};
+        use crate::{NullToolOutputSink, ToolOutputSink};
+
+        let dir = tempdir().unwrap();
+        let base = dir.path();
+        fs::write(base.join("main.rs"), "fn main() {}").unwrap();
+
+        let vfs = Arc::new(SandboxedFs::new(RealFs, base));
+        let ctx = ToolContext::new(
+            "test",
+            CancellationToken::new(),
+            vfs,
+            None,
+            Arc::new(NullToolOutputSink) as Arc<dyn ToolOutputSink>,
+        );
+        let tool = GlobTool;
+
+        // Absolute pattern escapes the jail and must be refused.
+        let abs = tool
+            .execute_with_ctx(
+                json!({ "pattern": "/etc/**", "path": base.to_str().unwrap() }),
+                &ctx,
+            )
+            .await;
+        assert!(abs.is_error, "absolute pattern must be rejected");
+        assert!(abs.content.contains("escape the sandbox"));
+
+        // `..` traversal in the pattern also escapes and must be refused.
+        let dotdot = tool
+            .execute_with_ctx(
+                json!({ "pattern": "../**/*.rs", "path": base.to_str().unwrap() }),
+                &ctx,
+            )
+            .await;
+        assert!(dotdot.is_error, "traversal pattern must be rejected");
+        assert!(dotdot.content.contains("escape the sandbox"));
     }
 
     #[tokio::test]

--- a/crates/wcore-tools/src/path_validation.rs
+++ b/crates/wcore-tools/src/path_validation.rs
@@ -225,6 +225,61 @@ fn is_denied_system_path(path: &Path) -> bool {
         return true;
     }
 
+    // Windows read-path deny list. The POSIX suffixes above use forward
+    // slashes and case-sensitive matching, so they give ZERO protection on
+    // Windows where secrets live under `%USERPROFILE%\.ssh\`, `%APPDATA%`,
+    // and the `%WINDIR%\System32\config` registry hives, and paths are
+    // backslash-separated and case-insensitive. Mirror `file_safety.rs`'s
+    // Windows technique here for the READ path: lowercase the path (NTFS is
+    // case-insensitive) and match backslash-form denied substrings. Keep the
+    // POSIX entries above intact — they still apply to `\\?\`-style mixed
+    // inputs and to cross-platform test fixtures.
+    #[cfg(windows)]
+    {
+        let lower = s.to_ascii_lowercase();
+        // Backslash-form credential suffixes under the user profile / appdata.
+        const WINDOWS_DENIED_SUFFIXES: &[&str] = &[
+            r"\.ssh\id_rsa",
+            r"\.ssh\id_ed25519",
+            r"\.ssh\id_ecdsa",
+            r"\.ssh\id_dsa",
+            r"\.ssh\authorized_keys",
+            r"\.ssh\known_hosts",
+            r"\.aws\credentials",
+            r"\.gnupg\private-keys-v1.d",
+            r"\.kube\config",
+            r"\.config\wayland-core\credentials.toml",
+            r"\.wayland\credentials.toml",
+            r"\wayland-core\auth.json",
+            r"\wayland-core\credentials.enc",
+            r"\wayland-core\credentials.key.json",
+            r"\.wayland\cron\",
+            r"\.netrc",
+            r"\.npmrc",
+            r"\.pypirc",
+            r"\.docker\config.json",
+            r"\.gcloud\credentials.db",
+            r"\.azure\",
+        ];
+        if WINDOWS_DENIED_SUFFIXES
+            .iter()
+            .any(|sfx| lower.contains(sfx))
+        {
+            return true;
+        }
+        // `%WINDIR%\System32\config` registry hives (SAM / SYSTEM / SECURITY).
+        // Match component-wise on the lowercased path so a different
+        // SystemDrive (`D:\Windows\...`) is still caught.
+        const WINDOWS_HIVE_SUFFIXES: &[&str] = &[
+            r"\system32\config\sam",
+            r"\system32\config\system",
+            r"\system32\config\security",
+        ];
+        if WINDOWS_HIVE_SUFFIXES.iter().any(|sfx| lower.contains(sfx)) {
+            return true;
+        }
+    }
+
     // M-19 (residual bypass): the `/.wayland/cron/` suffix above only matches
     // the DEFAULT cron dir. The cron store resolves `$WAYLAND_HOME` first
     // (`wcore_cron::store::default_store_path`), so a relocated home puts
@@ -570,6 +625,60 @@ mod tests {
         );
 
         let _ = std::fs::remove_dir_all(&base);
+    }
+
+    // ----- Windows read-path deny list (F2) -----
+    //
+    // These mirror file_safety.rs's Windows write-deny tests for the READ
+    // guard. They use Windows-shaped absolute paths (`C:\Users\...`,
+    // `C:\Windows\System32\config\SAM`) which only validate as absolute on
+    // Windows, so they're gated to cfg(windows) and verified via CI.
+    #[cfg(windows)]
+    #[test]
+    fn windows_ssh_private_key_rejected() {
+        let err = validate_user_path(Path::new(r"C:\Users\alice\.ssh\id_rsa")).unwrap_err();
+        assert!(matches!(err, PathValidationError::SystemPath(_)));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_ssh_private_key_case_insensitive_rejected() {
+        // NTFS is case-insensitive; an upper/mixed-case spelling must still
+        // be denied.
+        let err = validate_user_path(Path::new(r"C:\Users\Alice\.SSH\ID_RSA")).unwrap_err();
+        assert!(matches!(err, PathValidationError::SystemPath(_)));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_aws_credentials_rejected() {
+        let err = validate_user_path(Path::new(
+            r"C:\Users\alice\AppData\Roaming\.aws\credentials",
+        ))
+        .unwrap_err();
+        assert!(matches!(err, PathValidationError::SystemPath(_)));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_sam_hive_rejected() {
+        let err = validate_user_path(Path::new(r"C:\Windows\System32\config\SAM")).unwrap_err();
+        assert!(matches!(err, PathValidationError::SystemPath(_)));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_system_hive_on_other_drive_rejected() {
+        // A relocated SystemDrive must still be caught (component-wise match).
+        let err = validate_user_path(Path::new(r"D:\Windows\System32\config\SYSTEM")).unwrap_err();
+        assert!(matches!(err, PathValidationError::SystemPath(_)));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_ordinary_path_allowed() {
+        let p = validate_user_path(Path::new(r"C:\work\notes.txt")).unwrap();
+        assert_eq!(p, PathBuf::from(r"C:\work\notes.txt"));
     }
 
     // Companion: a symlink to a benign file is still allowed (no


### PR DESCRIPTION
## Summary
Wave 2 of the deep-sweep remediation: the 7 remaining **High**-severity findings (F12/F29 landed in #34, F41/F39 in #33). All independently verified against source. From `.planning/2026-06-18-DEEP-SWEEP-AUDIT.md`.

## Fixes
| ID | Area | Fix |
|----|------|-----|
| **F1** | Sandbox | Glob globbed the `pattern` arg against the real FS with no VFS clamp — absolute (`/etc/**`) or `..` patterns escaped the SandboxedFs jail. Now rejected in the sandboxed entry. |
| **F2** | Security (Windows) | Read-path secret denylist was POSIX-only → zero protection on Windows. Added `#[cfg(windows)]` backslash/case-insensitive deny entries mirroring `file_safety.rs`. |
| **F3** | Provider | OpenAI **Responses** path never stripped orphaned `function_call_output`, reopening the wayland#85 400 that bricks gpt-5/Codex sessions. Added cleanup mirroring Chat Completions. |
| **F5** | DoS | Matrix media download: uncapped `resp.bytes()` + no timeout on attacker-controlled `mxc://` → `read_body_capped(100 MiB)` + 60s timeout. |
| **F6** | DoS | Matrix `/sync` buffered bodies uncapped in an infinite long-poll → capped reads + bounded parse. |
| **F7** | DoS | Streamable-HTTP MCP direct-JSON read uncapped + logged full body on error → capped (4 MiB) + redacted preview. |
| **F8** | DoS | ACP SSE buffered unbounded until the 24h timeout → 4 MiB max-buffer guard fails the stream. |

## Gates (box-gated)
clippy `--all-targets -D warnings` clean · nextest **1934 pass / 0 fail** (5 crates) · fmt clean. **F2 is `#[cfg(windows)]` — verified by inspection + Windows CI only** (the gate box is Linux).
