### PR TITLE
fix: OpenAI image default (gpt-image-1) + DeepSeek v4-flash 1M context (#265, #255)

### DIFF
--- a/crates/wcore-agent/src/tool_backends/image_gen.rs
+++ b/crates/wcore-agent/src/tool_backends/image_gen.rs
@@ -3,7 +3,7 @@
 //! Wires the existing `ImageGenerationBackend` trait (in
 //! `wcore-tools/src/image_generation_tool.rs`) to five real providers:
 //!
-//! 1. **OpenAI DALL-E 3** (`OPENAI_API_KEY`)
+//! 1. **OpenAI image** (`OPENAI_API_KEY`; `gpt-image-1` default, configurable)
 //! 2. **FAL FLUX schnell** (`FAL_API_KEY`)
 //! 3. **Gemini Imagen 3** (`GEMINI_API_KEY`)
 //! 4. **Hugging Face FLUX** (`HF_API_KEY`)
@@ -48,7 +48,7 @@ const HF_PER_CALL_TIMEOUT: Duration = Duration::from_secs(90);
 /// and config.
 ///
 /// Priority order (first match wins):
-/// 1. `OPENAI_API_KEY` → OpenAI DALL-E 3
+/// 1. `OPENAI_API_KEY` → OpenAI image (`gpt-image-1` default)
 /// 2. `FAL_API_KEY` → FAL FLUX schnell
 /// 3. `GEMINI_API_KEY` → Gemini Imagen 3
 /// 4. `HF_API_KEY` → Hugging Face FLUX
@@ -61,8 +61,12 @@ pub fn build_image_gen_backend(
     allow_pollinations: bool,
 ) -> Option<Arc<dyn ImageGenerationBackend>> {
     if let Some(key) = read_env_key("OPENAI_API_KEY") {
-        tracing::info!("image_gen: using OpenAI DALL-E 3 (OPENAI_API_KEY found)");
-        return Some(Arc::new(DalleBackend::new(key)));
+        let backend = DalleBackend::new(key);
+        tracing::info!(
+            "image_gen: using OpenAI {} (OPENAI_API_KEY found)",
+            backend.model
+        );
+        return Some(Arc::new(backend));
     }
     if let Some(key) = read_env_key("FAL_API_KEY") {
         tracing::info!("image_gen: using FAL FLUX schnell (FAL_API_KEY found)");
@@ -190,16 +194,38 @@ fn prompt_contains_email_pii(prompt: &str) -> bool {
 }
 
 // ---------------------------------------------------------------------
-// 1. OpenAI DALL-E 3
+// 1. OpenAI image generation (gpt-image-1 default; dall-e-3 configurable)
 // ---------------------------------------------------------------------
 
-/// OpenAI DALL-E 3 backend. Endpoint: `/v1/images/generations`. Supported
-/// sizes: `1024x1024` (square), `1792x1024` (landscape), `1024x1792`
-/// (portrait). Response shape: `{ "data": [{ "url": "..." }] }`.
+/// Default OpenAI image model. `gpt-image-1` is the current broadly-available
+/// model; `dall-e-3` is region/tier-gated and returns HTTP 400
+/// (`model does not exist`) on accounts that lack it (#265). Override per-account
+/// with the `OPENAI_IMAGE_MODEL` env var or [`DalleBackend::with_model`].
+pub const DEFAULT_OPENAI_IMAGE_MODEL: &str = "gpt-image-1";
+
+/// Resolve the OpenAI image model: the `OPENAI_IMAGE_MODEL` env var if set and
+/// non-empty, else [`DEFAULT_OPENAI_IMAGE_MODEL`]. Lets a user who only has
+/// `dall-e-3` (or a newer model) point the backend at it without a code change.
+fn openai_image_model_from_env() -> String {
+    std::env::var("OPENAI_IMAGE_MODEL")
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| DEFAULT_OPENAI_IMAGE_MODEL.to_string())
+}
+
+/// OpenAI image-generation backend. Endpoint: `/v1/images/generations`. The
+/// request size/quality and the response shape both depend on the model:
+/// `gpt-image-1` uses `1024x1024` / `1536x1024` / `1024x1536` and returns
+/// base64 (`data[0].b64_json`); `dall-e-3` uses `1024x1024` / `1792x1024` /
+/// `1024x1792`, accepts `quality`, and returns a URL (`data[0].url`). Both
+/// response shapes are handled.
 pub struct DalleBackend {
     client: Client,
     api_key: String,
     endpoint: String,
+    /// Model sent in the request body. Defaults via [`openai_image_model_from_env`].
+    model: String,
 }
 
 impl DalleBackend {
@@ -208,7 +234,14 @@ impl DalleBackend {
             client: build_ssrf_safe_tool_client(),
             api_key,
             endpoint: "https://api.openai.com/v1/images/generations".to_string(),
+            model: openai_image_model_from_env(),
         }
+    }
+
+    /// Override the model (e.g. `"dall-e-3"` for accounts that have it).
+    pub fn with_model(mut self, model: impl Into<String>) -> Self {
+        self.model = model.into();
+        self
     }
 
     #[cfg(test)]
@@ -217,23 +250,46 @@ impl DalleBackend {
             client: build_ssrf_safe_tool_client(),
             api_key,
             endpoint,
+            model: DEFAULT_OPENAI_IMAGE_MODEL.to_string(),
         }
     }
 
-    fn size_for(req: &ImageGenerationRequest) -> &'static str {
-        match req.aspect_ratio {
-            "square" => "1024x1024",
-            "portrait" => "1024x1792",
-            // landscape (default) or unknown
-            _ => "1792x1024",
+    /// `gpt-image-1` (and the `gpt-image-*` family) use a different size table
+    /// than `dall-e-*` and reject the `quality: "standard"` value.
+    fn is_gpt_image(&self) -> bool {
+        self.model.starts_with("gpt-image")
+    }
+
+    fn size_for(&self, req: &ImageGenerationRequest) -> &'static str {
+        if self.is_gpt_image() {
+            match req.aspect_ratio {
+                "square" => "1024x1024",
+                "portrait" => "1024x1536",
+                _ => "1536x1024",
+            }
+        } else {
+            match req.aspect_ratio {
+                "square" => "1024x1024",
+                "portrait" => "1024x1792",
+                // landscape (default) or unknown
+                _ => "1792x1024",
+            }
         }
     }
 
-    fn dimensions_for(req: &ImageGenerationRequest) -> (u32, u32) {
-        match req.aspect_ratio {
-            "square" => (1024, 1024),
-            "portrait" => (1024, 1792),
-            _ => (1792, 1024),
+    fn dimensions_for(&self, req: &ImageGenerationRequest) -> (u32, u32) {
+        if self.is_gpt_image() {
+            match req.aspect_ratio {
+                "square" => (1024, 1024),
+                "portrait" => (1024, 1536),
+                _ => (1536, 1024),
+            }
+        } else {
+            match req.aspect_ratio {
+                "square" => (1024, 1024),
+                "portrait" => (1024, 1792),
+                _ => (1792, 1024),
+            }
         }
     }
 }
@@ -244,15 +300,21 @@ impl ImageGenerationBackend for DalleBackend {
         &self,
         request: ImageGenerationRequest,
     ) -> Result<ImageGenerationResponse, ImageGenerationError> {
-        let size = Self::size_for(&request);
-        let (w, h) = Self::dimensions_for(&request);
-        let body = serde_json::json!({
-            "model": "dall-e-3",
+        let size = self.size_for(&request);
+        let (w, h) = self.dimensions_for(&request);
+        let mut body = serde_json::json!({
+            "model": self.model,
             "prompt": request.prompt,
             "size": size,
-            "quality": "standard",
             "n": 1,
         });
+        // `dall-e-*` accept `quality: "standard"|"hd"`; `gpt-image-1` rejects
+        // `"standard"` (it uses `low|medium|high|auto`, defaulting to auto), so
+        // only send the field for the dall-e family.
+        if !self.is_gpt_image() {
+            body["quality"] = serde_json::json!("standard");
+        }
+        let model = self.model.clone();
         let endpoint = self.endpoint.clone();
         let api_key = self.api_key.clone();
         let client = self.client.clone();
@@ -276,20 +338,32 @@ impl ImageGenerationBackend for DalleBackend {
                 return Err(map_http_error(status.as_u16(), &txt, "openai dall-e"));
             }
             let parsed: Value = serde_json::from_str(&txt).map_err(|e| {
-                ImageGenerationError::Other(format!("openai dall-e JSON parse: {e}"))
+                ImageGenerationError::Other(format!("openai image JSON parse: {e}"))
             })?;
-            let url = parsed
-                .pointer("/data/0/url")
+            // Response shape is model-dependent: dall-e-* return `data[0].url`,
+            // gpt-image-1 returns `data[0].b64_json` (base64, no URL). Accept
+            // either — a base64 payload is wrapped as a `data:` URI, matching the
+            // Gemini/HF backends.
+            let data0 = parsed.pointer("/data/0");
+            let image = if let Some(url) = data0
+                .and_then(|d| d.pointer("/url"))
                 .and_then(|v| v.as_str())
-                .map(str::to_string)
-                .ok_or_else(|| {
-                    ImageGenerationError::Other(
-                        "openai dall-e: missing data[0].url in response".to_string(),
-                    )
-                })?;
+            {
+                url.to_string()
+            } else if let Some(b64) = data0
+                .and_then(|d| d.pointer("/b64_json"))
+                .and_then(|v| v.as_str())
+            {
+                format!("data:image/png;base64,{b64}")
+            } else {
+                return Err(ImageGenerationError::Other(
+                    "openai image: missing both data[0].url and data[0].b64_json in response"
+                        .to_string(),
+                ));
+            };
             Ok(ImageGenerationResponse {
-                image: url,
-                used_provider: "OpenAI DALL-E 3".to_string(),
+                image,
+                used_provider: format!("OpenAI {model}"),
                 width: w,
                 height: h,
             })
@@ -786,9 +860,59 @@ mod tests {
             .await
             .expect("happy path");
         assert_eq!(resp.image, "https://example.com/dalle.png");
-        assert_eq!(resp.used_provider, "OpenAI DALL-E 3");
-        assert_eq!(resp.width, 1792);
+        // with_endpoint defaults to gpt-image-1; the `url` response path still
+        // works (any model that returns a URL is handled).
+        assert_eq!(resp.used_provider, "OpenAI gpt-image-1");
+        assert_eq!(resp.width, 1536);
         assert_eq!(resp.height, 1024);
+    }
+
+    #[tokio::test]
+    async fn openai_b64_json_response_wrapped_as_data_uri() {
+        // Regression for #265: gpt-image-1 returns base64, not a URL. The backend
+        // must wrap `data[0].b64_json` as a `data:` URI rather than error on the
+        // missing `url`.
+        let server = MockServer::start().await;
+        let b64 = base64::engine::general_purpose::STANDARD.encode(b"\x89PNG\r\n\x1a\nfake");
+        Mock::given(method("POST"))
+            .and(path("/v1/images/generations"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": [{ "b64_json": b64 }]
+            })))
+            .mount(&server)
+            .await;
+        let backend = DalleBackend::with_endpoint(
+            "sk-test".to_string(),
+            format!("{}/v1/images/generations", server.uri()),
+        );
+        let resp = backend
+            .generate(req("a sunset", "landscape"))
+            .await
+            .expect("b64_json path");
+        assert!(
+            resp.image.starts_with("data:image/png;base64,"),
+            "gpt-image-1 base64 must become a data URI, got: {}",
+            resp.image
+        );
+        assert_eq!(resp.used_provider, "OpenAI gpt-image-1");
+    }
+
+    #[test]
+    fn openai_default_model_is_gpt_image_1_and_overridable() {
+        // Regression for #265: the default must NOT be dall-e-3.
+        let backend = DalleBackend::with_endpoint(
+            "sk-test".to_string(),
+            "https://unused.example.com/v1/images/generations".to_string(),
+        );
+        assert_eq!(backend.model, DEFAULT_OPENAI_IMAGE_MODEL);
+        assert_eq!(backend.model, "gpt-image-1");
+        let overridden = DalleBackend::with_endpoint(
+            "sk-test".to_string(),
+            "https://unused.example.com/v1/images/generations".to_string(),
+        )
+        .with_model("dall-e-3");
+        assert_eq!(overridden.model, "dall-e-3");
+        assert!(!overridden.is_gpt_image());
     }
 
     #[tokio::test]
@@ -980,18 +1104,23 @@ mod tests {
 
     #[test]
     fn aspect_ratio_maps_correctly_per_provider() {
-        let cases: &[(&str, &str, &str)] = &[
-            // (input aspect, DALL-E expected size, FAL expected aspect)
-            ("square", "1024x1024", "square_hd"),
-            ("landscape", "1792x1024", "landscape_16_9"),
-            ("portrait", "1024x1792", "portrait_4_3"),
+        // gpt-image-1 and dall-e-3 use different size tables (#265).
+        let gpt = DalleBackend::with_endpoint("k".to_string(), "http://unused".to_string());
+        let dalle = DalleBackend::with_endpoint("k".to_string(), "http://unused".to_string())
+            .with_model("dall-e-3");
+        let cases: &[(&str, &str, &str, &str)] = &[
+            // (input aspect, gpt-image-1 size, dall-e-3 size, FAL aspect)
+            ("square", "1024x1024", "1024x1024", "square_hd"),
+            ("landscape", "1536x1024", "1792x1024", "landscape_16_9"),
+            ("portrait", "1024x1536", "1024x1792", "portrait_4_3"),
         ];
-        for (aspect, dalle_size, fal_aspect) in cases {
+        for (aspect, gpt_size, dalle_size, fal_aspect) in cases {
             let r = req("x", aspect);
+            assert_eq!(gpt.size_for(&r), *gpt_size, "gpt-image-1 size for {aspect}");
             assert_eq!(
-                DalleBackend::size_for(&r),
+                dalle.size_for(&r),
                 *dalle_size,
-                "DALL-E size for {aspect}"
+                "dall-e-3 size for {aspect}"
             );
             assert_eq!(
                 FalFluxBackend::fal_aspect(&r),
@@ -1018,18 +1147,15 @@ mod tests {
 
     #[test]
     fn dalle_dimensions_match_size_table() {
-        assert_eq!(
-            DalleBackend::dimensions_for(&req("x", "square")),
-            (1024, 1024)
-        );
-        assert_eq!(
-            DalleBackend::dimensions_for(&req("x", "landscape")),
-            (1792, 1024)
-        );
-        assert_eq!(
-            DalleBackend::dimensions_for(&req("x", "portrait")),
-            (1024, 1792)
-        );
+        let gpt = DalleBackend::with_endpoint("k".to_string(), "http://unused".to_string());
+        let dalle = DalleBackend::with_endpoint("k".to_string(), "http://unused".to_string())
+            .with_model("dall-e-3");
+        assert_eq!(gpt.dimensions_for(&req("x", "square")), (1024, 1024));
+        assert_eq!(gpt.dimensions_for(&req("x", "landscape")), (1536, 1024));
+        assert_eq!(gpt.dimensions_for(&req("x", "portrait")), (1024, 1536));
+        assert_eq!(dalle.dimensions_for(&req("x", "square")), (1024, 1024));
+        assert_eq!(dalle.dimensions_for(&req("x", "landscape")), (1792, 1024));
+        assert_eq!(dalle.dimensions_for(&req("x", "portrait")), (1024, 1792));
     }
 
     // -- FAL happy path --

--- a/crates/wcore-agent/src/tool_backends/image_gen.rs
+++ b/crates/wcore-agent/src/tool_backends/image_gen.rs
@@ -335,7 +335,20 @@ impl ImageGenerationBackend for DalleBackend {
                 .await
                 .map_err(|e| ImageGenerationError::Other(format!("openai dall-e body: {e}")))?;
             if !status.is_success() {
-                return Err(map_http_error(status.as_u16(), &txt, "openai dall-e"));
+                let code = status.as_u16();
+                // gpt-image-1 (the new default) needs a verified OpenAI org; an
+                // account that only has dall-e-3 access gets 403 (or a 400 model
+                // error). Signpost the OPENAI_IMAGE_MODEL escape hatch so the user
+                // can switch back without reading the source (#265 follow-up).
+                if code == 403 || (code == 400 && txt.to_ascii_lowercase().contains("model")) {
+                    let preview: String = txt.chars().take(300).collect();
+                    return Err(ImageGenerationError::Other(format!(
+                        "openai image model {model:?} returned HTTP {code}: {preview}. If your \
+                         account lacks access to {model:?}, set OPENAI_IMAGE_MODEL to a model you \
+                         can use (e.g. dall-e-3)."
+                    )));
+                }
+                return Err(map_http_error(code, &txt, "openai image"));
             }
             let parsed: Value = serde_json::from_str(&txt).map_err(|e| {
                 ImageGenerationError::Other(format!("openai image JSON parse: {e}"))
@@ -746,7 +759,7 @@ impl ImageGenerationBackend for PollinationsBackend {
 mod tests {
     use super::*;
     use serial_test::serial;
-    use wiremock::matchers::{header, method, path};
+    use wiremock::matchers::{body_json, header, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     // -- env-var hygiene ------------------------------------------------
@@ -913,6 +926,90 @@ mod tests {
         .with_model("dall-e-3");
         assert_eq!(overridden.model, "dall-e-3");
         assert!(!overridden.is_gpt_image());
+    }
+
+    #[tokio::test]
+    async fn openai_request_body_is_model_aware() {
+        // #265 root-cause assertion: the request body actually sent on the wire
+        // must be model-aware. wiremock `body_json` is an EXACT match, so the
+        // call only succeeds if the body is byte-for-byte what we assert — which
+        // also proves `quality` is OMITTED for gpt-image-1 (an extra field would
+        // fail the exact match) and PRESENT for dall-e-3.
+        let server = MockServer::start().await;
+        // gpt-image-1 (default): no `quality`, gpt-image size table.
+        Mock::given(method("POST"))
+            .and(path("/gpt/v1/images/generations"))
+            .and(body_json(serde_json::json!({
+                "model": "gpt-image-1",
+                "prompt": "a sunset",
+                "size": "1536x1024",
+                "n": 1,
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": [{ "url": "https://example.com/x.png" }]
+            })))
+            .mount(&server)
+            .await;
+        // dall-e-3: includes `quality: standard`, dall-e size table.
+        Mock::given(method("POST"))
+            .and(path("/dalle/v1/images/generations"))
+            .and(body_json(serde_json::json!({
+                "model": "dall-e-3",
+                "prompt": "a sunset",
+                "size": "1792x1024",
+                "quality": "standard",
+                "n": 1,
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": [{ "url": "https://example.com/y.png" }]
+            })))
+            .mount(&server)
+            .await;
+
+        let gpt = DalleBackend::with_endpoint(
+            "sk-test".to_string(),
+            format!("{}/gpt/v1/images/generations", server.uri()),
+        );
+        gpt.generate(req("a sunset", "landscape"))
+            .await
+            .expect("gpt-image-1 body must match exactly (no `quality`, 1536x1024)");
+
+        let dalle = DalleBackend::with_endpoint(
+            "sk-test".to_string(),
+            format!("{}/dalle/v1/images/generations", server.uri()),
+        )
+        .with_model("dall-e-3");
+        dalle
+            .generate(req("a sunset", "landscape"))
+            .await
+            .expect("dall-e-3 body must match exactly (quality=standard, 1792x1024)");
+    }
+
+    #[tokio::test]
+    async fn openai_403_surfaces_image_model_escape_hatch() {
+        // #265: an org without gpt-image-1 access gets 403; the error must point
+        // the user at OPENAI_IMAGE_MODEL rather than dead-ending.
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(
+                ResponseTemplate::new(403)
+                    .set_body_string("{\"error\":{\"message\":\"forbidden\"}}"),
+            )
+            .mount(&server)
+            .await;
+        let backend = DalleBackend::with_endpoint(
+            "sk-test".to_string(),
+            format!("{}/v1/images/generations", server.uri()),
+        );
+        let err = backend
+            .generate(req("a sunset", "landscape"))
+            .await
+            .expect_err("403 must surface as an error");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("OPENAI_IMAGE_MODEL"),
+            "403 error must signpost the OPENAI_IMAGE_MODEL escape hatch, got: {msg}"
+        );
     }
 
     #[tokio::test]

--- a/crates/wcore-config/src/limits.rs
+++ b/crates/wcore-config/src/limits.rs
@@ -56,6 +56,21 @@ pub fn model_output_ceiling(_provider: &str, model: &str) -> Option<(u32, u32)> 
         return Some((64_000, 131_072));
     }
 
+    // --- DeepSeek V4-Flash family (1,000,000-token context) ---
+    // Fixes #255: with no entry, deepseek-v4-flash fell to the unknown-model
+    // floor (8_192 output) and its 1M context window was never consulted.
+    // Verified against api-docs.deepseek.com (2026-06-23): deepseek-v4-flash is
+    // the canonical id; `deepseek-chat` / `deepseek-reasoner` are its (deprecated)
+    // non-thinking / thinking aliases that map to the SAME model, so all three
+    // share the 1,000,000 context window. Output ceiling is held at the
+    // conservative 8_192 — the documented max is far higher, but this table errs
+    // LOW on purpose (undersizing costs a continuation round; over-claiming 400s
+    // — see the module header). Exact id checks (not a bare `deepseek` prefix)
+    // so `deepseek-v4-pro` / a future `deepseek-v5` won't inherit these limits.
+    if m.contains("deepseek-v4-flash") || m == "deepseek-chat" || m == "deepseek-reasoner" {
+        return Some((8_192, 1_000_000));
+    }
+
     None
 }
 
@@ -107,5 +122,30 @@ mod tests {
         assert_eq!(model_output_ceiling("flux-router", "flux-standard"), None);
         assert_eq!(model_output_ceiling("openai", "some-future-model"), None);
         assert_eq!(model_output_ceiling("ollama", "llama3.1"), None);
+    }
+
+    #[test]
+    fn deepseek_v4_flash_family_uses_1m_context_window() {
+        // #255: the canonical id and both deprecated aliases share the 1M window.
+        for id in ["deepseek-v4-flash", "deepseek-chat", "deepseek-reasoner"] {
+            assert_eq!(
+                model_output_ceiling("deepseek", id),
+                Some((8_192, 1_000_000)),
+                "{id} must report the 1,000,000-token context window"
+            );
+        }
+        // Case-insensitive match (the lookup lowercases first).
+        assert_eq!(
+            model_output_ceiling("deepseek", "DeepSeek-V4-Flash"),
+            Some((8_192, 1_000_000))
+        );
+    }
+
+    #[test]
+    fn deepseek_unmapped_variants_fail_open() {
+        // v4-pro is a distinct model; a future v5 is unknown — neither may
+        // inherit v4-flash's limits (the id checks are intentionally specific).
+        assert_eq!(model_output_ceiling("deepseek", "deepseek-v4-pro"), None);
+        assert_eq!(model_output_ceiling("deepseek", "deepseek-v5"), None);
     }
 }


### PR DESCRIPTION
Two independent, user-reported provider/catalog fixes. No dependency on the in-flight isolated-profiles work (split out for a fast patch).

## #265 — OpenAI image generation 400s on `dall-e-3`
`DalleBackend` hardcoded `"model": "dall-e-3"`, which returns HTTP 400 (`model does not exist`) on accounts/regions where it isn't enabled.

- Default to **`gpt-image-1`** (broadly available), overridable via the `OPENAI_IMAGE_MODEL` env var or `DalleBackend::with_model`.
- **Model-aware** size/quality: `gpt-image-1` uses `1024x1024` / `1536x1024` / `1024x1536` and rejects `quality: "standard"` (omitted for it; kept for `dall-e-*`).
- **Both response shapes** handled: `dall-e-*` return `data[0].url`; `gpt-image-1` returns `data[0].b64_json` (now wrapped as a `data:` URI, matching the Gemini/HF backends).
- New tests: default-model regression, `with_model` override, and a `b64_json` round-trip.

## #255 — `deepseek-v4-flash` capped at the unknown-model floor instead of its 1M window
`limits.rs::model_output_ceiling` had no DeepSeek arm, so `deepseek-v4-flash` fell to the `(8_192, unknown)` floor and its **1,000,000-token context window was never consulted**.

- Add the arm: `deepseek-v4-flash` → `(8_192, 1_000_000)`. Verified against api-docs.deepseek.com that `deepseek-chat` / `deepseek-reasoner` are **deprecated aliases of v4-flash** (non-thinking / thinking) and share the window, so all three map together. Output ceiling held at the conservative `8_192` per this table's documented err-low policy (over-claiming output 400s).
- `deepseek-v4-pro` and a hypothetical `deepseek-v5` deliberately stay unmapped (fail open).

## Verification
Hetzner-gated green as part of the parent branch: `cargo fmt`/`clippy -D warnings` clean for `wcore-agent` + `wcore-config`; the new image_gen + limits tests pass. CI here validates all platforms.