### PR TITLE
docs: refresh across the board for 0.12.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ One command. The agent reads the file, runs `grep`/`glob` across the tree, reaso
 
 </div>
 
+**Paste a key, get a provider.** Paste an API key (or run `/connect` in the TUI) and the engine fingerprints the provider from the key's shape, validates it live, and stores it in your OS keyring. From there, `/config` exposes Essentials and Advanced editors, `/doctor` shows provider, key, and MCP health, and `/effective` prints the resolved config with secrets redacted.
+
 ## What it is
 
 - **A standalone engine.** The engine is the product, not a feature bolted onto an editor and not a wrapper around one vendor's API.
@@ -89,8 +91,10 @@ wayland-core --help
 
 Most terminal agents are married to one vendor. Wayland Core is built provider-neutral from the foundation up: the engine only ever sees provider-neutral types, and every vendor's quirks are pushed into a configuration layer instead of the code.
 
-- **~20 first-class provider integrations**, written in-tree: Anthropic, OpenAI, Google Gemini, Google Vertex AI, AWS Bedrock (real SigV4 signing and event-stream framing), Cohere, Azure OpenAI, plus Groq, DeepSeek, Mistral, Together, Fireworks, xAI, Qwen, Moonshot, Nvidia, Cerebras, Perplexity, OpenRouter, and Ollama for local models.
+- **~20 first-class provider integrations**, written in-tree: Anthropic, OpenAI, Google Gemini, Google Vertex AI, AWS Bedrock (real SigV4 signing and event-stream framing), Cohere, Azure OpenAI, plus Groq, DeepSeek, Mistral, Together, Fireworks, xAI, Qwen, Moonshot, MiniMax, Nvidia, Cerebras, Perplexity, OpenRouter, and Ollama for local models.
+- **Sign in with ChatGPT** (OAuth, no API key): `wayland-core auth login chatgpt`, then run with `--provider openai-chatgpt`.
 - **A 104-entry [models.dev](https://models.dev) catalog** on top of those, so 100+ more endpoints are selectable by id with no code change.
+- **Live model discovery** for connected providers — Bedrock `ListFoundationModels`, Gemini, and OpenAI-compatible `list_models` — cached on disk for 24h and surfaced in the arrow-key `/model` and `/provider` pickers.
 - **Switching vendors is a config change, not a fork.** There is no `if base_url.contains("openai.com")` anywhere in the codebase.
 
 **ProviderCompat** is the rule that makes that true. Point `base_url` at any OpenAI-compatible endpoint and describe its differences as data:

--- a/crates/wcore-config/src/shell.rs
+++ b/crates/wcore-config/src/shell.rs
@@ -41,6 +41,50 @@ pub fn shell_info() -> ShellInfo {
     }
 }
 
+/// Shell argv prefix for the agent **Bash tool**, honoring an optional
+/// Windows PowerShell override.
+///
+/// Returns the program + flag(s) that precede the command string in the
+/// BashTool argv: `["sh", "-c"]` on Unix and `["cmd", "/C"]` on Windows by
+/// default. On Windows ONLY, `WAYLAND_BASH_SHELL` switches the interpreter:
+/// `powershell` → `["powershell", "-NoProfile", "-Command"]` (Windows
+/// PowerShell 5.1, always present) and `pwsh` → the same with `pwsh`
+/// (PowerShell 7+, if installed). Any other value falls back to `cmd /C`.
+///
+/// Scope is deliberately the BashTool only — the hook, MCP-stdio, and skill
+/// shell paths keep `cmd /C` so their established quoting/shim contracts are
+/// unchanged. This does not alter the injection surface: BashTool already
+/// runs an LLM-supplied string through a shell interpreter (its contract);
+/// this only chooses which interpreter, and the denylist + sandbox still
+/// apply to the resulting argv. See issue: PowerShell-on-Windows request.
+pub fn bash_shell_argv_prefix() -> Vec<String> {
+    bash_shell_prefix_for(
+        cfg!(windows),
+        std::env::var("WAYLAND_BASH_SHELL").ok().as_deref(),
+    )
+}
+
+/// Pure core of [`bash_shell_argv_prefix`], split out so every branch —
+/// including the Windows/PowerShell ones — is unit-testable on any host.
+fn bash_shell_prefix_for(is_windows: bool, win_shell: Option<&str>) -> Vec<String> {
+    if !is_windows {
+        return vec!["sh".to_string(), "-c".to_string()];
+    }
+    match win_shell.map(|s| s.trim().to_ascii_lowercase()).as_deref() {
+        Some("powershell") => vec![
+            "powershell".to_string(),
+            "-NoProfile".to_string(),
+            "-Command".to_string(),
+        ],
+        Some("pwsh") => vec![
+            "pwsh".to_string(),
+            "-NoProfile".to_string(),
+            "-Command".to_string(),
+        ],
+        _ => vec!["cmd".to_string(), "/C".to_string()],
+    }
+}
+
 /// Shell-string mode: run `sh -c <str>` (Unix) / `cmd /C <str>` (Windows).
 ///
 /// Returns an unstarted `tokio::process::Command` so callers can attach
@@ -151,6 +195,48 @@ mod tests {
             assert_eq!(info.program, "sh");
             assert_eq!(info.flag, "-c");
         }
