### PR TITLE
fix(audit): 19 low/medium defects (deep-sweep Wave 4)

### DIFF
--- a/crates/wcore-browser/src/backends/camoufox.rs
+++ b/crates/wcore-browser/src/backends/camoufox.rs
@@ -180,7 +180,7 @@ impl BrowserProvider for CamoufoxBackend {
                 url,
                 wait_until_loaded,
             } => {
-                let body = json!({ "url": url, "wait_until_loaded": wait_until_loaded });
+                let body = json!({ "url": &url, "wait_until_loaded": wait_until_loaded });
                 // The Camoufox sidecar's /navigate endpoint MUST return the
                 // post-redirect landing URL as `final_url`. We re-check it
                 // against the policy so a 3xx chain that lands on
@@ -191,9 +191,21 @@ impl BrowserProvider for CamoufoxBackend {
                 let resp: serde_json::Value = self
                     .post_json_lenient(&format!("/sessions/{sid}/navigate"), &body)
                     .await?;
-                if let Some(policy) = self.policy.as_ref()
-                    && let Some(final_url) = resp.get("final_url").and_then(|v| v.as_str())
-                {
+                if let Some(policy) = self.policy.as_ref() {
+                    // FAIL CLOSED: when a policy is in force, the sidecar MUST
+                    // hand back a parseable `final_url`. If it's absent or
+                    // non-string we cannot re-check the post-redirect landing
+                    // URL — the `and_then` short-circuit would otherwise SKIP
+                    // `policy.evaluate` and return Ok, silently bypassing
+                    // BLOCKER #3's redirect-SSRF defense. Deny instead.
+                    let Some(final_url) = resp.get("final_url").and_then(|v| v.as_str()) else {
+                        return Err(BrowserOpError::PolicyDenied {
+                            url: url.clone(),
+                            reason: "post-redirect final_url missing/unparseable; \
+                                     failing closed to enforce redirect policy"
+                                .to_string(),
+                        });
+                    };
                     match policy.evaluate(final_url) {
                         PolicyOutcome::Allow => {}
                         PolicyOutcome::Deny { reason } => {
@@ -443,6 +455,68 @@ mod tests {
             }
             other => panic!("unexpected: {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn navigate_fails_closed_when_final_url_missing_under_policy() {
+        // F18: when a policy is installed, a navigate response that lacks a
+        // parseable `final_url` MUST be denied (fail closed) instead of the
+        // `and_then` short-circuit silently skipping the policy re-check.
+        use crate::policy::{BrowserPolicy, PolicyAction};
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/sessions/sess-fc/navigate"))
+            // No `final_url` field in the body.
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({"ok": true})))
+            .mount(&server)
+            .await;
+        // Allow-everything policy: proves the deny is the missing-final_url
+        // fail-closed guard, not the policy decision itself.
+        let policy = BrowserPolicy::new(PolicyAction::Allow, vec!["example.com".into()], vec![]);
+        let cf = CamoufoxBackend::with_policy(server.uri(), policy);
+        let r = cf
+            .dispatch(
+                &SessionCtx::for_test("sess-fc"),
+                BrowserOp::Navigate {
+                    url: "https://example.com/".into(),
+                    wait_until_loaded: true,
+                },
+            )
+            .await;
+        match r {
+            Err(BrowserOpError::PolicyDenied { reason, .. }) => {
+                assert!(
+                    reason.contains("final_url") && reason.contains("failing closed"),
+                    "unexpected reason: {reason}"
+                );
+            }
+            other => panic!("expected PolicyDenied fail-closed, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn navigate_without_policy_tolerates_missing_final_url() {
+        // The fail-closed guard only applies when a policy is present. With no
+        // policy (legacy "trust the sidecar" mode), a missing `final_url` must
+        // still return Ok.
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/sessions/sess-np/navigate"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({"ok": true})))
+            .mount(&server)
+            .await;
+        let cf = CamoufoxBackend::new(server.uri());
+        let r = cf
+            .dispatch(
+                &SessionCtx::for_test("sess-np"),
+                BrowserOp::Navigate {
+                    url: "https://example.com/".into(),
+                    wait_until_loaded: true,
+                },
+            )
+            .await
+            .unwrap();
+        assert!(matches!(r, OpResult::Ok));
     }
 
     #[tokio::test]

--- a/crates/wcore-browser/src/selection.rs
+++ b/crates/wcore-browser/src/selection.rs
@@ -59,7 +59,27 @@ pub fn select_provider(inputs: SelectionInputs) -> Arc<dyn BrowserProvider> {
             && matches!(inputs.hint, ProviderHint::Browserbase)
             && let Some(bb) = BrowserbaseBackend::from_env()
         {
-            return Arc::new(bb) as Arc<dyn BrowserProvider>;
+            // F17: Browserbase navigation happens server-side in the cloud
+            // browser, so a client-side `reqwest::redirect::Policy` on our
+            // calls to `api.browserbase.com` CANNOT constrain where the
+            // remote browser is redirected — the BLOCKER #3 redirect-SSRF
+            // defense (and the always-on metadata/loopback/private blocks)
+            // are unenforceable for this backend. When a `BrowserPolicy` is
+            // in force we therefore REFUSE Browserbase and fall through to
+            // Camoufox, which does enforce the policy. Only `policy == None`
+            // (the legacy "trust the sidecar" mode with no enforcement
+            // expectation) permits the cloud backend.
+            if inputs.policy.is_some() {
+                tracing::warn!(
+                    "ProviderHint::Browserbase requested with a BrowserPolicy set, but the \
+                     Browserbase backend cannot enforce the URL policy (navigation + redirects \
+                     happen server-side in the cloud browser). Refusing Browserbase and falling \
+                     back to Camoufox so the policy is enforced. Clear the policy to use \
+                     Browserbase, or use Camoufox/Chromium for policy-enforced browsing."
+                );
+            } else {
+                return Arc::new(bb) as Arc<dyn BrowserProvider>;
+            }
         }
     }
     // 2. Chromium: explicit hint AND feature on.
@@ -131,6 +151,26 @@ mod tests {
             ..Default::default()
         });
         assert_eq!(p.backend_name(), "camoufox");
+    }
+
+    #[cfg(feature = "browserbase")]
+    #[test]
+    fn browserbase_refused_when_policy_set_falls_back_to_camoufox() {
+        // F17: Browserbase cannot enforce a BrowserPolicy (navigation +
+        // redirects are server-side in the cloud browser). When a policy is
+        // present, selection must refuse Browserbase and fall back to Camoufox
+        // — regardless of whether BROWSERBASE_* creds are set in the env.
+        let p = select_provider(SelectionInputs {
+            hint: ProviderHint::Browserbase,
+            allow_cloud: true,
+            policy: Some(BrowserPolicy::default()),
+            ..Default::default()
+        });
+        assert_eq!(
+            p.backend_name(),
+            "camoufox",
+            "a set policy must refuse the policy-incapable Browserbase backend"
+        );
     }
 
     #[test]

--- a/crates/wcore-browser/src/supervisor.rs
+++ b/crates/wcore-browser/src/supervisor.rs
@@ -135,10 +135,11 @@ impl BrowserSupervisor {
         });
         drop(guard);
         if let Some(h) = removed {
-            terminate_pid(h.pid);
-            // Drop the stashed Child handle so its fds + zombie slot are
-            // released instead of being held for the host process lifetime.
-            release_child(session_id);
+            // F25: kill through the stashed Child handle when present (race-free
+            // vs PID reuse), falling back to the raw PID for orphan recovery.
+            // `terminate_session` also removes the stashed handle, releasing its
+            // fds + zombie slot instead of holding them for the host lifetime.
+            terminate_session(session_id, h.pid);
             let pid_path = self.config.pid_dir.join(format!("{session_id}.pid"));
             let _ = std::fs::remove_file(&pid_path);
             true
@@ -168,7 +169,13 @@ impl BrowserSupervisor {
         let interval = self.config.reaper_interval;
         let sessions = Arc::clone(&self.sessions);
         let pid_dir = self.config.pid_dir.clone();
-        *self.reaper_cancel.lock() = Some(cancel.clone());
+        // F24: a second `start_reaper` would otherwise overwrite the stored
+        // token, orphaning the prior reaper + healthcheck tasks (they hold the
+        // OLD token and never get cancelled). Cancel and replace atomically so
+        // the previous task pair shuts down before the new one starts.
+        if let Some(prev) = self.reaper_cancel.lock().replace(cancel.clone()) {
+            prev.cancel();
+        }
 
         // Schedule the healthcheck loop on the same cancellation token. A
         // zero interval means "disabled" — `tokio::time::interval` panics on a
@@ -176,7 +183,12 @@ impl BrowserSupervisor {
         if !self.config.healthcheck_interval.is_zero() {
             let cancel_for_health = cancel.clone();
             let hc_interval = self.config.healthcheck_interval;
-            let sup = Arc::clone(self);
+            // F23: capture a `Weak<Self>` (not a strong `Arc`). A strong ref
+            // here forms a refcount cycle that keeps the supervisor alive
+            // forever, so `Drop` (which cancels the reaper) never runs. With a
+            // Weak we `upgrade()` per tick and stop the loop the moment the
+            // supervisor is dropped — breaking the cycle.
+            let sup = Arc::downgrade(self);
             tokio::spawn(async move {
                 let mut ticker = tokio::time::interval(hc_interval);
                 ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
@@ -187,6 +199,8 @@ impl BrowserSupervisor {
                     tokio::select! {
                         _ = cancel_for_health.cancelled() => break,
                         _ = ticker.tick() => {
+                            // Stop probing once the supervisor is gone.
+                            let Some(sup) = sup.upgrade() else { break };
                             // Best-effort liveness probe; errors are non-fatal
                             // (sidecar may be starting/restarting).
                             let _ = sup.healthcheck(hc_interval).await;
@@ -207,7 +221,10 @@ impl BrowserSupervisor {
                         let mut orphan_sessions: Vec<String> = Vec::new();
                         for h in &snapshot {
                             if !process_alive(h.parent_pid) {
-                                terminate_pid(h.pid);
+                                // F25: prefer the stashed Child handle (race-free
+                                // vs PID reuse); fall back to the raw PID for
+                                // cross-boot orphans with no handle.
+                                terminate_session(&h.session_id, h.pid);
                                 orphan_sessions.push(h.session_id.clone());
                             }
                         }
@@ -298,11 +315,22 @@ fn retain_child(session: &str, child: tokio::process::Child) {
     children_map().lock().insert(session.to_string(), child);
 }
 
-/// Drop the stashed `Child` handle for `session`, releasing its fds + zombie
-/// slot so the OS can reap it. Called by `on_session_end` after `terminate_pid`
-/// so the handle no longer loiters for the host process lifetime.
-fn release_child(session: &str) {
-    children_map().lock().remove(session);
+/// Terminate the backend for `session` race-free. When a stashed
+/// [`tokio::process::Child`] handle exists (the in-process spawn path) we kill
+/// THROUGH it — the kernel guarantees the signal targets that exact child even
+/// if the recorded numeric PID has since been recycled by the OS (F25). Only
+/// when no handle exists (cross-boot orphan recovery, where the child was
+/// spawned by a previous host process) do we fall back to signalling the raw
+/// `pid`.
+fn terminate_session(session: &str, pid: u32) {
+    let mut map = children_map().lock();
+    if let Some(mut child) = map.remove(session) {
+        // start_kill targets the Child by handle — immune to PID reuse.
+        let _ = child.start_kill();
+    } else {
+        drop(map);
+        terminate_pid(pid);
+    }
 }
 
 /// Returns `true` if the process with `pid` is alive. Implementation:
@@ -551,6 +579,33 @@ mod tests {
             !children_map().lock().contains_key(sid),
             "on_session_end must remove the stashed child handle"
         );
+    }
+
+    #[tokio::test]
+    async fn start_reaper_twice_cancels_prior_task_pair() {
+        // F24: a second `start_reaper` must cancel the first token so the prior
+        // reaper + healthcheck tasks shut down instead of leaking. Assert the
+        // first-returned token is cancelled once the second call runs.
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg = SupervisorConfig {
+            pid_dir: tmp.path().to_path_buf(),
+            reaper_interval: Duration::from_secs(3600),
+            healthcheck_interval: Duration::from_secs(3600),
+            healthcheck_url: "http://unused.invalid/".into(),
+        };
+        let sup = Arc::new(BrowserSupervisor::with_config(cfg));
+        let first = sup.start_reaper();
+        assert!(
+            !first.is_cancelled(),
+            "first token live before second start"
+        );
+        let second = sup.start_reaper();
+        assert!(
+            first.is_cancelled(),
+            "second start_reaper must cancel the first token (F24)"
+        );
+        assert!(!second.is_cancelled(), "second token must be live");
+        second.cancel();
     }
 
     #[tokio::test]

--- a/crates/wcore-browser/src/tool.rs
+++ b/crates/wcore-browser/src/tool.rs
@@ -297,11 +297,33 @@ impl BrowserTool {
         if let Some(s) = self.sessions.lock().get(&key) {
             return Ok(s.clone());
         }
+        // The lock is released across this `await` (we must not hold a
+        // `parking_lot::Mutex` guard over an await point). Two concurrent
+        // first-calls for the same key can therefore both miss above and both
+        // open a backend session. F38: re-check the map under the lock after
+        // opening — if a racing call already inserted a session, we are the
+        // loser; close the session we just opened (so it isn't orphaned) and
+        // use the winner's id.
         let sess = self.provider.open_session(false).await?;
-        self.sessions
-            .lock()
-            .insert(key, sess.ctx.session_id.clone());
-        Ok(sess.ctx.session_id)
+        let winner = {
+            let mut guard = self.sessions.lock();
+            match guard.get(&key) {
+                Some(existing) => Some(existing.clone()),
+                None => {
+                    guard.insert(key, sess.ctx.session_id.clone());
+                    None
+                }
+            }
+        };
+        match winner {
+            Some(existing) => {
+                // We lost the race: close our just-opened session to avoid
+                // leaking it, then return the winner's id.
+                let _ = self.provider.close_session(&sess.ctx).await;
+                Ok(existing)
+            }
+            None => Ok(sess.ctx.session_id),
+        }
     }
 
     /// Apply policy for URL-bearing ops. Non-URL ops always pass.
@@ -790,6 +812,89 @@ mod tests {
             r.is_error,
             "symlink-escape dest must be rejected: {}",
             r.content
+        );
+    }
+
+    /// F38: two concurrent first-calls to `ensure_session` for the same key
+    /// must converge on ONE session. The losing call closes the backend
+    /// session it opened (no orphan) and both callers see the same id.
+    #[tokio::test]
+    async fn ensure_session_race_closes_loser_and_converges() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        struct CountingBackend {
+            next_id: AtomicUsize,
+            opened: Arc<AtomicUsize>,
+            closed: Arc<AtomicUsize>,
+        }
+
+        #[async_trait]
+        impl BrowserProvider for CountingBackend {
+            async fn open_session(
+                &self,
+                persistent_profile: bool,
+            ) -> Result<BrowserSession, BrowserOpError> {
+                // Yield so two concurrent callers interleave past the initial
+                // miss before either inserts — reproducing the race.
+                tokio::task::yield_now().await;
+                let n = self.next_id.fetch_add(1, Ordering::SeqCst);
+                self.opened.fetch_add(1, Ordering::SeqCst);
+                Ok(BrowserSession {
+                    ctx: SessionCtx::for_test(format!("sess-{n}")),
+                    persistent_profile,
+                })
+            }
+            async fn close_session(&self, _ctx: &SessionCtx) -> Result<(), BrowserOpError> {
+                self.closed.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            }
+            async fn dispatch(
+                &self,
+                _ctx: &SessionCtx,
+                _op: BrowserOp,
+            ) -> Result<OpResult, BrowserOpError> {
+                Ok(OpResult::Ok)
+            }
+            fn backend_name(&self) -> &'static str {
+                "counting"
+            }
+        }
+
+        let opened = Arc::new(AtomicUsize::new(0));
+        let closed = Arc::new(AtomicUsize::new(0));
+        let tool = Arc::new(BrowserTool::new(
+            Arc::new(CountingBackend {
+                next_id: AtomicUsize::new(0),
+                opened: opened.clone(),
+                closed: closed.clone(),
+            }),
+            BrowserPolicy::default(),
+            Arc::new(BrowserSupervisor::new()),
+        ));
+
+        let t1 = {
+            let tool = tool.clone();
+            tokio::spawn(async move { tool.ensure_session(Some("writer")).await })
+        };
+        let t2 = {
+            let tool = tool.clone();
+            tokio::spawn(async move { tool.ensure_session(Some("writer")).await })
+        };
+        let id1 = t1.await.unwrap().unwrap();
+        let id2 = t2.await.unwrap().unwrap();
+
+        // Both callers converge on the same surviving session id.
+        assert_eq!(id1, id2, "both callers must see the same session id");
+        // Exactly one session remains tracked for the key.
+        assert_eq!(tool.sessions.lock().get("writer"), Some(&id1));
+        // If both raced to open (the common case under yield_now), the loser
+        // must have been closed. We never close more than we opened, and the
+        // surviving id is never the one that got closed.
+        let n_opened = opened.load(Ordering::SeqCst);
+        let n_closed = closed.load(Ordering::SeqCst);
+        assert!(
+            n_closed == n_opened.saturating_sub(1),
+            "expected exactly one fewer close than open (opened={n_opened}, closed={n_closed})"
         );
     }
 

--- a/crates/wcore-channel-discord/src/gateway.rs
+++ b/crates/wcore-channel-discord/src/gateway.rs
@@ -965,10 +965,13 @@ async fn run_one_session(
                             && let Some(im) =
                                 map_message_create(mc, allowed_channel_ids, bot_id)
                         {
-                            inbox
-                                .lock()
-                                .await
-                                .push_back(ChannelEvent::MessageReceived { msg: im });
+                            // F9 — bounded, drop-oldest inbox so a message
+                            // flood cannot grow the queue unbounded.
+                            let mut guard = inbox.lock().await;
+                            wcore_channels::push_bounded(
+                                &mut guard,
+                                ChannelEvent::MessageReceived { msg: im },
+                            );
                         }
                         // Other DISPATCH events (GUILD_CREATE, …) are not
                         // surfaced.

--- a/crates/wcore-channel-email/src/imap.rs
+++ b/crates/wcore-channel-email/src/imap.rs
@@ -301,7 +301,8 @@ fn poll_once(
         runtime_handle.block_on(async {
             let mut guard = inbox.lock().await;
             for e in new_events {
-                guard.push_back(e);
+                // F9 — bounded, drop-oldest inbox against a flood.
+                wcore_channels::push_bounded(&mut guard, e);
             }
         });
     }

--- a/crates/wcore-channel-imessage/src/channel.rs
+++ b/crates/wcore-channel-imessage/src/channel.rs
@@ -356,10 +356,9 @@ async fn poll_loop(
                         ..Default::default()
                     };
 
-                    inbox
-                        .lock()
-                        .await
-                        .push_back(ChannelEvent::MessageReceived { msg });
+                    // F9 — bounded, drop-oldest inbox against a flood.
+                    let mut guard = inbox.lock().await;
+                    wcore_channels::push_bounded(&mut guard, ChannelEvent::MessageReceived { msg });
                 }
             }
             Err(e) => {

--- a/crates/wcore-channel-matrix/src/sync.rs
+++ b/crates/wcore-channel-matrix/src/sync.rs
@@ -209,7 +209,8 @@ pub(crate) async fn sync_loop(args: SyncArgs) {
                     if !events.is_empty() {
                         let mut guard = inbox.lock().await;
                         for e in events {
-                            guard.push_back(e);
+                            // F9 — bounded, drop-oldest inbox against a flood.
+                            wcore_channels::push_bounded(&mut guard, e);
                         }
                     }
                 }

--- a/crates/wcore-channel-msteams/src/lib.rs
+++ b/crates/wcore-channel-msteams/src/lib.rs
@@ -133,10 +133,9 @@ impl MsTeamsChannel {
     /// some other way.
     pub async fn ingest_activity(&self, raw_body: &str) -> Result<(), MsTeamsError> {
         if let Some(msg) = inbound::activity_to_incoming(raw_body, &self.config.service_url)? {
-            self.inbox
-                .lock()
-                .await
-                .push_back(ChannelEvent::MessageReceived { msg });
+            // F9 — bounded, drop-oldest inbox against a flood.
+            let mut guard = self.inbox.lock().await;
+            wcore_channels::push_bounded(&mut guard, ChannelEvent::MessageReceived { msg });
         }
         Ok(())
     }

--- a/crates/wcore-channel-signal/src/subprocess.rs
+++ b/crates/wcore-channel-signal/src/subprocess.rs
@@ -200,10 +200,12 @@ async fn dispatch_line(
             match serde_json::from_value::<ReceiveParams>(params) {
                 Ok(parsed) => {
                     if let Some(msg) = build_incoming(&parsed) {
-                        inbox
-                            .lock()
-                            .await
-                            .push_back(ChannelEvent::MessageReceived { msg });
+                        // F9 — bounded, drop-oldest inbox against a flood.
+                        let mut guard = inbox.lock().await;
+                        wcore_channels::push_bounded(
+                            &mut guard,
+                            ChannelEvent::MessageReceived { msg },
+                        );
                     }
                 }
                 Err(e) => {

--- a/crates/wcore-channel-slack/src/lib.rs
+++ b/crates/wcore-channel-slack/src/lib.rs
@@ -125,7 +125,9 @@ impl SlackChannel {
         match inbound::parse_webhook(raw_body)? {
             inbound::Parsed::Challenge(c) => Ok(Some(c)),
             inbound::Parsed::Event(ev) => {
-                self.inbox.lock().await.push_back(ev);
+                // F9 — bounded, drop-oldest inbox against a flood.
+                let mut guard = self.inbox.lock().await;
+                wcore_channels::push_bounded(&mut guard, ev);
                 Ok(None)
             }
             inbound::Parsed::Ignored => Ok(None),

--- a/crates/wcore-channel-sms/src/lib.rs
+++ b/crates/wcore-channel-sms/src/lib.rs
@@ -135,10 +135,9 @@ impl SmsChannel {
 
         let pairs = inbound::verify_signature(auth_token, full_url, raw_body, signature)?;
         let msg = inbound::pairs_to_incoming(&pairs)?;
-        self.inbox
-            .lock()
-            .await
-            .push_back(ChannelEvent::MessageReceived { msg });
+        // F9 — bounded, drop-oldest inbox against a flood.
+        let mut guard = self.inbox.lock().await;
+        wcore_channels::push_bounded(&mut guard, ChannelEvent::MessageReceived { msg });
         Ok(())
     }
 }

--- a/crates/wcore-channel-telegram/src/longpoll.rs
+++ b/crates/wcore-channel-telegram/src/longpoll.rs
@@ -400,7 +400,8 @@ async fn ingest_updates(
     if !events.is_empty() {
         let mut guard = inbox.lock().await;
         for e in events {
-            guard.push_back(e);
+            // F9 — bounded, drop-oldest inbox against a flood.
+            wcore_channels::push_bounded(&mut guard, e);
         }
     }
 }

--- a/crates/wcore-channel-whatsapp/src/lib.rs
+++ b/crates/wcore-channel-whatsapp/src/lib.rs
@@ -127,7 +127,8 @@ impl WhatsappChannel {
         }
         let mut inbox = self.inbox.lock().await;
         for ev in events {
-            inbox.push_back(ev);
+            // F9 — bounded, drop-oldest inbox against a flood.
+            wcore_channels::push_bounded(&mut inbox, ev);
         }
         Ok(())
     }

--- a/crates/wcore-channels/src/event.rs
+++ b/crates/wcore-channels/src/event.rs
@@ -1,6 +1,42 @@
 //! `ChannelEvent` — uniform event shape across platforms.
 
+use std::collections::VecDeque;
+use std::sync::atomic::{AtomicBool, Ordering};
+
 use serde::{Deserialize, Serialize};
+
+/// Maximum number of buffered inbound events held in a channel adapter's
+/// inbox before `poll_events` drains it. A remote peer can flood inbound
+/// messages faster than the host polls; without a cap the inbox
+/// `VecDeque` grows unbounded and OOMs the process (audit F9). 1024 events
+/// is far more than any healthy poll cadence leaves un-drained, yet small
+/// enough to bound memory.
+pub const MAX_INBOX: usize = 1024;
+
+/// Tracks whether the drop-oldest overflow warning has already been logged
+/// so a sustained flood emits exactly one warning rather than one per
+/// dropped event.
+static INBOX_OVERFLOW_WARNED: AtomicBool = AtomicBool::new(false);
+
+/// Push `event` onto a channel adapter's inbox with a bounded, drop-oldest
+/// overflow policy (audit F9). When the inbox is already at [`MAX_INBOX`]
+/// the oldest buffered event is dropped before the new one is pushed, and a
+/// warning is logged once. Shared by every channel adapter so the bound is
+/// applied uniformly (no per-crate copy of the cap logic).
+pub fn push_bounded(inbox: &mut VecDeque<ChannelEvent>, event: ChannelEvent) {
+    if inbox.len() >= MAX_INBOX {
+        inbox.pop_front();
+        if !INBOX_OVERFLOW_WARNED.swap(true, Ordering::Relaxed) {
+            tracing::warn!(
+                target: "wcore_channels::inbox",
+                max_inbox = MAX_INBOX,
+                "channel inbox full — dropping oldest buffered event; \
+                 poll_events is not draining fast enough"
+            );
+        }
+    }
+    inbox.push_back(event);
+}
 
 /// Connection state for a channel. Surfaces through
 /// `ChannelEvent::ConnectionStateChanged` so the UI can show online
@@ -246,4 +282,77 @@ pub enum ChannelEvent {
     ConnectionStateChanged { state: ConnectionState },
     AuthExpired { reason: String },
     PlatformWarning { message: String },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Cheap, distinguishable event tagged with `n` so FIFO order is
+    /// observable without constructing a full `IncomingMessage`.
+    fn ev(n: usize) -> ChannelEvent {
+        ChannelEvent::AuthExpired {
+            reason: n.to_string(),
+        }
+    }
+
+    fn tag(e: &ChannelEvent) -> usize {
+        match e {
+            ChannelEvent::AuthExpired { reason } => reason.parse().unwrap(),
+            _ => unreachable!("test only pushes AuthExpired events"),
+        }
+    }
+
+    #[test]
+    fn push_bounded_keeps_under_cap_in_order() {
+        let mut inbox = VecDeque::new();
+        for n in 0..10 {
+            push_bounded(&mut inbox, ev(n));
+        }
+        assert_eq!(inbox.len(), 10, "below cap, nothing is dropped");
+        assert_eq!(tag(&inbox[0]), 0, "oldest stays at the front");
+        assert_eq!(tag(&inbox[9]), 9, "newest at the back");
+    }
+
+    #[test]
+    fn push_bounded_drops_oldest_on_overflow() {
+        let mut inbox = VecDeque::new();
+        // Push one more than the cap. The first event (0) must be evicted.
+        for n in 0..=MAX_INBOX {
+            push_bounded(&mut inbox, ev(n));
+        }
+        assert_eq!(inbox.len(), MAX_INBOX, "length is capped at MAX_INBOX");
+        assert_eq!(
+            tag(inbox.front().unwrap()),
+            1,
+            "the oldest event (0) was dropped, so the front is now 1"
+        );
+        assert_eq!(
+            tag(inbox.back().unwrap()),
+            MAX_INBOX,
+            "the newest event is retained at the back"
+        );
+    }
+
+    #[test]
+    fn push_bounded_sustained_overflow_stays_capped() {
+        let mut inbox = VecDeque::new();
+        // Flood well past the cap; the inbox must never exceed MAX_INBOX and
+        // must retain the most-recent MAX_INBOX events (drop-oldest).
+        let total = MAX_INBOX * 3;
+        for n in 0..total {
+            push_bounded(&mut inbox, ev(n));
+        }
+        assert_eq!(inbox.len(), MAX_INBOX);
+        assert_eq!(
+            tag(inbox.front().unwrap()),
+            total - MAX_INBOX,
+            "front is the oldest of the retained tail window"
+        );
+        assert_eq!(
+            tag(inbox.back().unwrap()),
+            total - 1,
+            "back is the most-recent event"
+        );
+    }
 }

--- a/crates/wcore-channels/src/lib.rs
+++ b/crates/wcore-channels/src/lib.rs
@@ -33,8 +33,8 @@ pub use dispatch::{
 };
 pub use error::ChannelError;
 pub use event::{
-    Attachment, ChannelEvent, ChatType, ConnectionState, IncomingMessage, MediaKind, MentionKind,
-    MessageReceipt,
+    Attachment, ChannelEvent, ChatType, ConnectionState, IncomingMessage, MAX_INBOX, MediaKind,
+    MentionKind, MessageReceipt, push_bounded,
 };
 pub use manager::{ChannelManager, TaggedEvent};
 pub use mock::MockChannel;

--- a/crates/wcore-cli/src/tui/engine_bridge.rs
+++ b/crates/wcore-cli/src/tui/engine_bridge.rs
@@ -29,6 +29,7 @@
 use std::collections::HashSet;
 use std::io;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
 use tokio::sync::mpsc::UnboundedSender;
@@ -773,6 +774,17 @@ pub struct TuiEngine {
     /// before a submit so the spawned turn task can resolve an `@output`
     /// reference. Consumed (`take`n) per submit; `None` between turns.
     pending_at_ref_output: Option<String>,
+    /// F37: monotonic generation counter for deferred rebinds. When the
+    /// engine lock is contended, `rebind_with_config` spawns a task that
+    /// applies the new binding once the in-flight turn releases the lock.
+    /// Two binding-changing commands during one turn each spawn such a task,
+    /// and tokio does not order their lock acquisitions — so the
+    /// later-issued config could land first, leaving the engine on a stale
+    /// binding. Each deferred rebind bumps this counter and captures its own
+    /// generation; after acquiring the lock the task re-checks the counter
+    /// and skips its swap if a newer rebind has superseded it, so only the
+    /// most recently requested config is ever applied.
+    rebind_generation: Arc<AtomicU64>,
 }
 
 impl TuiEngine {
@@ -806,6 +818,7 @@ impl TuiEngine {
             repo_root: PathBuf::from("."),
             session_store: None,
             pending_at_ref_output: None,
+            rebind_generation: Arc::new(AtomicU64::new(0)),
         }
     }
 
@@ -1398,6 +1411,12 @@ impl TuiEngine {
         // the session is force-pinned, preserve the live posture by skipping the
         // approval set_mode below.
         let apply_mode = !force_pinned;
+        // F37: claim a generation for THIS rebind request. A later rebind
+        // issued while a turn still holds the engine lock will claim a higher
+        // generation; the deferred task below checks this before applying so a
+        // superseded (older) config never lands after a newer one.
+        let my_generation = self.rebind_generation.fetch_add(1, Ordering::SeqCst) + 1;
+        let rebind_generation = self.rebind_generation.clone();
         // N3: swap synchronously when the engine lock is uncontended (the common
         // case right after onboarding completion or a /config save, when no turn
         // is in flight) so an immediate first submit cannot race onto the old
@@ -1428,6 +1447,14 @@ impl TuiEngine {
                     // in-flight turn wholly on the old binding; the new posture
                     // lands atomically with the swap, for the next turn.
                     let mut guard = engine_for_task.lock().await;
+                    // F37: a newer rebind may have been issued (and may have
+                    // already applied) while this task waited for the lock.
+                    // Applying this now-stale config would clobber the newer
+                    // binding. Skip if superseded — only the latest desired
+                    // config wins.
+                    if rebind_generation.load(Ordering::SeqCst) != my_generation {
+                        return;
+                    }
                     if apply_mode {
                         approval.set_mode(task_mode);
                     }
@@ -1749,15 +1776,33 @@ impl TuiEngine {
         name: String,
         mut config: wcore_config::config::McpServerConfig,
     ) {
-        // Resolve `${cred:KEY}` header references just before connecting.
-        // Best-effort: if the store can't be opened, the literal header is left
-        // in place and the connect fails honestly below (no silent empty bearer).
-        // A no-reference header (the plain `/mcp add` path) never touches the store.
+        // Resolve `${cred:KEY}` header references just before connecting. This
+        // is the single-server live-add path: per the `mcp_cred_refs` contract,
+        // a resolution failure (missing key / store error / malformed ref) is a
+        // HARD error the user must see — the user just asked to connect THIS
+        // server, so silently falling through to a literal `${cred:...}` bearer
+        // would be a confusing mis-connect (F22). A no-reference header (the
+        // plain `/mcp add` path) never touches the store and never errors.
         if let Ok(cfg) =
             wcore_config::config::Config::resolve(&wcore_config::config::CliArgs::default())
             && let Ok(store) = cfg.open_credentials_store()
+            && let Err(e) =
+                wcore_config::mcp_cred_refs::resolve_server_headers(&mut config, &*store)
         {
-            let _ = wcore_config::mcp_cred_refs::resolve_server_headers(&mut config, &*store);
+            let reason = format!("{e}");
+            let _ = tx.send(ProtocolEvent::McpFailed {
+                name: name.clone(),
+                reason: reason.clone(),
+            });
+            let _ = tx.send(ProtocolEvent::Error {
+                msg_id: None,
+                error: ErrorInfo {
+                    code: "mcp_add".to_string(),
+                    message: format!("Couldn't connect MCP server '{name}': {reason}"),
+                    retryable: false,
+                },
+            });
+            return;
         }
 
         let mut single = std::collections::HashMap::new();

--- a/crates/wcore-cli/src/tui/surfaces/config.rs
+++ b/crates/wcore-cli/src/tui/surfaces/config.rs
@@ -585,14 +585,6 @@ pub struct ConfigSurface {
     providers_focus: usize,
     /// `Some` while the Tools & Providers credentials modal is open.
     credentials_modal: Option<CredentialsModal>,
-    /// H1: one-shot signal that a credentials-modal save just wrote a
-    /// provider key to `~/.wayland/.env`. The credentials write happens deep
-    /// inside `handle_providers_key` with no `App` access; this flag lets
-    /// `handle_key` (which holds `&mut App`) raise `App::rebind_request` so the
-    /// router rebinds the live engine — `Config::resolve` re-reads the `.env`
-    /// file, so the freshly entered key reaches the wire via `create_provider`
-    /// without a restart. Consumed (reset) by `handle_key` after dispatch.
-    credential_saved: bool,
 }
 
 impl Default for ConfigSurface {
@@ -622,7 +614,6 @@ impl ConfigSurface {
             save_error: None,
             providers_focus: 0,
             credentials_modal: None,
-            credential_saved: false,
         }
     }
 
@@ -1675,7 +1666,11 @@ impl CredentialsModal {
         };
         match wcore_config::env_file::write_env_var(&env_path, key, &value) {
             Ok(()) => {
-                self.status = format!("Saved {key} to ~/.wayland/.env · applying to this session");
+                // F21: `resolve_api_key` reads cli→config→store→process-env and
+                // never the `.env` file, so a key written here is invisible until
+                // a restart reloads `.env` into the process env. The status must
+                // not claim a live application that does not happen.
+                self.status = "Saved to ~/.wayland/.env · applies on next launch".into();
                 self.last_ok = true;
                 true
             }
@@ -1725,7 +1720,6 @@ impl Surface for ConfigSurface {
         self.expert_editor = None;
         self.providers_focus = 0;
         self.credentials_modal = None;
-        self.credential_saved = false;
     }
 
     fn render(&mut self, frame: &mut Frame, area: Rect, app: &App, theme: &Theme) {
@@ -1831,14 +1825,6 @@ impl Surface for ConfigSurface {
         };
         if self.baseline != baseline_before && !self.is_dirty() {
             app.rebind_request = crate::tui::app::RebindRequest::Tier1Save;
-        }
-        // H1: a credentials-modal write also requires a rebind so the new
-        // provider key reaches the wire live. The write happens inside
-        // `handle_providers_key` (no `App` access); consume its one-shot flag
-        // here where `&mut App` is in scope.
-        if self.credential_saved {
-            self.credential_saved = false;
-            app.rebind_request = crate::tui::app::RebindRequest::Credential;
         }
         action
     }
@@ -2979,13 +2965,11 @@ impl ConfigSurface {
             match key.code {
                 KeyCode::Enter => {
                     if let Some(modal) = self.credentials_modal.as_mut() {
-                        // H1: a successful credential write must rebind the
-                        // live engine (so the new key takes effect without a
-                        // restart). Raise the one-shot flag `handle_key`
-                        // consumes into `App::rebind_request`.
-                        if modal.save() {
-                            self.credential_saved = true;
-                        }
+                        // F21: this writes the key to `~/.wayland/.env`, which
+                        // `resolve_api_key` does not read until a restart — so
+                        // there is intentionally no live rebind here. The modal
+                        // status reflects "applies on next launch".
+                        modal.save();
                     }
                     // Stay on the modal so the user can see the status
                     // message. Esc closes.

--- a/crates/wcore-cli/src/tui/surfaces/diagnostics.rs
+++ b/crates/wcore-cli/src/tui/surfaces/diagnostics.rs
@@ -910,12 +910,23 @@ impl DiagnosticsSurface {
         self.start_health_probe();
     }
 
-    /// Start the async system + provider-health probe (idempotent: replacing
-    /// any in-flight handle). Marks both results not-yet-collected so the
-    /// render shows the "probing…" state until [`Self::poll_health`] applies
-    /// each. The prior rows are kept until then, so a re-run (`r`) updates in
-    /// place rather than flashing to empty.
+    /// Start the async system + provider-health probe. Marks both results
+    /// not-yet-collected so the render shows the "probing…" state until
+    /// [`Self::poll_health`] applies each. The prior rows are kept until then,
+    /// so a re-run (`r`) updates in place rather than flashing to empty.
+    ///
+    /// F40: a probe that is still in flight is NOT replaced. Each
+    /// `spawn_health_probe` spins up a detached `std::thread` with its own
+    /// `current_thread` runtime running an uncapped provider-health check;
+    /// mashing `r` (or re-entering `/doctor`) while the egress layer stalls the
+    /// HTTP probe would otherwise leak one such thread+runtime per trigger.
+    /// `health_pending` is `Some` exactly while a probe is unresolved
+    /// ([`Self::poll_health`] clears it to `None` once both results settle or
+    /// the UI timeout fires), so an in-flight probe short-circuits the re-start.
     fn start_health_probe(&mut self) {
+        if self.health_pending.is_some() {
+            return;
+        }
         self.doctor_collected = false;
         self.health_collected = false;
         self.health_timed_out = false;

--- a/crates/wcore-mcp/src/transport/sse.rs
+++ b/crates/wcore-mcp/src/transport/sse.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 use async_trait::async_trait;
 use reqwest::header::{HeaderMap, HeaderValue};
@@ -35,6 +35,9 @@ pub struct SseTransport {
     _listener: tokio::task::JoinHandle<()>,
     /// Per-request timeout for the response `oneshot` (audit C6).
     request_timeout: std::time::Duration,
+    /// Set by `close()` so a new `request()` fast-fails instead of parking
+    /// on a `oneshot` whose listener has been aborted (audit F26).
+    closed: AtomicBool,
 }
 
 impl SseTransport {
@@ -266,6 +269,7 @@ impl SseTransport {
             next_id: AtomicU64::new(1),
             _listener: listener,
             request_timeout,
+            closed: AtomicBool::new(false),
         })
     }
 
@@ -277,6 +281,13 @@ impl SseTransport {
 #[async_trait]
 impl McpTransport for SseTransport {
     async fn request(&self, req: &JsonRpcRequest) -> Result<JsonRpcResponse, McpError> {
+        // F26 — after `close()` the listener is aborted and can no longer
+        // route responses. Fast-fail rather than registering a `pending`
+        // entry that would only resolve via the per-request timeout.
+        if self.closed.load(Ordering::SeqCst) {
+            return Err(McpError::Transport("SSE MCP transport is closed".into()));
+        }
+
         let req_id = req
             .id
             .ok_or_else(|| McpError::Transport("Request must have an id".into()))?;
@@ -374,7 +385,16 @@ impl McpTransport for SseTransport {
     }
 
     async fn close(&self) -> Result<(), McpError> {
+        // Mark closed first so any new `request()` fast-fails instead of
+        // parking on a oneshot the aborted listener can never resolve (F26).
+        self.closed.store(true, Ordering::SeqCst);
         self._listener.abort();
+        // Drain the pending map and drop every parked sender so concurrently
+        // parked `request()` futures wake immediately via their
+        // `Ok(Err(_))` ("Response channel closed unexpectedly") arm, rather
+        // than waiting out the full per-request timeout. Mirrors the
+        // listener's own drain-on-exit (Rank 26).
+        self.pending.lock().await.clear();
         Ok(())
     }
 }
@@ -527,6 +547,7 @@ mod tests {
             // oneshot for this request can only be resolved by the timeout.
             _listener: tokio::spawn(async {}),
             request_timeout: Duration::from_millis(500),
+            closed: std::sync::atomic::AtomicBool::new(false),
         };
 
         let req = JsonRpcRequest::new(1, "tools/call", None);
@@ -603,6 +624,7 @@ mod tests {
             next_id: AtomicU64::new(1),
             _listener: tokio::spawn(async {}),
             request_timeout: Duration::from_millis(500),
+            closed: std::sync::atomic::AtomicBool::new(false),
         };
 
         let req = JsonRpcRequest::new(1, "tools/call", None);
@@ -697,6 +719,7 @@ mod tests {
             // fast, this test would hang for ~30s and the elapsed assert would
             // catch the regression.
             request_timeout: Duration::from_secs(30),
+            closed: std::sync::atomic::AtomicBool::new(false),
         };
 
         let req = JsonRpcRequest::new(1, "tools/call", None);

--- a/crates/wcore-mcp/src/transport/stdio.rs
+++ b/crates/wcore-mcp/src/transport/stdio.rs
@@ -196,12 +196,22 @@ fn windows_cmd_quote(arg: &str) -> String {
 /// resolves it against PATH/PATHEXT itself (`node` → `node.exe`/`node.cmd`).
 /// Running it through [`windows_cmd_quote`] produced `^"node^"`, which cmd read
 /// as a literal-quoted name and failed to resolve, so the MCP server never
-/// started (wayland#164). A bare name passes through unchanged; a path with
-/// whitespace is wrapped in the plain double quotes `cmd /C` expects for the
-/// executable token (no caret-escaping). Pure + platform-independent so it is
-/// unit-testable on any host.
+/// started (wayland#164). A bare name passes through unchanged; a name with
+/// whitespace OR any cmd metacharacter is wrapped in the plain double quotes
+/// `cmd /C` expects for the executable token (no caret-escaping). Pure +
+/// platform-independent so it is unit-testable on any host.
+///
+/// F34: whitespace alone was not enough. A whitespace-free program token such
+/// as `foo&calc` would otherwise reach `cmd /C foo&calc` unquoted, where cmd
+/// reads `&` as a command separator and runs `calc`. Wrapping the token in `"`
+/// makes cmd treat `& | < > ^ ( ) %` etc. inside it as literal filename
+/// characters (the executable token is parsed as a single quoted name), so a
+/// metachar-bearing name can't smuggle a second command onto the line.
 fn windows_program_token(command: &str) -> String {
-    if command.chars().any(char::is_whitespace) {
+    // cmd.exe metacharacters that, unquoted, would be interpreted on the
+    // command line rather than treated as part of the program name.
+    const CMD_META: &[char] = &['&', '|', '<', '>', '^', '(', ')', '%', '!', '"'];
+    if command.chars().any(char::is_whitespace) || command.chars().any(|c| CMD_META.contains(&c)) {
         format!("\"{command}\"")
     } else {
         command.to_string()
@@ -327,6 +337,31 @@ mod cmd_quote_tests {
             !out.contains('^'),
             "program token must never be caret-escaped: {out:?}"
         );
+    }
+
+    // F34: a whitespace-FREE program token carrying a cmd metacharacter must be
+    // wrapped in quotes so cmd cannot interpret it. Without the fix `foo&calc`
+    // reached `cmd /C foo&calc` and cmd ran `calc`.
+    #[test]
+    fn program_token_quotes_metachar_bearing_bare_names() {
+        for (input, expected) in [
+            ("foo&calc", "\"foo&calc\""),
+            ("a|b", "\"a|b\""),
+            ("x>y", "\"x>y\""),
+            ("p(q)", "\"p(q)\""),
+            ("z^w", "\"z^w\""),
+            ("v%PATH%", "\"v%PATH%\""),
+        ] {
+            let out = windows_program_token(input);
+            assert_eq!(out, expected, "metachar token {input:?} must be quoted");
+            // The quoting must be plain double quotes — never caret-escaped.
+            assert!(
+                !out.contains('^') || input.contains('^'),
+                "program token must not introduce carets: {out:?}"
+            );
+        }
+        // A clean bare name still passes through untouched (fast path).
+        assert_eq!(windows_program_token("node"), "node");
     }
 }
 
@@ -765,11 +800,17 @@ impl McpTransport for StdioTransport {
 
         // Join the background tasks so they don't leak (audit C9).
         if let Some(handle) = self.reader_task.lock().await.take() {
+            // F33 — `timeout` consumes `handle`, so capture an abort handle
+            // first; otherwise the timeout arm only DROPS the JoinHandle
+            // (which detaches, not aborts) and the reader task leaks. This
+            // mirrors how `stderr_task` below aborts its handle.
+            let abort = handle.abort_handle();
             match timeout(Duration::from_secs(1), handle).await {
                 Ok(Ok(())) => {}
                 Ok(Err(e)) => warn!(error = %e, "[mcp] stdio reader join error"),
                 Err(_) => {
                     warn!("[mcp] stdio reader did not finish within 1s — aborting");
+                    abort.abort();
                 }
             }
         }

--- a/crates/wcore-observability/src/sink.rs
+++ b/crates/wcore-observability/src/sink.rs
@@ -106,11 +106,14 @@ impl InMemorySink {
     }
 
     pub fn snapshot(&self) -> Vec<Value> {
-        self.inner.lock().map(|g| g.clone()).unwrap_or_default()
+        // Recover the buffer on poison rather than coercing to empty —
+        // a poisoning panic elsewhere must not hide already-captured
+        // traces from diagnostics tooling.
+        self.inner.lock().unwrap_or_else(|e| e.into_inner()).clone()
     }
 
     pub fn len(&self) -> usize {
-        self.inner.lock().map(|g| g.len()).unwrap_or(0)
+        self.inner.lock().unwrap_or_else(|e| e.into_inner()).len()
     }
 
     pub fn is_empty(&self) -> bool {
@@ -336,6 +339,32 @@ mod tests {
         assert_eq!(snap[0]["turn"], 0);
         assert_eq!(snap[1]["turn"], 1);
         assert_eq!(snap[2]["turn"], 2);
+    }
+
+    #[test]
+    fn in_memory_sink_survives_mutex_poison() {
+        // A panic while holding the lock poisons the Mutex. snapshot()/len()
+        // must still surface the buffered traces (recover via into_inner)
+        // rather than masking them as empty.
+        let s = InMemorySink::new();
+        s.emit(&json!({ "turn": 0 }));
+        s.emit(&json!({ "turn": 1 }));
+
+        let s_poison = s.clone();
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = s_poison.inner.lock().unwrap();
+            panic!("poison the mutex while holding the guard");
+        }));
+
+        assert!(
+            s.inner.is_poisoned(),
+            "mutex must be poisoned after the panic"
+        );
+        assert_eq!(s.len(), 2, "len must recover buffered traces after poison");
+        let snap = s.snapshot();
+        assert_eq!(snap.len(), 2, "snapshot must recover traces after poison");
+        assert_eq!(snap[0]["turn"], 0);
+        assert_eq!(snap[1]["turn"], 1);
     }
 
     #[test]

--- a/crates/wcore-sandbox/src/backends/bwrap.rs
+++ b/crates/wcore-sandbox/src/backends/bwrap.rs
@@ -256,7 +256,12 @@ impl SandboxBackend for BubblewrapBackend {
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
-            .env_clear();
+            .env_clear()
+            // Reap the bwrap process if our Child handle is dropped — the
+            // timeout arm below relies on this to kill the namespace tree
+            // instead of leaking it. Mirrors no_sandbox.rs. bwrap's
+            // --die-with-parent then tears down the inner sandboxed process.
+            .kill_on_drop(true);
 
         // S3 — Landlock (feature-gated, Linux-only). Apply the ruleset
         // inside the child via `pre_exec` so it propagates across execve()
@@ -306,12 +311,11 @@ impl SandboxBackend for BubblewrapBackend {
                 return Err(SandboxError::ExecFailed(format!("bwrap wait failed: {e}")));
             }
             Err(_elapsed) => {
-                // child has already moved into wait_with_output; pid escapes
-                // our handle. bwrap's --die-with-parent will kill the
-                // namespace tree once the engine drops the handle, but since
-                // wait_with_output owns the child we cannot signal here.
-                // Best we can do is return Timeout; the bwrap parent will
-                // exit when its child does.
+                // `timeout` dropped `wait_fut` on elapse, which drops the
+                // Child it owns. With `kill_on_drop(true)` set above, that
+                // drop reaps the bwrap process; bwrap's --die-with-parent
+                // then tears down the inner namespace tree — no pid escapes
+                // our handle.
                 return Err(SandboxError::Timeout);
             }
         };

--- a/crates/wcore-sandbox/src/backends/sandbox_exec.rs
+++ b/crates/wcore-sandbox/src/backends/sandbox_exec.rs
@@ -252,6 +252,11 @@ impl SandboxBackend for SandboxExecBackend {
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
+        // Reap the child if this future is dropped — e.g. when the
+        // `tokio::time::timeout` below elapses and drops the in-flight
+        // `run_fut` (which owns the Child). Without this the sandboxed
+        // process tree escapes on timeout. Mirrors no_sandbox.rs.
+        child_cmd.kill_on_drop(true);
 
         let run_fut = async {
             let child = child_cmd

--- a/crates/wcore-tools/src/grep.rs
+++ b/crates/wcore-tools/src/grep.rs
@@ -1,6 +1,8 @@
+use std::path::Path;
+
 use async_trait::async_trait;
 use serde_json::{Value, json};
-use tokio::process::Command;
+use wcore_config::shell::shell_command_argv;
 
 use wcore_protocol::events::ToolCategory;
 use wcore_types::tool::{JsonSchema, ToolResult};
@@ -56,28 +58,8 @@ impl Tool for GrepTool {
     }
 
     async fn execute(&self, input: Value) -> ToolResult {
-        let Some(pattern) = input["pattern"].as_str() else {
-            return ToolResult {
-                content: "Missing required parameter: pattern".to_string(),
-                is_error: true,
-            };
-        };
-
-        let path = input["path"].as_str().unwrap_or(".");
-
-        let glob_pattern = input["glob"].as_str();
-        let case_insensitive = input["case_insensitive"].as_bool().unwrap_or(false);
-
-        // Try ripgrep first, fallback to grep
-        let result = try_ripgrep(pattern, path, glob_pattern, case_insensitive).await;
-
-        match result {
-            Ok(output) => output,
-            Err(_) => {
-                // Fallback to grep
-                try_grep(pattern, path, case_insensitive).await
-            }
-        }
+        // No `ToolContext` here, so no jail root to anchor the scan to.
+        run_grep(&input, None).await
     }
 
     /// W8b — vfs-aware variant. Grep itself shells out to rg/grep so it
@@ -88,7 +70,7 @@ impl Tool for GrepTool {
     /// tool refuses to launch the subprocess.
     async fn execute_with_ctx(&self, input: Value, ctx: &ToolContext) -> ToolResult {
         let path_arg = input["path"].as_str().unwrap_or(".");
-        let path = std::path::Path::new(path_arg);
+        let path = Path::new(path_arg);
         // Containment probe — only the error variant matters; we don't
         // care whether the path currently exists, just that the vfs
         // would allow access to it.
@@ -98,7 +80,12 @@ impl Tool for GrepTool {
                 is_error: true,
             };
         }
-        self.execute(input).await
+        // F36: anchor the subprocess working directory to the sandbox root so a
+        // relative search path (the default ".") resolves against the jail, not
+        // the process cwd — mirroring how Read/Write/Edit resolve against the
+        // jail root. `None` for an unconstrained vfs (top-level RealFs) leaves
+        // the subprocess in the process cwd, preserving existing behaviour.
+        run_grep(&input, ctx.vfs.root()).await
     }
 
     fn max_result_size(&self) -> usize {
@@ -116,28 +103,59 @@ impl Tool for GrepTool {
     }
 }
 
+/// Shared entry point for both `execute` and `execute_with_ctx`. `search_root`
+/// is the jail root the subprocess should run inside (`Some` for a sandboxed
+/// sub-agent, `None` for the unconstrained top-level case).
+async fn run_grep(input: &Value, search_root: Option<&Path>) -> ToolResult {
+    let Some(pattern) = input["pattern"].as_str() else {
+        return ToolResult {
+            content: "Missing required parameter: pattern".to_string(),
+            is_error: true,
+        };
+    };
+    let path = input["path"].as_str().unwrap_or(".");
+    let glob_pattern = input["glob"].as_str();
+    let case_insensitive = input["case_insensitive"].as_bool().unwrap_or(false);
+
+    // Try ripgrep first, fallback to grep.
+    match try_ripgrep(pattern, path, glob_pattern, case_insensitive, search_root).await {
+        Ok(output) => output,
+        Err(_) => try_grep(pattern, path, case_insensitive, search_root).await,
+    }
+}
+
 async fn try_ripgrep(
     pattern: &str,
     path: &str,
     glob_pattern: Option<&str>,
     case_insensitive: bool,
+    search_root: Option<&Path>,
 ) -> Result<ToolResult, std::io::Error> {
-    let mut cmd = Command::new("rg");
-    // `--no-config` ignores RIPGREP_CONFIG_PATH / .ripgreprc, which could
-    // otherwise inject flags (e.g. `--pre`) into this agent-driven invocation.
-    cmd.arg("--no-config").arg("-n");
-
+    // F43: route through `wcore_config::shell::shell_command_argv` for
+    // cross-platform PATHEXT resolution and kill-on-drop, rather than
+    // `Command::new` directly. Still argv mode — the pattern/path reach `rg`
+    // as literal argv entries, no shell ever interprets them.
+    let mut args: Vec<&str> = vec!["--no-config", "-n"];
     if let Some(g) = glob_pattern {
-        cmd.arg("--glob").arg(g);
+        args.push("--glob");
+        args.push(g);
     }
     if case_insensitive {
-        cmd.arg("-i");
+        args.push("-i");
     }
-
     // `--` terminates option parsing: a model-supplied pattern such as
     // `--pre=<cmd>` is then treated as a search pattern, not a ripgrep flag
     // (which would otherwise allow arbitrary per-file command execution).
-    cmd.arg("--").arg(pattern).arg(path);
+    args.push("--");
+    args.push(pattern);
+    args.push(path);
+
+    let mut cmd = shell_command_argv("rg", &args);
+    // F36: anchor the scan inside the jail root so a relative `path` resolves
+    // against the sandbox, not the process cwd.
+    if let Some(root) = search_root {
+        cmd.current_dir(root);
+    }
 
     let output = cmd.output().await?;
     let stdout = String::from_utf8_lossy(&output.stdout);
@@ -165,29 +183,48 @@ async fn try_ripgrep(
     })
 }
 
-async fn try_grep(pattern: &str, path: &str, case_insensitive: bool) -> ToolResult {
+async fn try_grep(
+    pattern: &str,
+    path: &str,
+    case_insensitive: bool,
+    search_root: Option<&Path>,
+) -> ToolResult {
+    // F43: route through `shell_command_argv` (argv mode, no shell) on both
+    // platforms for consistent PATHEXT resolution + kill-on-drop.
     let mut cmd = if cfg!(windows) {
-        let mut c = Command::new("findstr");
-        c.arg("/S")
-            .arg("/N")
-            .arg("/R")
-            .arg(pattern)
-            .arg(format!("{}\\*", path.trim_end_matches(['\\', '/'])));
+        // F35: pass the pattern via `/R /C:<pattern>` rather than a bare
+        // positional arg. findstr treats any positional arg beginning with `/`
+        // as a switch (it has no `--` terminator), so a pattern like `/C:foo`
+        // was consumed as an option. `/C:` names the search string explicitly,
+        // and `/R` keeps it a REGULAR EXPRESSION — preserving the regex
+        // semantics the bare-`/R` form had (and matching the Unix `grep`/`rg`
+        // regex contract). The `/C:` value is a single argv entry, so a leading
+        // `/` in the pattern can no longer be switch-parsed.
+        let dir = format!("{}\\*", path.trim_end_matches(['\\', '/']));
+        let cflag = format!("/C:{pattern}");
+        let mut args: Vec<&str> = vec!["/S", "/N", "/R"];
         if case_insensitive {
-            c.arg("/I");
+            args.push("/I");
         }
-        c
+        args.push(&cflag);
+        args.push(&dir);
+        shell_command_argv("findstr", &args)
     } else {
-        let mut c = Command::new("grep");
-        c.arg("-rn");
+        let mut args: Vec<&str> = vec!["-rn"];
         if case_insensitive {
-            c.arg("-i");
+            args.push("-i");
         }
         // `--` stops option parsing so a pattern beginning with `-` cannot be
         // interpreted as a grep flag.
-        c.arg("--").arg(pattern).arg(path);
-        c
+        args.push("--");
+        args.push(pattern);
+        args.push(path);
+        shell_command_argv("grep", &args)
     };
+    // F36: contain the scan to the jail root (see `try_ripgrep`).
+    if let Some(root) = search_root {
+        cmd.current_dir(root);
+    }
 
     match cmd.output().await {
         Ok(output) => {
@@ -227,5 +264,38 @@ mod tests {
         let result = tool.execute(input).await;
         assert!(!result.is_error, "grep failed: {}", result.content);
         assert!(result.content.contains("GrepTool"));
+    }
+
+    /// F36 — under a `SandboxedFs` jail, a relative search path (the default
+    /// ".") must resolve against the JAIL ROOT, not the process cwd. We plant a
+    /// marker file inside a tempdir jail (and NOT in the process cwd) and assert
+    /// the grep finds it via `path: "."` — which is only possible if the
+    /// subprocess ran with `.current_dir(jail_root)`.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn grep_relative_path_is_contained_to_the_jail_root() {
+        use crate::context::ToolContext;
+        use crate::vfs::{RealFs, SandboxedFs};
+        use std::sync::Arc;
+
+        let jail = tempfile::tempdir().expect("tempdir");
+        let marker = "WAYLAND_GREP_JAIL_MARKER_F36";
+        std::fs::write(jail.path().join("needle.txt"), format!("{marker}\n"))
+            .expect("write marker into the jail");
+
+        let mut ctx = ToolContext::test_default();
+        ctx.vfs = Arc::new(SandboxedFs::new(RealFs, jail.path()));
+
+        let tool = GrepTool;
+        // Default path "." — must be anchored to the jail, not the test's cwd.
+        let input = json!({ "pattern": marker, "path": "." });
+        let result = tool.execute_with_ctx(input, &ctx).await;
+
+        assert!(!result.is_error, "grep failed: {}", result.content);
+        assert!(
+            result.content.contains(marker),
+            "relative '.' grep must find the marker inside the jail root, got: {}",
+            result.content
+        );
     }
 }

--- a/crates/wcore-tools/src/vfs.rs
+++ b/crates/wcore-tools/src/vfs.rs
@@ -53,6 +53,16 @@ pub trait VirtualFs: Send + Sync {
     async fn list(&self, dir: &Path) -> Result<Vec<PathBuf>, VfsError>;
     async fn remove_file(&self, path: &Path) -> Result<(), VfsError>;
     async fn metadata(&self, path: &Path) -> Result<VfsMetadata, VfsError>;
+
+    /// The containment root for a sandboxed filesystem, or `None` for an
+    /// unconstrained one (`RealFs`, `InMemoryFs`). Tools that shell out to a
+    /// subprocess (e.g. Grep → `rg`/`grep`) can't route the scan through the
+    /// vfs, so they use this to anchor the subprocess working directory to the
+    /// jail root — making a relative search path resolve against the sandbox,
+    /// not the process cwd (F36).
+    fn root(&self) -> Option<&Path> {
+        None
+    }
 }
 
 /// Minimum metadata surface tools need (size + is_dir). Avoids leaking
@@ -317,5 +327,8 @@ impl<F: VirtualFs + 'static> VirtualFs for SandboxedFs<F> {
     async fn metadata(&self, path: &Path) -> Result<VfsMetadata, VfsError> {
         let p = self.contain(path)?;
         self.inner.metadata(&p).await
+    }
+    fn root(&self) -> Option<&Path> {
+        Some(&self.root)
     }
 }


### PR DESCRIPTION
## Summary
Wave 4 (final remediation wave) — 19 low/medium-severity defects across browser, sandbox, channels, MCP transports, observability, TUI, and cross-platform tools. From `.planning/2026-06-18-DEEP-SWEEP-AUDIT.md`.

### Browser lifecycle / policy
- **F17** Browserbase dropped `BrowserPolicy` (redirect-SSRF unenforceable cloud-side) → refused under restrictive policy, falls back to Camoufox.
- **F18** Camoufox `final_url` SSRF check failed **open** when absent → now fails closed.
- **F23** healthcheck task held `Arc<Self>` (cycle defeating Drop) → `Weak`. **F24** double `start_reaper` leaked tasks → cancel prior. **F25** SIGTERM on a reusable raw PID → stashed `Child`. **F38** `ensure_session` race orphaned sessions → re-check + close loser.

### Sandbox / channels / transport leaks
- **F4** bwrap + sandbox-exec leaked the process tree on timeout → `kill_on_drop(true)`.
- **F9** unbounded `VecDeque` inbox across **10** channel adapters → one shared bounded helper in `wcore-channels` (cap 1024, drop-oldest + warn).
- **F26** MCP SSE `close()` left parked requests waiting the full timeout → drain + closed flag. **F33** MCP stdio `close()` only detached the reader → `handle.abort()`. **F42** `InMemorySink` poison hid traces → `into_inner()`.

### TUI / cross-platform tools
- **F21** CredentialsModal falsely claimed live `.env` apply + no-op rebind → honest text, rebind removed. **F22** `/mcp add` dropped `${cred:}` errors → surfaced. **F37** out-of-order deferred rebinds → generation counter. **F40** `/doctor` re-probe leaked threads → guarded.
- **F34** Windows stdio metachar program names through `cmd /C` → quote on metachar. **F35** findstr leading-`/` pattern as switch → `/R /C:`. **F36** grep root fell to process cwd → contained to jail. **F43** grep `Command::new` → `shell_command_argv`.

## Gates (box-gated)
clippy `--workspace --all-targets -D warnings` clean · nextest **3493 pass / 0 fail** (17 crates) · fmt clean. New tests for F9/F18/F24/F34/F36/F38/F42. **F2/F34/F35 are Windows paths — verified by inspection + Windows CI only** (gate box is Linux).
