### PR TITLE
fix(providers): provider auth robustness — Grok OAuth, region failover, auth errors

### DIFF
--- a/crates/wcore-agent/src/bootstrap.rs
+++ b/crates/wcore-agent/src/bootstrap.rs
@@ -2886,9 +2886,58 @@ pub fn build_native_or_chatgpt_provider(config: &Config) -> anyhow::Result<Arc<d
             config.compat.clone(),
             config.debug.clone(),
         )))
+    } else if matches!(config.provider, ProviderType::Xai) && xai_oauth_available() {
+        // "Sign in with X (Grok)": when refreshable OAuth credentials exist
+        // (engine store or the Grok CLI's ~/.grok/auth.json), drive the xAI
+        // provider over a bearer that refreshes near expiry — so a Grok session
+        // survives the ~6h token lifetime instead of dying mid-turn on a stale
+        // snapshot. Falls through to the static-key path below when no OAuth
+        // credential is present (a plain `xai` API key still works unchanged).
+        // NOTE: keyed on `ProviderType::Xai`, so an embedding app must spawn
+        // Grok as `--provider xai` (not `--provider openai`) to get this AND the
+        // grok-4.3 stop-param fix that lives in `xai_defaults`.
+        let storage = crate::oauth::OAuthStorage::from_home()
+            .map_err(|e| anyhow::anyhow!("xai oauth storage: {e}"))?;
+        let mgr = Arc::new(crate::oauth::xai::XaiTokenManager::new(storage));
+        let bearer: wcore_providers::AsyncTokenSource = {
+            let mgr = mgr.clone();
+            Arc::new(move || {
+                let mgr = mgr.clone();
+                Box::pin(async move {
+                    mgr.get()
+                        .await
+                        .map_err(wcore_providers::ProviderError::Connection)
+                })
+            })
+        };
+        let base_url = if config.base_url.is_empty() {
+            wcore_providers::xai::XAI_DEFAULT_BASE_URL.to_string()
+        } else {
+            config.base_url.clone()
+        };
+        Ok(Arc::new(wcore_providers::xai::XaiProvider::with_bearer(
+            bearer,
+            &base_url,
+            config.compat.clone(),
+            config.debug.clone(),
+        )))
     } else {
         Ok(wcore_providers::create_native_provider(config))
     }
+}
+
+/// True when xAI OAuth credentials are available to refresh from — either the
+/// engine's own store (`~/.wayland/oauth/xai.json`) or the Grok CLI's
+/// `~/.grok/auth.json`. Gates the OAuth path so a plain `xai` API key still
+/// flows through the static-key provider unchanged.
+fn xai_oauth_available() -> bool {
+    if crate::oauth::xai::read_grok_cli_tokens().is_some() {
+        return true;
+    }
+    crate::oauth::OAuthStorage::from_home()
+        .ok()
+        .and_then(|s| s.load(crate::oauth::xai::PROVIDER).ok().flatten())
+        .is_some()
 }
 
 /// OAuth-aware analogue of [`wcore_providers::create_provider`].