+    }
+
+    #[test]
+    fn bash_prefix_unix_is_sh_dash_c_regardless_of_env() {
+        // The PowerShell override is Windows-only; on Unix it is ignored.
+        assert_eq!(bash_shell_prefix_for(false, None), vec!["sh", "-c"]);
+        assert_eq!(
+            bash_shell_prefix_for(false, Some("powershell")),
+            vec!["sh", "-c"]
+        );
+    }
+
+    #[test]
+    fn bash_prefix_windows_defaults_to_cmd() {
+        assert_eq!(bash_shell_prefix_for(true, None), vec!["cmd", "/C"]);
+        // An unrecognized value falls back to cmd, never an empty/invalid argv.
+        assert_eq!(bash_shell_prefix_for(true, Some("bash")), vec!["cmd", "/C"]);
+    }
+
+    #[test]
+    fn bash_prefix_windows_powershell_override() {
+        assert_eq!(
+            bash_shell_prefix_for(true, Some("powershell")),
+            vec!["powershell", "-NoProfile", "-Command"]
+        );
+        // Case-insensitive and whitespace-tolerant.
+        assert_eq!(
+            bash_shell_prefix_for(true, Some("  PowerShell ")),
+            vec!["powershell", "-NoProfile", "-Command"]
+        );
+        assert_eq!(
+            bash_shell_prefix_for(true, Some("pwsh")),
+            vec!["pwsh", "-NoProfile", "-Command"]
+        );
+    }
+
+    #[test]
+    fn bash_prefix_default_branches_match_shell_info() {
+        // Guard against drift between the prefix defaults and shell_info().
+        let info = shell_info();
+        let expected = vec![info.program.to_string(), info.flag.to_string()];
+        assert_eq!(bash_shell_prefix_for(cfg!(windows), None), expected);
     }
 
     #[tokio::test]

--- a/crates/wcore-tools/src/bash.rs
+++ b/crates/wcore-tools/src/bash.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 use regex::RegexSet;
 use serde_json::{Value, json};
 
