### PR TITLE
fix(skills): keep the hello test fixture out of the shipped catalog

### DIFF
--- a/crates/wcore-skills/src/bundled/mod.rs
+++ b/crates/wcore-skills/src/bundled/mod.rs
@@ -1,3 +1,8 @@
+// `hello` is a framework-validation fixture (see `hello.rs`) — compiled and
+// registered ONLY under `cfg(test)` so it never reaches the shipped skill
+// catalog. In production it leaked: models saw it in every session's catalog
+// and narrated skipping it into user-facing output.
+#[cfg(test)]
 mod hello;
 
 use std::path::PathBuf;
@@ -108,6 +113,13 @@ pub async fn prepare_bundled_skills() -> Vec<SkillMetadata> {
 /// times (useful in tests).
 pub fn init_bundled_skills() {
     clear_bundled_skills_inner();
+    // The only bundled skill today is the `hello` test fixture, which must NOT
+    // ship in the production catalog (models notice it and narrate skipping
+    // it). Register it solely under `cfg(test)` so the bundled-skill framework
+    // stays exercised by TC-10.04 / TC-10.28 without leaking to users. In a
+    // shipped build this clears the registry and registers nothing — correct,
+    // since no production bundled skills exist yet.
+    #[cfg(test)]
     hello::register_hello_skill();
 }
 


### PR DESCRIPTION
**Found during a live training-video recording** — the model narrated "I'll skip the 'hello' skill hint — it's a test greeting skill" on screen.

`crates/wcore-skills/src/bundled/hello.rs` is a framework-validation fixture (its doc comment says it exists "to validate the bundled skill framework") but was registered unconditionally in `init_bundled_skills()` with `user_invocable: true` and `disable_model_invocation: false`. So it appeared in the skill catalog of **every** wcore session, and models noticed it and narrated skipping it into user-facing output.

**Fix:** gate `mod hello` and its registration behind `#[cfg(test)]`. The bundled-skill framework stays exercised by TC-10.04 / TC-10.28, but a shipped build clears the registry and registers nothing (correct — no production bundled skills exist yet). No model ever sees `hello` again.

Verified: clippy clean, 34 bundled-skill tests pass.

Engine handoff item #2 of `ENGINE-HANDOFF-2026-06-20-askuserquestion-and-hello-skill.md`. (Item #1, ask_user/AskUserQuestion as a structured question event, is a larger protocol change being scoped separately.)