### PR TITLE
fix(providers): omit tools for Groq Compound agentic models

### DIFF
--- a/crates/wcore-providers/src/openai.rs
+++ b/crates/wcore-providers/src/openai.rs
@@ -531,7 +531,12 @@ impl OpenAIProvider {
         }
         body[max_tokens_field] = json!(request.max_tokens);
 
-        if !request.tools.is_empty() {
+        // Attach tools, but gate on the model family: Groq's agentic Compound
+        // models reject a caller-supplied `tools` array with a 400 that kills
+        // the turn (they do their own internal tool use). Per-request, since one
+        // provider serves many models in a session — mirrors the
+        // `reasoning_effort` gate below.
+        if !request.tools.is_empty() && openai_compat::model_supports_tool_calling(&request.model) {
             body["tools"] = json!(Self::build_tools(&request.tools));
         }
 
@@ -1858,6 +1863,44 @@ mod tests {
             body["stop"],
             json!(["\n\nLet me know if", "\n\nFeel free to"]),
             "OpenAI must emit stops under the `stop` key as an array"
+        );
+    }
+
+    // --- Groq Compound: tools omitted for agentic models -------------------
+
+    fn one_tool() -> Vec<ToolDef> {
+        vec![ToolDef {
+            name: "Read".into(),
+            description: "Read a file".into(),
+            input_schema: json!({"type": "object", "properties": {"path": {"type": "string"}}}),
+            deferred: false,
+        }]
+    }
+
+    #[test]
+    fn build_request_body_emits_tools_for_normal_model() {
+        let mut req = stop_req();
+        req.tools = one_tool();
+        let body = stop_provider().build_request_body(&req);
+        assert!(
+            body.get("tools")
+                .and_then(|t| t.as_array())
+                .is_some_and(|a| a.len() == 1),
+            "a normal model must carry the caller's tools"
+        );
+    }
+
+    #[test]
+    fn build_request_body_omits_tools_for_groq_compound() {
+        // Groq Compound 400s on a `tools` array — the engine must omit it so the
+        // turn succeeds instead of breaking.
+        let mut req = stop_req();
+        req.model = "compound-beta".into();
+        req.tools = one_tool();
+        let body = stop_provider().build_request_body(&req);
+        assert!(
+            body.get("tools").is_none(),
+            "Groq Compound must receive NO `tools` field (it rejects tool calling)"
         );
     }
 

--- a/crates/wcore-providers/src/openai_compat.rs
+++ b/crates/wcore-providers/src/openai_compat.rs
@@ -113,6 +113,20 @@ pub fn accepts_temperature(model: &str) -> bool {
     !is_o_series(&m)
 }
 
+/// True when the model accepts caller-supplied tool-calling parameters
+/// (the `tools` array) on the Chat Completions request.
+///
+/// Groq's **Compound** / **Compound Mini** are agentic models that perform
+/// their own internal tool use and REJECT a caller `tools` array with a 400
+/// `` `tool calling` is not supported ``, which kills the whole turn. Every
+/// other model served over the OpenAI-compatible surface accepts tools, so
+/// default to true and special-case only the Groq Compound family. Like the
+/// sibling predicates this is per-request (one `OpenAIProvider` serves many
+/// models in a session) and case-insensitive.
+pub fn model_supports_tool_calling(model: &str) -> bool {
+    !is_groq_compound(&lower(model))
+}
+
 /// `o1`, `o1-mini`, `o1-preview`, `o3`, `o3-mini`, ... — match exactly the
 /// `o<digit>` prefix so we don't accidentally catch unrelated model names
 /// like `octo-7b`.