--- a/crates/wcore-agent/src/engine.rs
+++ b/crates/wcore-agent/src/engine.rs
@@ -3411,9 +3411,14 @@ impl AgentEngine {
             // only when the route optimizes client-side. On router-optimized
             // routes the server already trims output, so we leave the Vec
             // empty and providers emit no stop field.
-            let stop_sequences = if self.compat.input_optimization() == "client" {
+            let stop_sequences = if self.compat.input_optimization() == "client"
+                && self.compat.supports_stop_param()
+            {
                 FLUFF_STOP_SEQUENCES.iter().map(|s| s.to_string()).collect()
             } else {
+                // Either the route is router-optimized (server trims output) or
+                // the provider rejects `stop` (e.g. xAI grok-4.3 400s on it) —
+                // leave empty so providers emit no `stop` field.
                 Vec::new()
             };
 

--- a/crates/wcore-agent/src/oauth/mod.rs
+++ b/crates/wcore-agent/src/oauth/mod.rs
@@ -23,6 +23,7 @@ pub mod chatgpt;
 pub mod flow;
 pub mod pkce;
 pub mod storage;
+pub mod xai;
 
 pub use chatgpt::{
     ChatGptLoginStatus, ChatGptTokenManager, CodexClaims, build_chatgpt_flow, decode_codex_claims,

--- a/crates/wcore-agent/src/oauth/xai.rs
+++ b/crates/wcore-agent/src/oauth/xai.rs
@@ -1,0 +1,488 @@
+//! "Sign in with X (Grok)" — xAI OAuth token manager.
+//!
+//! Engine-native parity with [`super::chatgpt`]: owns load / refresh / persist
+//! of the xAI OAuth tokens so a Grok session survives the ~6h access-token
+//! lifetime without the host re-spawning. Bootstrap builds an async bearer
+//! closure over [`XaiTokenManager::get`] and hands it to the OpenAI-compatible
+//! provider (`wcore-providers` stays free of any OAuth dependency).
+//!
+//! Two differences from ChatGPT, both verified live (2026-06-18):
+//! - xAI's refresh grant REQUIRES the `scope` form field (ChatGPT omits it).
+//! - The access token works directly against `api.x.ai/v1` as a plain bearer
+//!   (no account-id header, no Codex backend), so [`get`] returns just the
+//!   token string.
+//!
+//! Token source. Two places hold xAI credentials, and the manager prefers
+//! whichever is FRESHER so it rarely has to refresh itself (which avoids
+//! racing the Grok CLI for the single-use, rotating refresh token):
+//! - the engine's own store `~/.wayland/oauth/xai.json` (written by
+//!   `wayland auth login grok`, by an embedding app, or by a prior refresh);
+//! - the Grok CLI's `~/.grok/auth.json` (the CLI keeps it fresh), whose `key`
+//!   field is the access token, nested under a `"https://auth.x.ai::<cid>"`
+//!   wrapper.
+//!
+//! Rotation. xAI rotates the refresh token on every refresh (single-use), so a
+//! refresh that succeeds but fails to persist is a HARD error (C4) — the old
+//! token is already burned server-side.
+
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use tokio::sync::Mutex;
+
+use crate::oauth::{OAuthFlow, OAuthStorage, OAuthTokens, RefreshError, SingleFlightRefresh};
+
+/// Provider name used by [`OAuthStorage`] when persisting tokens.
+pub const PROVIDER: &str = "xai";
+
+/// xAI OIDC token endpoint (refresh grant). Confirmed live from the discovery
+/// doc at `https://auth.x.ai/.well-known/openid-configuration`.
+const XAI_TOKEN_URL: &str = "https://auth.x.ai/oauth2/token";
+
+/// xAI OIDC authorize endpoint (browser PKCE login — used by `auth login grok`).
+const XAI_AUTH_URL: &str = "https://auth.x.ai/oauth2/authorize";
+
+/// Public desktop PKCE client_id (no secret). Verified live: this id refreshes
+/// the SuperGrok / Grok-CLI token against `auth.x.ai`. Override at runtime with
+/// `WAYLAND_XAI_OAUTH_CLIENT_ID` so a corrected value needs no rebuild.
+const XAI_CLIENT_ID_DEFAULT: &str = "b1a00492-073a-47ea-816f-4c329264a828";
+
+/// Scopes requested. `grok-cli:access` + `api:access` are the SuperGrok
+/// entitlements; `offline_access` yields the refresh token. xAI's refresh
+/// grant echoes these in the form body (verified live).
+const XAI_SCOPES: &str = "openid profile email offline_access grok-cli:access api:access";
+
+/// Refresh `REFRESH_LEAD_SECS` before the token actually expires so a turn
+/// never starts on a token that lapses mid-flight.
+const REFRESH_LEAD_SECS: u64 = 120;
+
+/// Per network call ceiling for the refresh round-trip.
+const PER_CALL_TIMEOUT: Duration = Duration::from_secs(20);
+
+/// Sentinel marking a `429` refresh (rate limit, not auth failure) so the
+/// caller can keep using a still-valid current token (C3).
+const RATE_LIMIT_SENTINEL: &str = "__xai_refresh_rate_limited__";
+
+/// Resolve the client_id: env override wins over the pinned default.
+fn xai_client_id() -> String {
+    std::env::var("WAYLAND_XAI_OAUTH_CLIENT_ID")
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| XAI_CLIENT_ID_DEFAULT.to_string())
+}
+
+/// Build the xAI OAuth flow descriptor. Only `token_url` + `client_id` matter
+/// for the refresh-only path; the authorize fields are for the login flow.
+pub fn build_xai_flow() -> OAuthFlow {
+    OAuthFlow::new(
+        xai_client_id(),
+        None,
+        XAI_AUTH_URL,
+        XAI_TOKEN_URL,
+        XAI_SCOPES.split(' ').map(str::to_string).collect(),
+    )
+}
+
+/// Decode a JWT's `exp` (epoch seconds) without verifying the signature — used
+/// to read the access-token expiry out of the Grok CLI's `key`. Returns `None`
+/// when the segment is absent / not base64url / not JSON / lacks `exp`.
+fn decode_jwt_exp(token: &str) -> Option<u64> {
+    use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
+    let seg = token.split('.').nth(1)?;
+    let bytes = URL_SAFE_NO_PAD.decode(seg).ok()?;
+    let v: serde_json::Value = serde_json::from_slice(&bytes).ok()?;
+    v.get("exp").and_then(|e| e.as_u64())
+}
+
+/// Path to the Grok CLI credential file: `$GROK_HOME/auth.json`, default
+/// `~/.grok/auth.json`. Mirrors `chatgpt::codex_home_dir`.
+fn grok_auth_json_path() -> Option<std::path::PathBuf> {
+    if let Ok(dir) = std::env::var("GROK_HOME")
+        && !dir.trim().is_empty()
+    {
+        return Some(std::path::PathBuf::from(dir).join("auth.json"));
+    }
+    Some(dirs::home_dir()?.join(".grok").join("auth.json"))
+}
+
+/// Read the Grok CLI's `~/.grok/auth.json` into our token shape. The file nests
+/// the bundle under a single `"https://auth.x.ai::<client_id>"` wrapper whose
+/// `key` is the access token; the expiry comes from the JWT's `exp` (the file's
+/// own `expires_at` string has been observed stale). Returns `None` when the
+/// file is absent / malformed / carries no `key`.
+pub fn read_grok_cli_tokens() -> Option<OAuthTokens> {
+    let path = grok_auth_json_path()?;
+    let bytes = std::fs::read(&path).ok()?;
+    let doc: serde_json::Value = serde_json::from_slice(&bytes).ok()?;
+    // Find the nested entry that carries a `key` (the host-prefixed wrapper).
+    let entry = doc
+        .as_object()?
+        .values()
+        .find_map(|v| v.as_object().filter(|o| o.contains_key("key")))?;
+    let key = entry.get("key")?.as_str()?.to_string();
+    let refresh_token = entry
+        .get("refresh_token")
+        .and_then(|v| v.as_str())
+        .map(str::to_string);
+    let expires_at_unix_secs = decode_jwt_exp(&key);
+    Some(OAuthTokens {
+        access_token: key,
+        refresh_token,
+        expires_at_unix_secs,
+        token_type: "Bearer".to_string(),
+        scope: Some(XAI_SCOPES.to_string()),
+        id_token: None,
+    })
+}
+
+/// Owns load / refresh / persist of the xAI OAuth tokens. Built by bootstrap;
+/// the async bearer closure handed to the provider calls [`XaiTokenManager::get`].
+pub struct XaiTokenManager {
+    flow: Arc<OAuthFlow>,
+    single_flight: Arc<SingleFlightRefresh>,
+    client: wcore_egress::EgressClient,
+    storage: OAuthStorage,
+    cached: Mutex<Option<OAuthTokens>>,
+}
+
+impl XaiTokenManager {
+    pub fn new(storage: OAuthStorage) -> Self {
+        Self {
+            flow: Arc::new(build_xai_flow()),
+            single_flight: Arc::new(SingleFlightRefresh::new()),
+            client: wcore_egress::EgressClient::tool(),
+            storage,
+            cached: Mutex::new(None),
+        }
+    }
+
+    /// Construct with an explicit flow descriptor (out-of-crate tests point the
+    /// refresh round-trip at a local mock token server).
+    #[doc(hidden)]
+    pub fn new_with_flow(storage: OAuthStorage, flow: OAuthFlow) -> Self {
+        Self {
+            flow: Arc::new(flow),
+            single_flight: Arc::new(SingleFlightRefresh::new()),
+            client: wcore_egress::EgressClient::tool(),
+            storage,
+            cached: Mutex::new(None),
+        }
+    }
+
+    fn now_secs() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0)
+    }
+
+    /// Valid for at least `REFRESH_LEAD_SECS` more seconds. A missing expiry is
+    /// treated as stale (forces a refresh) rather than fresh.
+    fn token_is_fresh(t: &OAuthTokens) -> bool {
+        let Some(exp) = t.expires_at_unix_secs else {
+            return false;
+        };
+        exp.saturating_sub(REFRESH_LEAD_SECS) > Self::now_secs()
+    }
+
+    /// Past actual expiry (no lead window). Used by the 429 path.
+    fn token_is_hard_expired(t: &OAuthTokens) -> bool {
+        let Some(exp) = t.expires_at_unix_secs else {
+            return true;
+        };
+        exp <= Self::now_secs()
+    }
+
+    /// Pick the token that expires later (None expiry sorts earliest).
+    fn fresher(a: Option<OAuthTokens>, b: Option<OAuthTokens>) -> Option<OAuthTokens> {
+        match (a, b) {
+            (Some(a), Some(b)) => {
+                let ea = a.expires_at_unix_secs.unwrap_or(0);
+                let eb = b.expires_at_unix_secs.unwrap_or(0);
+                Some(if eb > ea { b } else { a })
+            }
+            (a, None) => a,
+            (None, b) => b,
+        }
+    }
+
+    /// Load the active token: in-memory cache, else the FRESHER of the engine
+    /// store and the Grok CLI file. Preferring the fresher source means that
+    /// when the Grok CLI has already refreshed, we ride its token instead of
+    /// doing our own (avoids racing it for the single-use refresh token).
+    /// A miss returns `Ok(None)` so the caller can surface login guidance.
+    async fn load_active(&self) -> Result<Option<OAuthTokens>, String> {
+        let mut guard = self.cached.lock().await;
+        if guard.is_some() {
+            return Ok(guard.clone());
+        }
+        let from_store = self
+            .storage
+            .load(PROVIDER)
+            .map_err(|e| format!("oauth storage load failed: {e}"))?;
+        let from_cli = read_grok_cli_tokens();
+        let chosen = Self::fresher(from_store, from_cli);
+        *guard = chosen.clone();
+        Ok(chosen)
+    }
+
+    /// Clear the in-memory token cache (logout calls this).
+    pub async fn clear_cache(&self) {
+        *self.cached.lock().await = None;
+    }
+
+    /// Return the access token, refreshing if near expiry.
+    pub async fn get(&self) -> Result<String, String> {
+        let tokens = self.load_active().await?.ok_or_else(|| {
+            "not signed in to Grok — sign in with X in the app, install the Grok CLI, \
+             or run `wayland auth login grok`"
+                .to_string()
+        })?;
+        let tokens = if Self::token_is_fresh(&tokens) {
+            tokens
+        } else {
+            self.refresh(tokens).await?
+        };
+        Ok(tokens.access_token)
+    }
+
+    /// Refresh `current` via the rotating-refresh-token grant.
+    ///
+    /// C3: a `429` keeps the still-valid current token. C4: a refresh that
+    /// rotated the refresh token but failed to persist is a HARD error.
+    async fn refresh(&self, current: OAuthTokens) -> Result<OAuthTokens, String> {
+        let refresh_token = current.refresh_token.clone().ok_or(
+            "no refresh_token for Grok — sign in with X again or run `wayland auth login grok`",
+        )?;
+        let client = self.client.clone();
+        let token_url = self.flow.token_url.clone();
+        let client_id = self.flow.client_id.clone();
+
+        let refreshed = self
+            .single_flight
+            .refresh(move || async move {
+                // xAI REQUIRES the scope field on refresh (unlike ChatGPT).
+                let form: Vec<(&str, String)> = vec![
+                    ("grant_type", "refresh_token".into()),
+                    ("refresh_token", refresh_token),
+                    ("client_id", client_id),
+                    ("scope", XAI_SCOPES.into()),
+                ];
+                let res = tokio::time::timeout(
+                    PER_CALL_TIMEOUT,
+                    client.post(&token_url).form(&form).send(),
+                )
+                .await
+                .map_err(|_| RefreshError::Transport("refresh timed out".into()))?
+                .map_err(|e| RefreshError::Transport(e.to_string()))?;
+
+                let status = res.status();
+                let body = res
+                    .text()
+                    .await
+                    .map_err(|e| RefreshError::Transport(e.to_string()))?;
+
+                if status.as_u16() == 429 {
+                    return Err(RefreshError::Transport(RATE_LIMIT_SENTINEL.into()));
+                }
+                if !status.is_success() {
+                    // Surface only the status, never the token-endpoint body.
+                    return Err(RefreshError::ProviderRejected(format!(
+                        "token endpoint rejected refresh: HTTP {}",
+                        status.as_u16()
+                    )));
+                }
+                let raw: serde_json::Value = serde_json::from_str(&body)
+                    .map_err(|e| RefreshError::Transport(format!("malformed token JSON: {e}")))?;
+                let now = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .map(|d| d.as_secs())
+                    .unwrap_or(0);
+                Ok(OAuthTokens {
+                    access_token: raw
+                        .get("access_token")
+                        .and_then(|v| v.as_str())
+                        .ok_or_else(|| {
+                            RefreshError::ProviderRejected("missing access_token".into())
+                        })?
+                        .to_string(),
+                    refresh_token: raw
+                        .get("refresh_token")
+                        .and_then(|v| v.as_str())
+                        .map(str::to_string),
+                    expires_at_unix_secs: raw
+                        .get("expires_in")
+                        .and_then(|v| v.as_u64())
+                        .map(|s| now + s),
+                    token_type: raw
+                        .get("token_type")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("Bearer")
+                        .to_string(),
+                    scope: raw
+                        .get("scope")
+                        .and_then(|v| v.as_str())
+                        .map(str::to_string),
+                    id_token: raw
+                        .get("id_token")
+                        .and_then(|v| v.as_str())
+                        .map(str::to_string),
+                })
+            })
+            .await;
+
+        let refreshed = match refreshed {
+            Ok(t) => t,
+            Err(RefreshError::Transport(msg)) if msg == RATE_LIMIT_SENTINEL => {
+                if Self::token_is_hard_expired(&current) {
+                    return Err(
+                        "Grok refresh is rate limited (429) and the access token has expired — \
+                         try again shortly."
+                            .to_string(),
+                    );
+                }
+                *self.cached.lock().await = Some(current.clone());
+                return Ok(current);
+            }
+            Err(e) => return Err(format!("refresh failed: {e}")),
+        };
+
+        // C4: rotation vs server-omitted refresh token.
+        let rotated = refreshed.refresh_token.is_some();
+        let mut to_store = refreshed;
+        if to_store.refresh_token.is_none() {
+            to_store.refresh_token = current.refresh_token.clone();
+        }
+        if let Err(e) = self.storage.store(PROVIDER, &to_store) {
+            if rotated {
+                return Err(format!(
+                    "Grok refresh rotated the refresh token but persisting it failed ({e}); \
+                     sign in with X again to re-authenticate"
+                ));
+            }
+            tracing::warn!(error = %e, "failed to persist refreshed Grok access token");
+        }
+        *self.cached.lock().await = Some(to_store.clone());
+        Ok(to_store)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn token(access: &str, refresh: Option<&str>, exp: Option<u64>) -> OAuthTokens {
+        OAuthTokens {
+            access_token: access.into(),
+            refresh_token: refresh.map(str::to_string),
+            expires_at_unix_secs: exp,
+            token_type: "Bearer".into(),
+            scope: None,
+            id_token: None,
+        }
+    }
+
+    fn far_future() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0)
+            + 3600
+    }
+
+    #[test]
+    fn flow_uses_xai_endpoints_and_default_client() {
+        let f = build_xai_flow();
+        assert_eq!(f.token_url, XAI_TOKEN_URL);
+        assert_eq!(f.client_id, XAI_CLIENT_ID_DEFAULT);
+        assert!(f.scopes.iter().any(|s| s == "api:access"));
+        assert!(f.scopes.iter().any(|s| s == "offline_access"));
+    }
+
+    #[test]
+    fn fresher_prefers_the_later_expiry() {
+        let a = token("a", None, Some(100));
+        let b = token("b", None, Some(200));
+        assert_eq!(
+            XaiTokenManager::fresher(Some(a.clone()), Some(b.clone()))
+                .unwrap()
+                .access_token,
+            "b"
+        );
+        // None expiry loses to a real one; a single Some wins over None.
+        assert_eq!(
+            XaiTokenManager::fresher(Some(token("x", None, None)), Some(a.clone()))
+                .unwrap()
+                .access_token,
+            "a"
+        );
+        assert_eq!(
+            XaiTokenManager::fresher(Some(a), None)
+                .unwrap()
+                .access_token,
+            "a"
+        );
+    }
+
+    #[test]
+    fn freshness_window_respects_lead_secs() {
+        assert!(XaiTokenManager::token_is_fresh(&token(
+            "a",
+            Some("r"),
+            Some(far_future())
+        )));
+        // Inside the 120s lead window → stale.
+        let soon = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0)
+            + 30;
+        assert!(!XaiTokenManager::token_is_fresh(&token(
+            "a",
+            Some("r"),
+            Some(soon)
+        )));
+        // Unknown expiry → stale (forces refresh).
+        assert!(!XaiTokenManager::token_is_fresh(&token(
+            "a",
+            Some("r"),
+            None
+        )));
+    }
+
+    #[tokio::test]
+    async fn get_returns_a_fresh_stored_token_without_refreshing() {
+        // Isolate from any real ~/.grok/auth.json so the test is deterministic.
+        unsafe { std::env::set_var("GROK_HOME", "/nonexistent-grok-home-for-test") };
+        let tmp = TempDir::new().unwrap();
+        let storage = OAuthStorage::at_root(tmp.path().join("oauth")).unwrap();
+        storage
+            .store(PROVIDER, &token("at-fresh", Some("rt"), Some(far_future())))
+            .unwrap();
+        let mgr = XaiTokenManager::new(storage);
+        assert_eq!(mgr.get().await.unwrap(), "at-fresh");
+        unsafe { std::env::remove_var("GROK_HOME") };
+    }
+
+    #[test]
+    fn reads_real_grok_auth_json_shape() {
+        // The host-prefixed wrapper with a `key` is extracted; a JWT `key`
+        // yields an expiry from its `exp` claim.
+        let tmp = TempDir::new().unwrap();
+        let home = tmp.path();
+        std::fs::create_dir_all(home.join(".grok")).unwrap();
+        // {"exp": 9999999999} payload, unsigned, base64url.
+        let jwt = "aGVhZA.eyJleHAiOiA5OTk5OTk5OTk5fQ.sig";
+        let doc = format!(
+            r#"{{"https://auth.x.ai::cid":{{"key":"{jwt}","refresh_token":"rt-xyz","email":"x@y.z"}}}}"#
+        );
+        std::fs::write(home.join(".grok").join("auth.json"), doc).unwrap();
+        unsafe { std::env::set_var("GROK_HOME", home.join(".grok")) };
+        let t = read_grok_cli_tokens().expect("parses the real shape");
+        assert_eq!(t.access_token, jwt);
+        assert_eq!(t.refresh_token.as_deref(), Some("rt-xyz"));
+        assert_eq!(t.expires_at_unix_secs, Some(9_999_999_999));
+        unsafe { std::env::remove_var("GROK_HOME") };
+    }
+}

