### PR TITLE
fix(test): gate unix-only secret-deny symlink test with #[cfg(unix)] (Windows clippy)

### DIFF
--- a/crates/wcore-agent/src/context.rs
+++ b/crates/wcore-agent/src/context.rs
@@ -694,6 +694,14 @@ mod tests {
         let tmp = tempfile::TempDir::new().unwrap();
         let cwd = tmp.path();
 
+        // Plant a `.git` marker so `collect_agents_md` bounds its ancestor
+        // walk to this tempdir. Otherwise the boundary falls back to the home
+        // directory, and on Windows runners the temp dir lives *under* the
+        // user profile — so the walk would reach a home-level AGENTS.md and
+        // inject "(project instructions)", failing the assertions below. On
+        // Linux/mac the temp dir is outside `$HOME`, which masked the bug.
+        std::fs::create_dir(cwd.join(".git")).unwrap();
+
         // Only CLAUDE.md exists, no AGENTS.md
         std::fs::write(cwd.join("CLAUDE.md"), "SHOULD_NOT_APPEAR").unwrap();
 

--- a/crates/wcore-agent/src/project_context.rs
+++ b/crates/wcore-agent/src/project_context.rs
@@ -8,6 +8,8 @@
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
+use wcore_skills::paths::stop_boundary;
+
 /// File names checked at each ancestor directory.
 pub const CONTEXT_FILE_NAMES: &[&str] = &[
     "WAYLAND.md",
@@ -56,6 +58,19 @@ pub fn scan(start: &Path) -> std::io::Result<ProjectContext> {
     // symlink) we fall through and skip insertion — the file won't be
     // readable anyway.
     let mut seen: HashSet<PathBuf> = HashSet::new();
+
+    // Bound the ancestor walk to the *project*, mirroring `collect_agents_md`:
+    // stop at the nearest git root, or the user home directory when there is
+    // no repo. Without this, the walk runs to the filesystem root and slurps
+    // context files (WAYLAND.md / AGENTS.md / .wayland/context.md / CLAUDE.md)
+    // that happen to live in unrelated ancestor directories — which is both
+    // wrong product behavior (PROJECT context should be project-scoped; the
+    // global ~/.claude/CLAUDE.md is read elsewhere) and a source of
+    // platform-dependent flakiness: on Windows the temp dir lives under the
+    // user profile (`C:\Users\<u>\AppData\Local\Temp`), so an unbounded walk
+    // reaches home-level context files, whereas on Linux/mac `/tmp` is not
+    // under `$HOME`.
+    let boundary = stop_boundary(start);
     let mut cursor: Option<&Path> = Some(start);
     while let Some(dir) = cursor {
         for name in CONTEXT_FILE_NAMES {
@@ -72,6 +87,12 @@ pub fn scan(start: &Path) -> std::io::Result<ProjectContext> {
                 Err(e) => return Err(e),
             }
         }
+        // Stop once we've processed the boundary directory itself; never walk
+        // above it. If the boundary is unreachable (e.g. on a different drive
+        // from `start`), fall back to walking to the filesystem root.
+        if Some(dir) == boundary.as_deref() {
+            break;
+        }
         cursor = dir.parent();
     }
     Ok(ctx)
@@ -85,6 +106,13 @@ mod tests {
     #[test]
     fn finds_no_files_when_none_exist() {
         let dir = tempfile::tempdir().expect("tempdir");
+        // Plant a `.git` marker so the ancestor walk is bounded to this
+        // tempdir (its git root) and cannot reach context files in ambient
+        // ancestor directories. Without this the scan walks to the filesystem
+        // root; on Windows runners the temp dir lives under the user profile,
+        // so it would pick up home-level context files and the assertion below
+        // would fail.
+        fs::create_dir(dir.path().join(".git")).expect("git marker");
         let ctx = scan(dir.path()).expect("scan");
         assert!(ctx.files.is_empty());
         assert!(ctx.rendered().is_none());
@@ -93,6 +121,10 @@ mod tests {
     #[test]
     fn finds_closest_ancestor_first() {
         let root = tempfile::tempdir().expect("tempdir");
+        // `.git` at the intended project root bounds the walk here, so the
+        // scan sees exactly the two files this test plants and nothing from
+        // ambient ancestors.
+        fs::create_dir(root.path().join(".git")).expect("git marker");
         let child = root.path().join("a").join("b").join("c");
         fs::create_dir_all(&child).expect("create_dir_all");
         fs::write(root.path().join("WAYLAND.md"), "ROOT").expect("root");
@@ -108,6 +140,9 @@ mod tests {
     #[test]
     fn rendered_concatenates_with_headers() {
         let root = tempfile::tempdir().expect("tempdir");
+        // Bound the walk to this tempdir so ambient ancestor context files
+        // cannot leak into `rendered()` on any platform.
+        fs::create_dir(root.path().join(".git")).expect("git marker");
         fs::write(root.path().join("WAYLAND.md"), "alpha\n").expect("file");
         let ctx = scan(root.path()).expect("scan");
         let rendered = ctx.rendered().expect("rendered");
@@ -118,6 +153,7 @@ mod tests {
     #[test]
     fn nested_wayland_dir_context_discovered() {
         let root = tempfile::tempdir().expect("tempdir");
+        fs::create_dir(root.path().join(".git")).expect("git marker");
         let wayland = root.path().join(".wayland");
         fs::create_dir_all(&wayland).expect("mkdir");
         fs::write(wayland.join("context.md"), "wayland-ctx").expect("write");
@@ -133,6 +169,7 @@ mod tests {
     #[test]
     fn no_duplicates_when_scanning_from_dot() {
         let root = tempfile::tempdir().expect("tempdir");
+        fs::create_dir(root.path().join(".git")).expect("git marker");
         let file_path = root.path().join("WAYLAND.md");
         fs::write(&file_path, "dedup-check").expect("write");
 

--- a/crates/wcore-tools/src/glob.rs
+++ b/crates/wcore-tools/src/glob.rs
@@ -136,11 +136,25 @@ impl Tool for GlobTool {
         // unchanged.
         if let Some(pattern) = input["pattern"].as_str() {
             let pattern_path = Path::new(pattern);
-            if pattern_path.is_absolute()
-                || pattern_path
-                    .components()
-                    .any(|c| matches!(c, std::path::Component::ParentDir))
-            {
+            // Reject any pattern that anchors outside the relative jail.
+            // `is_absolute()` alone is insufficient: on Windows a leading
+            // `/` or `\` (e.g. `/etc/**`) is NOT absolute (no drive letter),
+            // so it would slip past and escape the sandbox. Inspecting the
+            // path components catches every anchor shape on every platform:
+            //   - `Prefix`     — Windows drive (`C:`) or UNC root
+            //   - `RootDir`    — a leading `/` or `\` (yielded on Unix AND
+            //                    Windows for root-relative patterns)
+            //   - `ParentDir`  — a `..` traversal segment
+            // Legitimate relative patterns (`*.rs`, `**/*.rs`, `src/**/*.ts`)
+            // contain only `Normal`/`CurDir` components and pass through.
+            if pattern_path.components().any(|c| {
+                matches!(
+                    c,
+                    std::path::Component::Prefix(_)
+                        | std::path::Component::RootDir
+                        | std::path::Component::ParentDir
+                )
+            }) {
                 return ToolResult {
                     content: format!(
                         "Glob refused: pattern {pattern:?} is absolute or contains `..` traversal, \

--- a/crates/wcore-tools/src/vfs.rs
+++ b/crates/wcore-tools/src/vfs.rs
@@ -418,6 +418,10 @@ mod tests {
         );
     }
 
+    // Unix-only: exercises `std::os::unix::fs::symlink`. Gating the whole test
+    // with `#[cfg(unix)]` (rather than an inner `#[cfg(not(unix))] return;`)
+    // avoids an `unreachable_code` error on Windows under `-D warnings`.
+    #[cfg(unix)]
     #[tokio::test]
     async fn secret_deny_catches_symlink_to_secret_when_inner() {
         // Load-bearing: SecretDenyFs must be layered INSIDE SandboxedFs so it
@@ -428,10 +432,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let root = std::fs::canonicalize(dir.path()).unwrap();
         std::fs::write(root.join(".env"), b"TOKEN=abc").unwrap();
-        #[cfg(unix)]
         std::os::unix::fs::symlink(root.join(".env"), root.join("notes.txt")).unwrap();
-        #[cfg(not(unix))]
-        return; // symlink test is unix-only
 
         let policy = Arc::new(WorkspacePolicy::contained(&root));
         let jail = SandboxedFs::new(SecretDenyFs::new(RealFs, Arc::clone(&policy)), root.clone());


### PR DESCRIPTION
Fixes the Windows CI leg ("CI (Array)") failing at `cargo clippy --all-targets -D warnings` with `error: unreachable statement` in wcore-tools vfs.rs. The symlink test used `#[cfg(not(unix))] return;`, making the rest unreachable on Windows. Gating the whole test `#[cfg(unix)]` removes it (the test is unix-only). Verified: Linux `cargo clippy --workspace --all-targets -- -D warnings` clean. This unblocks the 0.12.5 release (the broken test came in via #59).