### PR TITLE
fix(config,cli): raise default max_tokens to 32000; json-stream honors approval_mode

### DIFF
--- a/crates/wcore-cli/src/main.rs
+++ b/crates/wcore-cli/src/main.rs
@@ -2309,6 +2309,13 @@ async fn run_json_stream_mode(
             .with_sub_agent_traces(true),
     );
     let approval_manager = Arc::new(ToolApprovalManager::new());
+    // Seed the initial approval posture from config (`[default] approval_mode`)
+    // — the TUI path does this at boot, but the json-stream path historically
+    // only honored `--force`, so a config-set `approval_mode = "force"` had NO
+    // effect for hosts/apps (which run json-stream). That left the session at
+    // Default, gating every mutating tool behind an `approval_required` the
+    // host may never answer. `--force` still overrides to Force below.
+    approval_manager.set_mode(approval_mode_to_session(config.approval_mode));
     // F-002: plumb --force into json-stream mode. In the TUI path the
     // approval manager is flipped to Force before the engine boots; the
     // json-stream path was missing the same step, causing every mutating

--- a/crates/wcore-config/src/config.rs
+++ b/crates/wcore-config/src/config.rs
@@ -714,7 +714,15 @@ fn default_provider() -> String {
     "anthropic".to_string()
 }
 fn default_max_tokens() -> u32 {
-    8192
+    // Output-token CAP (not a target — only generated tokens are billed). 8192
+    // truncated real build turns: a single full-HTML generation needed ~19k
+    // output tokens and got cut off, after which the engine choked on the
+    // broken file. 32000 covers large code/doc generations with headroom and
+    // is within every frontier model's output limit (the primary targets).
+    // NOTE: this is a flat default; a per-model cap (clamped to the model's
+    // output limit, à la hermes `chat_completions` / deepcode `get_safe_max`)
+    // is the proper follow-up for small-output models.
+    32000
 }
 fn default_allow_list() -> Vec<String> {
     // Read-only info-gathering tools — no destructive action, safe to
@@ -3078,7 +3086,7 @@ const DEFAULT_CONFIG_TEMPLATE: &str = r#"# wayland-core configuration
 [default]
 provider = "anthropic"            # built-in provider or custom alias from [providers.<name>]
 # model = "claude-sonnet-4-6"      # default; see default_model_for() in this crate
-max_tokens = 8192
+max_tokens = 32000                # output-token cap; raise for large build turns, lower for small-output models
 # max_turns = 30                  # optional: omit for unlimited turns
 # system_prompt = "..."          # optional custom system prompt
 
@@ -3586,7 +3594,7 @@ mod tests {
             },
             ..Default::default()
         };
-        // Project stays at built-in defaults (provider = "anthropic", max_tokens = 8192, max_turns = None)
+        // Project stays at built-in defaults (provider = "anthropic", max_tokens = 32000, max_turns = None)
         let project = ConfigFile::default();
 
         let merged = merge_config_files(global, project);
@@ -3974,7 +3982,7 @@ allow = ["commit", "review-pr", "db:*"]
         let config: ConfigFile = toml::from_str("").unwrap();
 
         assert_eq!(config.default.provider, "anthropic");
-        assert_eq!(config.default.max_tokens, 8192);
+        assert_eq!(config.default.max_tokens, 32000);
         assert_eq!(config.default.max_turns, None);
         assert!(config.default.model.is_none());
         assert!(config.providers.is_empty());


### PR DESCRIPTION
**Interim fixes** for the autonomous-build stalls (proper fix = per-model output sizing + truncation auto-continue, handed off separately).

### 1. `default_max_tokens` 8192 → 32000
8192 truncated real build turns — a single full-HTML generation needed **19,131 output tokens**, hit the cap, and the engine then choked on the broken file (the "Response was truncated" card). 32000 covers large output with headroom, within every frontier model's limit. Updated the code default + `DEFAULT_CONFIG_TEMPLATE`. *Flat default is interim; per-model clamp is the real fix.*

### 2. json-stream honors `[default] approval_mode`
The TUI path seeds the approval posture from config at boot; json-stream only honored `--force`, so a config-set `approval_mode = "force"` had **no effect** for the app (which runs json-stream). The session stayed at Default and gated every mutating tool behind an `approval_required` the host may never answer.

**Reproduced live** (real Flux Auto, 5-file build): no force → 1 `approval_required` → **0 files written**; with force → **all 5 written**. `set_mode:yolo` before the turn also works — proving the engine gate is correct; the bug was that Force wasn't active.

Verified: wcore-cli compiles, wcore-config tests pass (the one CI timeout is a pre-existing flaky credentials-crypto test, unrelated).

Caveat: the truncation half is also fixable per-user via `config.toml max_tokens`; this makes the default sane for everyone.