@@ -135,6 +149,16 @@ fn is_o_series(lower_model: &str) -> bool {
 /// correct as long as future `gpt-5*` releases keep the family shape.
 fn is_gpt5(lower_model: &str) -> bool {
     lower_model.starts_with("gpt-5")
+}
+
+/// Groq's agentic Compound family: `compound-beta`, `compound-beta-mini`, and
+/// the namespaced `groq/compound*` catalog ids. Strip any `provider/` prefix and
+/// match by leading `compound` so we don't catch unrelated models that merely
+/// contain the substring (e.g. `octo-compound-7b`). These models reject the
+/// `tools` parameter.
+fn is_groq_compound(lower_model: &str) -> bool {
+    let id = lower_model.rsplit('/').next().unwrap_or(lower_model);
+    id.starts_with("compound")
 }
 
 #[cfg(test)]
@@ -364,5 +388,41 @@ mod tests {
     fn accepts_temperature_case_insensitive() {
         assert!(!accepts_temperature("O1"));
         assert!(accepts_temperature("GPT-4o"));
+    }
+
+    // --- model_supports_tool_calling (Groq Compound) ----------------------
+
+    #[test]
+    fn compound_family_rejects_tool_calling() {
+        // Groq's agentic Compound ids: bare, beta, mini, and namespaced.
+        assert!(!model_supports_tool_calling("compound-beta"));
+        assert!(!model_supports_tool_calling("compound-beta-mini"));
+        assert!(!model_supports_tool_calling("compound"));
+        assert!(!model_supports_tool_calling("compound-mini"));
+        assert!(!model_supports_tool_calling("groq/compound-beta"));
+    }
+
+    #[test]
+    fn compound_predicate_is_case_insensitive() {
+        assert!(!model_supports_tool_calling("Compound-Beta"));
+        assert!(!model_supports_tool_calling("GROQ/COMPOUND"));
+    }
+
+    #[test]
+    fn normal_models_support_tool_calling() {
+        // Plain Groq + every other openai-compat model accept tools.
+        assert!(model_supports_tool_calling("openai/gpt-oss-120b"));
+        assert!(model_supports_tool_calling("llama-3.3-70b-versatile"));
+        assert!(model_supports_tool_calling("gpt-4o"));
+        assert!(model_supports_tool_calling("gpt-5"));
+        assert!(model_supports_tool_calling("deepseek-chat"));
+    }
+
+    #[test]
+    fn compound_predicate_is_not_overgreedy() {
+        // A model that merely CONTAINS "compound" but doesn't lead with it must
+        // keep tools — only the Compound family is special-cased.
+        assert!(model_supports_tool_calling("octo-compound-7b"));
+        assert!(model_supports_tool_calling("acme/super-compound"));
     }
 }


### PR DESCRIPTION
## Groq Compound rejects tool-calling → breaks the chat turn

**Reported from the desktop app**, verified live against bundled `wayland-core 0.12.3` → Groq Compound Mini.

### Symptom
Pick **Groq → Compound** or **Compound Mini** and send any message: the turn fails instantly with an `error` frame then `finish` (`finish_reason: error`, 0 in / 0 out tokens):

```
Provider error: API error 400: {"error":{"message":"`tool calling` is not supported …"}}
```

### Root cause
Groq's Compound / Compound Mini are **agentic** models that perform their own internal tool use and reject a caller-supplied `tools` array on `/chat/completions`. The engine attaches tools to every chat request, so Groq 400s on Compound. Plain Groq models (`openai/gpt-oss-120b`, etc.) accept tools and work — Groq routing itself is fine; only the Compound family was mis-handled.

### Fix (Option 2 from the engine handoff — suppress tools, keep it working)
Gate the `tools` field on a per-model predicate, `openai_compat::model_supports_tool_calling(model)`, applied right where `tools` is inserted in `build_request_body` — mirroring the existing per-request `reasoning_effort` gate. This must be per-request: one `OpenAIProvider` serves many models in a session, so a provider-level compat flag can't decide it.

- Compound now returns real completions; wayland-side tools weren't applicable to it anyway (it does its own tool use).
- Covers **every** entry path — picker, `--model`, and config — not just the picker. (Considered dropping it from the catalog, but the Groq catalog is dynamic, so that would only hide it from the picker; a typed/config model id would still 400.)
- The predicate strips any `provider/` namespace and matches a leading `compound`, so it catches `compound-beta`, `compound-beta-mini`, `groq/compound*` but not unrelated names like `octo-compound-7b`.

### Not in scope
The app separately swallowed this error frame (chat hung "Processing…" forever) — being fixed app-side, independent of this engine fix.

### Tests
- `model_supports_tool_calling`: family match, case-insensitivity, not-overgreedy, and normal models keep tools.
- `build_request_body`: `tools` omitted for `compound-beta`, present for a normal model.
- `cargo nextest -p wcore-providers` green (116 + 2 targeted), clippy clean, fmt clean.

### Verify after merge
Bundle the engine, pick Groq Compound, send "PING" → real completion (200, tokens > 0, `finish_reason: stop`).
