### PR TITLE
fix(#200): unblock native Gemini egress + stop silent finish_reason=error turns

### DIFF
--- a/crates/wcore-agent/src/egress/defaults.rs
+++ b/crates/wcore-agent/src/egress/defaults.rs
@@ -113,6 +113,16 @@ pub fn build_allowlist(config: &Config) -> AllowList {
         allow.allow_host("dashscope.aliyuncs.com");
     }
 
+    // FerroxLabs/wayland#200: native Gemini's default base_url is empty (the
+    // provider crate supplies generativelanguage.googleapis.com internally), so
+    // the host is NOT auto-derived above. Allow the EXACT host off the provider
+    // TYPE so a default-configured Gemini user's first chat POST isn't blocked
+    // as exfil-shaped. Not WELL_KNOWN/apex: googleapis.com is shared-platform
+    // (hosts many Google services), so apex-allowing it would over-allow.
+    if config.provider == ProviderType::Gemini {
+        allow.allow_host("generativelanguage.googleapis.com");
+    }
+
     // Operator additions.
     for entry in &config.security.egress_allow {
         let e = entry.trim();
@@ -261,6 +271,46 @@ mod tests {
             EgressVerdict::Allow,
             "Qwen allow must not apex-allow all of aliyuncs.com"
         );
+    }
+
+    #[test]
+    fn native_gemini_host_is_allowlisted_for_gemini_provider() {
+        // FerroxLabs/wayland#200: native Gemini's default base_url is EMPTY (the
+        // provider crate supplies generativelanguage.googleapis.com internally),
+        // so the host is NOT auto-derived. Without an explicit allow off the
+        // provider TYPE, every chat POST is classified Exfil→Deny and Gemini is
+        // dead on arrival under the default egress policy.
+        let mut c = cfg("", &[]);
+        c.provider = ProviderType::Gemini;
+        let allow = build_allowlist(&c);
+        assert_eq!(
+            classify(
+                &Method::POST,
+                &u(
+                    "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=sse"
+                ),
+                &allow
+            ),
+            EgressVerdict::Allow,
+            "native Gemini host must be reachable out of the box (empty base_url)"
+        );
+    }
+
+    #[test]
+    fn non_gemini_provider_does_not_allow_gemini_host() {
+        // The native-Gemini allow is provider-scoped: a different active provider
+        // must NOT silently open generativelanguage.googleapis.com.
+        let allow = build_allowlist(&cfg("https://api.anthropic.com", &[]));
+        assert!(matches!(
+            classify(
+                &Method::POST,
+                &u(
+                    "https://generativelanguage.googleapis.com/v1beta/models/x:streamGenerateContent"
+                ),
+                &allow
+            ),
+            EgressVerdict::Exfil { .. }
+        ));
     }
 
     #[test]

--- a/crates/wcore-cli/src/acp_engine.rs
+++ b/crates/wcore-cli/src/acp_engine.rs
@@ -575,6 +575,27 @@ impl EngineSession {
             guard.set_cancel_token(turn_cancel.clone());
             match guard.run(&text, &msg_id).await {
                 Ok(result) => {
+                    if result.finish_reason == FinishReason::Error {
+                        // FerroxLabs/wayland#200: a turn can end Ok with finish_reason=Error when
+                        // the provider returned a Done event carrying an unrecognized/empty
+                        // finish_reason (mapped to FinishReason::Error) — e.g. an OpenAI model
+                        // whose finish_reason string the engine doesn't map yet. The engine
+                        // classifies that as success, so without this the host would emit a
+                        // contentless stream_end and the turn would fail SILENTLY. Surface it.
+                        let _ = tx.send(ProtocolEvent::Error {
+                            msg_id: Some(msg_id.clone()),
+                            error: wcore_protocol::events::ErrorInfo {
+                                code: "finish_reason_error".to_string(),
+                                message: "The model ended the turn with an error and no output \
+                                    (finish_reason=error). The provider likely returned an empty \
+                                    response or an unrecognized completion status. Check the engine \
+                                    log for an 'unrecognized finish_reason' warning, and verify the \
+                                    model name and provider."
+                                    .to_string(),
+                                retryable: false,
+                            },
+                        });
+                    }
                     let _ = tx.send(stream_end_event(&msg_id, &result));
                     term.disarm();
                 }

--- a/crates/wcore-cli/src/main.rs
+++ b/crates/wcore-cli/src/main.rs
@@ -2610,6 +2610,20 @@ async fn run_json_stream_mode(
                             result = &mut engine_fut => {
                                 match result {
                                     Ok(result) => {
+                                        if result.finish_reason == FinishReason::Error {
+                                            // FerroxLabs/wayland#200: a turn can end Ok with finish_reason=Error when
+                                            // the provider returned a Done event carrying an unrecognized/empty
+                                            // finish_reason (mapped to FinishReason::Error) — e.g. an OpenAI model
+                                            // whose finish_reason string the engine doesn't map yet. The engine
+                                            // classifies that as success, so without this the host would emit a
+                                            // contentless stream_end and the turn would fail SILENTLY. Surface it.
+                                            output.emit_error(
+                                                "The model ended the turn with an error and no output (finish_reason=error). \
+                                                 The provider likely returned an empty response or an unrecognized completion status. \
+                                                 Check the engine log for an 'unrecognized finish_reason' warning, and verify the model name and provider.",
+                                                false,
+                                            );
+                                        }
                                         output.emit_stream_end(
                                             &msg_id,
                                             result.turns,


### PR DESCRIPTION
## Summary

Fixes two distinct engine bugs behind FerroxLabs/wayland#200 (P0 — "all chat replies error, every model/provider, 0 tokens, finish_reason: error"). Both root causes were traced to source; one is reproduced by a new unit test. Branches off `main` (0.12.4).

## Bug 1 — native Gemini is egress-blocked out of the box

`ProviderType::Gemini`'s default `base_url` is **empty** (the provider crate supplies `generativelanguage.googleapis.com` internally), so the egress allowlist never derives the host. Every chat POST is then classified exfil-shaped → **Denied before it leaves the process** — matching the reporter's `egress security ENFORCING — exfil-shaped traffic … blocked` log. The 0.12.3 work enumerated every empty-`base_url` provider needing an explicit allow (flux, minimax, minimaxi, nvidia, cerebras, Qwen) but **omitted Gemini**.

**Fix:** allow `generativelanguage.googleapis.com` off the provider TYPE (exact host, not apex — `googleapis.com` is shared-platform), mirroring the existing Qwen/ChatGPT-Codex precedent in `build_allowlist`.

**Reproduced:** the new `native_gemini_host_is_allowlisted_for_gemini_provider` test went `Exfil { host: "generativelanguage.googleapis.com" }` → `Allow`. A negative test (`non_gemini_provider_does_not_allow_gemini_host`) keeps the host closed for non-Gemini sessions.

## Bug 2 — turns that end `finish_reason: Error` fail silently

`map_openai_finish_reason` maps any **unrecognized** finish_reason string to `FinishReason::Error` and emits a normal `Done` event. The engine classifies a `Done`-with-no-stream-error as **success**, returning `Ok(result)` with `finish_reason == Error`. The host's Ok arm then emitted a contentless `stream_end` with **no error event** — the "OpenAI fails silently / 0 tokens" symptom (and the reasoning-model "Processing 4 min then nothing"). The raw unrecognized reason was only in a `tracing::warn!` the user never sees.

**Fix:** in both the json-stream (desktop) and ACP Ok arms, surface an error event when `result.finish_reason == Error` before the terminal `stream_end`. Verified this does **not** false-positive on the `MaxTurns` turn-cap path (that returns `FinishReason::Length`, and its caller already surfaces its own reason).

## Scope / honesty

- Bug 1 fully unblocks **default-config** Gemini users. If a deployment sets `base_url` for Gemini, egress already allowed it and the reporter's Gemini `400 "Please pass a valid API key"` is a separate key-attach issue.
- Bug 2 **surfaces** the real OpenAI failure rather than fixing its cause — the engine log now-visible `unrecognized finish_reason "<x>"` tells us the final one-line `map_openai_finish_reason` mapping to add (follow-up once we have the string).

## Red herrings ruled out (documented for the issue)

- The egress "ENFORCING" banner is a one-time bootstrap log, not a per-request block.
- The missing "using Google Gemini" startup line is the **audio backend** init log (transcription/tts), unrelated to the chat path — its absence is expected.
- `init_history injected … chars=9355` is a normal host system-prompt injection; not a turn-abort.

## Verification

- `cargo test -p wcore-agent --lib egress::defaults` → 15 passed.
- `cargo clippy -p wcore-agent -p wcore-cli --all-targets` → clean on changed code.
- `cargo fmt --all --check` clean; `cargo build -p wcore-cli` clean.

Closes nothing automatically — recommend `state:fixed-pending-release` once cut in a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