--- a/crates/wcore-agent/src/output/protocol_sink.rs
+++ b/crates/wcore-agent/src/output/protocol_sink.rs
@@ -555,10 +555,17 @@ impl OutputSink for ProtocolSink {
     }
 
     fn emit_error(&self, msg: &str, retryable: bool) {
+        // Distinguish auth failures with a machine-readable code so the host can
+        // branch (prompt re-auth, or refresh an OAuth token and re-spawn the
+        // turn) instead of string-parsing the message or treating a stale-token
+        // 401 as a generic dead turn. `retryable` is left untouched: a 401 is
+        // NOT engine-retryable (re-sending the same doomed credential just burns
+        // the budget) — the host drives the refresh+retry off the `code`.
+        let code = auth_error_code(msg).unwrap_or("engine_error");
         let _ = self.writer.emit(&ProtocolEvent::Error {
             msg_id: None,
             error: ErrorInfo {
-                code: "engine_error".to_string(),
+                code: code.to_string(),
                 message: msg.to_string(),
                 retryable,
             },
@@ -804,6 +811,37 @@ impl OutputSink for ProtocolSink {
     }
 }
 
+/// Map a provider error message to a distinguishable auth error `code`, or
+/// `None` for non-auth errors (which stay `engine_error`). A 401 is a
+/// refreshable credential failure (`auth_required` — the host can re-auth or
+/// refresh an OAuth token and retry); a 403 is a hard permission failure
+/// (`auth_invalid`). Detection mirrors the provider-error shapes the engine
+/// formats elsewhere ("API 401: …", "API error 401: …", "status: 401",
+/// "401 Unauthorized", "(401)"), staying conservative to avoid tagging an
+/// unrelated message that merely contains the digits.
+fn auth_error_code(msg: &str) -> Option<&'static str> {
+    if message_carries_status(msg, "401") {
+        Some("auth_required")
+    } else if message_carries_status(msg, "403") {
+        Some("auth_invalid")
+    } else {
+        None
+    }
+}
+
+/// True when `msg` carries `code` as an HTTP status in one of the provider
+/// error shapes the engine emits, rather than as an incidental substring.
+fn message_carries_status(msg: &str, code: &str) -> bool {
+    msg.contains(&format!("API error {code}"))
+        || msg.contains(&format!("API {code}:"))
+        || msg.contains(&format!("API {code} "))
+        || msg.contains(&format!("status: {code}"))
+        || msg.contains(&format!("status code {code}"))
+        || msg.contains(&format!("({code})"))
+        || msg.contains(&format!("{code} Unauthorized"))
+        || msg.contains(&format!("{code} Forbidden"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -920,5 +958,47 @@ mod tests {
             "a hard error must report retryable=false: {:?}",
             snap[0]
         );
+    }
+
+    #[test]
+    fn auth_error_code_tags_401_as_auth_required() {
+        // The shapes the engine actually formats for a provider 401 — the host
+        // needs a stable `code` to drive token-refresh/re-auth, not the prose.
+        for msg in [
+            "API 401: invalid api key",
+            "API error 401: authentication_error",
+            "Provider stream failed after retries: API 401: token expired",
+            "The inference provider rejected the API key (401)",
+            "401 Unauthorized",
+        ] {
+            assert_eq!(
+                auth_error_code(msg),
+                Some("auth_required"),
+                "a 401 must map to auth_required: {msg:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn auth_error_code_tags_403_as_auth_invalid() {
+        assert_eq!(
+            auth_error_code("API 403: permission_error"),
+            Some("auth_invalid")
+        );
+        assert_eq!(auth_error_code("403 Forbidden"), Some("auth_invalid"));
+    }
+
+    #[test]
+    fn auth_error_code_none_for_non_auth() {
+        // A 400/500 (and messages that merely contain the digits) must NOT be
+        // mistaken for auth — they stay engine_error.
+        for msg in [
+            "API 400: invalid_request_error",
+            "Provider stream failed after retries: API 500: internal error",
+            "request id 4015 timed out",
+            "provider stream closed before a Done event (truncated response)",
+        ] {
+            assert_eq!(auth_error_code(msg), None, "non-auth must be None: {msg:?}");
+        }
     }
 }

--- a/crates/wcore-config/src/compat.rs
+++ b/crates/wcore-config/src/compat.rs
@@ -173,6 +173,16 @@ pub struct ProviderCompat {
     /// which region issued their key. `None` (the default) disables failover.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub auth_fallback_base_url: Option<String>,
+
+    /// Whether the provider accepts the OpenAI `stop` parameter. The engine
+    /// attaches "fluff" stop sequences as an output token-optimization on
+    /// client-optimized routes; some providers' reasoning models reject the
+    /// `stop` parameter outright with a 400 (xAI's `grok-4.3`: *"Model grok-4.3
+    /// does not support parameter stop"*, verified live 2026-06-18). Set
+    /// `false` to suppress the optimization so those models work. `None`
+    /// defaults to `true` — every existing provider keeps sending `stop`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub supports_stop_param: Option<bool>,
 }
 
 impl ProviderCompat {
@@ -482,6 +492,10 @@ impl ProviderCompat {
         // Base URL ends in `/v1`; pin `api_path` to avoid `/v1/v1`.
         Self {
             api_path: Some("/chat/completions".into()),
+            // grok-4.3 (a reasoning model) 400s on the `stop` parameter, which
+            // the engine otherwise attaches as a client-side output
+            // optimization — suppress it so Grok models actually run.
+            supports_stop_param: Some(false),
             ..Self::openai_compat_provider("xai")
         }
     }
@@ -598,6 +612,7 @@ impl ProviderCompat {
             auth_fallback_base_url: user
                 .auth_fallback_base_url
                 .or(defaults.auth_fallback_base_url),
+            supports_stop_param: user.supports_stop_param.or(defaults.supports_stop_param),
         }
     }
 
@@ -633,6 +648,12 @@ impl ProviderCompat {
 
     pub fn api_path(&self) -> &str {
         self.api_path.as_deref().unwrap_or("/v1/chat/completions")
+    }
+
+    /// Whether to send the OpenAI `stop` parameter. Defaults to `true`; xAI
+    /// sets it `false` because `grok-4.3` (a reasoning model) 400s on `stop`.
+    pub fn supports_stop_param(&self) -> bool {
+        self.supports_stop_param.unwrap_or(true)
     }
 
     pub fn supports_thinking(&self) -> bool {
@@ -834,6 +855,20 @@ mod tests {
         ] {
             assert_eq!(compat.api_path(), "/chat/completions");
         }
+    }
+
+    #[test]
+    fn xai_suppresses_stop_param_but_others_keep_it() {
+        // grok-4.3 400s on `stop`, so xAI must report supports_stop_param=false;
+        // every other provider keeps the default true (engine still attaches the
+        // fluff-stop output optimization on client-optimized routes).
+        assert!(
+            !ProviderCompat::xai_defaults().supports_stop_param(),
+            "xAI must suppress the stop parameter (grok-4.3 rejects it)"
+        );
+        assert!(ProviderCompat::openai_defaults().supports_stop_param());
+        assert!(ProviderCompat::anthropic_defaults().supports_stop_param());
+        assert!(ProviderCompat::groq_defaults().supports_stop_param());
     }
 
     #[test]

--- a/crates/wcore-config/src/compat.rs
+++ b/crates/wcore-config/src/compat.rs
@@ -161,6 +161,18 @@ pub struct ProviderCompat {
     /// Set via `[compat] azure_auth_mode = "aad-bearer"`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub azure_auth_mode: Option<crate::config::AzureAuthMode>,
+
+    /// Alternate API base URL to retry against when the primary `base_url`
+    /// rejects the credential with a 401. Some providers run two region-locked
+    /// platforms that share the wire protocol but NOT the key namespace, so a
+    /// valid key issued on one platform 401s on the other's host. MiniMax is the
+    /// motivating case (`api.minimax.io` vs `api.minimaxi.com` — a key works on
+    /// exactly one, verified live 2026-06-18). When set, a 401 on the primary
+    /// transparently retries the same key against this host and pins whichever
+    /// authenticates for the rest of the session, so the user never has to know
+    /// which region issued their key. `None` (the default) disables failover.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auth_fallback_base_url: Option<String>,
 }
 
 impl ProviderCompat {
@@ -239,6 +251,11 @@ impl ProviderCompat {
             cost_per_output_token: Some(0.0),
             cost_per_cache_read_token: None,
             cost_per_cache_write_token: None,
+            // MiniMax runs two region-locked platforms with separate key
+            // namespaces. The default `base_url` targets `api.minimax.io`; a key
+            // issued on the other platform 401s there, so on a 401 retry the same
+            // key against `api.minimaxi.com` and pin whichever authenticates.
+            auth_fallback_base_url: Some("https://api.minimaxi.com/anthropic".into()),
             ..Self::anthropic_defaults()
         }
     }
@@ -578,6 +595,9 @@ impl ProviderCompat {
                 .uses_max_completion_tokens
                 .or(defaults.uses_max_completion_tokens),
             azure_auth_mode: user.azure_auth_mode.or(defaults.azure_auth_mode),
+            auth_fallback_base_url: user
+                .auth_fallback_base_url
+                .or(defaults.auth_fallback_base_url),
         }
     }
 
@@ -763,6 +783,13 @@ mod tests {
         assert_eq!(compat.cost_per_input_token, Some(0.0));
         assert_eq!(compat.cost_per_output_token, Some(0.0));
         assert_eq!(compat.cost_per_cache_read_token, None);
+        // Region-locked-key failover: a 401 on the default `api.minimax.io`
+        // host retries `api.minimaxi.com` so a key from either MiniMax platform
+        // works without the user knowing which region issued it.
+        assert_eq!(
+            compat.auth_fallback_base_url.as_deref(),
+            Some("https://api.minimaxi.com/anthropic")
+        );
     }
 
     #[test]

--- a/crates/wcore-config/src/compat.rs
+++ b/crates/wcore-config/src/compat.rs
@@ -510,6 +510,11 @@ impl ProviderCompat {
         // Base URL ends in `/v1`; pin `api_path` to avoid `/v1/v1`.
         Self {
             api_path: Some("/chat/completions".into()),
+            // Moonshot (Kimi) runs two region-locked platforms with separate key
+            // namespaces, like MiniMax. The default base URL targets the
+            // international host (`api.moonshot.ai`); a mainland-China key 401s
+            // there, so on a 401 retry the same key against `api.moonshot.cn`.
+            auth_fallback_base_url: Some("https://api.moonshot.cn/v1".into()),
             ..Self::openai_compat_provider("moonshot")
         }
     }
@@ -869,6 +874,31 @@ mod tests {
         assert!(ProviderCompat::openai_defaults().supports_stop_param());
         assert!(ProviderCompat::anthropic_defaults().supports_stop_param());
         assert!(ProviderCompat::groq_defaults().supports_stop_param());
+    }
+
+    #[test]
+    fn dual_region_providers_set_auth_fallback() {
+        // Moonshot (Kimi) and MiniMax both run two region-locked platforms with
+        // separate key namespaces, so a key from the other region 401s on the
+        // default host and must fail over.
+        assert_eq!(
+            ProviderCompat::moonshot_defaults()
+                .auth_fallback_base_url
+                .as_deref(),
+            Some("https://api.moonshot.cn/v1")
+        );
+        assert_eq!(
+            ProviderCompat::minimax_defaults()
+                .auth_fallback_base_url
+                .as_deref(),
+            Some("https://api.minimaxi.com/anthropic")
+        );
+        // Single-region providers leave it unset.
+        assert!(
+            ProviderCompat::openai_defaults()
+                .auth_fallback_base_url
+                .is_none()
+        );
     }
 
     #[test]

--- a/crates/wcore-config/src/config.rs
+++ b/crates/wcore-config/src/config.rs
@@ -1151,6 +1151,23 @@ fn chatgpt_oauth_token_path() -> PathBuf {
     profile_home().join("oauth").join("chatgpt.json")
 }
 
+/// Whether an xAI (Grok) OAuth credential exists to authenticate out-of-band:
+/// the engine's own store (`~/.wayland/oauth/xai.json`) or the Grok CLI's
+/// `~/.grok/auth.json` (`$GROK_HOME/auth.json` when set). File-existence only —
+/// the actual parse + refresh lives in `wcore_agent::oauth::xai` (config can't
+/// depend on agent), mirroring how the ChatGPT presence check is split.
+fn xai_oauth_credentials_present() -> bool {
+    if profile_home().join("oauth").join("xai.json").exists() {
+        return true;
+    }
+    let grok = std::env::var("GROK_HOME")
+        .ok()
+        .filter(|d| !d.trim().is_empty())
+        .map(|d| PathBuf::from(d).join("auth.json"))
+        .or_else(|| dirs::home_dir().map(|h| h.join(".grok").join("auth.json")));
+    grok.is_some_and(|p| p.exists())
+}
+
 /// Whether `provider`'s credential is present right now, decided synchronously
 /// with no network. The single source of truth shared by the `/provider`
 /// picker (`wcore-cli`) and the model-catalog refresh service
@@ -1909,6 +1926,14 @@ fn resolve_api_key(
             }
         }
         ProviderType::Xai => {
+            // Grok "Sign in with X" authenticates via OAuth tokens resolved
+            // out-of-band by the bootstrap-built bearer source (same shape as
+            // ChatGPT). Exempt from the api-key gate when an xAI OAuth
+            // credential exists — otherwise a plain `xai` API key still works
+            // via XAI_API_KEY below.
+            if xai_oauth_credentials_present() {
+                return Ok(String::new());
+            }
             if let Ok(key) = std::env::var("XAI_API_KEY") {
                 return Ok(key);
             }

--- a/crates/wcore-providers/src/anthropic.rs
+++ b/crates/wcore-providers/src/anthropic.rs
@@ -33,6 +33,11 @@ pub struct AnthropicProvider {
     alias_key: String,
     compat: ProviderCompat,
     debug: DebugConfig,
+    /// Once a `compat.auth_fallback_base_url` retry authenticates (region-locked
+    /// key failover), the working host is pinned here so every subsequent
+    /// request tries it first instead of re-paying the primary's 401. `None`
+    /// until a fallback has succeeded.
+    pinned_base_url: Arc<Mutex<Option<String>>>,
 }
 
 impl AnthropicProvider {
@@ -45,6 +50,7 @@ impl AnthropicProvider {
             alias_key: "anthropic".to_string(),
             compat,
             debug,
+            pinned_base_url: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -96,6 +102,82 @@ impl AnthropicProvider {
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .mark_failure(key);
+    }
+
+    /// The host to try first: a fallback that previously authenticated this
+    /// session (region-locked-key failover) if one is pinned, else the
+    /// configured primary `base_url`.
+    fn effective_base_url(&self) -> String {
+        self.pinned_base_url
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
+            .unwrap_or_else(|| self.base_url.clone())
+    }
+
+    /// Remember the host that authenticated so subsequent requests skip the
+    /// primary's certain 401.
+    fn pin_base_url(&self, url: &str) {
+        *self
+            .pinned_base_url
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(url.to_string());
+    }
+
+    /// Send one streaming request to a specific `base_url`. Returns the event
+    /// receiver on 2xx, or the mapped [`ProviderError`] on any failure. Region
+    /// failover (retrying an alternate host) is the caller's concern — this
+    /// method targets exactly the host it is given.
+    async fn try_stream(
+        &self,
+        base_url: &str,
+        key: &str,
+        body: &Value,
+    ) -> Result<mpsc::Receiver<LlmEvent>, ProviderError> {
+        let url = format!("{}/v1/messages", base_url);
+        let response = builder_send_with_retry(
+            self.client
+                .post(&url)
+                .headers(self.build_headers(key)?)
+                .json(body),
+        )
+        .await?;
+
+        let status = response.status();
+        if !status.is_success() {
+            // Demote this key on auth / rate-limit failures so the next request
+            // rotates to another key in the pool (no-op for a single key).
+            if matches!(status.as_u16(), 401 | 403 | 429) {
+                self.mark_key_failure(key);
+            }
+            // E-H1 / L3: capture headers before `.text()` consumes the body
+            // so a 429 can honour `Retry-After` (header, then nested body).
+            let headers = response.headers().clone();
+            let body_text = response.text().await.unwrap_or_default();
+            if status.as_u16() == 429 {
+                return Err(ProviderError::RateLimited {
+                    retry_after_ms: crate::retry::resolve_retry_after_ms(&headers, &body_text),
+                });
+            }
+            return Err(ProviderError::Api {
+                status: status.as_u16(),
+                message: body_text,
+            });
+        }
+
+        // 2xx: this key works — make it sticky for subsequent requests.
+        self.mark_key_success(key);
+
+        let (tx, rx) = mpsc::channel(64);
+        let debug = self.debug.clone();
+
+        tokio::spawn(async move {
+            if let Err(e) = anthropic_shared::process_sse_stream(response, &tx, &debug).await {
+                let _ = tx.send(LlmEvent::Error(e.to_string())).await;
+            }
+        });
+
+        Ok(rx)
     }
 
     /// Build request headers authenticating with the supplied `key`. Anthropic
@@ -256,56 +338,44 @@ impl LlmProvider for AnthropicProvider {
         &self,
         request: &LlmRequest,
     ) -> Result<mpsc::Receiver<LlmEvent>, ProviderError> {
-        let url = format!("{}/v1/messages", self.base_url);
         let body = self.build_request_body(request);
 
         dump_request_body(&self.debug, &body);
         reset_response_dump(&self.debug);
 
+        // Select the key ONCE and reuse it across the failover attempt: the same
+        // credential is tried against both hosts (a region-locked key is valid on
+        // exactly one), so re-selecting — which could rotate or hit a cooldown —
+        // would defeat the retry.
         let key = self.select_key()?;
-        let response = builder_send_with_retry(
-            self.client
-                .post(&url)
-                .headers(self.build_headers(&key)?)
-                .json(&body),
-        )
-        .await?;
+        let primary = self.effective_base_url();
 
-        let status = response.status();
-        if !status.is_success() {
-            // Demote this key on auth / rate-limit failures so the next request
-            // rotates to another key in the pool (no-op for a single key).
-            if matches!(status.as_u16(), 401 | 403 | 429) {
-                self.mark_key_failure(&key);
+        match self.try_stream(&primary, &key, &body).await {
+            Ok(rx) => Ok(rx),
+            // Region-locked-key failover: a credential rejected here (401/403)
+            // may belong to the provider's alternate platform. When a fallback
+            // host is configured and we haven't already pinned to it, retry the
+            // SAME key there; pin it for the session on success so later requests
+            // skip the primary's certain 401. See `compat.auth_fallback_base_url`.
+            Err(ProviderError::Api { status, .. })
+                if matches!(status, 401 | 403)
+                    && self
+                        .compat
+                        .auth_fallback_base_url
+                        .as_deref()
+                        .is_some_and(|fb| fb != primary) =>
+            {
+                let fallback = self
+                    .compat
+                    .auth_fallback_base_url
+                    .clone()
+                    .expect("is_some_and guarantees Some");
+                let rx = self.try_stream(&fallback, &key, &body).await?;
+                self.pin_base_url(&fallback);
+                Ok(rx)
             }
-            // E-H1 / L3: capture headers before `.text()` consumes the body
-            // so a 429 can honour `Retry-After` (header, then nested body).
-            let headers = response.headers().clone();
-            let body_text = response.text().await.unwrap_or_default();
-            if status.as_u16() == 429 {
-                return Err(ProviderError::RateLimited {
-                    retry_after_ms: crate::retry::resolve_retry_after_ms(&headers, &body_text),
-                });
-            }
-            return Err(ProviderError::Api {
-                status: status.as_u16(),
-                message: body_text,
-            });
+            Err(e) => Err(e),
         }
-
-        // 2xx: this key works — make it sticky for subsequent requests.
-        self.mark_key_success(&key);
-
-        let (tx, rx) = mpsc::channel(64);
-        let debug = self.debug.clone();
-
-        tokio::spawn(async move {
-            if let Err(e) = anthropic_shared::process_sse_stream(response, &tx, &debug).await {
-                let _ = tx.send(LlmEvent::Error(e.to_string())).await;
-            }
-        });
-
-        Ok(rx)
     }
 
     fn alias_key(&self) -> &str {

--- a/crates/wcore-providers/src/lib.rs
+++ b/crates/wcore-providers/src/lib.rs
@@ -54,6 +54,7 @@ pub use classify::classify_failover;
 pub use cooldown::{CooldownClass, CooldownState, CooldownTracker};
 pub use failover::{FailoverError, FailoverReason, wrap_provider_error};
 pub use key_rotation::{KeyPool, split_keys};
+pub use openai::{AsyncTokenSource, OpenAIProvider};
 pub use openai_chatgpt::{AsyncBearerSource, BearerCreds, OpenAIChatGptProvider};
 pub use registry::{ProviderFactory, ProviderRegistry, RegistryError, WaylandProviderRegistry};
 pub use resilient::{

--- a/crates/wcore-providers/src/openai.rs
+++ b/crates/wcore-providers/src/openai.rs
@@ -1,3 +1,5 @@
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
@@ -20,6 +22,16 @@ use crate::{
 use wcore_config::compat::ProviderCompat;
 use wcore_config::debug::DebugConfig;
 
+/// An async source of a fresh bearer token, resolved once per request. Returns
+/// the raw token string to place in `Authorization: Bearer …`. Used by OAuth
+/// providers (e.g. xAI/Grok) whose access token must be refreshed near expiry
+/// — the closure owns the refresh round-trip, so the provider always sends a
+/// live credential without the engine snapshotting a token that goes stale.
+/// Distinct from a static API key: when set it fully replaces the key pool.
+pub type AsyncTokenSource = Arc<
+    dyn Fn() -> Pin<Box<dyn Future<Output = Result<String, ProviderError>> + Send>> + Send + Sync,
+>;
+
 pub struct OpenAIProvider {
     client: wcore_egress::EgressClient,
     /// Rotation pool over one-or-more API keys. A single configured key yields
@@ -28,6 +40,10 @@ pub struct OpenAIProvider {
     /// here, so this seam covers the whole family at once. Wrapped in
     /// `Arc<Mutex<…>>` so `&self` request methods can rotate/demote keys.
     keys: Arc<Mutex<KeyPool>>,
+    /// When set, the per-request credential comes from this async source
+    /// (OAuth, refreshed near expiry) instead of the static `keys` pool. The
+    /// pool is empty in that case and `select_key` is never consulted.
+    bearer: Option<AsyncTokenSource>,
     base_url: String,
     compat: ProviderCompat,
     debug: DebugConfig,
@@ -38,6 +54,27 @@ impl OpenAIProvider {
         Self {
             client: crate::http_client::build(),
             keys: Arc::new(Mutex::new(KeyPool::new(split_keys(api_key)))),
+            bearer: None,
+            base_url: base_url.to_string(),
+            compat,
+            debug,
+        }
+    }
+
+    /// Build over an async OAuth bearer source instead of a static API key.
+    /// Every request resolves (and, if near expiry, refreshes) the token via
+    /// `bearer` before sending — so an OAuth session never dies mid-turn on a
+    /// stale snapshot. The key pool is empty; `select_key` is never used.
+    pub fn with_bearer(
+        bearer: AsyncTokenSource,
+        base_url: &str,
+        compat: ProviderCompat,
+        debug: DebugConfig,
+    ) -> Self {
+        Self {
+            client: crate::http_client::build(),
+            keys: Arc::new(Mutex::new(KeyPool::new(Vec::new()))),
+            bearer: Some(bearer),
             base_url: base_url.to_string(),
             compat,
             debug,
@@ -745,7 +782,16 @@ impl LlmProvider for OpenAIProvider {
         dump_request_body(&self.debug, &body);
         reset_response_dump(&self.debug);
 
-        let key = self.select_key()?;
+        // OAuth providers resolve (and refresh near expiry) a fresh bearer per
+        // request; static-key providers select from the rotation pool. The
+        // key-pool demote/promote bookkeeping below only applies to the static
+        // path — for OAuth there is one credential and the token source owns
+        // refresh, so the `mark_key_*` calls are skipped.
+        let using_bearer = self.bearer.is_some();
+        let key = match &self.bearer {
+            Some(src) => (src)().await?,
+            None => self.select_key()?,
+        };
         let response = builder_send_with_retry(
             self.client
                 .post(&url)
@@ -758,7 +804,7 @@ impl LlmProvider for OpenAIProvider {
         if !status.is_success() {
             // Demote this key on auth / rate-limit failures so the next request
             // rotates to another key in the pool (no-op for a single key).
-            if matches!(status.as_u16(), 401 | 403 | 429) {
+            if !using_bearer && matches!(status.as_u16(), 401 | 403 | 429) {
                 self.mark_key_failure(&key);
             }
             // E-H1 / L3: capture headers before `.text()` consumes the body
@@ -780,7 +826,10 @@ impl LlmProvider for OpenAIProvider {
         }
 
         // 2xx: this key works — make it sticky for subsequent requests.
-        self.mark_key_success(&key);
+        // (No-op for the OAuth bearer path, which holds a single credential.)
+        if !using_bearer {
+            self.mark_key_success(&key);
+        }
 
         let (tx, rx) = mpsc::channel(64);
         let debug = self.debug.clone();

--- a/crates/wcore-providers/src/openai.rs
+++ b/crates/wcore-providers/src/openai.rs
@@ -45,6 +45,11 @@ pub struct OpenAIProvider {
     /// pool is empty in that case and `select_key` is never consulted.
     bearer: Option<AsyncTokenSource>,
     base_url: String,
+    /// Once a `compat.auth_fallback_base_url` retry authenticates (region-locked
+    /// key failover), the working host is pinned here so every later request
+    /// tries it first. `None` until a fallback has succeeded. Mirrors the same
+    /// field on `AnthropicProvider`.
+    pinned_base_url: Arc<Mutex<Option<String>>>,
     compat: ProviderCompat,
     debug: DebugConfig,
 }
@@ -56,6 +61,7 @@ impl OpenAIProvider {
             keys: Arc::new(Mutex::new(KeyPool::new(split_keys(api_key)))),
             bearer: None,
             base_url: base_url.to_string(),
+            pinned_base_url: Arc::new(Mutex::new(None)),
             compat,
             debug,
         }
@@ -76,6 +82,7 @@ impl OpenAIProvider {
             keys: Arc::new(Mutex::new(KeyPool::new(Vec::new()))),
             bearer: Some(bearer),
             base_url: base_url.to_string(),
+            pinned_base_url: Arc::new(Mutex::new(None)),
             compat,
             debug,
         }
@@ -379,8 +386,94 @@ impl OpenAIProvider {
     /// path and append `/responses` so the Responses request shares the `/v1`
     /// API root. When the path has no such suffix (an unusual override) fall
     /// back to the canonical `/v1/responses` under the base URL.
-    fn responses_url(&self) -> String {
-        let base = self.base_url.trim_end_matches('/');
+    /// The host to try first: a fallback that previously authenticated this
+    /// session (region-locked-key failover) if pinned, else the configured
+    /// primary `base_url`.
+    fn effective_base_url(&self) -> String {
+        self.pinned_base_url
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
+            .unwrap_or_else(|| self.base_url.clone())
+    }
+
+    /// Remember the host that authenticated so later requests skip the primary's
+    /// certain 401.
+    fn pin_base_url(&self, url: &str) {
+        *self
+            .pinned_base_url
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(url.to_string());
+    }
+
+    /// Build the request URL for a specific `base_url` (chat-completions or, for
+    /// the gpt-5 family, the Responses API). Separated from `self.base_url` so
+    /// the region-failover path can target an alternate host.
+    fn url_for(&self, base_url: &str, use_responses: bool) -> String {
+        if use_responses {
+            self.responses_url_for(base_url)
+        } else {
+            format!("{}{}", base_url, self.compat.api_path())
+        }
+    }
+
+    /// Send one streaming request to a specific `base_url` and return the 2xx
+    /// response, or the mapped [`ProviderError`]. Region failover (retrying an
+    /// alternate host on a 401/403) is the caller's concern — this targets
+    /// exactly the host it is given. `key` is resolved once by the caller and
+    /// reused across hosts (a region-locked key is valid on exactly one).
+    async fn try_send(
+        &self,
+        base_url: &str,
+        use_responses: bool,
+        body: &Value,
+        key: &str,
+        using_bearer: bool,
+    ) -> Result<reqwest::Response, ProviderError> {
+        let url = self.url_for(base_url, use_responses);
+        let response = builder_send_with_retry(
+            self.client
+                .post(&url)
+                .headers(self.build_headers(key)?)
+                .json(body),
+        )
+        .await?;
+
+        let status = response.status();
+        if !status.is_success() {
+            // Demote this key on auth / rate-limit failures so the next request
+            // rotates to another key in the pool (no-op for a single key, and
+            // skipped for the OAuth bearer path which holds one credential).
+            if !using_bearer && matches!(status.as_u16(), 401 | 403 | 429) {
+                self.mark_key_failure(key);
+            }
+            // E-H1 / L3: capture headers before `.text()` consumes the body
+            // so a 429 can honour `Retry-After` (header, then nested body).
+            let headers = response.headers().clone();
+            let body_text = response
+                .text()
+                .await
+                .unwrap_or_else(|e| format!("<body read failed: {e}>"));
+            if status.as_u16() == 429 {
+                return Err(ProviderError::RateLimited {
+                    retry_after_ms: crate::retry::resolve_retry_after_ms(&headers, &body_text),
+                });
+            }
+            return Err(ProviderError::Api {
+                status: status.as_u16(),
+                message: body_text,
+            });
+        }
+
+        // 2xx: this key works — make it sticky for subsequent requests.
+        if !using_bearer {
+            self.mark_key_success(key);
+        }
+        Ok(response)
+    }
+
+    fn responses_url_for(&self, base_url: &str) -> String {
+        let base = base_url.trim_end_matches('/');
         let path = self.compat.api_path();
         match path.strip_suffix("/chat/completions") {
             Some(root) => format!("{base}{root}/responses"),
@@ -767,69 +860,58 @@ impl LlmProvider for OpenAIProvider {
         // `/v1/chat/completions` and MUST use the Responses API. Everything
         // else keeps the chat path unchanged. See `uses_responses_api`.
         let use_responses = self.uses_responses_api(request);
-        let (url, body) = if use_responses {
-            (
-                self.responses_url(),
-                openai_responses::build_responses_body(request, &self.compat),
-            )
+        let body = if use_responses {
+            openai_responses::build_responses_body(request, &self.compat)
         } else {
-            (
-                format!("{}{}", self.base_url, self.compat.api_path()),
-                self.build_request_body(request),
-            )
+            self.build_request_body(request)
         };
 
         dump_request_body(&self.debug, &body);
         reset_response_dump(&self.debug);
 
         // OAuth providers resolve (and refresh near expiry) a fresh bearer per
-        // request; static-key providers select from the rotation pool. The
-        // key-pool demote/promote bookkeeping below only applies to the static
-        // path — for OAuth there is one credential and the token source owns
-        // refresh, so the `mark_key_*` calls are skipped.
+        // request; static-key providers select from the rotation pool. The key
+        // is resolved ONCE and reused across the failover attempt — the same
+        // credential is tried against both hosts (a region-locked key is valid
+        // on exactly one).
         let using_bearer = self.bearer.is_some();
         let key = match &self.bearer {
             Some(src) => (src)().await?,
             None => self.select_key()?,
         };
-        let response = builder_send_with_retry(
-            self.client
-                .post(&url)
-                .headers(self.build_headers(&key)?)
-                .json(&body),
-        )
-        .await?;
 
-        let status = response.status();
-        if !status.is_success() {
-            // Demote this key on auth / rate-limit failures so the next request
-            // rotates to another key in the pool (no-op for a single key).
-            if !using_bearer && matches!(status.as_u16(), 401 | 403 | 429) {
-                self.mark_key_failure(&key);
+        let primary = self.effective_base_url();
+        let response = match self
+            .try_send(&primary, use_responses, &body, &key, using_bearer)
+            .await
+        {
+            Ok(resp) => resp,
+            // Region-locked-key failover: a credential rejected here (401/403)
+            // may belong to the provider's alternate platform (e.g. Moonshot's
+            // `api.moonshot.cn` vs `.ai`). When a fallback host is configured
+            // and we haven't already pinned it, retry the SAME key there; pin it
+            // for the session on success. See `compat.auth_fallback_base_url`.
+            Err(ProviderError::Api { status, .. })
+                if matches!(status, 401 | 403)
+                    && self
+                        .compat
+                        .auth_fallback_base_url
+                        .as_deref()
+                        .is_some_and(|fb| fb != primary) =>
+            {
+                let fallback = self
+                    .compat
+                    .auth_fallback_base_url
+                    .clone()
+                    .expect("is_some_and guarantees Some");
+                let resp = self
+                    .try_send(&fallback, use_responses, &body, &key, using_bearer)
+                    .await?;
+                self.pin_base_url(&fallback);
+                resp
             }
-            // E-H1 / L3: capture headers before `.text()` consumes the body
-            // so a 429 can honour `Retry-After` (header, then nested body).
-            let headers = response.headers().clone();
-            let body_text = response
-                .text()
-                .await
-                .unwrap_or_else(|e| format!("<body read failed: {e}>"));
-            if status.as_u16() == 429 {
-                return Err(ProviderError::RateLimited {
-                    retry_after_ms: crate::retry::resolve_retry_after_ms(&headers, &body_text),
-                });
-            }
-            return Err(ProviderError::Api {
-                status: status.as_u16(),
-                message: body_text,
-            });
-        }
-
-        // 2xx: this key works — make it sticky for subsequent requests.
-        // (No-op for the OAuth bearer path, which holds a single credential.)
-        if !using_bearer {
-            self.mark_key_success(&key);
-        }
+            Err(e) => return Err(e),
+        };
 
         let (tx, rx) = mpsc::channel(64);
         let debug = self.debug.clone();
@@ -1454,7 +1536,10 @@ mod tests {
             openai_compat(),
             DebugConfig::default(),
         );
-        assert_eq!(p.responses_url(), "https://api.openai.com/v1/responses");
+        assert_eq!(
+            p.responses_url_for(&p.base_url),
+            "https://api.openai.com/v1/responses"
+        );
     }
 
     #[test]
@@ -1471,7 +1556,10 @@ mod tests {
             compat,
             DebugConfig::default(),
         );
-        assert_eq!(p.responses_url(), "https://api.example.com/v1/responses");
+        assert_eq!(
+            p.responses_url_for(&p.base_url),
+            "https://api.example.com/v1/responses"
+        );
     }
 
     #[test]

--- a/crates/wcore-providers/src/xai.rs
+++ b/crates/wcore-providers/src/xai.rs
@@ -44,6 +44,21 @@ impl XaiProvider {
     pub fn with_defaults(api_key: &str, compat: ProviderCompat, debug: DebugConfig) -> Self {
         Self::new(api_key, XAI_DEFAULT_BASE_URL, compat, debug)
     }
+
+    /// Construct over an async OAuth bearer source (Grok "Sign in with X").
+    /// The token is refreshed near expiry on every turn, so a Grok session
+    /// survives the ~6h access-token lifetime without the host re-spawning —
+    /// matching how the engine already handles "Sign in with ChatGPT".
+    pub fn with_bearer(
+        bearer: crate::AsyncTokenSource,
+        base_url: &str,
+        compat: ProviderCompat,
+        debug: DebugConfig,
+    ) -> Self {
+        Self {
+            inner: OpenAIProvider::with_bearer(bearer, base_url, compat, debug),
+        }
+    }
 }
 
 #[async_trait]

--- a/crates/wcore-providers/tests/provider_anthropic_test.rs
+++ b/crates/wcore-providers/tests/provider_anthropic_test.rs
@@ -732,3 +732,129 @@ async fn test_anthropic_429_honours_retry_after_header() {
         e => panic!("expected RateLimited, got: {e:?}"),
     }
 }
+
+// ---------------------------------------------------------------------------
+// Region-locked-key failover (compat.auth_fallback_base_url)
+// ---------------------------------------------------------------------------
+
+/// A 401 on the primary host with a configured `auth_fallback_base_url` must
+/// transparently retry the SAME key against the fallback host and succeed.
+/// Motivating case: MiniMax's two region-locked platforms (`api.minimax.io`
+/// vs `api.minimaxi.com`) — a valid key works on exactly one.
+#[tokio::test]
+async fn test_anthropic_region_failover_retries_alternate_host_on_401() {
+    let primary = MockServer::start().await;
+    let fallback = MockServer::start().await;
+
+    // Primary rejects the key.
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(ResponseTemplate::new(401).set_body_string(
+            r#"{"type":"error","error":{"type":"authentication_error","message":"invalid api key"}}"#,
+        ))
+        .mount(&primary)
+        .await;
+
+    // Fallback accepts the same key.
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_raw(text_sse_body("from fallback"), "text/event-stream"),
+        )
+        .mount(&fallback)
+        .await;
+
+    let mut compat = ProviderCompat::anthropic_defaults();
+    compat.auth_fallback_base_url = Some(fallback.uri());
+
+    let provider = AnthropicProvider::new(
+        "region-locked-key",
+        &primary.uri(),
+        compat,
+        DebugConfig::default(),
+    )
+    .with_cache(false);
+
+    let rx = provider
+        .stream(&minimal_request())
+        .await
+        .expect("failover to the fallback host must succeed");
+    let events = collect_events(rx).await;
+
+    let got_text = events
+        .iter()
+        .any(|e| matches!(e, LlmEvent::TextDelta(t) if t == "from fallback"));
+    assert!(
+        got_text,
+        "expected the fallback host's response; got: {events:?}"
+    );
+}
+
+/// Once the fallback authenticates it is PINNED: a second request goes straight
+/// to the fallback and does not re-pay the primary's certain 401.
+#[tokio::test]
+async fn test_anthropic_region_failover_pins_working_host() {
+    let primary = MockServer::start().await;
+    let fallback = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(ResponseTemplate::new(401).set_body_string("nope"))
+        .mount(&primary)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_raw(text_sse_body("ok"), "text/event-stream"),
+        )
+        .mount(&fallback)
+        .await;
+
+    let mut compat = ProviderCompat::anthropic_defaults();
+    compat.auth_fallback_base_url = Some(fallback.uri());
+    let provider = AnthropicProvider::new("k", &primary.uri(), compat, DebugConfig::default())
+        .with_cache(false);
+
+    // First request: primary 401 -> fallback 200, pins the fallback.
+    collect_events(provider.stream(&minimal_request()).await.unwrap()).await;
+    // Second request: must resolve on the pinned fallback only.
+    collect_events(provider.stream(&minimal_request()).await.unwrap()).await;
+
+    let primary_hits = primary.received_requests().await.unwrap().len();
+    assert_eq!(
+        primary_hits, 1,
+        "after pinning, the primary host must not be retried"
+    );
+    let fallback_hits = fallback.received_requests().await.unwrap().len();
+    assert_eq!(
+        fallback_hits, 2,
+        "both requests must resolve on the pinned fallback host"
+    );
+}
+
+/// With NO fallback configured (the default for ordinary Anthropic providers),
+/// a 401 surfaces as the error unchanged — no behavior drift.
+#[tokio::test]
+async fn test_anthropic_no_failover_without_fallback_configured() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(ResponseTemplate::new(401).set_body_string("denied"))
+        .mount(&server)
+        .await;
+
+    // anthropic_defaults() leaves auth_fallback_base_url = None.
+    let provider = AnthropicProvider::new(
+        "k",
+        &server.uri(),
+        ProviderCompat::anthropic_defaults(),
+        DebugConfig::default(),
+    )
+    .with_cache(false);
+
+    match provider.stream(&minimal_request()).await {
+        Err(ProviderError::Api { status, .. }) => assert_eq!(status, 401),
+        other => panic!("expected Api(401) with no failover, got: {other:?}"),
+    }
+}

--- a/crates/wcore-providers/tests/provider_openai_test.rs
+++ b/crates/wcore-providers/tests/provider_openai_test.rs
@@ -1033,3 +1033,92 @@ async fn test_openai_unterminated_sse_frame_is_capped() {
         events.len()
     );
 }
+
+// ---------------------------------------------------------------------------
+// Region-locked-key failover (compat.auth_fallback_base_url) on the
+// OpenAI-compatible path — motivating case: Moonshot's `api.moonshot.ai`
+// (international) vs `api.moonshot.cn` (China), a key works on exactly one.
+// ---------------------------------------------------------------------------
+
+/// A 401 on the primary host with a configured `auth_fallback_base_url` must
+/// transparently retry the SAME key against the fallback host and succeed.
+#[tokio::test]
+async fn openai_region_failover_retries_alternate_host_on_401() {
+    let primary = MockServer::start().await;
+    let fallback = MockServer::start().await;
+
+    // Primary rejects the key.
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(ResponseTemplate::new(401).set_body_string(
+            r#"{"error":{"message":"invalid api key","type":"authentication_error"}}"#,
+        ))
+        .mount(&primary)
+        .await;
+
+    // Fallback accepts the same key and returns a normal text stream.
+    let chunk = json!({
+        "id": "c1", "object": "chat.completion.chunk",
+        "choices": [{"index": 0, "delta": {"content": "from fallback"}, "finish_reason": null}]
+    })
+    .to_string();
+    let stop = json!({
+        "id": "c1", "object": "chat.completion.chunk",
+        "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+        "usage": {"prompt_tokens": 1, "completion_tokens": 2, "total_tokens": 3}
+    })
+    .to_string();
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_raw(build_sse_body(&[&chunk, &stop]), "text/event-stream"),
+        )
+        .mount(&fallback)
+        .await;
+
+    let mut compat = ProviderCompat::openai_defaults();
+    compat.auth_fallback_base_url = Some(fallback.uri());
+
+    let provider = OpenAIProvider::new(
+        "region-locked-key",
+        &primary.uri(),
+        compat,
+        DebugConfig::default(),
+    );
+    let rx = provider
+        .stream(&make_request())
+        .await
+        .expect("failover to the fallback host must succeed");
+    let events = collect_events(rx).await;
+
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, LlmEvent::TextDelta(t) if t == "from fallback")),
+        "expected the fallback host's response; got: {events:?}"
+    );
+}
+
+/// With NO fallback configured (the default), a 401 surfaces unchanged — no
+/// behavior drift for ordinary OpenAI-compatible providers.
+#[tokio::test]
+async fn openai_no_failover_without_fallback_configured() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(ResponseTemplate::new(401).set_body_string("denied"))
+        .mount(&server)
+        .await;
+
+    let provider = OpenAIProvider::new(
+        "k",
+        &server.uri(),
+        ProviderCompat::openai_defaults(),
+        DebugConfig::default(),
+    );
+    match provider.stream(&make_request()).await {
+        Err(wcore_providers::ProviderError::Api { status, .. }) => assert_eq!(status, 401),
+        other => panic!("expected Api(401) with no failover, got: {other:?}"),
+    }
+}


### PR DESCRIPTION
Makes connected providers actually work in Wayland Core: Grok via OAuth, region-locked keys that fail over, and 401s the host can act on. Each fix is box-gated (clippy + tests + fmt) and the live ones are confirmed against the real binary on a remote build box.

## What's in it (7 commits)
1. **MiniMax region-locked-key 401 failover** (Anthropic wire) — `api.minimax.io` vs `api.minimaxi.com` share the wire but not the key namespace; on a 401 the engine retries the same key against the alternate host and pins the winner. Verified live (same key 429s on `.io`, 401s on `.com`).
2. **Distinguishable auth error** — 401 → `auth_required` (refreshable), 403 → `auth_invalid`, instead of a generic `engine_error`, at the ProtocolSink chokepoint every error funnels through. The hook the host needs to refresh + retry.
3. **Async OAuth bearer seam** on the OpenAI-compatible (`/v1/chat/completions`) path — `OpenAIProvider::with_bearer` / `AsyncTokenSource`, parity with the Responses-API ChatGPT path. Keystone for Grok OAuth.
4. **xAI `stop`-param fix** — grok-4.3 (reasoning model) 400s on the `stop` parameter the engine attaches as an output optimization. Compat `supports_stop_param` (xai → false). **This was the actual reason Grok failed even with a valid token** — reproduced via raw curl, fixed, and confirmed live (`* GROK ENGINE OK`).
5. **Moonshot region-locked-key 401 failover** (OpenAI-compatible path) — same two-region split as MiniMax (`api.moonshot.ai` vs `api.moonshot.cn`); ports the failover onto `OpenAIProvider` so it now covers both wire formats and any future dual-region OpenAI-compatible provider.
6. **Engine-native xAI (Grok) OAuth with refresh** — ChatGPT parity. `oauth/xai.rs` XaiTokenManager (single-flight, 120s lead, rotation C3/C4 — xAI rotates single-use refresh tokens, verified live), sources from the engine store or `~/.grok/auth.json` (prefers fresher). Bootstrap builds the refreshing bearer; config exempts xai from the api-key gate when an OAuth credential exists. **Verified live end-to-end**: no API key set, `-p xai -m grok-4.3` streams (`* GROK OAUTH OK`); refresh + client_id proven against the live token endpoint (HTTP 200, rotating).

## App-side follow-up (separate repo)
An embedding app must spawn Grok as `--provider xai` (not `--provider openai`) to get the OAuth path AND the grok-4.3 stop-param fix (which live in `xai_defaults`). Tracked on the app side.

Toward 0.12.2.