-use wcore_config::shell::shell_info;
+use wcore_config::shell::bash_shell_argv_prefix;
 use wcore_protocol::events::ToolCategory;
 use wcore_sandbox::{
     NetworkPolicy, SandboxChunk, SandboxCommand, SandboxManifest, SandboxOutput, SyscallPolicy,
@@ -67,12 +67,10 @@ const MAX_TIMEOUT_MS: u64 = 600_000;
 /// escape: the env is already secret-scrubbed and the network now defaults
 /// closed.
 fn build_sandbox_pieces(command: &str) -> (SandboxManifest, SandboxCommand) {
-    let info = shell_info();
-    let argv = vec![
-        info.program.to_string(),
-        info.flag.to_string(),
-        command.to_string(),
-    ];
+    // Shell prefix honors the Windows `WAYLAND_BASH_SHELL=powershell|pwsh`
+    // override (BashTool only); defaults to `sh -c` / `cmd /C`.
+    let mut argv = bash_shell_argv_prefix();
+    argv.push(command.to_string());
     let manifest = SandboxManifest {
         network: default_bash_network_policy(),
         // Curated env — secrets excluded, see the doc-comment above.

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -115,6 +115,32 @@ With caching enabled, stats show cache data:
 
 ---
 
+## OAuth Providers
+
+Two providers authenticate via OAuth rather than a raw API key, with tokens
+managed entirely by the engine:
+
+- **Sign in with ChatGPT** — interactive subscription login. Run
+  `wayland-core auth login chatgpt` (loopback PKCE flow; `--device` for a
+  headless device-code flow, `--import-codex` to reuse an existing Codex CLI
+  login). This is the only wired `auth login` verb.
+- **Grok (xAI)** — there is no `auth login` verb for Grok. Use it with
+  `--provider xai`; the engine refreshes its OAuth tokens automatically. Grok
+  CLI logins are importable: if `~/.grok/auth.json` exists, the engine reads
+  and keeps it fresh.
+
+### Token Storage & Security
+
+- Tokens are stored encrypted at `~/.wayland/oauth/{provider}.json`, with
+  directory mode `0700` and file mode `0600` on Unix.
+- PKCE (S256) and a CSRF `state` token are mandatory on the login flow; the
+  callback compares `state` in constant time.
+- Refresh is engine-managed: concurrent refreshes coalesce into a single
+  network round-trip (single-flight), and tokens renew automatically before
+  expiry — no manual re-login.
+
+---
+
 ## VCR Recording & Replay
 
 Record real API interactions and replay them in tests — no API key or network needed.
@@ -225,6 +251,11 @@ export WCORE_MEMORY_DIR=/custom/path
 The legacy `AIONRS_MEMORY_DIR` is still honored as a backward-compat alias —
 useful if you're migrating from an older `aionrs` configuration. When both are
 set, `WCORE_MEMORY_DIR` wins.
+
+On Windows, `WAYLAND_BASH_SHELL=powershell` (Windows PowerShell 5.1) or
+`WAYLAND_BASH_SHELL=pwsh` (PowerShell 7+) switches the BashTool interpreter
+from the default `cmd`. It is a no-op on Unix. See
+[docs/tools.md](tools.md) for details.
 
 ### How It Works
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,11 +7,15 @@
 
 ## 1. Layer map
 
-Wayland-Core is a Cargo workspace of 19 internal `wcore-*` crates plus 5
-`wayland-*` plugin crates (24 total). Dependencies flow **downward** in the
+Wayland-Core is a Cargo workspace of ~49 internal `wcore-*` crates plus 5
+`wayland-*` plugin crates (54 total). Dependencies flow **downward** in the
 diagram below — never introduce circular or upward references. The full
 crate table with one-line responsibilities lives in
 [AGENTS.md §Crate Map](../AGENTS.md#crate-map).
+
+> The diagram below shows only the **load-bearing spine** plus the substrate
+> band — it is not an exhaustive crate listing. For the live, complete set run
+> `cargo metadata` or read [AGENTS.md §10](../AGENTS.md#10-project-context--wayland-core).
 
 ```
                            ┌──────────────────┐
@@ -47,6 +51,21 @@ crate table with one-line responsibilities lives in
               │  zero internal deps)             │
               └──────────────────────────────────┘
 
+  Substrate band (peers of the mid tier, grouped by concern — not every
+  crate is drawn on the spine above):
+    security/sandbox  : wcore-sandbox, wcore-egress, wcore-safety,
+                        wcore-permissions
+    economics         : wcore-budget, wcore-pricing
+    messaging/channels: wcore-channels, wcore-channels-registry, and the
+                        wcore-channel-* connectors (discord, email,
+                        imessage, matrix, msteams, signal, slack, sms,
+                        telegram, whatsapp)
+    plugin runtimes   : wcore-plugin-subprocess, wcore-plugin-wasm
+    host integration  : wcore-acp, wcore-dispatch, wcore-swarm
+    misc              : wcore-cron, wcore-replay, wcore-user-model,
+                        wcore-eval-scenarios, wcore-fixture-harness,
+                        wcore-honcho-adapter, wcore-agents-pack
+
   wcore-repomap is a deliberate island — NO internal `wcore-*` deps.
 
   Plugins (wayland-ollama, wayland-browser, wayland-cua, wayland-ijfw,
@@ -59,6 +78,11 @@ The mid-tier crates fan out from `wcore-agent` and converge on
 `wcore-config` / `wcore-protocol` / `wcore-types` at the bottom. New
 functionality must land in the **lowest crate where it semantically
 belongs** — see [§4 Where to put new code](#4-where-to-put-new-code).
+
+`wcore-agent` also hosts the **ForgeFlows (Dynamic Workflows)** engine
+(`crates/wcore-agent/src/orchestration/workflow/`): declarative RON lowers
+to the existing `GraphConfig` IR and executes via `WorkflowRunner` over the
+spawner path — see [docs/workflows.md](workflows.md).
 
 ## 2. Cross-crate invariants
 
@@ -214,6 +238,10 @@ not subsume each other.
 | A new evaluation metric | `wcore-eval` |
 | A new prompt mutator (GEPA) | `wcore-evolve/src/mutator/` |
 | A new permission rule | `wcore-permissions` |
+| A new channel connector | `wcore-channel-<name>` (register via `wcore-channels-registry`) |
+| A new shell sandbox backend | `wcore-sandbox` |
+| A new egress / network rule | `wcore-egress` |
+| A budget cap or pricing entry | `wcore-budget` / `wcore-pricing` |
 | A new observability span / sink | `wcore-observability` |
 | A new shell helper or platform-specific path | `wcore-config` (centralize, then call from anywhere) |
 | A new JSON stream event type | `wcore-protocol` (and mirror in `wcore-plugin-api` if plugins need it) |
@@ -232,5 +260,6 @@ is the most common source of subsequent refactors.
 - [docs/mcp.md](mcp.md) — MCP server integration, transport types, deferred loading
 - [docs/advanced.md](advanced.md) — sub-agents, hooks, memory, plan mode, context compression
 - [docs/json-stream-protocol.md](json-stream-protocol.md) — JSON Lines protocol for host integration (e.g. the Wayland desktop app)
+- [docs/workflows.md](workflows.md) — ForgeFlows (Dynamic Workflows): RON → `GraphConfig` IR → `WorkflowRunner`
 - [docs/wcore-evolve.md](wcore-evolve.md) — GEPA evolution loop deep dive
 - [docs/troubleshooting.md](troubleshooting.md) — common errors and solutions

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,11 +2,28 @@
 
 ## Installation
 
-```bash
-# Build from source
-cargo build --release
+**npm** (recommended — pulls the right prebuilt binary for your platform):
 
-# Binary location
+```bash
+npm install -g @ferroxlabs/wayland-core
+wayland-core --version
+
+# or run it once with no install
+npx @ferroxlabs/wayland-core "summarize the TODOs in this repo"
+```
+
+**Prebuilt signed binaries** for macOS (arm64/x64), Linux (arm64/x64), and
+Windows (arm64/x64) are on the
+[Releases](https://github.com/FerroxLabs/wayland-core/releases) page, each
+verifiable against `wayland-core-checksums.txt`.
+
+**From source** (Rust 1.95+):
+
+```bash
+cargo install --git https://github.com/FerroxLabs/wayland-core wcore-cli
+
+# or build the workspace directly
+cargo build --release
 ./target/release/wayland-core
 ```
 
@@ -26,13 +43,62 @@ wayland-core [OPTIONS] [PROMPT]...
 | Parameter | Description |
 |-----------|-------------|
 | `--provider <name>` | Provider: `anthropic`, `openai`, `bedrock`, `vertex`, or a custom alias |
-| `--model <id>` | Model name |
+| `--model <id>`, `-m` | Model name |
+| `--api-key <key>`, `-k` | API key (overrides config / env) |
+| `--base-url <url>`, `-b` | Base URL for the API |
 | `--profile <name>` | Named profile from config file |
+| `--agent <name>` | Built-in agent persona to inherit (e.g. `architect`, `debugger`) |
+| `--list-agents` | List built-in agent personas and exit |
+| `--max-tokens <n>` | Max output tokens per response |
+| `--max-turns <n>` | Max agent loop turns |
+| `--system-prompt <text>` | Custom system prompt |
+| `--force` | Approve every tool call without prompting (aliases: `--yolo`, `--dangerously-skip-permissions`) |
+| `--auto-approve` | Skip all tool confirmations |
+| `--project-dir <path>` | Directory to load the project `.wayland-core.toml` from (defaults to CWD) |
+| `--continue`, `-c` | Resume the most-recent session |
+| `--resume <id>` | Resume a previous session |
+| `--session-id <id>` | Use a specific session ID instead of auto-generating one |
+| `--list-sessions` | List saved sessions and exit |
+| `--no-tui` | Fall back to the line-based REPL instead of the TUI |
+| `--no-memory` | Run stateless — disable long-term memory for this run |
+| `--json-stream` | JSON Lines mode for host integration |
 | `--compaction <level>` | Output compaction: `off`, `safe` (default), `full` |
 | `--toon` | Enable TOON tabular encoding (with `full` compaction) |
-| `--auto-approve` | Skip all tool confirmations |
-| `--json-stream` | JSON Lines mode for host integration |
-| `--resume <id>` | Resume a previous session |
+| `--init-config` | Generate a default config file and exit |
+| `--config-path` | Print the config file path and exit |
+| `--doctor` | Run the system-dependency / provider health doctor |
+
+Diagnostic and replay flags (`--skills-audit`, `--replay`, `--memory-show`,
+`--probe-mcp`, …) are intentionally omitted here — run `wayland-core --help`
+for the full set.
+
+---
+
+## Subcommands
+
+Beyond the flag-driven agent/REPL path, `wayland-core` exposes a set of
+verb subcommands. The headline ones:
+
+| Subcommand | Purpose |
+|------------|---------|
+| `auth` | Manage provider API keys and OAuth sign-in (see [Authentication](#authentication)) |
+| `setup` | Re-run the interactive onboarding (connect / configure) flow |
+| `self-update` | Update to the latest signed release (`--check-only` to just compare versions) |
+| `models list` | Print known models from the bundled catalog (`--provider` to filter) |
+| `mcp-serve` | Serve the engine's own tools as an MCP server (stdio / SSE) for other clients |
+
+The rest:
+
+| Subcommand | Purpose |
+|------------|---------|
+| `plugin` | Install / list / remove plugins |
+| `swarm` | Dispatch a worktree-isolated worker swarm |
+| `workflow` (alias `forgeflows`) | Validate / list / run saved `.ron` workflows |
+| `project-context` | Print the resolved project context (WAYLAND.md / AGENTS.md / CLAUDE.md) |
+| `init` | Scaffold `.wayland/config.toml` + `WAYLAND.md` in the current directory |
+| `acp` | ACP server / client surface |
+| `agent` | Manage user-defined agents (create / list / show / edit / delete) |
+| `cron` | Manage scheduled cron jobs (add / list / remove / enable / disable) |
 
 ---
 
@@ -163,6 +229,42 @@ plan_directory = ".wayland-core/plans"
 > with your ChatGPT subscription via `wayland-core auth login chatgpt`, then run
 > with `--provider openai-chatgpt`. See [Sign in with ChatGPT](providers.md#sign-in-with-chatgpt).
 
+### Authentication
+
+The `auth` subcommand manages provider credentials directly against the global
+`config.toml` — the lightweight alternative to the full onboarding flow:
+
+```bash
+# List every configured provider with a masked key
+wayland-core auth list
+
+# Add (or replace) a key — validated live against the provider before it is
+# written. Use `autodetect` to infer the provider from the key's prefix.
+wayland-core auth add anthropic sk-ant-xxx
+wayland-core auth add autodetect sk-or-v1-xxx
+wayland-core auth add openai sk-xxx --no-validate   # skip the live check
+
+# Remove a provider's key
+wayland-core auth remove openai
+```
+
+**OAuth sign-in.** The only OAuth sign-in is ChatGPT — sign in with your
+ChatGPT subscription instead of an OpenAI API key:
+
+```bash
+wayland-core auth login chatgpt            # opens a browser (loopback PKCE)
+wayland-core auth login chatgpt --device   # headless device-code flow (SSH/remote)
+wayland-core auth login chatgpt --import-codex  # import an existing Codex CLI login
+wayland-core auth status                   # show signed-in provider, plan, token expiry
+wayland-core auth logout chatgpt           # delete the stored OAuth token
+```
+
+After signing in, run with `--provider openai-chatgpt`.
+
+> xAI / Grok is **not** an OAuth sign-in — it is an API-key provider. Add the
+> key (`wayland-core auth add xai <key>`) and run with `--provider xai`; the
+> engine refreshes any internal OAuth tokens on its own.
+
 ### Custom Provider Alias
 
 If a backend is compatible with a built-in provider's protocol, you can declare an alias under `providers.<alias>`:
@@ -186,7 +288,16 @@ base_url = "https://my-service.example.com/api/openai"
 
 ## Quick Start
 
-### 1. Initialize and Configure
+### 1. Connect a Provider (paste-to-connect)
+
+The fastest path is to just run `wayland-core` (or `wayland-core setup`) and
+paste an API key when prompted. It fingerprints the provider from the key's
+shape, validates it live against the provider's model endpoint (a confidence
+ladder: Detected → CanListModels → Ready), stores it (OS keyring by default,
+plaintext fallback), and makes it the default provider — with no restart. You
+can also paste a key from inside the TUI at any time with `/connect`.
+
+Prefer to edit the config by hand instead:
 
 ```bash
 wayland-core --init-config
@@ -237,6 +348,23 @@ wayland-core "List all Rust files in this project"
 
 ---
 
+## TUI commands
+
+Inside the full-screen TUI, slash commands drive configuration and inspection.
+Type `/` from any surface to open a command palette. The high-value ones:
+
+| Command | What it does |
+|---------|--------------|
+| `/connect` | Paste an API key to fingerprint, live-validate, and connect a provider |
+| `/config` | All settings — Essentials and Advanced editors |
+| `/doctor` | Provider / key / MCP health, plus DISCOVERED rows for connectable providers |
+| `/effective` | View the resolved config, with secrets redacted |
+| `/model` | Switch model (arrow-key picker, cross-provider) |
+| `/provider` | Switch provider (arrow-key picker) |
+| `/mcp` | List MCP servers; `/mcp connect` to connect a discovered one |
+
+---
+
 ## Tool Confirmation
 
 Destructive tools (Write, Edit, Bash) prompt for confirmation before execution:
@@ -267,6 +395,9 @@ Sessions auto-save to `.wayland-core/sessions/`.
 # List saved sessions
 wayland-core --list-sessions
 
+# Resume the most-recent session (shortcut for --resume <latest-id>)
+wayland-core --continue          # or -c
+
 # Resume the latest session
 wayland-core --resume latest
 
@@ -277,6 +408,7 @@ wayland-core --resume a1b2c3
 wayland-core --session-id my-conv-123
 ```
 
+- `--continue` / `-c` resumes the most-recent session; it is mutually exclusive with `--resume` and `--session-id`
 - `--session-id` and `--resume` are mutually exclusive
 - `--session-id` errors if the ID already exists
 - Both flags work in interactive and `--json-stream` mode

--- a/docs/json-stream-protocol.md
+++ b/docs/json-stream-protocol.md
@@ -262,11 +262,16 @@ An error occurred. The agent may or may not continue depending on severity.
 
 | Error Code | Description |
 |------------|-------------|
-| `provider_error` | LLM API error (rate limit, auth, etc.) |
+| `provider_error` | LLM API error (rate limit, etc.) |
+| `auth_required` | Provider rejected the credential (HTTP 401). Refreshable — the host should re-auth / refresh the OAuth token and re-send the turn. `retryable` is left as the engine set it (typically `false`, since re-sending the same credential just burns budget), so hosts drive retry off the **code**, not the flag. |
+| `auth_invalid` | Provider denied access (HTTP 403). Hard failure — do not retry. |
 | `tool_error` | Built-in tool execution error |
 | `config_error` | Configuration or initialization error |
 | `protocol_error` | Invalid command from client |
 | `internal_error` | Unexpected internal error |
+| `engine_error` | Fallback code for any error not matched to a more specific code above. |
+
+> Hosts should branch on `error.code`, not parse `error.message`.
 
 ### 1.11 `info`
 
@@ -661,6 +666,26 @@ Agent should emit error and let the conversation continue if possible:
     "code": "provider_error",
     "message": "Rate limit exceeded. Retry after 30s.",
     "retryable": true
+  }
+}
+```
+
+**Auth failures** carry a distinct code so the host can branch without parsing
+the message. A `401` becomes `auth_required` — refreshable: the host should
+re-auth (or refresh the OAuth token) and re-send the turn. A `403` becomes
+`auth_invalid` — a hard failure the host must not retry. For both, the engine
+leaves `retryable` as-is (typically `false`, since re-sending the same
+credential just burns budget); hosts drive retry off `error.code`, not the flag.
+Any error not matched to a specific code falls back to `engine_error`.
+
+```json
+{
+  "type": "error",
+  "msg_id": "m3",
+  "error": {
+    "code": "auth_required",
+    "message": "API error 401: invalid x-api-key",
+    "retryable": false
   }
 }
 ```

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -33,6 +33,60 @@ url = "https://tools.example.com/mcp"
 headers = { Authorization = "Bearer xxx" }
 ```
 
+## Zero-config discovery (Forge local servers)
+
+Forge-suite desktop apps (e.g. Agent Vault) advertise a loopback MCP server by
+writing a shared file at `<OS config dir>/forge/mcp-servers.json` — the *real*
+config dir (`dirs::config_dir()`), NOT `WAYLAND_HOME`, since it is a
+cross-application convention written by *other* apps about the actual machine.
+Wayland Core auto-detects those entries and surfaces them as **DISCOVERED** rows
+in `/doctor`. Nothing connects automatically: a discovery entry is a **hint, not
+liveness** (a producer crash leaves a stale entry behind), so you connect a row
+explicitly with `/mcp connect [name]` (or by selecting the row and pressing
+Enter).
+
+On connect, the engine runs the two-step bootstrap:
+
+1. **Liveness probe** — `GET <metadata_url>`. The connect is only offered when a
+   `200` comes back *and* the server's reported `name` matches the discovery
+   entry. A mismatch (or any non-200) is treated as a stale/impostor entry and
+   rejected.
+2. **Grant** — `POST <grant_url>`. This pops an **Approve** prompt in the
+   producer app; the call only returns successfully after the user clicks
+   Approve. The response maps to a structured outcome:
+
+   | Status | Outcome |
+   |--------|---------|
+   | `200` | Granted — a scoped bearer token is returned and stored, and the server connects live |
+   | `403` | Denied (user declined, no UI, or timed out) |
+   | `400` | Bad scopes — surfaced with the server's message |
+   | `429` | Rate-limited — back off |
+
+The token is stored out of `config.toml` via a credential reference (see
+[Token storage](#token-storage-cred-references) below).
+
+### Token storage (`${cred:}` references)
+
+The scoped bearer token is never written into `config.toml`. Instead the
+persisted `Authorization` header carries a `${cred:KEY}` reference, with the key
+convention `mcp:<server>:token`. The literal `${cred:...}` stays on disk; the
+real secret is looked up from the credentials store and substituted in **at the
+connect boundary, on a clone** of the server map — so an accidental re-serialize
+of the in-memory config can't leak the token back to disk. Resolution **fails
+closed**: a missing key aborts the whole header value rather than emitting a
+blank or half-resolved bearer.
+
+The on-disk shape for a discovered Forge server:
+
+```toml
+[mcp.servers.agent-vault]
+transport = "streamable-http"
+url = "http://127.0.0.1:3456/mcp"
+allow_local = true
+[mcp.servers.agent-vault.headers]
+Authorization = "Bearer ${cred:mcp:agent-vault:token}"
+```
+
 ## Transport Types
 
 | Transport | Description | Use Case |
@@ -40,6 +94,12 @@ headers = { Authorization = "Bearer xxx" }
 | `stdio` | Launch local subprocess, communicate via stdin/stdout | Local MCP servers (npx, uvx) |
 | `sse` | GET for SSE event stream, POST for requests | Remote MCP servers |
 | `streamable-http` | HTTP POST, supports SSE streaming responses | Remote MCP servers |
+
+> **Windows stdio resolution.** On Windows, a `stdio` server launched by bare
+> name (`npx`, `uvx`, `node`) resolves through `cmd /C` so that `.cmd`/`.bat`
+> PATHEXT shims (`npx.cmd`, `node.cmd`) — which raw `CreateProcess` refuses to
+> find on `PATH` — are resolved correctly. This is automatic; no host action or
+> config knob is needed.
 
 ## Deferred Loading
 
@@ -86,6 +146,11 @@ headers = { Authorization = "Bearer <AGENT_VAULT_MCP_TOKEN>" }
 |---------------|----------|
 | `false` (default) | Loopback and all private/internal targets are rejected at connect time |
 | `true` | Loopback (`127.0.0.0/8`, `::1`, `localhost`) is permitted; all other private/internal/metadata ranges remain blocked |
+
+To keep the bearer token out of `config.toml`, a header value may use a
+`${cred:KEY}` reference (e.g. `Authorization = "Bearer ${cred:mcp:agent-vault:token}"`)
+— the literal reference is stored on disk and the secret is resolved from the
+credentials store at connect time. See [Token storage](#token-storage-cred-references).
 
 ## Tool Naming
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -2,13 +2,51 @@
 
 ## Supported Providers
 
-| Provider | Auth Method | Notes |
-|----------|------------|-------|
-| Anthropic | API Key | Prompt caching, streaming, vision |
-| OpenAI | API Key | Compatible with DeepSeek, Qwen, Ollama, vLLM |
-| OpenAI (ChatGPT) | OAuth (Sign in with ChatGPT) | Routes through the ChatGPT Codex backend on your subscription — see [Sign in with ChatGPT](#sign-in-with-chatgpt) |
-| AWS Bedrock | SigV4 | Regional endpoints, AWS credential chain |
-| Google Vertex AI | GCP OAuth2 / Service Account | Metadata server auto-detection |
+Pass any of these to `--provider` (or set `provider` in config). Aliases resolve
+to the same built-in. The canonical list lives in `BUILTIN_PROVIDER_NAMES`
+(`crates/wcore-config/src/config.rs`).
+
+| Provider | Slug (aliases) | Notes |
+|----------|----------------|-------|
+| Anthropic | `anthropic` | Native wire — prompt caching, streaming, vision |
+| OpenAI | `openai` | Chat-completions wire; base for most OpenAI-compatible providers |
+| AWS Bedrock | `bedrock` | Hosts Claude; SigV4 + AWS credential chain |
+| Google Vertex AI | `vertex` | Hosts Claude; GCP OAuth2 / service account |
+| Google Gemini | `gemini` (`google`) | Native Gemini wire (functionDeclarations, thoughtSignature) |
+| Azure OpenAI | `azure-openai` (`azure`) | Azure-hosted OpenAI deployments |
+| Together | `together` | OpenAI-compatible |
+| Fireworks | `fireworks` | OpenAI-compatible |
+| NVIDIA | `nvidia` | OpenAI-compatible (NIM) |
+| Perplexity | `perplexity` | OpenAI-compatible; `sonar` online-search models. Env `PERPLEXITY_API_KEY` |
+| Cerebras | `cerebras` | OpenAI-compatible, fast inference |
+| OpenRouter | `openrouter` | OpenAI-compatible router (100+ models) |
+| Flux Router | `flux-router` (`flux`) | OpenAI-compatible router |
+| DeepSeek | `deepseek` | OpenAI-compatible |
+| xAI / Grok | `xai` (`grok`) | OpenAI-compatible; OAuth or `XAI_API_KEY` — see [Sign in with Grok](#sign-in-with-grok-xai) |
+| Groq | `groq` | OpenAI-compatible, LPU inference |
+| Moonshot / Kimi | `moonshot` (`kimi`) | OpenAI-compatible, region-locked keys |
+| Qwen | `qwen` (`alibaba`, `dashscope`) | DashScope OpenAI-compat mode |
+| Mistral | `mistral` | OpenAI-compatible |
+| Cohere | `cohere` | OpenAI-compatible |
+| OpenAI (ChatGPT) | `openai-chatgpt` (`chatgpt`) | OAuth — routes through the ChatGPT Codex backend on your subscription. See [Sign in with ChatGPT](#sign-in-with-chatgpt) |
+| MiniMax | `minimax` (`minimaxi`) | Anthropic-wire provider; region-locked keys |
+
+---
+
+## Host integration: pick the right `--provider`
+
+An embedding app must spawn each provider under its **own** `--provider`, not
+under `--provider openai`. The `ProviderType` is what keys OAuth refresh, the
+`grok-4.3` stop-param suppression, and the correct `base_url`:
+
+- **Grok** → `--provider xai`. Spawned as `openai` it ignores the xAI OAuth
+  token files, sends the unsupported `stop` parameter, and hits
+  `api.openai.com` (401).
+- **Perplexity** → `--provider perplexity`. Spawned as `openai` it targets
+  `api.openai.com` instead of `api.perplexity.ai` and 401s.
+
+The same holds for every entry in the table above: the slug selects the wire,
+base URL, and compat preset.
 
 ---
 
@@ -31,7 +69,7 @@ Rules:
 
 - `provider = "my-service"` is a config-layer alias
 - `[providers.my-service].provider` must point at an underlying built-in provider
-- The underlying provider must currently be one of `anthropic`, `openai`, `bedrock`, `vertex`
+- The underlying provider must be one of the built-in provider slugs listed under [Supported Providers](#supported-providers)
 - The alias entry's `model`, `api_key`, `base_url`, and `compat` override the underlying provider's defaults
 
 This fits scenarios like DeepSeek gateways and internal OpenAI-compatible services.
@@ -54,6 +92,39 @@ include_usage_in_stream = false   # omit stream_options for picky OpenAI-compati
 
 The trade-off is no in-stream token counts for that provider. An empty stream now also
 surfaces a visible error instead of a silent no-op.
+
+A related compat field is `supports_stop_param` (default `true`). The engine
+attaches "fluff" stop sequences as a client-side output token-optimization, but
+some reasoning models / endpoints reject the OpenAI `stop` parameter outright
+with a 400 (xAI's `grok-4.3`: *"Model grok-4.3 does not support parameter
+stop"*). Set it `false` to suppress the optimization so those models run — xAI
+sets this by default:
+
+```toml
+[providers.my-reasoning-endpoint.compat]
+supports_stop_param = false
+```
+
+---
+
+## Region-locked keys (MiniMax, Moonshot)
+
+MiniMax and Moonshot each run **two** region-locked platforms that share the
+wire protocol but **not** the key namespace — a key issued on one host 401s on
+the other:
+
+| Provider | Default host | Alternate host |
+|----------|--------------|----------------|
+| MiniMax | `api.minimax.io` | `api.minimaxi.com` |
+| Moonshot | `api.moonshot.ai` | `api.moonshot.cn` |
+
+On a 401/403 the engine retries the **same** key against the alternate host and
+pins whichever authenticates for the rest of the session — no user action and no
+config required. This is driven by the `auth_fallback_base_url` compat field
+(set by `minimax_defaults` / `moonshot_defaults` in
+`crates/wcore-config/src/compat.rs`; the retry-and-pin lives in
+`wcore-providers` `anthropic.rs` / `openai.rs`). If a key 401s on **both**
+regions it is simply invalid — issue one on the other region's console.
 
 ---
 
@@ -310,6 +381,43 @@ the open-source Codex/OpenClaw clients do and is **tolerated in practice today**
 but there is no cited explicit permission; "allowed in practice" is an
 observation, not a guarantee. If OpenAI tightens client/originator/edge checks,
 this path may break — API-key auth is the supported, always-works alternative.
+
+---
+
+## Sign in with Grok (xAI)
+
+Grok runs under `--provider xai` (alias `grok`). There is **no** `auth login`
+command for it — connect one of two ways:
+
+**API key.** Set `XAI_API_KEY` (or `api_key` in `[providers.xai]`) and run:
+
+```bash
+wayland-core --provider xai --model grok-4.3 "explain this repo"
+```
+
+**OAuth refresh.** The engine refreshes xAI OAuth tokens itself, at parity with
+[Sign in with ChatGPT](#sign-in-with-chatgpt) (load / refresh / persist over the
+~6h access-token lifetime, no host re-spawn). It does **not** start a browser
+login flow — it reads tokens that already exist on disk, from whichever source
+is **fresher**:
+
+```
+~/.grok/auth.json            # the Grok CLI's credential file ($GROK_HOME/auth.json when set)
+~/.wayland/oauth/xai.json    # the engine's own store (written by an app or a prior refresh)
+```
+
+Preferring the fresher file avoids racing the Grok CLI for the **single-use,
+rotating** refresh token (xAI rotates it on every refresh). Access tokens last
+~6h. When OAuth credentials are present, the `xai` API-key gate is exempt, so no
+`XAI_API_KEY` is needed. The OAuth client id is pinned but overridable at runtime
+via `WAYLAND_XAI_OAUTH_CLIENT_ID` (no rebuild). Evidence:
+`crates/wcore-agent/src/oauth/xai.rs`, `crates/wcore-config/src/config.rs`
+(`xai_oauth_credentials_present`).
+
+> Spawn Grok as `--provider xai`, never `--provider openai` — see
+> [Host integration: pick the right `--provider`](#host-integration-pick-the-right---provider).
+> Under `openai` the OAuth token files are ignored and the unsupported `stop`
+> parameter is sent.
 
 ---
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -44,6 +44,10 @@ Execute a shell command and return the result.
 
 - Default timeout: 120 seconds, max 600 seconds
 - Returns exit code, stdout, and stderr
+- Interpreter: `sh -c` on Unix, `cmd /C` on Windows. **Windows override:** set
+  `WAYLAND_BASH_SHELL=powershell` to run commands through Windows PowerShell
+  (`powershell -NoProfile -Command`), or `=pwsh` for PowerShell 7+. Affects the
+  Bash tool only — hook, MCP, and skill shells are unchanged.
 
 ## Grep
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -16,6 +16,46 @@ Provide an API key via any of: config file, `--api-key` flag, or environment var
 
 Verify your API key is correct and active.
 
+## MiniMax / Moonshot 401
+
+```
+[error] API error: API error 401: ...
+```
+
+Usually a region-locked key. MiniMax and Moonshot each run two platforms with
+separate key namespaces (`api.minimax.io` ↔ `api.minimaxi.com`, `api.moonshot.ai`
+↔ `api.moonshot.cn`). The engine auto-retries the same key against the alternate
+host and pins the winner, so a 401-then-success is normal. A **persistent** 401
+means the key is invalid on both regions — issue a key on the other region's
+console.
+
+## Perplexity 401 referencing platform.openai.com
+
+```
+[error] API error: API error 401: ... platform.openai.com ...
+```
+
+The session was started as `--provider openai`, so requests went to
+`api.openai.com` instead of `api.perplexity.ai`. Use `--provider perplexity`
+(env `PERPLEXITY_API_KEY`).
+
+## Grok signed in but 401, or "grok-4.3 does not support parameter stop"
+
+```
+[error] API error: API error 401: ...
+[error] API error: API error 400: Model grok-4.3 does not support parameter stop
+```
+
+Grok must run as `--provider xai`. Spawned as `--provider openai` it ignores the
+OAuth token files (`~/.grok/auth.json`, `~/.wayland/oauth/xai.json`) and sends an
+unsupported `stop` parameter. Under `--provider xai` the stop suppression is
+automatic.
+
+## OpenRouter model "vanishes" after one turn
+
+This is an **app-side** issue (the desktop app's model curator), not a core
+engine fault — there is no core fix. The engine keeps the selected model bound.
+
 ## Profile Not Found
 
 ```


### PR DESCRIPTION
Brings the docs up to the shipped 0.12.2 reality. **Every claim was ground-truthed against the actual code** by a four-way parallel audit + my own verification (crate names, CLI flags, provider list, error codes all confirmed against source; nothing invented).

## What changed (8 docs)
- **providers.md** — full built-in provider table (5 → 22, incl. MiniMax); region-locked-key failover (MiniMax/Moonshot); `Sign in with Grok (xAI)` OAuth refresh; `supports_stop_param` + `auth_fallback_base_url` compat fields; `--provider` host-integration note.
- **troubleshooting.md** — MiniMax/Moonshot 401, Perplexity-as-openai 401, Grok stop-param; OpenRouter vanish noted as **app-side, not a core fix**.
- **getting-started.md** — npm/binary install, ~28 flags (was 8), subcommands, `auth` verbs, `--continue`, paste-to-connect onboarding, TUI commands.
- **README.md** — ChatGPT OAuth, MiniMax, live model discovery, paste-to-connect.
- **mcp.md** — Forge zero-config discovery + `/mcp connect`, scoped-token grant with `${cred:}` headers (token never in config.toml), Windows stdio resolution.
- **json-stream-protocol.md** — `auth_required`/`auth_invalid` error codes + `engine_error` fallback; branch on `error.code`.
- **architecture.md** — crate count corrected (24 → **54**), substrate band for ~30 undocumented crates, ForgeFlows engine + workflows.md link.
- **advanced.md** — OAuth providers section, `WAYLAND_BASH_SHELL` toggle.

## Guardrails honored
No `wayland auth login grok` command was documented (it isn't wired — Grok is `--provider xai` + token-file refresh). OpenRouter model-vanish attributed to the app, not core. `add_mcp_server.allow_local` deliberately **not** documented after verifying it's not in the protocol struct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)