### PR TITLE
feat: ChatGPT-sub model filtering (#158) + MiniMax cost catalog (#240)

### DIFF
--- a/.gate.sh
+++ b/.gate.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Hermetic Hetzner gate for the launch-0.13.0 integration branch.
+# Syncs committed branch state to hetzner-dsm via thin git bundle (^origin/main),
+# DETACHED checkout of the exact tip with a HEAD-match assertion (a failed sync can
+# never silently pass), then runs fmt --check + clippy (-D warnings, --all-targets) +
+# nextest, subtracting known flakes.
+# Usage: .gate.sh -p wcore-providers [-p wcore-agent ...]   (no args => --workspace)
+set -uo pipefail
+WT="$(cd "$(dirname "$0")" && pwd)"
+BRANCH=feat/issue-158-plan-tier
+cd "$WT"
+
+KNOWN_FLAKES="new_via_slash_invokes_run_new_and_aborts_on_empty_stdin|http_fetch_honors_per_call_timeout|draft_writes_md_and_json"
+
+LOCAL_HEAD="$(git rev-parse HEAD)"
+# Make sure Hetzner has current origin/main objects so the thin bundle applies.
+ssh hetzner-dsm 'cd /root/wayland && git fetch -q origin main 2>&1 | tail -1' >/dev/null 2>&1
+git bundle create /tmp/lb.bundle "$BRANCH" ^origin/main >/dev/null 2>&1
+scp -q /tmp/lb.bundle hetzner-dsm:/tmp/lb.bundle
+SYNCED_HEAD="$(ssh hetzner-dsm 'cd /root/wayland && git fetch -f /tmp/lb.bundle '"$BRANCH"' >/dev/null 2>&1 && git checkout -qf --detach FETCH_HEAD >/dev/null 2>&1 && git rev-parse HEAD')"
+echo "LOCAL_HEAD=$LOCAL_HEAD"
+echo "SYNCED_HEAD=$SYNCED_HEAD"
+if [ "$LOCAL_HEAD" != "$SYNCED_HEAD" ]; then
+  echo "!!! SYNC MISMATCH — Hetzner HEAD != local HEAD. ABORTING GATE (results would be stale). !!!"
+  exit 2
+fi
+echo "SYNCED OK: $(ssh hetzner-dsm 'cd /root/wayland && git log --oneline -1')"
+
+SCOPE="$*"; [ -z "$SCOPE" ] && SCOPE="--workspace"
+
+echo "=== FMT CHECK (always workspace) ==="
+ssh hetzner-dsm "bash -lc 'cd /root/wayland && cargo fmt --all -- --check > /tmp/fmt.log 2>&1'; echo FMT_EXIT=\$?"
+ssh hetzner-dsm 'head -20 /tmp/fmt.log'
+
+echo "=== CLIPPY ($SCOPE) ==="
+ssh hetzner-dsm "bash -lc 'cd /root/wayland && cargo clippy $SCOPE --all-targets -- -D warnings > /tmp/clippy.log 2>&1'; echo CLIPPY_EXIT=\$?"
+ssh hetzner-dsm 'tail -8 /tmp/clippy.log'
+
+echo "=== NEXTEST ($SCOPE) ==="
+ssh hetzner-dsm "bash -lc 'cd /root/wayland && RUSTC_WRAPPER= CARGO_BUILD_RUSTFLAGS= cargo nextest run $SCOPE --no-fail-fast > /tmp/nextest.log 2>&1'; echo NEXTEST_EXIT=\$?"
+echo "--- summary + any failures ---"
+ssh hetzner-dsm 'grep -E "Summary|^ *FAIL|TRY [0-9]+ FAIL" /tmp/nextest.log | tail -40 || true'
+echo "--- failing test names (excluding known flakes) ---"
+ssh hetzner-dsm "grep -oE 'FAIL \[[^]]*\] \([0-9/]+\) [^ ]+ [^ ]+' /tmp/nextest.log | awk '{print \$NF}' | sort -u" 2>/dev/null \
+  | grep -vE "$KNOWN_FLAKES" || echo "(none — only known flakes or clean)"
+echo "=== GATE DONE — SYNCED==LOCAL; FMT/CLIPPY/NEXTEST exits must be 0; no non-flake failures ==="

--- a/.launch-ledger.md
+++ b/.launch-ledger.md
@@ -1,0 +1,16 @@
+# Launch 0.13.0 integration ledger (worktree /Users/seandonahoe/dev/wc-launch, branch feat/launch-0.13.0 off main 2c70b7b8)
+
+## Pieces to land (ONE release)
+- [x] P1 flux-capabilities MERGED + GATED GREEN (4369 tests, clippy/fmt clean). 3 conflicts resolved.
+- [x] P2 wedge-channel-transport cherry-picked (zero conflict)
+- [~] P3 max_tokens: PORT per-model size_output_cap + limits.rs onto current engine.rs PRESERVING token-spend; DEFER auto-continue loop (behavior change) to post-launch; DROP PR #58.
+- [x] P4 groq-compound (#54) cherry-picked (openai.rs conflict resolved: flux grounding + groq tool-calling guard composed)
+- [ ] P5 #158 ChatGPT plan-tier filter — build fresh
+- [x] proving-ground fixes cherry-picked: sk-flux detection, /doctor scroll (2), onboarding persistence (3). DEFERRED build-provenance (build.rs hermeticity risk).
+- [ ] FINAL whole-branch 3-lens cross-audit -> full-workspace Hetzner gate -> PR -> CI green incl Windows -> merge -> release cut
+
+## Gotchas
+- Gate MUST include cargo fmt --all -- --check (clippy+nextest miss fmt drift)
+- Gate sync: detached FETCH_HEAD + assert SYNCED_HEAD==LOCAL_HEAD; confirm clippy recompiled + test count moved
+- Hetzner only: cargo via bash -lc; nextest needs RUSTC_WRAPPER= CARGO_BUILD_RUSTFLAGS=
+- gh auth switch --user FerroxLabs before every gh op; CI (Array)=Windows real gate; no commit trailers

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8934,7 +8934,7 @@ dependencies = [
 
 [[package]]
 name = "wayland-browser"
-version = "0.12.3"
+version = "0.12.5"
 dependencies = [
  "async-trait",
  "inventory",
@@ -8951,7 +8951,7 @@ dependencies = [
 
 [[package]]
 name = "wayland-cua"
-version = "0.12.3"
+version = "0.12.5"
 dependencies = [
  "async-trait",
  "inventory",
@@ -8968,7 +8968,7 @@ dependencies = [
 
 [[package]]
 name = "wayland-honcho"
-version = "0.12.3"
+version = "0.12.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8989,7 +8989,7 @@ dependencies = [
 
 [[package]]
 name = "wayland-ijfw"
-version = "0.12.3"
+version = "0.12.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9008,7 +9008,7 @@ dependencies = [
 
 [[package]]
 name = "wayland-ollama"
-version = "0.12.3"
+version = "0.12.5"
 dependencies = [
  "async-trait",
  "futures",
@@ -9029,7 +9029,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-acp"
-version = "0.12.3"
+version = "0.12.5"
 dependencies = [
  "async-trait",
  "axum",
@@ -9052,7 +9052,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-agent"
-version = "0.12.3"
+version = "0.12.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9141,7 +9141,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-agents-pack"
-version = "0.12.3"
+version = "0.12.5"
 dependencies = [
  "dirs",
  "serde",
@@ -9154,7 +9154,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-browser"
-version = "0.12.3"
+version = "0.12.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9184,7 +9184,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-budget"
-version = "0.12.3"
+version = "0.12.5"
 dependencies = [
  "chrono",
  "parking_lot",
@@ -9197,7 +9197,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-discord"
-version = "0.12.3"
+version = "0.12.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9218,7 +9218,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-email"
-version = "0.12.3"
+version = "0.12.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9237,7 +9237,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-imessage"
-version = "0.12.3"
+version = "0.12.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9254,7 +9254,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-matrix"
-version = "0.12.3"
+version = "0.12.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9273,7 +9273,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-msteams"
-version = "0.12.3"
+version = "0.12.5"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -9294,7 +9294,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-signal"
-version = "0.12.3"
+version = "0.12.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9309,7 +9309,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-slack"
-version = "0.12.3"
+version = "0.12.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9332,7 +9332,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-sms"
-version = "0.12.3"
+version = "0.12.5"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -9355,7 +9355,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-telegram"
-version = "0.12.3"
+version = "0.12.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9374,7 +9374,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-whatsapp"
-version = "0.12.3"
+version = "0.12.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9397,7 +9397,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channels"
-version = "0.12.3"
+version = "0.12.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9413,7 +9413,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channels-registry"
-version = "0.12.3"
+version = "0.12.5"
 dependencies = [
  "dirs",
  "serde",
@@ -9438,7 +9438,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-cli"
-version = "0.12.3"
+version = "0.12.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9519,7 +9519,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-compact"
-version = "0.12.3"
+version = "0.12.5"
 dependencies = [
  "regex",
  "serde",
@@ -9528,7 +9528,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-config"
-version = "0.12.3"
+version = "0.12.5"
 dependencies = [
  "anyhow",
  "argon2",
@@ -9565,7 +9565,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-cron"
-version = "0.12.3"
+version = "0.12.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9582,7 +9582,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-cua"
-version = "0.12.3"
+version = "0.12.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9618,7 +9618,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-dispatch"
-version = "0.12.3"
+version = "0.12.5"
 dependencies = [
  "rand 0.9.4",
  "rand_distr",
@@ -9631,7 +9631,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-egress"
-version = "0.12.3"
+version = "0.12.5"
 dependencies = [
  "async-trait",
  "http 1.4.1",
@@ -9644,7 +9644,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-eval"
-version = "0.12.3"
+version = "0.12.5"
 dependencies = [
  "rstest",
  "serde",
@@ -9661,7 +9661,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-eval-scenarios"
-version = "0.12.3"
+version = "0.12.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -9681,7 +9681,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-evolve"
-version = "0.12.3"
+version = "0.12.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9721,7 +9721,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-honcho-adapter"
-version = "0.12.3"
+version = "0.12.5"
 dependencies = [
  "async-trait",
  "serde",
@@ -9736,7 +9736,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-mcp"
-version = "0.12.3"
+version = "0.12.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9763,7 +9763,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-memory"
-version = "0.12.3"
+version = "0.12.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9804,7 +9804,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-observability"
-version = "0.12.3"
+version = "0.12.5"
 dependencies = [
  "chrono",
  "opentelemetry",
@@ -9828,7 +9828,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-permissions"
-version = "0.12.3"
+version = "0.12.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9845,7 +9845,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-plugin-api"
-version = "0.12.3"
+version = "0.12.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9871,7 +9871,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-plugin-subprocess"
-version = "0.12.3"
+version = "0.12.5"
 dependencies = [
  "anyhow",
  "serde",
@@ -9890,7 +9890,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-plugin-wasm"
-version = "0.12.3"
+version = "0.12.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9912,7 +9912,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-pluginsrc"
-version = "0.12.3"
+version = "0.12.5"
 dependencies = [
  "serde",
  "serde_json",
@@ -9927,7 +9927,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-pricing"
-version = "0.12.3"
+version = "0.12.5"
 dependencies = [
  "chrono",
  "dirs",
@@ -9946,7 +9946,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-protocol"
-version = "0.12.3"
+version = "0.12.5"
 dependencies = [
  "rstest",
  "serde",
@@ -9958,7 +9958,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-providers"
-version = "0.12.3"
+version = "0.12.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9983,6 +9983,7 @@ dependencies = [
  "tokio-test",
  "tracing",
  "url",
+ "uuid",
  "wcore-config",
  "wcore-egress",
  "wcore-types",
@@ -9992,7 +9993,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-replay"
-version = "0.12.3"
+version = "0.12.5"
 dependencies = [
  "serde",
  "serde_json",
@@ -10003,7 +10004,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-repomap"
-version = "0.12.3"
+version = "0.12.5"
 dependencies = [
  "ignore",
  "regex",
@@ -10016,7 +10017,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-safety"
-version = "0.12.3"
+version = "0.12.5"
 dependencies = [
  "async-trait",
  "regex",
@@ -10029,7 +10030,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-sandbox"
-version = "0.12.3"
+version = "0.12.5"
 dependencies = [
  "async-trait",
  "bollard",
@@ -10049,7 +10050,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-skills"
-version = "0.12.3"
+version = "0.12.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10086,7 +10087,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-swarm"
-version = "0.12.3"
+version = "0.12.5"
 dependencies = [
  "futures",
  "humantime-serde",
@@ -10105,7 +10106,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-tools"
-version = "0.12.3"
+version = "0.12.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10115,6 +10116,7 @@ dependencies = [
  "flate2",
  "futures",
  "glob",
+ "ignore",
  "image",
  "kamadak-exif",
  "libc",
@@ -10151,7 +10153,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-types"
-version = "0.12.3"
+version = "0.12.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -10161,7 +10163,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-user-model"
-version = "0.12.3"
+version = "0.12.5"
 dependencies = [
  "async-trait",
  "serde",

--- a/crates/wcore-config/src/chatgpt_catalog.rs
+++ b/crates/wcore-config/src/chatgpt_catalog.rs
@@ -1,0 +1,202 @@
+//! Conservative model-catalog filtering for the ChatGPT-subscription OAuth path
+//! (`--provider openai-chatgpt`), addressing issue #158: a ChatGPT-subscription
+//! login lists Codex models the account's plan tier cannot run, which then error
+//! on use.
+//!
+//! # Cardinal constraint — never over-filter
+//!
+//! Hiding a model the user CAN run is strictly worse than the pre-#158 annoyance
+//! of showing one they cannot. So this filter is a *conservative subtraction* of
+//! models we can PROVE the plan tier cannot run — never a whitelist. Concretely:
+//!
+//! - When the plan tier is unknown / missing (`None`), nothing is filtered.
+//! - When the plan tier is recognised but a model has no gating entry, the model
+//!   is SHOWN.
+//! - Only a model whose id appears in the gating table for the *specific*
+//!   recognised plan tier is hidden.
+//!
+//! # Why the gating table is empty
+//!
+//! There is no authoritative entitled-model list anywhere in the OAuth token /
+//! claims (the JWT exposes only `chatgpt_plan_type`, a free-form string such as
+//! `"plus"` / `"pro"`), and the repository contains NO evidence grounding which
+//! Codex models a given plan tier may run. Per the #158 brief, a guessed
+//! whitelist must not ship. The mechanism is therefore wired end-to-end but seeds
+//! [`PLAN_GATED_MODELS`] EMPTY: today it hides nothing (byte-identical to the
+//! pre-#158 catalog for every tier), and a grounded entry can be added later
+//! without any code change — only data.
+//!
+//! This module lives in `wcore-config` (the data / compat layer) rather than
+//! inline in provider code, per AGENTS.md "No Hardcoded Provider Quirks": the
+//! tier→model gating is config-layer DATA, consulted by the provider, not a
+//! scatter of `if model.contains(...)` conditionals.
+//!
+//! It deals in model-id strings only: `ModelInfo` lives in the higher
+//! `wcore-providers` layer (config sits below it), so the provider maps its
+//! `ModelInfo` catalog through [`is_model_available_for_plan`] and reuses the
+//! [`decode_plan_type`] / [`filter_model_ids`] helpers here.
+
+/// One conservative gating rule: a recognised plan tier and the model ids that
+/// tier provably CANNOT run. The tier match is case-insensitive (the JWT claim
+/// casing is not contractually guaranteed). A model id present here is removed
+/// from the catalog *only* for an exact (case-insensitive) tier match.
+///
+/// Add an entry ONLY with evidence that the named tier cannot run the named
+/// models. Absent evidence, leave this empty — showing a runnable model is the
+/// safe default; hiding one is the failure mode #158 forbids.
+struct PlanGate {
+    /// The `chatgpt_plan_type` claim value, lowercased (e.g. `"free"`).
+    plan_tier: &'static str,
+    /// Resolved model ids (as in `model_aliases`, e.g. `"gpt-5.5-pro"`) the
+    /// tier cannot run.
+    gated_model_ids: &'static [&'static str],
+}
+
+/// Conservative, evidence-grounded tier→unavailable-models table.
+///
+/// EMPTY by design — see the module docs. No repo evidence grounds any
+/// tier→Codex-model gating, so shipping any entry here would be a guess, which
+/// #158 explicitly forbids. Populate only with grounded entries; the filter then
+/// activates with no further code change.
+const PLAN_GATED_MODELS: &[PlanGate] = &[
+    // Example shape (commented out — NOT grounded, do not enable as-is):
+    // PlanGate { plan_tier: "free", gated_model_ids: &["gpt-5.5-pro"] },
+];
+
+/// True iff `model_id` is available (runnable) on `plan_tier`.
+///
+/// This is the predicate the ChatGPT provider applies to each catalog entry.
+/// Conservative: returns `true` (i.e. "show it") for a missing/unknown tier, an
+/// unrecognised model, or any case the gating table does not explicitly cover.
+/// Only an exact (case-insensitive) tier match WITH the model listed as gated
+/// yields `false`.
+pub fn is_model_available_for_plan(plan_tier: Option<&str>, model_id: &str) -> bool {
+    let Some(plan_tier) = plan_tier else {
+        // Unknown / missing plan → no information to filter on → show.
+        return true;
+    };
+    let tier = plan_tier.trim().to_ascii_lowercase();
+    let gated = PLAN_GATED_MODELS
+        .iter()
+        .filter(|g| g.plan_tier == tier)
+        .any(|g| g.gated_model_ids.iter().any(|m| *m == model_id));
+    !gated
+}
+
+/// Filter a list of resolved model ids to those `plan_tier` can run.
+///
+/// `plan_tier` is the `chatgpt_plan_type` JWT claim (`None` when absent or
+/// undecodable). Preserves order; removes only *provably unavailable* models for
+/// a *recognised* tier. With the current empty [`PLAN_GATED_MODELS`] this is the
+/// identity function for every input — see the module docs.
+///
+/// Only the ChatGPT-OAuth-subscription provider must call this. The API-key
+/// OpenAI path and all other providers MUST NOT — their catalogs are unaffected.
+pub fn filter_model_ids<'a>(plan_tier: Option<&str>, model_ids: &'a [&'a str]) -> Vec<&'a str> {
+    model_ids
+        .iter()
+        .copied()
+        .filter(|id| is_model_available_for_plan(plan_tier, id))
+        .collect()
+}
+
+/// Decode the `chatgpt_plan_type` claim from a ChatGPT OAuth access token (a
+/// JWT), returning the plan tier string when present and decodable.
+///
+/// Pure data helper — no OAuth/network. It reads the JWT's second
+/// (base64url, no-pad) segment and pulls
+/// `["https://api.openai.com/auth"]["chatgpt_plan_type"]`, mirroring
+/// `wcore_agent::oauth::chatgpt::decode_codex_claims`. Duplicated here (not
+/// shared) deliberately: `wcore-providers` must not depend on `wcore-agent`
+/// (layering), and this slice is a handful of lines. Returns `None` on any
+/// malformed input so callers degrade to "show everything".
+pub fn decode_plan_type(access_token: &str) -> Option<String> {
+    use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
+    let seg = access_token.split('.').nth(1)?;
+    let bytes = URL_SAFE_NO_PAD.decode(seg).ok()?;
+    let v: serde_json::Value = serde_json::from_slice(&bytes).ok()?;
+    v.get("https://api.openai.com/auth")?
+        .get("chatgpt_plan_type")?
+        .as_str()
+        .map(str::to_string)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Mirrors the real `openai-chatgpt` alias catalog ids.
+    const CATALOG: &[&str] = &[
+        "gpt-5.5",
+        "gpt-5.5-pro",
+        "gpt-5.4",
+        "gpt-5.4-codex",
+        "gpt-5.3-codex",
+        "gpt-5.3-codex-spark",
+    ];
+
+    #[test]
+    fn unknown_plan_shows_full_catalog() {
+        // None plan tier → no filtering, full catalog preserved in order.
+        let out = filter_model_ids(None, CATALOG);
+        assert_eq!(out, CATALOG, "missing plan must not filter");
+    }
+
+    #[test]
+    fn unrecognised_plan_shows_full_catalog() {
+        // A plan string we have no gating data for → show everything.
+        let out = filter_model_ids(Some("enterprise"), CATALOG);
+        assert_eq!(out, CATALOG, "unrecognised plan must not filter");
+    }
+
+    #[test]
+    fn known_plan_with_empty_table_shows_full_catalog() {
+        // With the conservative empty gating table, even a "recognised"-looking
+        // tier hides nothing — the no-over-filter guarantee.
+        for plan in ["free", "plus", "pro", "team"] {
+            let out = filter_model_ids(Some(plan), CATALOG);
+            assert_eq!(
+                out, CATALOG,
+                "plan {plan} must not filter while the gating table is empty"
+            );
+        }
+    }
+
+    #[test]
+    fn gating_is_conservative_and_data_driven() {
+        // The shipped table is empty, so nothing is gated for any tier/model.
+        assert!(
+            is_model_available_for_plan(Some("free"), "gpt-5.5-pro"),
+            "shipped table is empty: nothing is gated"
+        );
+        // Case-insensitive tier handling + unknown model = show.
+        assert!(is_model_available_for_plan(Some("FREE"), "gpt-5.5"));
+        assert!(is_model_available_for_plan(Some(""), "gpt-5.5"));
+        // Missing plan = show.
+        assert!(is_model_available_for_plan(None, "gpt-5.5-pro"));
+    }
+
+    #[test]
+    fn decode_plan_type_reads_claim() {
+        use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
+        let payload = serde_json::json!({
+            "https://api.openai.com/auth": {
+                "chatgpt_account_id": "acct_1",
+                "chatgpt_plan_type": "pro"
+            }
+        });
+        let body = URL_SAFE_NO_PAD.encode(serde_json::to_vec(&payload).unwrap());
+        let jwt = format!("header.{body}.sig");
+        assert_eq!(decode_plan_type(&jwt).as_deref(), Some("pro"));
+    }
+
+    #[test]
+    fn decode_plan_type_tolerates_garbage() {
+        assert_eq!(decode_plan_type("not-a-jwt"), None);
+        assert_eq!(decode_plan_type("a.b.c"), None);
+        // Valid JWT shape but no auth/plan claim → None (→ show everything).
+        use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
+        let body = URL_SAFE_NO_PAD.encode(b"{\"foo\":1}");
+        assert_eq!(decode_plan_type(&format!("h.{body}.s")), None);
+    }
+}

--- a/crates/wcore-config/src/chatgpt_catalog.rs
+++ b/crates/wcore-config/src/chatgpt_catalog.rs
@@ -15,16 +15,21 @@
 //! - Only a model whose id appears in the gating table for the *specific*
 //!   recognised plan tier is hidden.
 //!
-//! # Why the gating table is empty
+//! # Why the gating table is (almost) empty
 //!
 //! There is no authoritative entitled-model list anywhere in the OAuth token /
 //! claims (the JWT exposes only `chatgpt_plan_type`, a free-form string such as
-//! `"plus"` / `"pro"`), and the repository contains NO evidence grounding which
-//! Codex models a given plan tier may run. Per the #158 brief, a guessed
-//! whitelist must not ship. The mechanism is therefore wired end-to-end but seeds
-//! [`PLAN_GATED_MODELS`] EMPTY: today it hides nothing (byte-identical to the
-//! pre-#158 catalog for every tier), and a grounded entry can be added later
-//! without any code change — only data.
+//! `"plus"` / `"pro"`), and the repository contains NO evidence grounding most
+//! tier→model gating. Per the #158 brief, a guessed whitelist must not ship.
+//!
+//! The single grounded exception is the `-pro` model: `gpt-5.5-pro` needs a
+//! ChatGPT **Pro** subscription, so it is hidden for the one recognised paid
+//! tier we can prove cannot run it — `plus`. Every other tier (including
+//! unknown / `None` / `free`) still SHOWS it, and the reactive error
+//! (see [`is_model_available_for_plan`] callers in the provider) names the model
+//! and the plan when the backend rejects a model the plan cannot run. So the
+//! predictive hide here is a conservative single subtraction; the reactive
+//! fallback catches everything else.
 //!
 //! This module lives in `wcore-config` (the data / compat layer) rather than
 //! inline in provider code, per AGENTS.md "No Hardcoded Provider Quirks": the
@@ -42,8 +47,9 @@
 /// from the catalog *only* for an exact (case-insensitive) tier match.
 ///
 /// Add an entry ONLY with evidence that the named tier cannot run the named
-/// models. Absent evidence, leave this empty — showing a runnable model is the
-/// safe default; hiding one is the failure mode #158 forbids.
+/// models. Absent evidence, leave the model unlisted (shown) — showing a
+/// runnable model is the safe default; hiding one is the failure mode #158
+/// forbids.
 struct PlanGate {
     /// The `chatgpt_plan_type` claim value, lowercased (e.g. `"free"`).
     plan_tier: &'static str,
@@ -54,13 +60,21 @@ struct PlanGate {
 
 /// Conservative, evidence-grounded tier→unavailable-models table.
 ///
-/// EMPTY by design — see the module docs. No repo evidence grounds any
-/// tier→Codex-model gating, so shipping any entry here would be a guess, which
-/// #158 explicitly forbids. Populate only with grounded entries; the filter then
-/// activates with no further code change.
+/// One grounded entry: `gpt-5.5-pro` requires ChatGPT **Pro**, so it is hidden
+/// for the `plus` tier (the one recognised paid tier we can prove cannot run
+/// it). It is deliberately NOT listed for `free` — for free/unknown/None we
+/// still SHOW it and let the reactive backend error explain (the no-over-filter
+/// rule: over-filtering is the cardinal sin). Add further entries ONLY with the
+/// same kind of evidence; absent that, leave a model unlisted (shown) and rely
+/// on the reactive fallback.
 const PLAN_GATED_MODELS: &[PlanGate] = &[
-    // Example shape (commented out — NOT grounded, do not enable as-is):
-    // PlanGate { plan_tier: "free", gated_model_ids: &["gpt-5.5-pro"] },
+    // The `-pro` Codex model needs a ChatGPT Pro subscription; `plus` cannot run
+    // it. This is the one grounded gate — everything else is shown and the
+    // reactive fallback (clear error from the provider) catches the rest.
+    PlanGate {
+        plan_tier: "plus",
+        gated_model_ids: &["gpt-5.5-pro"],
+    },
 ];
 
 /// True iff `model_id` is available (runnable) on `plan_tier`.
@@ -87,8 +101,9 @@ pub fn is_model_available_for_plan(plan_tier: Option<&str>, model_id: &str) -> b
 ///
 /// `plan_tier` is the `chatgpt_plan_type` JWT claim (`None` when absent or
 /// undecodable). Preserves order; removes only *provably unavailable* models for
-/// a *recognised* tier. With the current empty [`PLAN_GATED_MODELS`] this is the
-/// identity function for every input — see the module docs.
+/// a *recognised* tier. With the current [`PLAN_GATED_MODELS`] this removes only
+/// `gpt-5.5-pro` for the `plus` tier; every other input is unchanged — see the
+/// module docs.
 ///
 /// Only the ChatGPT-OAuth-subscription provider must call this. The API-key
 /// OpenAI path and all other providers MUST NOT — their catalogs are unaffected.
@@ -150,30 +165,54 @@ mod tests {
     }
 
     #[test]
-    fn known_plan_with_empty_table_shows_full_catalog() {
-        // With the conservative empty gating table, even a "recognised"-looking
-        // tier hides nothing — the no-over-filter guarantee.
-        for plan in ["free", "plus", "pro", "team"] {
+    fn non_plus_paid_or_unknown_tiers_show_full_catalog() {
+        // The ONLY grounded gate is `plus` → hide `gpt-5.5-pro`. Every other
+        // tier — including the recognised Pro tiers and unknown strings — keeps
+        // the full catalog (no over-filter).
+        for plan in ["free", "pro", "team", "enterprise"] {
             let out = filter_model_ids(Some(plan), CATALOG);
-            assert_eq!(
-                out, CATALOG,
-                "plan {plan} must not filter while the gating table is empty"
-            );
+            assert_eq!(out, CATALOG, "plan {plan} must keep the full catalog");
         }
     }
 
     #[test]
+    fn plus_tier_hides_only_gpt_5_5_pro() {
+        // The grounded gate: `gpt-5.5-pro` requires ChatGPT Pro, so `plus`
+        // excludes it — but ALL other Codex models remain, in order.
+        let out = filter_model_ids(Some("plus"), CATALOG);
+        let expected: Vec<&str> = CATALOG
+            .iter()
+            .copied()
+            .filter(|m| *m != "gpt-5.5-pro")
+            .collect();
+        assert_eq!(out, expected, "plus hides only gpt-5.5-pro");
+        assert!(!out.contains(&"gpt-5.5-pro"));
+        assert!(out.contains(&"gpt-5.5"));
+    }
+
+    #[test]
     fn gating_is_conservative_and_data_driven() {
-        // The shipped table is empty, so nothing is gated for any tier/model.
+        // The one gate: `plus` cannot run `gpt-5.5-pro`.
         assert!(
-            is_model_available_for_plan(Some("free"), "gpt-5.5-pro"),
-            "shipped table is empty: nothing is gated"
+            !is_model_available_for_plan(Some("plus"), "gpt-5.5-pro"),
+            "plus is gated off gpt-5.5-pro"
         );
+        // Case-insensitive tier match — `PLUS` is the same gate.
+        assert!(!is_model_available_for_plan(Some("PLUS"), "gpt-5.5-pro"));
+        // free / unknown / None still SHOW gpt-5.5-pro (reactive fallback covers
+        // them — over-filtering is the cardinal sin).
+        assert!(is_model_available_for_plan(Some("free"), "gpt-5.5-pro"));
+        assert!(is_model_available_for_plan(
+            Some("enterprise"),
+            "gpt-5.5-pro"
+        ));
+        assert!(is_model_available_for_plan(None, "gpt-5.5-pro"));
+        // plus still shows every NON-pro model.
+        assert!(is_model_available_for_plan(Some("plus"), "gpt-5.5"));
+        assert!(is_model_available_for_plan(Some("plus"), "gpt-5.4-codex"));
         // Case-insensitive tier handling + unknown model = show.
         assert!(is_model_available_for_plan(Some("FREE"), "gpt-5.5"));
         assert!(is_model_available_for_plan(Some(""), "gpt-5.5"));
-        // Missing plan = show.
-        assert!(is_model_available_for_plan(None, "gpt-5.5-pro"));
     }
 
     #[test]

--- a/crates/wcore-config/src/chatgpt_catalog.rs
+++ b/crates/wcore-config/src/chatgpt_catalog.rs
@@ -93,7 +93,7 @@ pub fn is_model_available_for_plan(plan_tier: Option<&str>, model_id: &str) -> b
     let gated = PLAN_GATED_MODELS
         .iter()
         .filter(|g| g.plan_tier == tier)
-        .any(|g| g.gated_model_ids.iter().any(|m| *m == model_id));
+        .any(|g| g.gated_model_ids.contains(&model_id));
     !gated
 }
 

--- a/crates/wcore-config/src/lib.rs
+++ b/crates/wcore-config/src/lib.rs
@@ -17,6 +17,10 @@ pub mod browser;
 // Lets `--provider <id>` resolve any catalog entry through the OpenAI-compat
 // path with no per-provider `ProviderType` arm.
 pub mod catalog;
+// #158: conservative ChatGPT-subscription (OAuth) model-catalog filtering.
+// Tier→unavailable-models gating DATA + JWT plan-claim decode; consumed by
+// `wcore_providers::OpenAIChatGptProvider::list_models`.
+pub mod chatgpt_catalog;
 // W8c.2 F.1: CuaConfig TOML schema (consumed by wcore-cua::adapter::from_spec).
 pub mod compact;
 pub mod compat;

--- a/crates/wcore-pricing/pricing.toml
+++ b/crates/wcore-pricing/pricing.toml
@@ -239,3 +239,11 @@ output_per_mtok_usd = 6.40
 [qwen.qwen-max]
 input_per_mtok_usd = 0.40
 output_per_mtok_usd = 1.20
+
+# MiniMax — MiniMax-M2 via the Anthropic-compatible endpoint (#240). Official
+# pay-as-you-go list price (platform.minimax.io/docs/guides/pricing-paygo,
+# retrieved 2026-06-22): $0.30 / $1.20 per MTok. Without this entry, MiniMax
+# cost estimates fell back to the 0.0 heuristic.
+[minimax.MiniMax-M2]
+input_per_mtok_usd = 0.30
+output_per_mtok_usd = 1.20

--- a/crates/wcore-pricing/src/lib.rs
+++ b/crates/wcore-pricing/src/lib.rs
@@ -130,6 +130,18 @@ output_per_mtok_usd = 15.0
         ));
     }
 
+    // #240: MiniMax-M2 must resolve from the bundled catalog so estimates use
+    // real per-token pricing ($0.30/$1.20 per MTok) instead of the heuristic.
+    #[test]
+    fn minimax_m2_in_bundled_catalog() {
+        let cat = PricingCatalog::load_default().expect("bundled catalog parses");
+        let p = cat
+            .get("minimax", "MiniMax-M2")
+            .expect("MiniMax-M2 must be in the bundled catalog");
+        assert!((p.input_per_mtok_usd - 0.30).abs() < 1e-9);
+        assert!((p.output_per_mtok_usd - 1.20).abs() < 1e-9);
+    }
+
     #[test]
     fn unknown_model_errors() {
         let cat = fixture_catalog();

--- a/crates/wcore-providers/src/openai_chatgpt.rs
+++ b/crates/wcore-providers/src/openai_chatgpt.rs
@@ -191,6 +191,41 @@ impl LlmProvider for OpenAIChatGptProvider {
         "openai-chatgpt"
     }
 
+    /// #158 — filter the Codex catalog to what the ChatGPT subscription's plan
+    /// tier can actually run, so the `/model` picker (via `engine_bridge`) does
+    /// not offer models that 4xx on use.
+    ///
+    /// Conservative by construction (never over-filters):
+    /// - We resolve the plan tier by decoding the live OAuth access token's
+    ///   `chatgpt_plan_type` claim. If the bearer fetch fails (offline / not
+    ///   signed in) or the claim is absent/undecodable, the tier is `None` and
+    ///   NOTHING is filtered — the full alias catalog is returned, matching the
+    ///   trait contract that `list_models` must floor to the alias catalog
+    ///   rather than error.
+    /// - The actual subtraction is driven by the conservative, currently-empty
+    ///   `wcore_config::chatgpt_catalog` gating table; an unrecognised tier or
+    ///   model is always shown.
+    ///
+    /// Only this OAuth-subscription provider filters. The API-key OpenAI path
+    /// (`OpenAIProvider`) and every other provider are untouched.
+    async fn list_models(&self) -> anyhow::Result<Vec<crate::ModelInfo>> {
+        let full = crate::alias_models(self.alias_key());
+        // Best-effort plan-tier resolution: any failure → None → show everything.
+        let plan_tier = (self.bearer)()
+            .await
+            .ok()
+            .and_then(|creds| wcore_config::chatgpt_catalog::decode_plan_type(&creds.access_token));
+        Ok(full
+            .into_iter()
+            .filter(|m| {
+                wcore_config::chatgpt_catalog::is_model_available_for_plan(
+                    plan_tier.as_deref(),
+                    &m.id,
+                )
+            })
+            .collect())
+    }
+
     async fn stream(
         &self,
         request: &LlmRequest,
@@ -254,6 +289,35 @@ mod tests {
             ProviderCompat::default(),
             DebugConfig::default(),
         )
+    }
+
+    /// A bearer whose access token is a JWT carrying the given plan claim. Used
+    /// by the #158 `list_models` tier-filter tests.
+    fn bearer_with_plan(plan: &'static str) -> AsyncBearerSource {
+        use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
+        let payload = serde_json::json!({
+            "https://api.openai.com/auth": {
+                "chatgpt_account_id": "acct_test",
+                "chatgpt_plan_type": plan
+            }
+        });
+        let body = URL_SAFE_NO_PAD.encode(serde_json::to_vec(&payload).unwrap());
+        let jwt = format!("h.{body}.s");
+        Arc::new(move || {
+            let jwt = jwt.clone();
+            Box::pin(async move {
+                Ok(BearerCreds {
+                    access_token: jwt,
+                    account_id: "acct_test".into(),
+                })
+            })
+        })
+    }
+
+    /// A bearer that always fails (offline / not signed in). `list_models` must
+    /// still floor to the full alias catalog rather than error.
+    fn failing_bearer() -> AsyncBearerSource {
+        Arc::new(|| Box::pin(async { Err(ProviderError::Connection("offline".into())) }))
     }
 
     fn request_with_tools(tools: Vec<ToolDef>) -> LlmRequest {
@@ -356,5 +420,63 @@ mod tests {
         assert_eq!(with_tools["tool_choice"], json!("auto"));
         assert_eq!(with_tools["parallel_tool_calls"], json!(true));
         assert!(with_tools["tools"].is_array());
+    }
+
+    // --- #158: plan-tier model-catalog filtering ------------------------
+
+    /// The full Codex alias catalog ids, most-capable first.
+    fn full_catalog_ids() -> Vec<String> {
+        crate::alias_models("openai-chatgpt")
+            .into_iter()
+            .map(|m| m.id)
+            .collect()
+    }
+
+    async fn listed_ids(p: &OpenAIChatGptProvider) -> Vec<String> {
+        p.list_models()
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|m| m.id)
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn list_models_with_known_plan_keeps_full_catalog_while_table_empty() {
+        // A signed-in "pro" plan resolves a tier, but the conservative gating
+        // table is empty, so the full Codex catalog is returned (no
+        // over-filtering, no regression).
+        let p = OpenAIChatGptProvider::new(
+            bearer_with_plan("pro"),
+            ProviderCompat::default(),
+            DebugConfig::default(),
+        );
+        assert_eq!(listed_ids(&p).await, full_catalog_ids());
+    }
+
+    #[tokio::test]
+    async fn list_models_with_unrecognised_plan_keeps_full_catalog() {
+        let p = OpenAIChatGptProvider::new(
+            bearer_with_plan("enterprise"),
+            ProviderCompat::default(),
+            DebugConfig::default(),
+        );
+        assert_eq!(listed_ids(&p).await, full_catalog_ids());
+    }
+
+    #[tokio::test]
+    async fn list_models_floors_to_full_catalog_when_bearer_fails() {
+        // Offline / not signed in: the bearer errors, the tier is unknown, and
+        // `list_models` must NOT error — it floors to the full alias catalog.
+        let p = OpenAIChatGptProvider::new(
+            failing_bearer(),
+            ProviderCompat::default(),
+            DebugConfig::default(),
+        );
+        assert_eq!(listed_ids(&p).await, full_catalog_ids());
+        assert!(
+            !full_catalog_ids().is_empty(),
+            "catalog must be non-empty so the picker never renders blank"
+        );
     }
 }

--- a/crates/wcore-providers/src/openai_chatgpt.rs
+++ b/crates/wcore-providers/src/openai_chatgpt.rs
@@ -185,6 +185,77 @@ impl OpenAIChatGptProvider {
     }
 }
 
+/// #158 reactive fallback: turn a Codex backend rejection that is *clearly* a
+/// "your plan can't run this model" refusal into a clear, actionable message.
+///
+/// Returns `Some(message)` ONLY when the rejection body unambiguously concerns
+/// the model/plan (a recognised OpenAI error `code` such as `model_not_found` /
+/// `model_not_supported`, or a body phrase naming a model/access/plan problem).
+/// In every other case it returns `None` so the caller passes the raw body
+/// through unchanged — we do NOT fabricate plan-gate detection out of a generic
+/// 4xx, because the Codex backend's plan refusal is not cleanly distinguishable
+/// from other client errors by status alone.
+///
+/// When the plan tier is known (decoded from the OAuth bearer), the message also
+/// lists what that plan CAN run, reusing the same conservative catalog +
+/// [`is_model_available_for_plan`](wcore_config::chatgpt_catalog::is_model_available_for_plan)
+/// gate that drives the predictive hide — so the two never disagree.
+fn plan_gate_rejection_message(
+    status: u16,
+    body: &str,
+    model: &str,
+    plan_tier: Option<&str>,
+) -> Option<String> {
+    // Only 4xx client rejections are candidates — a 5xx/transient error is not a
+    // plan-gate refusal and must retain its retry semantics.
+    if !(400..500).contains(&status) {
+        return None;
+    }
+    let b = body.to_ascii_lowercase();
+    // Unambiguous model/plan signals only. OpenAI returns these for an unknown
+    // or not-entitled model; the message variants cover the human-readable
+    // "model ... does not exist or you do not have access" / plan phrasings.
+    let model_plan_signal = b.contains("model_not_found")
+        || b.contains("model_not_supported")
+        || b.contains("unsupported_model")
+        || b.contains("does not exist or you do not have access")
+        || b.contains("do not have access to")
+        || (b.contains(&model.to_ascii_lowercase())
+            && (b.contains("plan") || b.contains("not available") || b.contains("access")));
+    if !model_plan_signal {
+        return None;
+    }
+
+    // Compose the "you CAN run" list from the conservative catalog, filtered by
+    // the same plan-gate that drives the predictive hide. With no/unknown plan
+    // tier we can't claim a runnable set, so we keep the message model-scoped.
+    let catalog = crate::alias_models("openai-chatgpt");
+    match plan_tier {
+        Some(plan) => {
+            let runnable: Vec<&str> = catalog
+                .iter()
+                .filter(|m| {
+                    m.id != model
+                        && wcore_config::chatgpt_catalog::is_model_available_for_plan(
+                            Some(plan),
+                            &m.id,
+                        )
+                })
+                .map(|m| m.id.as_str())
+                .collect();
+            Some(format!(
+                "{model} isn't available on your ChatGPT plan ({plan}). \
+                 Models your plan can run: {}.",
+                runnable.join(", ")
+            ))
+        }
+        None => Some(format!(
+            "{model} isn't available on your current ChatGPT plan. \
+             Pick a different model with /model, or upgrade your ChatGPT subscription."
+        )),
+    }
+}
+
 #[async_trait]
 impl LlmProvider for OpenAIChatGptProvider {
     fn alias_key(&self) -> &str {
@@ -250,9 +321,24 @@ impl LlmProvider for OpenAIChatGptProvider {
             if status.as_u16() == 401 {
                 return Err(ProviderError::MissingApiKey);
             }
+            // #158 (reactive fallback) — if the backend clearly rejected the
+            // model BECAUSE the plan can't run it, replace the raw body with a
+            // message that names the model, the plan, and what the plan CAN run.
+            // Only fires when the body unambiguously signals a model/plan issue
+            // (see `plan_gate_rejection_message`); otherwise the body is passed
+            // through unchanged. The plan tier comes from the bearer we already
+            // resolved above.
+            let plan_tier = wcore_config::chatgpt_catalog::decode_plan_type(&creds.access_token);
+            let message = plan_gate_rejection_message(
+                status.as_u16(),
+                &text,
+                &request.model,
+                plan_tier.as_deref(),
+            )
+            .unwrap_or(text);
             return Err(ProviderError::Api {
                 status: status.as_u16(),
-                message: text,
+                message,
             });
         }
 
@@ -442,16 +528,37 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn list_models_with_known_plan_keeps_full_catalog_while_table_empty() {
-        // A signed-in "pro" plan resolves a tier, but the conservative gating
-        // table is empty, so the full Codex catalog is returned (no
-        // over-filtering, no regression).
+    async fn list_models_with_pro_plan_keeps_full_catalog() {
+        // A signed-in "pro" plan CAN run gpt-5.5-pro, so the full Codex catalog
+        // is returned (the gate only subtracts gpt-5.5-pro for `plus`).
         let p = OpenAIChatGptProvider::new(
             bearer_with_plan("pro"),
             ProviderCompat::default(),
             DebugConfig::default(),
         );
         assert_eq!(listed_ids(&p).await, full_catalog_ids());
+    }
+
+    #[tokio::test]
+    async fn list_models_with_plus_plan_hides_gpt_5_5_pro() {
+        // #158 grounded gate: `plus` cannot run gpt-5.5-pro, so the `/model`
+        // picker (which calls list_models) drops it — but keeps every other
+        // Codex model, in order.
+        let p = OpenAIChatGptProvider::new(
+            bearer_with_plan("plus"),
+            ProviderCompat::default(),
+            DebugConfig::default(),
+        );
+        let listed = listed_ids(&p).await;
+        assert!(
+            !listed.contains(&"gpt-5.5-pro".to_string()),
+            "plus must not be offered gpt-5.5-pro: {listed:?}"
+        );
+        let expected: Vec<String> = full_catalog_ids()
+            .into_iter()
+            .filter(|id| id != "gpt-5.5-pro")
+            .collect();
+        assert_eq!(listed, expected, "plus keeps all non-pro models in order");
     }
 
     #[tokio::test]
@@ -462,6 +569,53 @@ mod tests {
             DebugConfig::default(),
         );
         assert_eq!(listed_ids(&p).await, full_catalog_ids());
+    }
+
+    // --- #158 Task C: reactive plan-gate rejection message --------------
+
+    #[test]
+    fn rejection_with_model_code_and_known_plan_names_runnable_set() {
+        // OpenAI's "model not found / no access" envelope + a known plus plan →
+        // a clear message that names the model, the plan, and what plus CAN run.
+        let body = r#"{"error":{"message":"The model `gpt-5.5-pro` does not exist or you do not have access to it.","type":"invalid_request_error","code":"model_not_found"}}"#;
+        let msg =
+            plan_gate_rejection_message(404, body, "gpt-5.5-pro", Some("plus")).expect("plan-gate");
+        assert!(msg.contains("gpt-5.5-pro"));
+        assert!(msg.contains("plus"));
+        // plus can run gpt-5.5 but NOT gpt-5.5-pro — the runnable list reflects
+        // the same gate as the predictive hide.
+        assert!(msg.contains("gpt-5.5"));
+        assert!(
+            !msg.contains("gpt-5.5-pro,") && !msg.ends_with("gpt-5.5-pro."),
+            "the rejected model must not appear in the runnable set: {msg}"
+        );
+    }
+
+    #[test]
+    fn rejection_with_model_code_and_unknown_plan_is_model_scoped() {
+        // No plan tier → we can't claim a runnable set, but still improve the
+        // message (model-scoped + actionable) since the body clearly signals a
+        // model/plan issue.
+        let body = r#"{"error":{"code":"model_not_supported","message":"model not supported"}}"#;
+        let msg = plan_gate_rejection_message(403, body, "gpt-5.5-pro", None).expect("plan-gate");
+        assert!(msg.contains("gpt-5.5-pro"));
+        assert!(msg.contains("/model") || msg.contains("upgrade"));
+    }
+
+    #[test]
+    fn unrelated_4xx_is_left_unchanged() {
+        // A generic bad-request body that does NOT clearly concern the model/plan
+        // must NOT be rewritten — we don't fabricate plan-gate detection.
+        let body = r#"{"error":{"message":"Invalid value for 'temperature'.","type":"invalid_request_error","code":"invalid_value"}}"#;
+        assert!(plan_gate_rejection_message(400, body, "gpt-5.5", Some("plus")).is_none());
+    }
+
+    #[test]
+    fn server_error_is_never_treated_as_plan_gate() {
+        // A 5xx (even one that happens to mention the model) is transient and
+        // must retain retry semantics — never rewritten as a plan refusal.
+        let body = r#"{"error":{"message":"gpt-5.5-pro upstream had a plan glitch"}}"#;
+        assert!(plan_gate_rejection_message(503, body, "gpt-5.5-pro", Some("plus")).is_none());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## #158 ChatGPT-subscription model filtering + #240 MiniMax cost catalog

Two launch-substance additions for 0.12.6, gated green (clippy clean, fmt clean, 9026 tests) with a focused adversarial review (no over-filter, no false-positive errors, AGENTS.md compliant).

### #158 — ChatGPT-sub picker shows models the plan can't run
Two-part fix (predictive hide + reactive fallback), built to **never over-filter** (hiding a model the user CAN run is worse than the annoyance):
- **Predictive hide:** the ChatGPT-OAuth model catalog (`/model` surface) filters by plan tier. Conservative, data-driven gate in `wcore-config` (`chatgpt_catalog.rs`): the single grounded entry is `gpt-5.5-pro` → hidden only for the recognized `plus` tier. Unknown/missing/`free` tiers show the **full** catalog (no regression). `list_models()` never hard-fails (offline/malformed-token → full catalog).
- **Reactive fallback (covers ALL surfaces incl the cache-backed picker):** when the Codex backend rejects a model the plan can't run, the error is rewritten to a clear, actionable message naming the model + plan + what the plan CAN run — but only on a narrow, code/phrase-gated 4xx match (5xx passes through unchanged; unrelated 4xx unchanged). Predictive hide and the reactive "you can run" list share one source of truth, so they can't disagree.
- Picker pre-hide plumbing (threading the plan into the cache-backed discovery refresh) is intentionally **deferred** — it crosses the wcore-config/wcore-agent OAuth-token boundary and is non-localized; the reactive fallback covers that surface gracefully.

### #240 — MiniMax cost estimates fell back to heuristic
Added `[minimax.MiniMax-M2]` to the bundled pricing catalog at the **official** PAYG rate ($0.30/$1.20 per MTok, verified at platform.minimax.io). MiniMax cost estimates now use real per-token pricing instead of the 0.0 heuristic. Data-only + a resolution test.

Refs #158, #240, #135, #236.
