### PR TITLE
ci(bench): add 20-min timeout so a stalled runner fails fast

### DIFF
--- a/.github/workflows/bench-regression.yml
+++ b/.github/workflows/bench-regression.yml
@@ -26,6 +26,10 @@ jobs:
   bench-regression:
     name: Bench regression (linux)
     runs-on: ubuntu-latest
+    # A healthy run is ~4 min. Without a cap, a stalled hosted runner sits
+    # "in_progress" under GitHub's 6h default instead of failing fast, which
+    # blocks merges on an orphaned check (seen on #42). Fail fast → re-run.
+    timeout-minutes: 20
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
The `bench-regression` job had no `timeout-minutes`, so under GitHub's 6h default a stalled hosted runner sat `in_progress` instead of failing — orphaning the check and blocking the merge on #42 (couldn't cancel/rerun a still-running job).

A healthy bench run is ~4 min. Cap at 20 (matches `ci.yml`'s convention) so a stall becomes a fast red we can simply re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)