### PR TITLE
fix(skills): hide unreviewed auto-drafted skills from the model catalog

### DIFF
--- a/crates/wcore-skills/src/loader.rs
+++ b/crates/wcore-skills/src/loader.rs
@@ -399,7 +399,7 @@ async fn load_skill_file(
     // variable substitution in skill content.
     let skill_root = Some(skill_dir.to_string_lossy().into_owned());
 
-    let metadata = parse_skill_fields(
+    let mut metadata = parse_skill_fields(
         &parsed.frontmatter,
         &parsed.content,
         &resolved_name,
@@ -408,12 +408,38 @@ async fn load_skill_file(
         skill_root.as_deref(),
     );
 
+    // Auto-drafted skills carry a sibling `manifest.json` written by the
+    // SkillDrafter. Until a human reviews one (`needs_review: true`), it must
+    // NOT be advertised to the model: an unreviewed draft in the catalog makes
+    // models notice it and narrate skipping it into user-facing output (e.g. a
+    // skill drafted from trivial test turns). Keep it LOADED — so the user can
+    // still review or explicitly invoke it — but hide it from model invocation.
+    if draft_needs_review(skill_dir).await {
+        metadata.disable_model_invocation = true;
+    }
+
     let resolved_path = try_canonicalize(file_path).unwrap_or_else(|| file_path.to_owned());
 
     Some(LoadedSkill {
         metadata,
         resolved_path,
     })
+}
+
+/// True when `skill_dir` holds an auto-drafted skill that has not been reviewed
+/// yet — a sibling `manifest.json` with `"needs_review": true` (written by the
+/// `SkillDrafter`). Best-effort: a missing, unreadable, or malformed manifest,
+/// or one without the flag, means "not a pending draft" (`false`), so
+/// hand-authored skills are completely unaffected.
+async fn draft_needs_review(skill_dir: &Path) -> bool {
+    let manifest = skill_dir.join("manifest.json");
+    let Ok(bytes) = tokio::fs::read(&manifest).await else {
+        return false;
+    };
+    serde_json::from_slice::<serde_json::Value>(&bytes)
+        .ok()
+        .and_then(|v| v.get("needs_review").and_then(serde_json::Value::as_bool))
+        .unwrap_or(false)
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/wcore-skills/tests/wayland_home_auto_skill_loop.rs
+++ b/crates/wcore-skills/tests/wayland_home_auto_skill_loop.rs
@@ -102,3 +102,65 @@ async fn auto_drafted_skill_appears_in_catalog() {
         hit.unwrap().file_path
     );
 }
+
+/// Write an auto-drafted skill WITH the `SkillDrafter`'s sibling `manifest.json`.
+fn write_auto_skill_with_manifest(home: &Path, name: &str, needs_review: bool) {
+    let dir = home.join("skills").join("auto").join(name);
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(
+        dir.join("SKILL.md"),
+        format!("---\nname: {name}\ndescription: Auto-drafted recall skill\n---\n\nBody.\n"),
+    )
+    .unwrap();
+    fs::write(
+        dir.join("manifest.json"),
+        format!("{{\"auto_drafted\":true,\"needs_review\":{needs_review},\"name\":\"{name}\"}}"),
+    )
+    .unwrap();
+}
+
+#[tokio::test]
+#[serial(wayland_home_env)]
+async fn unreviewed_auto_draft_loads_but_is_hidden_from_the_model() {
+    // Regression: an auto-drafted skill the drafter wrote from trivial/test
+    // turns leaked into the model's catalog and got narrated in user-facing
+    // output. An unreviewed draft (`needs_review: true`) must NOT be
+    // model-invocable, yet must still LOAD so the user can review/invoke it.
+    let home = TempDir::new().unwrap();
+    let _guard = WaylandHomeGuard::set(home.path());
+    write_auto_skill_with_manifest(home.path(), "auto-needs-review", true);
+
+    let cwd = TempDir::new().unwrap();
+    let skills = load_all_skills(cwd.path(), &[], false, None).await;
+
+    let hit = skills
+        .iter()
+        .find(|s| s.name.ends_with("auto-needs-review"))
+        .expect("an unreviewed draft must still be loaded (for review/invocation)");
+    assert!(
+        hit.disable_model_invocation,
+        "an unreviewed auto-draft (needs_review=true) must be hidden from the model"
+    );
+}
+
+#[tokio::test]
+#[serial(wayland_home_env)]
+async fn reviewed_auto_draft_is_visible_to_the_model() {
+    // Once a human reviews a draft (`needs_review: false`) it becomes a normal
+    // model-visible skill — the gate keys off the flag, not on auto_drafted.
+    let home = TempDir::new().unwrap();
+    let _guard = WaylandHomeGuard::set(home.path());
+    write_auto_skill_with_manifest(home.path(), "auto-reviewed", false);
+
+    let cwd = TempDir::new().unwrap();
+    let skills = load_all_skills(cwd.path(), &[], false, None).await;
+
+    let hit = skills
+        .iter()
+        .find(|s| s.name.ends_with("auto-reviewed"))
+        .expect("a reviewed draft loads");
+    assert!(
+        !hit.disable_model_invocation,
+        "a reviewed draft (needs_review=false) stays model-visible"
+    );
+}


### PR DESCRIPTION
**Found during a live training-video recording** — the model narrated reasoning about an `auto-exactly-ping-reply` skill on screen.

**Root cause:** the `SkillDrafter` auto-drafts skills from observed-turn streaks and writes them to `$WAYLAND_HOME/skills/auto/<name>/` with a `manifest.json` carrying `needs_review: true`. The loader **never read that manifest**, so every unreviewed draft was advertised to the model immediately. In this case it drafted a skill from trivial `Reply with exactly: PING` **smoke-test turns** and leaked it into the catalog, where the model noticed it and narrated skipping it into user-facing output.

**Fix:** honor the flag at load time — when a skill dir has a sibling `manifest.json` with `needs_review: true`, force `disable_model_invocation = true`. The draft still **loads** (the user can review or explicitly invoke it) but is no longer shown to the model. Keying on the flag (not `auto_drafted`) means a *reviewed* draft becomes visible, and hand-authored skills (no manifest) are unaffected.

**Tests:** unreviewed draft loads-but-hidden; reviewed draft visible; existing auto-skill-loop tests unchanged. clippy + fmt clean.

Related: #55 (the `hello` bundled test fixture) is a separate skill-catalog leak from the same recording. Together they close the 'test/draft skills leaking to the model' class.

Follow-up worth considering (not in this PR): the drafter shouldn't draft from trivial signatures like `Reply with exactly: PING` in the first place — but hiding unreviewed drafts is the correct primary fix regardless of what gets drafted.