### PR TITLE
feat: isolated profiles — CLI-isolation slice (Phase 0 + 1 + 3A + 2)

### DIFF
--- a/crates/wcore-agent/src/plugins/loader.rs
+++ b/crates/wcore-agent/src/plugins/loader.rs
@@ -928,16 +928,15 @@ pub fn classify_runtime(
 ///    This is an explicit operator override: it REPLACES the default roots
 ///    (preserving the single-dir test isolation the on-disk discovery tests
 ///    rely on, and letting an operator pin discovery to one directory).
-/// 2. Otherwise → return both default roots, in order, de-duplicated:
-///    first [`PluginIdentity::default_plugin_root`]
-///    (`<data_dir>/wayland/plugins`), then `profile_home()/plugins` (the C3
-///    profile home, i.e. `~/.wayland/plugins`, where a declarative plugin
-///    installed by IJFW's installer lands).
+/// 2. Otherwise → resolve `default_plugin_root()` then `profile_home()/plugins`,
+///    de-duplicated. Post-isolation-sweep [`PluginIdentity::default_plugin_root`]
+///    is itself `<WAYLAND_HOME or ~/.wayland>/plugins`, so it coincides with
+///    `profile_home()/plugins` and the two collapse to a single root (where a
+///    declarative plugin installed by IJFW's installer lands).
 ///
 /// Each returned root is its OWN security anchor in [`PluginLoader::discover_on_disk`]:
 /// the per-root path-prefix gate + symlink defense apply identically to every
-/// root. The profile-home root is the same trust class (user-controlled home
-/// location) as the data-dir root.
+/// root (all are the same user-controlled-home trust class).
 ///
 /// May return an empty `Vec` only in the vanishingly rare case where the env
 /// var is unset AND `default_plugin_root()` somehow coincides after dedup with
@@ -1125,9 +1124,10 @@ mod tests {
     // `resolved_plugins_roots()` must:
     // - return ONLY the override dir when `$WAYLAND_PLUGINS_DIR` is set
     //   (preserving single-dir test isolation), and
-    // - return BOTH `default_plugin_root()` and `profile_home()/plugins`
-    //   when the override is unset (so an IJFW-installed declarative plugin
-    //   under `~/.wayland/plugins` is reachable).
+    // - resolve `default_plugin_root()` + `profile_home()/plugins` when the
+    //   override is unset; post-isolation-sweep these coincide and dedup to a
+    //   single `<WAYLAND_HOME or ~/.wayland>/plugins` root (so an IJFW-installed
+    //   declarative plugin under `~/.wayland/plugins` is reachable).
     // -----------------------------------------------------------------
 
     #[test]
@@ -1151,9 +1151,12 @@ mod tests {
 
     #[test]
     #[serial_test::serial]
-    fn resolved_plugins_roots_default_includes_data_dir_and_profile_home() {
-        // SAFETY: env mutation is serialized by `#[serial_test::serial]`.
-        // Both vars are saved + restored around the body.
+    fn resolved_plugins_roots_default_is_single_profile_home_root() {
+        // After the isolation sweep `default_plugin_root()` == `profile_home()/plugins`,
+        // so the two pushes in `resolved_plugins_roots()` collapse via `push_unique`
+        // to a SINGLE root rooted under WAYLAND_HOME.
+        // SAFETY: env mutation is serialized by `#[serial_test::serial]`; both vars
+        // are saved + restored around the body.
         let saved_plugins = std::env::var_os(ENV_PLUGINS_DIR);
         let saved_home = std::env::var_os("WAYLAND_HOME");
         let home = TempDir::new().unwrap();
@@ -1176,20 +1179,20 @@ mod tests {
             }
         }
 
-        let expected_data = PluginIdentity::default_plugin_root();
-        let expected_profile = home.path().join("plugins");
+        // Compute the expectation from the pinned home (NOT from
+        // default_plugin_root() after restore — its result now depends on the
+        // restored WAYLAND_HOME).
+        let expected = home.path().join("plugins");
         assert!(
-            roots.contains(&expected_data),
-            "default roots must include data-dir root {expected_data:?}; got {roots:?}"
+            roots.contains(&expected),
+            "default roots must include the profile-home plugins root {expected:?}; got {roots:?}"
         );
-        assert!(
-            roots.contains(&expected_profile),
-            "default roots must include profile-home root {expected_profile:?}; got {roots:?}"
+        // default_plugin_root() and profile_home()/plugins now coincide → deduped.
+        assert_eq!(
+            roots.iter().filter(|r| *r == &expected).count(),
+            1,
+            "the two former-distinct roots must dedup to ONE entry; got {roots:?}"
         );
-        // data_dir first, then profile_home (order preserved).
-        let di = roots.iter().position(|r| r == &expected_data).unwrap();
-        let pi = roots.iter().position(|r| r == &expected_profile).unwrap();
-        assert!(di < pi, "data-dir root must precede profile-home root");
     }
 
     // -----------------------------------------------------------------

--- a/crates/wcore-agent/src/plugins/sig_verifier.rs
+++ b/crates/wcore-agent/src/plugins/sig_verifier.rs
@@ -52,15 +52,19 @@ impl std::fmt::Display for KeySource {
 /// Resolve the trust-anchor directory.
 ///
 /// 1. `$WAYLAND_TRUSTED_KEYS_DIR` if set.
-/// 2. `~/.wayland/trusted-keys` otherwise.
-/// 3. `None` if neither is resolvable (no `$HOME`).
+/// 2. `<WAYLAND_HOME or ~/.wayland>/trusted-keys` otherwise.
+///
+/// Isolation: the fallback routes through `wcore_config::config::profile_home()`
+/// so each profile has its OWN trust-anchor set (a key trusted in profile A
+/// must not validate plugins in profile B). Byte-identical to
+/// `~/.wayland/trusted-keys` when `WAYLAND_HOME` is unset.
 pub fn trusted_keys_dir() -> Option<PathBuf> {
     if let Ok(d) = std::env::var(ENV_TRUSTED_KEYS_DIR)
         && !d.is_empty()
     {
         return Some(PathBuf::from(d));
     }
-    dirs::home_dir().map(|h| h.join(".wayland").join("trusted-keys"))
+    Some(wcore_config::config::profile_home().join("trusted-keys"))
 }
 
 /// Load every `*.pub` file in `dir` as a raw 32-byte ed25519 public key,
@@ -236,6 +240,48 @@ mod tests {
     use ed25519_dalek::{SigningKey, ed25519::signature::Signer};
     use rand::rngs::OsRng;
     use tempfile::TempDir;
+
+    /// Isolation (Phase 0): the trust-anchor dir follows `WAYLAND_HOME` so each
+    /// profile has its OWN trust set, and the explicit `$WAYLAND_TRUSTED_KEYS_DIR`
+    /// override still wins over it.
+    #[test]
+    #[serial_test::serial(wayland_home_env)]
+    fn trusted_keys_dir_follows_wayland_home_and_env_override() {
+        let wh = "WAYLAND_HOME";
+        let tk = ENV_TRUSTED_KEYS_DIR;
+        let prev_wh = std::env::var_os(wh);
+        let prev_tk = std::env::var_os(tk);
+        // 1. Fallback roots under WAYLAND_HOME (per-profile trust set).
+        unsafe {
+            std::env::remove_var(tk);
+            std::env::set_var(wh, "/tmp/wl-trust-test");
+        }
+        assert_eq!(
+            trusted_keys_dir(),
+            Some(PathBuf::from("/tmp/wl-trust-test").join("trusted-keys")),
+            "fallback must follow WAYLAND_HOME"
+        );
+        // 2. Explicit override still wins over WAYLAND_HOME.
+        unsafe {
+            std::env::set_var(tk, "/tmp/explicit-trust");
+        }
+        assert_eq!(
+            trusted_keys_dir(),
+            Some(PathBuf::from("/tmp/explicit-trust")),
+            "WAYLAND_TRUSTED_KEYS_DIR must win over WAYLAND_HOME"
+        );
+        // restore
+        unsafe {
+            match prev_wh {
+                Some(v) => std::env::set_var(wh, v),
+                None => std::env::remove_var(wh),
+            }
+            match prev_tk {
+                Some(v) => std::env::set_var(tk, v),
+                None => std::env::remove_var(tk),
+            }
+        }
+    }
 
     fn make_key() -> SigningKey {
         SigningKey::generate(&mut OsRng)

--- a/crates/wcore-agent/src/plugins/var_subst.rs
+++ b/crates/wcore-agent/src/plugins/var_subst.rs
@@ -29,14 +29,19 @@ pub struct PluginPathCtx {
 impl PluginPathCtx {
     /// Build the standard context for a plugin installed at `install_dir`.
     /// `${CLAUDE_PLUGIN_DATA}` resolves to
-    /// `<data_dir>/wayland/plugins/data/<sanitized-plugin-name>`.
+    /// `<profile_home>/plugins/data/<sanitized-plugin-name>` so it is
+    /// sandboxed by `WAYLAND_HOME`. On first access a one-time best-effort
+    /// migration copies the pre-isolation
+    /// `<data_dir>/wayland/plugins/data/<name>` tree here — but ONLY when
+    /// `WAYLAND_HOME` is unset (an isolated profile must not inherit
+    /// another profile's live plugin state / secrets).
     pub fn for_plugin(install_dir: &Path, plugin_name: &str, project: &Path) -> Self {
-        let data = dirs::data_dir()
-            .unwrap_or_else(|| install_dir.to_path_buf())
-            .join("wayland")
+        let safe_name = sanitize(plugin_name);
+        let data = wcore_config::config::profile_home()
             .join("plugins")
             .join("data")
-            .join(sanitize(plugin_name));
+            .join(&safe_name);
+        migrate_legacy_plugin_data(&safe_name, &data);
         Self {
             root: install_dir.to_path_buf(),
             data,
@@ -105,10 +110,174 @@ fn sanitize(s: &str) -> String {
         .collect()
 }
 
+/// One-time best-effort migration of a plugin's pre-isolation data dir
+/// (`<data_dir>/wayland/plugins/data/<name>`) into the `WAYLAND_HOME`-rooted
+/// location.
+///
+/// Gated + idempotent + atomic:
+///   * **Gate:** if `WAYLAND_HOME` is set, return — an isolated profile must
+///     NOT inherit another profile's live plugin state (credential caches,
+///     tokens, per-plugin DBs);
+///   * skip once `new_dir` exists (means *fully* migrated — atomic publish
+///     below, so this is never a torn partial);
+///   * copy the legacy tree into a temp sibling dir, then atomic-`rename` it
+///     onto `new_dir`.
+///
+/// Failures log at `warn` and never propagate — losing plugin data degrades
+/// gracefully (the plugin re-initializes); it must never crash boot.
+fn migrate_legacy_plugin_data(safe_name: &str, new_dir: &Path) {
+    // Explicit-isolation profiles never inherit shared legacy data.
+    if std::env::var_os("WAYLAND_HOME").is_some() {
+        return;
+    }
+    if new_dir.exists() {
+        return;
+    }
+    let Some(legacy) = dirs::data_dir().map(|d| {
+        d.join("wayland")
+            .join("plugins")
+            .join("data")
+            .join(safe_name)
+    }) else {
+        return;
+    };
+    if legacy == new_dir || !legacy.exists() {
+        return;
+    }
+    let Some(parent) = new_dir.parent() else {
+        return;
+    };
+    if let Err(e) = std::fs::create_dir_all(parent) {
+        tracing::warn!(error = %e, path = %new_dir.display(),
+            "plugin data: failed to create parent for legacy migration");
+        return;
+    }
+    // Stage into a temp sibling, then atomic-rename so `new_dir.exists()`
+    // is a "fully migrated" signal, never "started migrating".
+    let staging = parent.join(format!(".{safe_name}.migrating"));
+    let _ = std::fs::remove_dir_all(&staging); // clear any prior crash debris
+    if let Err(e) = copy_dir_recursive(&legacy, &staging) {
+        tracing::warn!(error = %e, from = %legacy.display(), to = %staging.display(),
+            "plugin data: legacy copy failed (plugin will re-init)");
+        let _ = std::fs::remove_dir_all(&staging);
+        return;
+    }
+    if let Err(e) = std::fs::rename(&staging, new_dir) {
+        // A concurrent migrator may have just published new_dir → discard.
+        tracing::warn!(error = %e, to = %new_dir.display(),
+            "plugin data: publish rename failed (plugin will re-init)");
+        let _ = std::fs::remove_dir_all(&staging);
+    }
+}
+
+/// Recursively copy `src` → `dst`, creating `dst` and all parents.
+fn copy_dir_recursive(src: &Path, dst: &Path) -> std::io::Result<()> {
+    std::fs::create_dir_all(dst)?;
+    for entry in std::fs::read_dir(src)? {
+        let entry = entry?;
+        let from = entry.path();
+        let to = dst.join(entry.file_name());
+        if entry.file_type()?.is_dir() {
+            copy_dir_recursive(&from, &to)?;
+        } else {
+            std::fs::copy(&from, &to)?;
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::collections::HashMap;
+
+    #[test]
+    #[serial_test::serial]
+    fn plugin_data_roots_under_wayland_home() {
+        let tmp = tempfile::tempdir().unwrap();
+        let prev = std::env::var_os("WAYLAND_HOME");
+        unsafe { std::env::set_var("WAYLAND_HOME", tmp.path()) };
+        let ctx = PluginPathCtx::for_plugin(Path::new("/install"), "my-plugin", Path::new("/proj"));
+        match prev {
+            Some(v) => unsafe { std::env::set_var("WAYLAND_HOME", v) },
+            None => unsafe { std::env::remove_var("WAYLAND_HOME") },
+        }
+        assert_eq!(
+            ctx.data,
+            tmp.path().join("plugins").join("data").join("my-plugin")
+        );
+    }
+
+    #[test]
+    fn copy_dir_recursive_copies_nested_tree() {
+        let tmp = tempfile::tempdir().unwrap();
+        let src = tmp.path().join("src");
+        let dst = tmp.path().join("dst");
+        std::fs::create_dir_all(src.join("sub")).unwrap();
+        std::fs::write(src.join("a.txt"), b"A").unwrap();
+        std::fs::write(src.join("sub").join("b.txt"), b"B").unwrap();
+        super::copy_dir_recursive(&src, &dst).unwrap();
+        assert_eq!(std::fs::read(dst.join("a.txt")).unwrap(), b"A");
+        assert_eq!(std::fs::read(dst.join("sub").join("b.txt")).unwrap(), b"B");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn migrate_skipped_when_wayland_home_set() {
+        let tmp = tempfile::tempdir().unwrap();
+        let new_dir = tmp.path().join("plugins").join("data").join("p");
+        let prev = std::env::var_os("WAYLAND_HOME");
+        unsafe { std::env::set_var("WAYLAND_HOME", tmp.path()) };
+        super::migrate_legacy_plugin_data("p", &new_dir);
+        match prev {
+            Some(v) => unsafe { std::env::set_var("WAYLAND_HOME", v) },
+            None => unsafe { std::env::remove_var("WAYLAND_HOME") },
+        }
+        assert!(!new_dir.exists());
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn migrate_noop_when_new_dir_exists() {
+        let tmp = tempfile::tempdir().unwrap();
+        let new_dir = tmp.path().join("plugins").join("data").join("p");
+        std::fs::create_dir_all(&new_dir).unwrap();
+        std::fs::write(new_dir.join("keep.txt"), b"keep").unwrap();
+        let prev = std::env::var_os("WAYLAND_HOME");
+        unsafe { std::env::remove_var("WAYLAND_HOME") };
+        super::migrate_legacy_plugin_data("p", &new_dir);
+        if let Some(v) = prev {
+            unsafe { std::env::set_var("WAYLAND_HOME", v) }
+        }
+        assert_eq!(std::fs::read(new_dir.join("keep.txt")).unwrap(), b"keep");
+    }
+
+    /// Trust-boundary guard: `wcore-plugin-api` is build-forbidden from
+    /// importing `wcore-config`, so `default_plugin_root()` hand-mirrors
+    /// `profile_home()`. This pins the mirror to the canonical resolver.
+    #[test]
+    #[serial_test::serial]
+    fn default_plugin_root_matches_canonical_resolver() {
+        use wcore_plugin_api::manifest::PluginIdentity;
+        let cases: [Option<&str>; 3] = [None, Some("/tmp/wh-equality-x"), Some("bad\nvalue")];
+        for case in cases {
+            let prev = std::env::var_os("WAYLAND_HOME");
+            match case {
+                Some(v) => unsafe { std::env::set_var("WAYLAND_HOME", v) },
+                None => unsafe { std::env::remove_var("WAYLAND_HOME") },
+            }
+            let mirror = PluginIdentity::default_plugin_root();
+            let canonical = wcore_config::config::profile_home().join("plugins");
+            match prev {
+                Some(v) => unsafe { std::env::set_var("WAYLAND_HOME", v) },
+                None => unsafe { std::env::remove_var("WAYLAND_HOME") },
+            }
+            assert_eq!(
+                mirror, canonical,
+                "default_plugin_root() drifted from profile_home()/plugins for WAYLAND_HOME={case:?}"
+            );
+        }
+    }
 
     fn ctx() -> PluginPathCtx {
         PluginPathCtx {

--- a/crates/wcore-agent/src/tool_backends/piper.rs
+++ b/crates/wcore-agent/src/tool_backends/piper.rs
@@ -276,11 +276,13 @@ fn validate_voice_name(name: &str) -> Result<&str, TtsError> {
     Ok(name)
 }
 
-/// Canonical default voices directory: `~/.wayland/piper-voices/`.
-/// Returns `None` if the home directory cannot be resolved (extremely
-/// hostile environment).
+/// Canonical default voices directory: `<WAYLAND_HOME or ~/.wayland>/piper-voices/`.
+///
+/// Isolation: routes through `wcore_config::config::profile_home()` so the voice
+/// cache follows `WAYLAND_HOME`. Byte-identical to `~/.wayland/piper-voices`
+/// when `WAYLAND_HOME` is unset.
 fn default_voices_dir() -> Option<PathBuf> {
-    dirs::home_dir().map(|h| h.join(".wayland").join("piper-voices"))
+    Some(wcore_config::config::profile_home().join("piper-voices"))
 }
 
 // ---------------------------------------------------------------------

--- a/crates/wcore-browser/src/supervisor.rs
+++ b/crates/wcore-browser/src/supervisor.rs
@@ -51,24 +51,12 @@ impl Default for SupervisorConfig {
 }
 
 fn home_pid_dir() -> PathBuf {
-    if let Some(home) = dirs_home() {
-        home.join(".wayland-core").join("browser").join("pids")
-    } else {
-        std::env::temp_dir()
-            .join("wayland-core")
-            .join("browser")
-            .join("pids")
-    }
-}
-
-fn dirs_home() -> Option<PathBuf> {
-    if let Some(h) = std::env::var_os("HOME") {
-        return Some(PathBuf::from(h));
-    }
-    if let Some(h) = std::env::var_os("USERPROFILE") {
-        return Some(PathBuf::from(h));
-    }
-    None
+    // isolation: route through profile_home() so browser PID tracking follows
+    // WAYLAND_HOME. PIDs are ephemeral; stale entries at the old location are
+    // harmless (the reaper only acts on PIDs it registered this session).
+    wcore_config::config::profile_home()
+        .join("browser")
+        .join("pids")
 }
 
 /// Tracked backend handle — session id + child PID + parent (host) PID. The
@@ -436,9 +424,24 @@ mod tests {
         let p = sup.pid_dir();
         let s = p.to_string_lossy();
         assert!(
-            s.contains("wayland-core") && s.contains("browser") && s.contains("pids"),
+            s.contains("browser") && s.contains("pids"),
             "unexpected pid dir: {s}"
         );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn pid_dir_roots_under_wayland_home() {
+        let tmp = tempfile::tempdir().unwrap();
+        let prev = std::env::var_os("WAYLAND_HOME");
+        // SAFETY: serialized via serial_test; env restored below.
+        unsafe { std::env::set_var("WAYLAND_HOME", tmp.path()) };
+        let dir = super::home_pid_dir();
+        match prev {
+            Some(v) => unsafe { std::env::set_var("WAYLAND_HOME", v) },
+            None => unsafe { std::env::remove_var("WAYLAND_HOME") },
+        }
+        assert_eq!(dir, tmp.path().join("browser").join("pids"));
     }
 
     #[test]

--- a/crates/wcore-cli/src/lib.rs
+++ b/crates/wcore-cli/src/lib.rs
@@ -98,6 +98,12 @@ pub mod provider_keys;
 // tempdir-backed config path.
 pub mod auth;
 
+// CLI surface: `wayland-core profile` — create / use / list / show / rename /
+// delete / export / import isolated profiles. Lives in the lib so every verb is
+// unit-testable against a tempdir-backed `WAYLAND_PROFILES_ROOT`. All
+// active-pointer access stays in `wcore_config::profile` (D2 single-reader lint).
+pub mod profile;
+
 // CLI surface: `wayland-core image` — FluxRouter image generation
 // (`POST /v1/images/generations`). Lives in the lib so credential
 // resolution + path numbering are unit-testable.

--- a/crates/wcore-cli/src/main.rs
+++ b/crates/wcore-cli/src/main.rs
@@ -577,6 +577,15 @@ fn open_tui_log_file() -> std::io::Result<std::fs::File> {
 }
 
 fn main() -> anyhow::Result<ExitCode> {
+    // Resolve the active isolated profile ONCE, here at process entry, and
+    // materialize it into WAYLAND_HOME (C2). This MUST precede
+    // load_wayland_env_file() below — that reads $WAYLAND_HOME/.env, so the home
+    // must be settled first — and runs while main() is still single-threaded
+    // (the Tokio runtime is built later, on the entry thread), so the set_var
+    // inside is sound. After this returns, WAYLAND_HOME is the sole source of
+    // truth; the active pointer is never read again.
+    wcore_config::profile::activate_for_launch();
+
     // Load ~/.wayland/.env (or $WAYLAND_HOME/.env) into the process environment
     // before ANY threads spawn. The Config TUI writes provider keys there
     // (surfaces/config.rs save); without this they never reach credential

--- a/crates/wcore-cli/src/main.rs
+++ b/crates/wcore-cli/src/main.rs
@@ -505,6 +505,12 @@ enum TopCmd {
     /// free / paid-but-uncleared Flux key returns an `upgrade_required`
     /// message — web_fetch is a paid-only capability.
     Fetch(wcore_cli::fetch::FetchArgs),
+    /// Manage isolated profiles — each is an independent `WAYLAND_HOME`-rooted
+    /// home with its own config, credentials, memory, and skills.
+    Profile {
+        #[command(subcommand)]
+        cmd: wcore_cli::profile::ProfileCmd,
+    },
 }
 
 /// F-089: `models` sub-subcommands.
@@ -1043,6 +1049,14 @@ async fn run() -> anyhow::Result<ExitCode> {
                 Ok(()) => Ok(ExitCode::SUCCESS),
                 Err(e) => {
                     eprintln!("wayland-core fetch: {e:#}");
+                    Ok(ExitCode::FAILURE)
+                }
+            },
+            // `profile::run` is synchronous — no `.await` (mirrors `TopCmd::Plugin`).
+            TopCmd::Profile { cmd } => match wcore_cli::profile::run(cmd) {
+                Ok(()) => Ok(ExitCode::SUCCESS),
+                Err(e) => {
+                    eprintln!("wayland-core profile: {e:#}");
                     Ok(ExitCode::FAILURE)
                 }
             },

--- a/crates/wcore-cli/src/main.rs
+++ b/crates/wcore-cli/src/main.rs
@@ -576,6 +576,38 @@ fn open_tui_log_file() -> std::io::Result<std::fs::File> {
         .open(log_dir.join("wayland-core.log"))
 }
 
+/// 3A / D3 fail-closed guard for `--json-stream` host mode.
+///
+/// A desktop host spawns `wayland-core --json-stream` and may drive a
+/// multi-profile UI. If it signals profile intent (`--profile`) but does NOT
+/// materialize the isolated home (`WAYLAND_HOME` unset — meaning
+/// [`wcore_config::profile::activate_for_launch`] could not resolve the profile
+/// to an existing home), refusing is the only safe choice: silently falling
+/// through to the SHARED default home would cross-write another account's
+/// credentials and memory — the Hermes #18594 corruption reproduced at the host
+/// boundary. Interactive CLI/TUI use is intentionally tolerant (it warns and
+/// falls through); only the host protocol is held to the strict contract.
+///
+/// Returns the loud error string when the run must be refused, else `Ok(())`.
+fn json_stream_profile_guard(
+    json_stream: bool,
+    profile: Option<&str>,
+    wayland_home_set: bool,
+) -> Result<(), String> {
+    if json_stream && profile.is_some() && !wayland_home_set {
+        return Err(format!(
+            "refusing to start --json-stream with --profile {:?} but no WAYLAND_HOME \
+             set. A host that drives profiles must set WAYLAND_HOME to the profile's \
+             isolated home before spawning the engine; otherwise the engine would \
+             write the shared default home and cross-write another profile's \
+             credentials and memory. Create the home with `wayland-core profile \
+             create`, or set WAYLAND_HOME per spawn.",
+            profile.unwrap_or("")
+        ));
+    }
+    Ok(())
+}
+
 fn main() -> anyhow::Result<ExitCode> {
     // Resolve the active isolated profile ONCE, here at process entry, and
     // materialize it into WAYLAND_HOME (C2). This MUST precede
@@ -1173,6 +1205,18 @@ async fn run() -> anyhow::Result<ExitCode> {
         .provider
         .clone()
         .unwrap_or_else(|| "anthropic".to_string());
+
+    // 3A / D3: fail closed BEFORE `cli.profile` is moved into CliArgs below. If
+    // the host signaled profile intent but no isolated home was materialized
+    // (WAYLAND_HOME was resolved once at process entry by activate_for_launch),
+    // refuse rather than silently writing the shared default home.
+    if let Err(msg) = json_stream_profile_guard(
+        cli.json_stream,
+        cli.profile.as_deref(),
+        std::env::var_os("WAYLAND_HOME").is_some(),
+    ) {
+        anyhow::bail!(msg);
+    }
 
     // Resolve config from files + CLI args + env vars
     let cli_args = CliArgs {
@@ -3003,6 +3047,36 @@ mod tests {
     use async_trait::async_trait;
     use serde_json::{Value, json};
     use wcore_mcp::manager::McpManager;
+
+    #[test]
+    fn json_stream_guard_blocks_profile_intent_without_home() {
+        // Host passed --profile but no WAYLAND_HOME materialized → refuse.
+        let err = json_stream_profile_guard(true, Some("work"), false)
+            .expect_err("must refuse profile intent without WAYLAND_HOME in json-stream");
+        assert!(
+            err.contains("WAYLAND_HOME"),
+            "message must name the fix: {err}"
+        );
+    }
+
+    #[test]
+    fn json_stream_guard_allows_when_home_set() {
+        // The host correctly set WAYLAND_HOME per spawn → proceed.
+        assert!(json_stream_profile_guard(true, Some("work"), true).is_ok());
+    }
+
+    #[test]
+    fn json_stream_guard_allows_without_profile_intent() {
+        // No --profile → default home is the legacy single-home contract.
+        assert!(json_stream_profile_guard(true, None, false).is_ok());
+    }
+
+    #[test]
+    fn json_stream_guard_is_noop_outside_json_stream() {
+        // Interactive CLI/TUI tolerates profile fall-through; only the host
+        // protocol is strict. Same inputs that block above must pass here.
+        assert!(json_stream_profile_guard(false, Some("work"), false).is_ok());
+    }
     use wcore_mcp::protocol::{JsonRpcRequest, JsonRpcResponse, McpToolDef};
     use wcore_mcp::transport::{McpError, McpTransport};
 

--- a/crates/wcore-cli/src/profile.rs
+++ b/crates/wcore-cli/src/profile.rs
@@ -1,0 +1,607 @@
+//! CLI surface: `wayland-core profile` — manage isolated profiles.
+//!
+//! Each profile is a self-contained `WAYLAND_HOME`-rooted home (its own config,
+//! credentials, OAuth, memory, skills) stored under `$WAYLAND_PROFILES_ROOT`
+//! (default `<os-config>/wayland-core-profiles/`). All active-pointer writes and
+//! profile enumeration live in [`wcore_config::profile`] — the D2 single-reader
+//! lint (`wcore-config/tests/active_pointer_single_reader_test.rs`) requires every
+//! pointer read/write to stay in that one module, so this CLI layer NEVER touches
+//! the pointer file directly; it calls the sanctioned helpers
+//! ([`wcore_config::profile::set_active_profile`],
+//! [`wcore_config::profile::active_profile_name`], …).
+//!
+//! `run` is the production entry; tests drive it directly under an `EnvGuard`
+//! that points `WAYLAND_PROFILES_ROOT` at a tempdir (the same pattern the
+//! `wcore_config::profile` unit tests use), so every verb is exercised against
+//! an isolated root without touching the real user home.
+
+use std::io::{IsTerminal, Write};
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+use clap::Subcommand;
+
+use wcore_config::profile;
+
+/// Isolated-profile management subcommands.
+#[derive(Subcommand, Debug)]
+pub enum ProfileCmd {
+    /// Create a new isolated profile.
+    ///
+    /// The profile starts empty (its own config/credentials/memory). With
+    /// `--base <name>` an inheritance marker is recorded (resolved at launch in a
+    /// later release; NO state — and never any secrets — is copied at create
+    /// time). Pass `--use` to also activate it for future launches.
+    Create {
+        /// Name of the new profile (ASCII letters/digits/`.`/`_`/`-`, case-folded).
+        name: String,
+        /// Record an inheritance base (an existing profile). No state is copied.
+        #[arg(long, value_name = "NAME")]
+        base: Option<String>,
+        /// Also set the new profile active for future launches.
+        #[arg(long = "use")]
+        activate: bool,
+    },
+    /// Set the active profile for future launches.
+    ///
+    /// Writes the `active` pointer; subsequent `wayland-core` invocations that do
+    /// not pass `--profile` or set `WAYLAND_HOME` will use it.
+    Use {
+        /// Name of an existing profile to activate.
+        name: String,
+    },
+    /// List all profiles (the active one is marked with `*`).
+    List,
+    /// Show a profile's home path and which stores it contains.
+    ///
+    /// Defaults to the active profile. Never prints secret values — only whether
+    /// each store is present.
+    Show {
+        /// Profile to inspect (defaults to the active profile).
+        name: Option<String>,
+    },
+    /// Rename a profile. Re-points the active selection if it named `old`.
+    Rename {
+        /// Current profile name.
+        old: String,
+        /// New profile name (must not already exist).
+        new: String,
+    },
+    /// Delete a profile and its entire home directory.
+    ///
+    /// Requires `--yes` (or an interactive confirm on a TTY). Refuses to delete
+    /// the currently-active profile without `--force`.
+    Delete {
+        /// Profile name to delete.
+        name: String,
+        /// Skip the interactive confirmation prompt.
+        #[arg(long)]
+        yes: bool,
+        /// Allow deleting the currently-active profile.
+        #[arg(long)]
+        force: bool,
+    },
+    /// Export a profile's home tree to a directory.
+    ///
+    /// Secrets (`credentials*` files and the `oauth/` directory) are EXCLUDED
+    /// unless `--include-secrets` is passed (which prints a stderr warning).
+    Export {
+        /// Name of the profile to export.
+        name: String,
+        /// Directory to write the exported tree into (created if absent).
+        /// Defaults to `<name>` in the current working directory.
+        #[arg(long, value_name = "PATH")]
+        out: Option<PathBuf>,
+        /// Include secrets (`credentials*` and `oauth/`) in the export.
+        #[arg(long)]
+        include_secrets: bool,
+    },
+    /// Import a directory tree as a new profile.
+    ///
+    /// The source must be an existing directory (e.g. a `profile export` tree).
+    /// Symlinks are never followed (zip-slip / path-escape defense). The profile
+    /// name defaults to the source directory's file name.
+    Import {
+        /// Path to the directory to adopt as the new profile.
+        path: PathBuf,
+        /// Name for the imported profile (defaults to the source dir's name).
+        #[arg(long = "as", value_name = "NAME")]
+        new_name: Option<String>,
+    },
+}
+
+/// Run a `profile` subcommand. Resolution of the profiles root happens inside the
+/// `wcore_config::profile` helpers (via `WAYLAND_PROFILES_ROOT` / the OS config
+/// dir), so this entry needs no path argument.
+pub fn run(cmd: ProfileCmd) -> Result<()> {
+    match cmd {
+        ProfileCmd::Create {
+            name,
+            base,
+            activate,
+        } => create_cmd(&name, base.as_deref(), activate),
+        ProfileCmd::Use { name } => use_cmd(&name),
+        ProfileCmd::List => list_cmd(),
+        ProfileCmd::Show { name } => show_cmd(name.as_deref()),
+        ProfileCmd::Rename { old, new } => rename_cmd(&old, &new),
+        ProfileCmd::Delete { name, yes, force } => delete_cmd(&name, yes, force),
+        ProfileCmd::Export {
+            name,
+            out,
+            include_secrets,
+        } => export_cmd(&name, out.as_deref(), include_secrets),
+        ProfileCmd::Import { path, new_name } => import_cmd(&path, new_name.as_deref()),
+    }
+}
+
+fn create_cmd(name: &str, base: Option<&str>, activate: bool) -> Result<()> {
+    let dir = profile::create_profile(name, base)
+        .with_context(|| format!("creating profile {name:?}"))?;
+    println!("Created profile {name:?} at {}", dir.display());
+    if let Some(b) = base {
+        println!("  base {b:?} recorded (inherited at launch; no state copied)");
+    }
+    if activate {
+        profile::set_active_profile(name)
+            .with_context(|| format!("activating profile {name:?}"))?;
+        println!("  set active");
+    }
+    Ok(())
+}
+
+fn use_cmd(name: &str) -> Result<()> {
+    profile::set_active_profile(name)
+        .with_context(|| format!("setting active profile {name:?}"))?;
+    println!("Active profile set to {name:?}.");
+    println!(
+        "Launches without --profile or WAYLAND_HOME will now use it; run `wayland-core profile show` to confirm."
+    );
+    Ok(())
+}
+
+fn list_cmd() -> Result<()> {
+    let profiles = profile::list_profiles();
+    if profiles.is_empty() {
+        println!("No profiles yet. Create one with `wayland-core profile create <name>`.");
+        return Ok(());
+    }
+    let active = profile::active_profile_name();
+    for name in &profiles {
+        let marker = if active.as_deref() == Some(name.as_str()) {
+            "* "
+        } else {
+            "  "
+        };
+        println!("{marker}{name}");
+    }
+    // A pointer that names a now-deleted profile is reported so the user can fix it.
+    if let Some(active) = &active
+        && !profiles.contains(active)
+    {
+        println!();
+        println!("warning: active profile {active:?} has no directory (dangling pointer)");
+    }
+    Ok(())
+}
+
+fn show_cmd(name: Option<&str>) -> Result<()> {
+    let name = match name {
+        Some(n) => n.to_string(),
+        None => profile::active_profile_name()
+            .context("no profile specified and no active profile set")?,
+    };
+    if !profile::profile_exists(&name) {
+        bail!("profile {name:?} does not exist");
+    }
+    let dir = profile::profile_dir(&name)?;
+    let is_active =
+        profile::active_profile_name().as_deref() == Some(name.to_ascii_lowercase().as_str());
+    println!(
+        "Profile: {name}{}",
+        if is_active { " (active)" } else { "" }
+    );
+    println!("Home:    {}", dir.display());
+    // Store presence only — NEVER print secret values.
+    let credentials_present = [
+        "credentials.toml",
+        "credentials.enc",
+        "credentials.kdf.json",
+    ]
+    .iter()
+    .any(|f| dir.join(f).exists());
+    let rows = [
+        ("config", dir.join("config.toml").exists()),
+        ("credentials", credentials_present),
+        ("oauth", dir.join("oauth").is_dir()),
+        ("memory", dir.join("memory").is_dir()),
+        ("skills", dir.join("skills").is_dir()),
+    ];
+    for (label, present) in rows {
+        println!("  {label:<12} {}", if present { "present" } else { "—" });
+    }
+    Ok(())
+}
+
+fn rename_cmd(old: &str, new: &str) -> Result<()> {
+    profile::rename_profile(old, new)
+        .with_context(|| format!("renaming profile {old:?} -> {new:?}"))?;
+    println!("Renamed profile {old:?} -> {new:?}.");
+    Ok(())
+}
+
+fn delete_cmd(name: &str, yes: bool, force: bool) -> Result<()> {
+    if !profile::profile_exists(name) {
+        bail!("profile {name:?} does not exist");
+    }
+    // Refuse the active profile unless explicitly forced.
+    if profile::is_active(name) && !force {
+        bail!("{name:?} is the active profile — pass --force to delete it anyway");
+    }
+    // Confirm unless --yes; on a non-interactive stdin, refuse rather than block.
+    if !yes {
+        if std::io::stdin().is_terminal() {
+            print!("Delete profile {name:?} and its entire home directory? [y/N] ");
+            std::io::stdout().flush().ok();
+            let mut line = String::new();
+            std::io::stdin()
+                .read_line(&mut line)
+                .context("reading confirmation")?;
+            if !matches!(line.trim(), "y" | "Y" | "yes" | "Yes") {
+                println!("Aborted.");
+                return Ok(());
+            }
+        } else {
+            bail!("refusing to delete {name:?} without --yes (no interactive terminal)");
+        }
+    }
+    profile::delete_profile(name).with_context(|| format!("deleting profile {name:?}"))?;
+    println!("Deleted profile {name:?}.");
+    Ok(())
+}
+
+fn export_cmd(name: &str, out: Option<&Path>, include_secrets: bool) -> Result<()> {
+    if !profile::profile_exists(name) {
+        bail!("profile {name:?} does not exist");
+    }
+    let dst = match out {
+        Some(p) => p.to_path_buf(),
+        None => PathBuf::from(name.to_ascii_lowercase()),
+    };
+    if include_secrets {
+        eprintln!(
+            "warning: exporting SECRETS (credentials + oauth) for {name:?} into {} — keep this export private",
+            dst.display()
+        );
+    }
+    let written = profile::export_profile(name, &dst, include_secrets)
+        .with_context(|| format!("exporting profile {name:?}"))?;
+    println!(
+        "Exported profile {name:?} to {} ({}).",
+        written.display(),
+        if include_secrets {
+            "including secrets"
+        } else {
+            "secrets excluded"
+        }
+    );
+    Ok(())
+}
+
+fn import_cmd(path: &Path, new_name: Option<&str>) -> Result<()> {
+    let name = match new_name {
+        Some(n) => n.to_string(),
+        None => path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .map(str::to_string)
+            .context("could not derive a profile name from the source path; pass --as <name>")?,
+    };
+    let dir = profile::import_profile(&name, path)
+        .with_context(|| format!("importing profile {name:?} from {}", path.display()))?;
+    println!(
+        "Imported profile {name:?} from {} into {}.",
+        path.display(),
+        dir.display()
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+    use tempfile::tempdir;
+
+    /// RAII env guard — restores prior values on drop so env-mutating tests stay
+    /// hermetic. Mirrors the guard in `wcore_config::profile`'s unit tests.
+    struct EnvGuard(Vec<(&'static str, Option<std::ffi::OsString>)>);
+    impl EnvGuard {
+        fn set(pairs: &[(&'static str, Option<&str>)]) -> Self {
+            let saved = pairs
+                .iter()
+                .map(|(k, v)| {
+                    let prev = std::env::var_os(k);
+                    match v {
+                        Some(val) => unsafe { std::env::set_var(k, val) },
+                        None => unsafe { std::env::remove_var(k) },
+                    }
+                    (*k, prev)
+                })
+                .collect();
+            Self(saved)
+        }
+    }
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            for (k, prev) in &self.0 {
+                match prev {
+                    Some(v) => unsafe { std::env::set_var(k, v) },
+                    None => unsafe { std::env::remove_var(k) },
+                }
+            }
+        }
+    }
+
+    /// Point `WAYLAND_PROFILES_ROOT` at a fresh tempdir; all CLI tests run serial
+    /// because they mutate the process env.
+    fn rooted() -> (EnvGuard, tempfile::TempDir) {
+        let dir = tempdir().unwrap();
+        let g = EnvGuard::set(&[
+            ("WAYLAND_PROFILES_ROOT", Some(dir.path().to_str().unwrap())),
+            ("WAYLAND_HOME", None),
+        ]);
+        (g, dir)
+    }
+
+    fn create(name: &str, activate: bool) -> Result<()> {
+        run(ProfileCmd::Create {
+            name: name.to_string(),
+            base: None,
+            activate,
+        })
+    }
+
+    #[test]
+    #[serial]
+    fn create_makes_dir_and_lists_without_activating() {
+        let (_g, _root) = rooted();
+        create("work", false).unwrap();
+        assert!(profile::profile_exists("work"));
+        assert_eq!(profile::list_profiles(), vec!["work"]);
+        // No --use → not active.
+        assert_eq!(profile::active_profile_name(), None);
+    }
+
+    #[test]
+    #[serial]
+    fn create_with_use_sets_active() {
+        let (_g, _root) = rooted();
+        create("work", true).unwrap();
+        assert_eq!(profile::active_profile_name(), Some("work".to_string()));
+    }
+
+    #[test]
+    #[serial]
+    fn create_with_base_records_marker_not_secrets() {
+        let (_g, _root) = rooted();
+        let base = profile::create_profile("base", None).unwrap();
+        std::fs::write(base.join("credentials.toml"), "secret").unwrap();
+        run(ProfileCmd::Create {
+            name: "child".to_string(),
+            base: Some("base".to_string()),
+            activate: false,
+        })
+        .unwrap();
+        let child = profile::profile_dir("child").unwrap();
+        assert!(child.join("profile.toml").exists());
+        assert!(
+            !child.join("credentials.toml").exists(),
+            "secret not copied"
+        );
+        // A missing base is a clear error, not a half-made profile.
+        assert!(
+            run(ProfileCmd::Create {
+                name: "orphan".to_string(),
+                base: Some("ghost".to_string()),
+                activate: false,
+            })
+            .is_err()
+        );
+        assert!(!profile::profile_exists("orphan"));
+    }
+
+    #[test]
+    #[serial]
+    fn use_sets_active_and_errors_on_missing() {
+        let (_g, _root) = rooted();
+        create("work", false).unwrap();
+        run(ProfileCmd::Use {
+            name: "Work".to_string(), // case-folds
+        })
+        .unwrap();
+        assert_eq!(profile::active_profile_name(), Some("work".to_string()));
+        assert!(
+            run(ProfileCmd::Use {
+                name: "ghost".to_string()
+            })
+            .is_err()
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn list_marks_active_and_reports_empty() {
+        let (_g, _root) = rooted();
+        // Empty state is not an error.
+        list_cmd().unwrap();
+        create("a", false).unwrap();
+        create("b", true).unwrap();
+        assert_eq!(profile::list_profiles(), vec!["a", "b"]);
+        list_cmd().unwrap();
+    }
+
+    #[test]
+    #[serial]
+    fn rename_moves_and_repoints_active() {
+        let (_g, _root) = rooted();
+        create("old", true).unwrap();
+        run(ProfileCmd::Rename {
+            old: "old".to_string(),
+            new: "new".to_string(),
+        })
+        .unwrap();
+        assert!(!profile::profile_exists("old"));
+        assert!(profile::profile_exists("new"));
+        assert_eq!(profile::active_profile_name(), Some("new".to_string()));
+        // Renaming onto an existing name errors.
+        create("taken", false).unwrap();
+        assert!(
+            run(ProfileCmd::Rename {
+                old: "new".to_string(),
+                new: "taken".to_string()
+            })
+            .is_err()
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn delete_refuses_active_without_force() {
+        let (_g, _root) = rooted();
+        create("work", true).unwrap();
+        let err = run(ProfileCmd::Delete {
+            name: "work".to_string(),
+            yes: true,
+            force: false,
+        })
+        .unwrap_err();
+        assert!(format!("{err:#}").contains("active"));
+        assert!(profile::profile_exists("work"), "must survive the refusal");
+    }
+
+    #[test]
+    #[serial]
+    fn delete_without_yes_on_non_tty_is_refused() {
+        let (_g, _root) = rooted();
+        create("work", false).unwrap();
+        // Precondition: not active, so we exercise the TTY/--yes gate, not the
+        // active-refuse gate. Under `cargo test` stdin is not a terminal.
+        assert!(!profile::is_active("work"));
+        assert!(
+            run(ProfileCmd::Delete {
+                name: "work".to_string(),
+                yes: false,
+                force: false,
+            })
+            .is_err()
+        );
+        assert!(profile::profile_exists("work"));
+    }
+
+    #[test]
+    #[serial]
+    fn delete_with_yes_removes_and_force_clears_active_pointer() {
+        let (_g, _root) = rooted();
+        create("work", false).unwrap();
+        run(ProfileCmd::Delete {
+            name: "work".to_string(),
+            yes: true,
+            force: false,
+        })
+        .unwrap();
+        assert!(!profile::profile_exists("work"));
+
+        create("active-one", true).unwrap();
+        run(ProfileCmd::Delete {
+            name: "active-one".to_string(),
+            yes: true,
+            force: true,
+        })
+        .unwrap();
+        assert!(!profile::profile_exists("active-one"));
+        assert_eq!(
+            profile::active_profile_name(),
+            None,
+            "deleting the active profile clears the pointer"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn export_excludes_secrets_by_default() {
+        let (_g, _root) = rooted();
+        let dir = profile::create_profile("work", None).unwrap();
+        std::fs::write(dir.join("config.toml"), "model='x'").unwrap();
+        std::fs::write(dir.join("credentials.toml"), "secret").unwrap();
+        std::fs::create_dir_all(dir.join("oauth")).unwrap();
+        std::fs::write(dir.join("oauth/t.json"), "{}").unwrap();
+
+        let out = tempdir().unwrap();
+        let dst = out.path().join("exp");
+        run(ProfileCmd::Export {
+            name: "work".to_string(),
+            out: Some(dst.clone()),
+            include_secrets: false,
+        })
+        .unwrap();
+        assert!(dst.join("config.toml").exists());
+        assert!(!dst.join("credentials.toml").exists(), "secret excluded");
+        assert!(!dst.join("oauth").exists(), "oauth excluded");
+
+        // --include-secrets copies them.
+        let dst2 = out.path().join("exp2");
+        run(ProfileCmd::Export {
+            name: "work".to_string(),
+            out: Some(dst2.clone()),
+            include_secrets: true,
+        })
+        .unwrap();
+        assert!(dst2.join("credentials.toml").exists());
+    }
+
+    #[test]
+    #[serial]
+    fn import_creates_profile_and_derives_name_from_dir() {
+        let (_g, _root) = rooted();
+        let src = tempdir().unwrap();
+        let tree = src.path().join("acme");
+        std::fs::create_dir_all(&tree).unwrap();
+        std::fs::write(tree.join("config.toml"), "model='y'").unwrap();
+
+        run(ProfileCmd::Import {
+            path: tree.clone(),
+            new_name: None,
+        })
+        .unwrap();
+        assert!(profile::profile_exists("acme"));
+        // Re-importing onto the same name errors.
+        assert!(
+            run(ProfileCmd::Import {
+                path: tree,
+                new_name: Some("acme".to_string()),
+            })
+            .is_err()
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn show_runs_for_active_and_named() {
+        let (_g, _root) = rooted();
+        create("work", true).unwrap();
+        // Default = active.
+        run(ProfileCmd::Show { name: None }).unwrap();
+        // Explicit name.
+        run(ProfileCmd::Show {
+            name: Some("work".to_string()),
+        })
+        .unwrap();
+        // Unknown name errors.
+        assert!(
+            run(ProfileCmd::Show {
+                name: Some("ghost".to_string())
+            })
+            .is_err()
+        );
+    }
+}

--- a/crates/wcore-config/src/config.rs
+++ b/crates/wcore-config/src/config.rs
@@ -2140,6 +2140,18 @@ pub fn app_config_dir() -> Option<PathBuf> {
     Some(wayland_config_dir())
 }
 
+/// The OS-native config root (`dirs::config_dir()`), deliberately NOT
+/// `WAYLAND_HOME`-scoped. This is the single sanctioned bypass of
+/// [`wayland_config_dir`] for the profiles control plane: `profiles_root()`
+/// (see [`crate::profile`]) must resolve OUTSIDE any one profile home — a
+/// profile home is a *child* of the profiles root — so it cannot route through
+/// the `WAYLAND_HOME`-aware resolver without becoming self-referential. Kept
+/// here in `config.rs` (the one file allow-listed by the hermeticity audit for
+/// raw `dirs::config_dir()`), so the audit's single-call-site invariant holds.
+pub(crate) fn os_native_config_root() -> Option<PathBuf> {
+    dirs::config_dir()
+}
+
 /// Canonical `~/.wayland` profile home.
 ///
 /// This is the stable dot-directory that plugins and their helper processes

--- a/crates/wcore-config/src/config.rs
+++ b/crates/wcore-config/src/config.rs
@@ -2064,8 +2064,12 @@ fn lookup_store_api_key(
 /// restart and without mutating process environment variables.
 ///
 /// The storage backend (keyring / plaintext-0600 / encrypted-file) is read
-/// from the on-disk `[storage.credentials]` block, exactly as resolution will
-/// read it. Returns an error for providers with no store slot
+/// from the on-disk `[storage.credentials]` block of the *profile-active*
+/// config — `load_global_config_file()` and `credentials_storage_path()` both
+/// honour `WAYLAND_HOME`, so under an isolated profile this reads that
+/// profile's config and writes into that profile's in-home store (the Auto
+/// default resolves to the in-home vault, never the shared keyring). Returns
+/// an error for providers with no store slot
 /// ([`credentials_store_key`] returns `None`) or on a store write failure. The
 /// value is never logged.
 pub fn store_provider_api_key(provider: ProviderType, api_key: &str) -> anyhow::Result<()> {

--- a/crates/wcore-config/src/credentials.rs
+++ b/crates/wcore-config/src/credentials.rs
@@ -599,6 +599,65 @@ impl CredentialsStore for EncryptedFileCredentialsStore {
     }
 }
 
+/// Non-consuming check for whether vault unlock material is available
+/// out-of-band, so [`open_store`] can choose the encrypted vault WITHOUT
+/// triggering an interactive passphrase prompt on a headless/desktop spawn.
+///
+/// Mirrors the NON-INTERACTIVE prefixes of
+/// [`EncryptedFileCredentialsStore::read_passphrase`]: a passphrase FD (Unix
+/// only — file descriptors are not a portable Windows concept, and
+/// `read_passphrase` likewise `#[cfg(unix)]`-gates the FD path) or the legacy
+/// `WAYLAND_VAULT_PASSPHRASE` env var. The interactive `rpassword` prompt is
+/// deliberately NOT treated as "present": selecting the vault must never block
+/// a non-interactive launch on a TTY.
+///
+/// The Windows branch intentionally omits the FD check: a Windows caller that
+/// set only `WAYLAND_VAULT_PASSPHRASE_FD` correctly falls back to plaintext
+/// rather than being routed to the vault and then hitting `read_passphrase`'s
+/// interactive prompt (whose FD path is also unix-only). Do NOT "fix" this by
+/// adding an unconditional FD check — that reintroduces the Windows TTY block.
+fn vault_unlock_material_present() -> bool {
+    #[cfg(unix)]
+    if std::env::var_os("WAYLAND_VAULT_PASSPHRASE_FD").is_some() {
+        return true;
+    }
+    std::env::var_os("WAYLAND_VAULT_PASSPHRASE").is_some()
+}
+
+/// Derive the encrypted-vault file pair that sits beside the plaintext
+/// credentials path (i.e. inside the active `WAYLAND_HOME`). Co-locating them
+/// means the existing parent-dir hardening already covers them. The `"."`
+/// fallback is unreachable in practice — every caller passes
+/// `credentials_storage_path()`, which always has a real parent dir.
+fn default_vault_paths(plaintext_path: &Path) -> (PathBuf, PathBuf) {
+    let dir = plaintext_path.parent().unwrap_or_else(|| Path::new("."));
+    (
+        dir.join("credentials.enc"),
+        dir.join("credentials.kdf.json"),
+    )
+}
+
+/// Warn ONCE, to stderr, that an isolated profile is persisting secrets as a
+/// plaintext-0600 file because no vault unlock material was supplied. The D1
+/// "warned fallback": secrets are still `0o600` and in-home, but not encrypted
+/// at rest. `Once`-guarded because `open_store` is called repeatedly per run
+/// (once per provider key lookup) and an unguarded warning would spam stderr.
+fn warn_isolated_plaintext_fallback(path: &Path) {
+    static WARNED: std::sync::Once = std::sync::Once::new();
+    WARNED.call_once(|| {
+        eprintln!(
+            "warning: WAYLAND_HOME is set (isolated profile) but no vault \
+             passphrase was supplied; storing credentials as plaintext-0600 at \
+             {}. To encrypt at rest, set WAYLAND_VAULT_PASSPHRASE_FD (a \
+             passphrase file descriptor — preferred) or WAYLAND_VAULT_PASSPHRASE \
+             (env var, visible via /proc/<pid>/environ). Secrets in a legacy OS \
+             keyring are not auto-imported into isolated profiles — re-enter \
+             them for this profile.",
+            path.display()
+        );
+    });
+}
+
 /// Factory selecting the configured backend.
 pub fn open_store(
     cfg: &CredentialsStorageConfig,
@@ -608,6 +667,26 @@ pub fn open_store(
         // Default: keyring primary + plaintext fallback when a keyring exists;
         // a bare plaintext store on headless/CI hosts where it does not. (F16)
         CredentialsBackend::Auto => {
+            // Isolated-profile homes (WAYLAND_HOME set) must NOT use the OS
+            // keyring: the keyring service is a process-global constant
+            // ("wayland-core") that bleeds secrets across every profile on the
+            // host (C4 / D1). For an isolated home, prefer the in-home encrypted
+            // vault when unlock material is supplied out-of-band; otherwise fall
+            // back to a stderr-warned plaintext-0600 file in-home — never the
+            // keyring. The legacy single (non-profile) home is unchanged below.
+            if std::env::var_os("WAYLAND_HOME").is_some() {
+                if vault_unlock_material_present() {
+                    let (cipher_path, key_params_path) = default_vault_paths(plaintext_path);
+                    return Ok(Box::new(EncryptedFileCredentialsStore::new(
+                        cipher_path,
+                        key_params_path,
+                    )));
+                }
+                warn_isolated_plaintext_fallback(plaintext_path);
+                return Ok(Box::new(PlaintextCredentialsStore::new(
+                    plaintext_path.to_path_buf(),
+                )));
+            }
             let service = cfg
                 .service_name
                 .clone()

--- a/crates/wcore-config/src/lib.rs
+++ b/crates/wcore-config/src/lib.rs
@@ -40,5 +40,6 @@ pub mod limits;
 pub mod mcp_cred_refs;
 pub mod plan;
 pub mod plugins_config;
+pub mod profile;
 pub mod shell;
 pub mod tools;

--- a/crates/wcore-config/src/profile.rs
+++ b/crates/wcore-config/src/profile.rs
@@ -794,15 +794,30 @@ mod tests {
         );
     }
 
+    /// An absolute path valid on BOTH Unix (`/tmp/<seg>`) and Windows
+    /// (`C:\<seg>`). `profiles_root()` rejects non-absolute overrides, and a
+    /// Unix `/tmp/...` is NOT absolute on Windows — so hardcoding it makes these
+    /// path-resolution tests fail under Windows CI (the override is rejected and
+    /// resolution falls through to the real config dir).
+    fn abs_root(seg: &str) -> String {
+        if cfg!(windows) {
+            format!("C:\\{seg}")
+        } else {
+            format!("/tmp/{seg}")
+        }
+    }
+
     #[test]
     #[serial]
     fn profiles_root_honors_explicit_override() {
-        let _g = EnvGuard::set(&[("WAYLAND_PROFILES_ROOT", Some("/tmp/custom-profiles"))]);
-        assert_eq!(profiles_root(), PathBuf::from("/tmp/custom-profiles"));
+        let root = abs_root("custom-profiles");
+        let _g = EnvGuard::set(&[("WAYLAND_PROFILES_ROOT", Some(root.as_str()))]);
+        assert_eq!(profiles_root(), PathBuf::from(&root));
 
         // A control-char-bearing override is ignored (falls through to default).
-        let _g2 = EnvGuard::set(&[("WAYLAND_PROFILES_ROOT", Some("/tmp/bad\nroot"))]);
-        assert_ne!(profiles_root(), PathBuf::from("/tmp/bad\nroot"));
+        let bad = format!("{}\nroot", abs_root("bad"));
+        let _g2 = EnvGuard::set(&[("WAYLAND_PROFILES_ROOT", Some(bad.as_str()))]);
+        assert_ne!(profiles_root(), PathBuf::from(&bad));
 
         // A RELATIVE override is ignored — would make every home CWD-dependent.
         let _g3 = EnvGuard::set(&[("WAYLAND_PROFILES_ROOT", Some("relative/profiles"))]);
@@ -817,17 +832,19 @@ mod tests {
     #[test]
     #[serial]
     fn profile_dir_case_folds_to_same_path() {
-        let _g = EnvGuard::set(&[("WAYLAND_PROFILES_ROOT", Some("/tmp/p"))]);
+        let root = abs_root("p");
+        let _g = EnvGuard::set(&[("WAYLAND_PROFILES_ROOT", Some(root.as_str()))]);
         let upper = profile_dir("Work").unwrap();
         let lower = profile_dir("work").unwrap();
         assert_eq!(upper, lower, "Work and work must map to the same directory");
-        assert_eq!(lower, PathBuf::from("/tmp/p/work"));
+        assert_eq!(lower, PathBuf::from(&root).join("work"));
     }
 
     #[test]
     #[serial]
     fn profile_dir_rejects_invalid_name() {
-        let _g = EnvGuard::set(&[("WAYLAND_PROFILES_ROOT", Some("/tmp/p"))]);
+        let root = abs_root("p");
+        let _g = EnvGuard::set(&[("WAYLAND_PROFILES_ROOT", Some(root.as_str()))]);
         assert!(profile_dir("../escape").is_err());
         assert!(profile_dir("a/b").is_err());
     }
@@ -835,13 +852,15 @@ mod tests {
     #[test]
     #[serial]
     fn active_pointer_is_under_root_not_in_a_home() {
+        let root = abs_root("p");
+        let home = abs_root("some-home");
         let _g = EnvGuard::set(&[
-            ("WAYLAND_PROFILES_ROOT", Some("/tmp/p")),
-            ("WAYLAND_HOME", Some("/tmp/some-home")),
+            ("WAYLAND_PROFILES_ROOT", Some(root.as_str())),
+            ("WAYLAND_HOME", Some(home.as_str())),
         ]);
         let ptr = active_pointer_path();
-        assert_eq!(ptr, PathBuf::from("/tmp/p/active"));
-        assert!(!ptr.starts_with("/tmp/some-home"));
+        assert_eq!(ptr, PathBuf::from(&root).join("active"));
+        assert!(!ptr.starts_with(&home));
     }
 
     fn argv(parts: &[&str]) -> std::vec::IntoIter<String> {

--- a/crates/wcore-config/src/profile.rs
+++ b/crates/wcore-config/src/profile.rs
@@ -1,0 +1,327 @@
+//! Isolated-profile control plane (Phase 1, Task 1.1).
+//!
+//! An *isolated profile* is a self-contained `WAYLAND_HOME`-rooted home (its own
+//! config, credentials, OAuth, memory, skills). This module owns the
+//! control-plane resolvers that LIST and LOCATE profiles — distinct from a
+//! single profile's home (`config::profile_home()`), which resolves state
+//! *inside* one profile.
+//!
+//! Load-bearing invariant (C2): [`profiles_root`] must NEVER read `WAYLAND_HOME`.
+//! A profile home is a *child* of the profiles root, so reading `WAYLAND_HOME`
+//! here would make the root resolve inside one of the very homes it enumerates.
+//! Activation (Task 1.2) reads the `active` pointer ONCE at process entry and
+//! materializes it into `WAYLAND_HOME`; nothing here is consulted again at
+//! runtime.
+
+use std::path::{Path, PathBuf};
+
+use thiserror::Error;
+
+/// Maximum profile-name length. Generous for human-chosen names while staying
+/// well under filesystem component limits (255 bytes on ext4/APFS/NTFS).
+pub const MAX_PROFILE_NAME_LEN: usize = 64;
+
+/// Errors from profile-name validation and path resolution.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum ProfileError {
+    /// The supplied name failed validation (C6). `reason` is a short,
+    /// human-readable explanation suitable for surfacing to the CLI user.
+    #[error("invalid profile name {name:?}: {reason}")]
+    InvalidName { name: String, reason: &'static str },
+}
+
+/// Windows reserved device names (case-insensitive, with or without an
+/// extension, e.g. `CON` and `con.txt` are both reserved). Rejected on every
+/// platform so a profile created on Linux cannot become unusable when the same
+/// home is opened on Windows.
+const WINDOWS_RESERVED: &[&str] = &[
+    "CON", "PRN", "AUX", "NUL", "COM0", "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7",
+    "COM8", "COM9", "LPT0", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9",
+];
+
+/// Names reserved for the profiles control plane itself — flat entries that live
+/// directly under [`profiles_root`] alongside the per-profile directories. A
+/// profile may not take one of these, or its home directory would collide with
+/// a control file. `active` is the [`active_pointer_path`] file; grow this list
+/// whenever a new well-known control-plane entry is added (e.g. a future
+/// `lock`). Compared case-folded, since [`profile_dir`] lowercases.
+const RESERVED_PROFILE_NAMES: &[&str] = &["active"];
+
+/// Validate a profile name (C6). The grammar is intentionally strict — these
+/// names become filesystem directory components, so anything ambiguous across
+/// platforms is rejected up front rather than sanitized:
+///
+/// * non-empty, at most [`MAX_PROFILE_NAME_LEN`] bytes;
+/// * only ASCII letters, digits, `.`, `_`, `-` (this alone rejects every path
+///   separator — `/`, `\` — plus `:`, spaces, NUL, and all control chars);
+/// * not composed solely of dots (rejects `.`, `..`, `...` → traversal / cwd);
+/// * no trailing `.` (Windows silently strips it → collides with the dotless
+///   name);
+/// * not a Windows reserved device name (`CON`, `NUL`, `COM1`…, with or without
+///   an extension).
+///
+/// Case is NOT rejected here — `Work` and `work` are both valid names that map
+/// to the SAME on-disk profile (see [`profile_dir`], which case-folds), matching
+/// case-insensitive-filesystem semantics. A leading `.` is rejected (it would
+/// create a hidden directory and invites dotfile confusion). The control-plane
+/// names in [`RESERVED_PROFILE_NAMES`] (e.g. `active`) are rejected so a profile
+/// home cannot collide with a control file under [`profiles_root`].
+#[must_use = "validation result must be checked before using the name"]
+pub fn validate_profile_name(name: &str) -> Result<(), ProfileError> {
+    let invalid = |reason: &'static str| ProfileError::InvalidName {
+        name: name.to_string(),
+        reason,
+    };
+
+    if name.is_empty() {
+        return Err(invalid("name must not be empty"));
+    }
+    if name.len() > MAX_PROFILE_NAME_LEN {
+        return Err(invalid("name too long (max 64 bytes)"));
+    }
+    if !name
+        .bytes()
+        .all(|b| b.is_ascii_alphanumeric() || b == b'.' || b == b'_' || b == b'-')
+    {
+        return Err(invalid(
+            "only ASCII letters, digits, '.', '_', '-' are allowed",
+        ));
+    }
+    if name.bytes().all(|b| b == b'.') {
+        return Err(invalid("name must not be all dots ('.', '..')"));
+    }
+    if name.starts_with('.') {
+        return Err(invalid("name must not start with '.'"));
+    }
+    if name.ends_with('.') {
+        return Err(invalid("name must not end with '.'"));
+    }
+    // Reserved-device check is on the stem (portion before the first '.'),
+    // because Windows reserves `CON` AND `CON.anything`.
+    let stem = name.split('.').next().unwrap_or(name).to_ascii_uppercase();
+    if WINDOWS_RESERVED.contains(&stem.as_str()) {
+        return Err(invalid("name is a reserved device name on Windows"));
+    }
+    if RESERVED_PROFILE_NAMES.contains(&name.to_ascii_lowercase().as_str()) {
+        return Err(invalid("name is reserved for the profiles control plane"));
+    }
+    Ok(())
+}
+
+/// The control-plane root that LISTS profiles.
+///
+/// Resolution order:
+///   1. `WAYLAND_PROFILES_ROOT` env var (explicit escape hatch / sandbox);
+///   2. `<os-native config dir>/wayland-core-profiles/` — a SIBLING of the
+///      legacy home, so the existing single home stays untouched as the implicit
+///      `default` profile.
+///
+/// NEVER reads `WAYLAND_HOME` (C2). The override must be an ABSOLUTE,
+/// control-char-free path — a relative override would make the profiles root
+/// (and thus every profile home) depend on the process CWD, so it is ignored
+/// and resolution falls through to the default. The last-resort fallback
+/// anchors to the current dir (absolute) only if the OS config dir cannot be
+/// resolved at all.
+#[must_use]
+pub fn profiles_root() -> PathBuf {
+    if let Ok(custom) = std::env::var("WAYLAND_PROFILES_ROOT")
+        && !custom.is_empty()
+        && !custom.chars().any(|c| c.is_control())
+        && Path::new(&custom).is_absolute()
+    {
+        return PathBuf::from(custom);
+    }
+    crate::config::os_native_config_root()
+        .or_else(|| std::env::current_dir().ok())
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("wayland-core-profiles")
+}
+
+/// The on-disk directory for a named profile, under [`profiles_root`].
+///
+/// The name is validated and **case-folded to lowercase** so `Work` and `work`
+/// resolve to the same directory on every platform (deterministic identity on
+/// case-sensitive *and* case-insensitive filesystems — C6). Returns
+/// [`ProfileError`] for an invalid name rather than silently joining a hostile
+/// component.
+#[must_use = "the resolved profile directory should be used"]
+pub fn profile_dir(name: &str) -> Result<PathBuf, ProfileError> {
+    validate_profile_name(name)?;
+    Ok(profiles_root().join(name.to_ascii_lowercase()))
+}
+
+/// Path of the `active` pointer file — a tiny file under [`profiles_root`]
+/// holding the name of the profile to activate when neither `WAYLAND_HOME` nor
+/// `--profile` is supplied. Read ONCE at process entry by activation (Task 1.2)
+/// and never again (C2). Living at the control-plane root (not inside any home)
+/// keeps it outside every profile's isolation boundary.
+pub fn active_pointer_path() -> PathBuf {
+    profiles_root().join("active")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    /// RAII env guard — restores prior values on drop so env-mutating tests stay
+    /// hermetic even under a thread-per-test `cargo test` runner.
+    struct EnvGuard(Vec<(&'static str, Option<std::ffi::OsString>)>);
+    impl EnvGuard {
+        fn set(pairs: &[(&'static str, Option<&str>)]) -> Self {
+            let saved = pairs
+                .iter()
+                .map(|(k, v)| {
+                    let prev = std::env::var_os(k);
+                    match v {
+                        Some(val) => unsafe { std::env::set_var(k, val) },
+                        None => unsafe { std::env::remove_var(k) },
+                    }
+                    (*k, prev)
+                })
+                .collect();
+            Self(saved)
+        }
+    }
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            for (k, prev) in &self.0 {
+                match prev {
+                    Some(v) => unsafe { std::env::set_var(k, v) },
+                    None => unsafe { std::env::remove_var(k) },
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn accepts_reasonable_names() {
+        for ok in [
+            "work",
+            "Work",
+            "my-profile_2.test",
+            "a",
+            "client.acme",
+            "x-1",
+        ] {
+            assert!(validate_profile_name(ok).is_ok(), "should accept {ok:?}");
+        }
+    }
+
+    #[test]
+    fn rejects_traversal_and_separators() {
+        for bad in [
+            "", "..", ".", "...", "a/b", "a\\b", "../etc", "a\0b", "a b", "a:b", "foo.", "café",
+            "a/../b", ".hidden", ".", "..foo",
+        ] {
+            assert!(validate_profile_name(bad).is_err(), "should reject {bad:?}");
+        }
+    }
+
+    #[test]
+    fn rejects_control_plane_reserved_names() {
+        // A profile named "active" would collide with active_pointer_path().
+        for bad in ["active", "Active", "ACTIVE"] {
+            assert!(
+                validate_profile_name(bad).is_err(),
+                "should reject control-plane name {bad:?}"
+            );
+        }
+        // ...but a name that merely contains it is fine.
+        assert!(validate_profile_name("active-work").is_ok());
+    }
+
+    #[test]
+    fn rejects_overlong_name() {
+        let long = "a".repeat(MAX_PROFILE_NAME_LEN + 1);
+        assert!(validate_profile_name(&long).is_err());
+        let max = "a".repeat(MAX_PROFILE_NAME_LEN);
+        assert!(validate_profile_name(&max).is_ok());
+    }
+
+    #[test]
+    fn rejects_windows_reserved_names_case_insensitively() {
+        for bad in [
+            "CON", "con", "Nul", "COM1", "lpt9", "aux", "con.txt", "NUL.cfg",
+        ] {
+            assert!(
+                validate_profile_name(bad).is_err(),
+                "should reject reserved {bad:?}"
+            );
+        }
+        // ...but a name that merely CONTAINS a reserved word is fine.
+        assert!(validate_profile_name("console").is_ok());
+        assert!(validate_profile_name("com10").is_ok());
+    }
+
+    #[test]
+    #[serial]
+    fn profiles_root_ignores_wayland_home() {
+        // profiles_root() must resolve identically whether or not WAYLAND_HOME
+        // is set, and must NEVER be a child of it (C2).
+        let _g = EnvGuard::set(&[("WAYLAND_HOME", None), ("WAYLAND_PROFILES_ROOT", None)]);
+        let without = profiles_root();
+
+        let _g2 = EnvGuard::set(&[("WAYLAND_HOME", Some("/tmp/some-isolated-home"))]);
+        let with = profiles_root();
+
+        assert_eq!(
+            without, with,
+            "profiles_root must not depend on WAYLAND_HOME"
+        );
+        assert!(
+            !with.starts_with("/tmp/some-isolated-home"),
+            "profiles_root must never resolve inside a profile home"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn profiles_root_honors_explicit_override() {
+        let _g = EnvGuard::set(&[("WAYLAND_PROFILES_ROOT", Some("/tmp/custom-profiles"))]);
+        assert_eq!(profiles_root(), PathBuf::from("/tmp/custom-profiles"));
+
+        // A control-char-bearing override is ignored (falls through to default).
+        let _g2 = EnvGuard::set(&[("WAYLAND_PROFILES_ROOT", Some("/tmp/bad\nroot"))]);
+        assert_ne!(profiles_root(), PathBuf::from("/tmp/bad\nroot"));
+
+        // A RELATIVE override is ignored — would make every home CWD-dependent.
+        let _g3 = EnvGuard::set(&[("WAYLAND_PROFILES_ROOT", Some("relative/profiles"))]);
+        let r = profiles_root();
+        assert_ne!(r, PathBuf::from("relative/profiles"));
+        assert!(
+            r.is_absolute() || r == PathBuf::from(".").join("wayland-core-profiles"),
+            "default profiles_root should be absolute (or the cwd-less fallback)"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn profile_dir_case_folds_to_same_path() {
+        let _g = EnvGuard::set(&[("WAYLAND_PROFILES_ROOT", Some("/tmp/p"))]);
+        let upper = profile_dir("Work").unwrap();
+        let lower = profile_dir("work").unwrap();
+        assert_eq!(upper, lower, "Work and work must map to the same directory");
+        assert_eq!(lower, PathBuf::from("/tmp/p/work"));
+    }
+
+    #[test]
+    #[serial]
+    fn profile_dir_rejects_invalid_name() {
+        let _g = EnvGuard::set(&[("WAYLAND_PROFILES_ROOT", Some("/tmp/p"))]);
+        assert!(profile_dir("../escape").is_err());
+        assert!(profile_dir("a/b").is_err());
+    }
+
+    #[test]
+    #[serial]
+    fn active_pointer_is_under_root_not_in_a_home() {
+        let _g = EnvGuard::set(&[
+            ("WAYLAND_PROFILES_ROOT", Some("/tmp/p")),
+            ("WAYLAND_HOME", Some("/tmp/some-home")),
+        ]);
+        let ptr = active_pointer_path();
+        assert_eq!(ptr, PathBuf::from("/tmp/p/active"));
+        assert!(!ptr.starts_with("/tmp/some-home"));
+    }
+}

--- a/crates/wcore-config/src/profile.rs
+++ b/crates/wcore-config/src/profile.rs
@@ -259,6 +259,411 @@ fn activate_for_launch_impl(args: impl Iterator<Item = String>) {
     }
 }
 
+// ===========================================================================
+// Phase 2: profile management control plane (CRUD + active-pointer writers +
+// export/import). EVERYTHING that reads OR writes the `active` pointer lives in
+// this file (D2 single-reader/writer lint); the CLI calls these helpers and
+// never touches the pointer file directly.
+// ===========================================================================
+
+/// Errors from profile management operations (CRUD, pointer writes,
+/// export/import). Distinct from [`ProfileError`] (pure name validation) because
+/// these wrap I/O — so this type is intentionally NOT `PartialEq`/`Eq`. A name
+/// problem surfaces through the `#[from] ProfileError` variant.
+#[derive(Debug, Error)]
+pub enum ProfileOpError {
+    /// The supplied name failed validation (C6); forwarded from
+    /// [`validate_profile_name`].
+    #[error(transparent)]
+    Name(#[from] ProfileError),
+
+    /// A profile with this (case-folded) name already exists on disk.
+    #[error("profile {0:?} already exists")]
+    AlreadyExists(String),
+
+    /// No profile with this (case-folded) name exists on disk.
+    #[error("profile {0:?} does not exist")]
+    NotFound(String),
+
+    /// An import/adopt source path escaped its expected root (path traversal,
+    /// absolute escape, or zip-slip-style `..`). C6 / SECURITY.
+    #[error("refusing unsafe path {path:?}: {reason}")]
+    UnsafePath { path: String, reason: &'static str },
+
+    /// Underlying filesystem error, tagged with the operation for context.
+    #[error("{op} failed: {source}")]
+    Io {
+        op: &'static str,
+        #[source]
+        source: std::io::Error,
+    },
+}
+
+impl ProfileOpError {
+    fn io(op: &'static str) -> impl FnOnce(std::io::Error) -> ProfileOpError {
+        move |source| ProfileOpError::Io { op, source }
+    }
+}
+
+/// Secret-bearing entries inside a profile home that must NEVER be exported
+/// (without an explicit opt-in) nor copied by `create --base`. Matched against
+/// each top-level entry's file name: an exact match for a directory (`oauth`)
+/// or a `credentials.*` / exact `credentials` prefix match for files. Keep this
+/// the single source of truth for "what is a secret in a profile home".
+const SECRET_DIR_NAMES: &[&str] = &["oauth"];
+const SECRET_FILE_PREFIX: &str = "credentials";
+
+/// Decide whether a top-level entry name within a profile home is a secret that
+/// the default (secret-excluding) export/copy path must skip. Directories named
+/// `oauth/` and any `credentials*` file (`credentials.toml`, `credentials.enc`,
+/// `credentials.kdf.json`) are secrets.
+///
+/// Assumption: secrets live at the profile-home ROOT (true today —
+/// `credentials*` resolves under `wayland_config_dir()` == `WAYLAND_HOME` and
+/// `oauth/` under `profile_home()` when a profile is active). The export filter
+/// only special-cases the top level; if the credential/oauth layout ever nests
+/// (e.g. `providers/<x>/credentials.toml`), update this set AND the copy depth
+/// handling together.
+fn is_secret_entry(file_name: &str) -> bool {
+    if SECRET_DIR_NAMES.contains(&file_name) {
+        return true;
+    }
+    // `credentials` exact, or `credentials.<ext>` — but NOT e.g.
+    // `credentials-notes` (defensive: only the dotted family is a secret).
+    file_name == SECRET_FILE_PREFIX
+        || file_name
+            .strip_prefix(SECRET_FILE_PREFIX)
+            .is_some_and(|rest| rest.starts_with('.'))
+}
+
+// --- active-pointer writers / display reader (D2: must live HERE) ----------
+
+/// Public, display-only reader of the active-profile name (e.g. for `profile
+/// list` / `profile show` to mark the active row). This is the ONLY sanctioned
+/// way for the CLI to learn the active profile WITHOUT touching the pointer file
+/// — the single-reader lint (`tests/active_pointer_single_reader_test.rs`) bans
+/// pointer access outside this module, so list/show call this instead. Returns
+/// the trimmed, case-folded name, or `None` if unset/empty/unreadable. Does NOT
+/// verify the profile still exists on disk (callers can cross-check against
+/// [`list_profiles`]); a dangling pointer is reported verbatim so the user can
+/// see and repair it.
+#[must_use]
+pub fn active_profile_name() -> Option<String> {
+    read_active_pointer().map(|n| n.to_ascii_lowercase())
+}
+
+/// Set the active profile by atomically writing its (validated, case-folded)
+/// name to [`active_pointer_path`]. The profile MUST already exist on disk
+/// (`profile set` does not create). Uses temp-file + rename ([`atomic_write`]),
+/// so a crash mid-write can never leave a half-written pointer that would
+/// mis-route the next launch (C2 / SECURITY: atomic pointer writes).
+///
+/// Errors: [`ProfileOpError::Name`] for an invalid name, [`NotFound`] if the
+/// profile directory is absent, [`Io`] on write failure.
+///
+/// [`NotFound`]: ProfileOpError::NotFound
+pub fn set_active_profile(name: &str) -> Result<(), ProfileOpError> {
+    let dir = profile_dir(name)?; // validates + case-folds
+    if !dir.is_dir() {
+        return Err(ProfileOpError::NotFound(name.to_ascii_lowercase()));
+    }
+    let lower = name.to_ascii_lowercase();
+    let ptr = active_pointer_path();
+    if let Some(parent) = ptr.parent() {
+        std::fs::create_dir_all(parent).map_err(ProfileOpError::io("create profiles root"))?;
+    }
+    // Newline-terminated to match what activation tolerates (read_active_pointer
+    // trims) and what a human `cat` expects.
+    crate::atomic_write(&ptr, format!("{lower}\n").as_bytes())
+        .map_err(ProfileOpError::io("write active pointer"))
+}
+
+/// Clear the active pointer (remove the file). Used when the active profile is
+/// deleted or renamed away, so the next launch falls through to the default
+/// home rather than chasing a dangling name. Removing a non-existent pointer is
+/// a no-op success (idempotent). Re-pointing on rename uses
+/// [`set_active_profile`] instead.
+pub fn clear_active_profile() -> Result<(), ProfileOpError> {
+    let ptr = active_pointer_path();
+    match std::fs::remove_file(&ptr) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(ProfileOpError::Io {
+            op: "clear active pointer",
+            source: e,
+        }),
+    }
+}
+
+/// True iff `name` is currently the active profile (case-folded compare). Reads
+/// the pointer via [`active_profile_name`] (the sanctioned display reader), so
+/// the CLI can refuse to delete/rename the active profile without `--force`
+/// without itself touching the pointer file.
+#[must_use]
+pub fn is_active(name: &str) -> bool {
+    match validate_profile_name(name) {
+        Ok(()) => active_profile_name().as_deref() == Some(name.to_ascii_lowercase().as_str()),
+        Err(_) => false,
+    }
+}
+
+// --- enumeration / existence ----------------------------------------------
+
+/// Enumerate the profiles under [`profiles_root`], sorted ascending. Returns the
+/// on-disk (already-lowercase) directory names that pass [`validate_profile_name`].
+/// Skips: the `active` pointer file, any non-directory entry, and any entry whose
+/// name fails validation (defensive — a manually-created junk dir never surfaces
+/// as a usable profile). A missing root yields an empty list, not an error.
+#[must_use]
+pub fn list_profiles() -> Vec<String> {
+    let root = profiles_root();
+    let Ok(entries) = std::fs::read_dir(&root) else {
+        return Vec::new();
+    };
+    let mut names: Vec<String> = entries
+        .flatten()
+        .filter(|e| e.file_type().is_ok_and(|t| t.is_dir()))
+        .filter_map(|e| e.file_name().into_string().ok())
+        .filter(|name| validate_profile_name(name).is_ok())
+        .collect();
+    names.sort();
+    names
+}
+
+/// True iff a profile directory for `name` exists (validated + case-folded). A
+/// validation failure returns `false` (an invalid name can have no profile).
+#[must_use]
+pub fn profile_exists(name: &str) -> bool {
+    match profile_dir(name) {
+        Ok(dir) => dir.is_dir(),
+        Err(_) => false,
+    }
+}
+
+// --- create / rename / delete ---------------------------------------------
+
+/// Create a new, empty profile directory under [`profiles_root`] and return its
+/// path. Errors with [`ProfileOpError::AlreadyExists`] if one is already there.
+///
+/// If `base` is supplied, it must name an existing profile; a `profile.toml`
+/// recording `base = "<base>"` is written inside the new dir. Inheritance is
+/// RESOLVED LATER (Phase 3) — create NEVER copies any state, and in particular
+/// never copies credentials or `oauth/` (SECURITY). The marker file is the only
+/// content written.
+pub fn create_profile(name: &str, base: Option<&str>) -> Result<PathBuf, ProfileOpError> {
+    let dir = profile_dir(name)?; // validates + case-folds
+    if dir.exists() {
+        return Err(ProfileOpError::AlreadyExists(name.to_ascii_lowercase()));
+    }
+    // Validate the base name (and its existence) BEFORE creating anything, so a
+    // bad --base leaves no half-made profile behind.
+    let base_lower = match base {
+        Some(b) => {
+            let base_dir = profile_dir(b)?;
+            if !base_dir.is_dir() {
+                return Err(ProfileOpError::NotFound(b.to_ascii_lowercase()));
+            }
+            Some(b.to_ascii_lowercase())
+        }
+        None => None,
+    };
+
+    std::fs::create_dir_all(&dir).map_err(ProfileOpError::io("create profile dir"))?;
+
+    if let Some(base_lower) = base_lower {
+        // Minimal, hand-written TOML — no serde round-trip needed for one key,
+        // and the base name is already validated (ASCII [A-Za-z0-9._-]) so it
+        // needs no TOML string escaping.
+        let marker = format!("base = \"{base_lower}\"\n");
+        crate::atomic_write(dir.join("profile.toml"), marker.as_bytes())
+            .map_err(ProfileOpError::io("write profile.toml"))?;
+    }
+    Ok(dir)
+}
+
+/// Rename a profile directory `old` → `new`. Both names are validated and
+/// case-folded. Errors: [`NotFound`] if `old` is absent, [`AlreadyExists`] if
+/// `new` is taken. On a same-name case-only rename (`work` → `Work`, identical
+/// on-disk path) this is a no-op success. If the active pointer currently names
+/// `old`, it is re-pointed to `new` (so the active selection follows the rename).
+///
+/// Non-atomicity: the directory move and the pointer re-point are two steps. If
+/// the pointer write fails AFTER the move succeeded, this returns `Err` even
+/// though the rename already happened, leaving the pointer naming the old (now
+/// absent) profile. That dangling pointer is harmless — activation warns and
+/// falls through to the default home — but the error does not convey that the
+/// rename itself succeeded.
+///
+/// [`NotFound`]: ProfileOpError::NotFound
+/// [`AlreadyExists`]: ProfileOpError::AlreadyExists
+pub fn rename_profile(old: &str, new: &str) -> Result<(), ProfileOpError> {
+    let old_dir = profile_dir(old)?;
+    let new_dir = profile_dir(new)?;
+    let old_lower = old.to_ascii_lowercase();
+    let new_lower = new.to_ascii_lowercase();
+
+    if old_dir == new_dir {
+        // Case-only "rename" maps to the same directory — nothing to move. The
+        // pointer (if it named old) already equals new case-folded.
+        return if old_dir.is_dir() {
+            Ok(())
+        } else {
+            Err(ProfileOpError::NotFound(old_lower))
+        };
+    }
+    if !old_dir.is_dir() {
+        return Err(ProfileOpError::NotFound(old_lower));
+    }
+    if new_dir.exists() {
+        return Err(ProfileOpError::AlreadyExists(new_lower));
+    }
+
+    // Capture active-status BEFORE the move (read via the sanctioned reader).
+    let was_active = is_active(&old_lower);
+
+    std::fs::rename(&old_dir, &new_dir).map_err(ProfileOpError::io("rename profile dir"))?;
+
+    if was_active {
+        // Re-point so the active selection follows the rename. The new dir now
+        // exists, so set_active_profile's existence check passes.
+        set_active_profile(&new_lower)?;
+    }
+    Ok(())
+}
+
+/// Remove a profile's directory tree. This is the low-level removal — it does
+/// NOT consult or clear the active pointer and does NOT refuse the active
+/// profile; the CLI layer decides that policy (via [`is_active`] + a `--force`
+/// flag) and is responsible for calling [`clear_active_profile`] afterward when
+/// it deletes the active one. Errors [`NotFound`] if the profile is absent.
+///
+/// [`NotFound`]: ProfileOpError::NotFound
+pub fn delete_profile_dir(name: &str) -> Result<(), ProfileOpError> {
+    let dir = profile_dir(name)?;
+    if !dir.is_dir() {
+        return Err(ProfileOpError::NotFound(name.to_ascii_lowercase()));
+    }
+    std::fs::remove_dir_all(&dir).map_err(ProfileOpError::io("remove profile dir"))
+}
+
+/// Delete a profile, clearing the active pointer first if this profile is the
+/// active one. Convenience wrapper over [`is_active`], [`clear_active_profile`],
+/// and [`delete_profile_dir`] for the common CLI path AFTER the handler has
+/// already confirmed intent (e.g. behind `--force`/`--yes` when active). The
+/// handler still owns the refuse-without-force decision — this function does not
+/// second-guess it, it just keeps the pointer consistent with the deletion.
+pub fn delete_profile(name: &str) -> Result<(), ProfileOpError> {
+    let lower = name.to_ascii_lowercase();
+    if is_active(&lower) {
+        clear_active_profile()?;
+    }
+    delete_profile_dir(&lower)
+}
+
+// --- export / import (recursive copy; secret-excluding by default) ----------
+
+/// Recursively copy `src` into `dst`, creating `dst` and parents. When
+/// `skip_secrets` is true, TOP-LEVEL secret entries ([`is_secret_entry`]) are
+/// skipped (we only special-case the top level, since `credentials*` / `oauth/`
+/// live directly in a profile home). Symlinks are NOT followed and NOT recreated
+/// (C6: no symlink/junction sharing) — a symlink encountered in the tree is
+/// skipped with no error, so a hostile symlink can never redirect the copy out
+/// of the tree.
+fn copy_tree_filtered(src: &Path, dst: &Path, skip_secrets: bool) -> Result<(), ProfileOpError> {
+    std::fs::create_dir_all(dst).map_err(ProfileOpError::io("create export dir"))?;
+    copy_tree_inner(src, dst, skip_secrets, true)
+}
+
+fn copy_tree_inner(
+    src: &Path,
+    dst: &Path,
+    skip_secrets: bool,
+    is_top_level: bool,
+) -> Result<(), ProfileOpError> {
+    for entry in std::fs::read_dir(src).map_err(ProfileOpError::io("read source dir"))? {
+        let entry = entry.map_err(ProfileOpError::io("read source entry"))?;
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy();
+        if is_top_level && skip_secrets && is_secret_entry(&name_str) {
+            continue;
+        }
+        let from = entry.path();
+        // Use symlink_metadata so a symlink is detected as a symlink (not its
+        // target) and skipped — never followed (C6).
+        let meta = from
+            .symlink_metadata()
+            .map_err(ProfileOpError::io("stat source entry"))?;
+        let to = dst.join(&name);
+        if meta.file_type().is_symlink() {
+            continue;
+        }
+        if meta.is_dir() {
+            std::fs::create_dir_all(&to).map_err(ProfileOpError::io("create dir"))?;
+            copy_tree_inner(&from, &to, skip_secrets, false)?;
+        } else {
+            std::fs::copy(&from, &to).map_err(ProfileOpError::io("copy file"))?;
+        }
+    }
+    Ok(())
+}
+
+/// Export a profile's home tree to `dst_dir` (a plain directory the caller
+/// chooses). By default secrets are EXCLUDED ([`is_secret_entry`]); pass
+/// `include_secrets = true` to copy them too — the CLI MUST warn on stderr when
+/// it does. Returns the destination path. Errors [`NotFound`] if the profile is
+/// absent. `dst_dir` must not already exist as a non-empty target the caller
+/// cares about — we create it and copy into it (existing files with the same
+/// name are overwritten by `std::fs::copy`).
+///
+/// [`NotFound`]: ProfileOpError::NotFound
+pub fn export_profile(
+    name: &str,
+    dst_dir: &Path,
+    include_secrets: bool,
+) -> Result<PathBuf, ProfileOpError> {
+    let src = profile_dir(name)?;
+    if !src.is_dir() {
+        return Err(ProfileOpError::NotFound(name.to_ascii_lowercase()));
+    }
+    copy_tree_filtered(&src, dst_dir, !include_secrets)?;
+    Ok(dst_dir.to_path_buf())
+}
+
+/// Import (adopt) a directory tree `src_dir` as a NEW profile `name`. The new
+/// profile must not already exist ([`AlreadyExists`]). `src_dir` is validated
+/// against path-escape: it must be an existing directory, and after
+/// canonicalization every entry copied stays within it (the recursive copy never
+/// follows symlinks, which is the zip-slip / path-escape defense — C6 /
+/// SECURITY). Secrets in the source are NOT filtered on import (the user is
+/// adopting a tree they supplied); the caller decides whether the source was an
+/// exclude-secrets export. Returns the created profile dir.
+///
+/// [`AlreadyExists`]: ProfileOpError::AlreadyExists
+pub fn import_profile(name: &str, src_dir: &Path) -> Result<PathBuf, ProfileOpError> {
+    let dst = profile_dir(name)?; // validates + case-folds
+    if dst.exists() {
+        return Err(ProfileOpError::AlreadyExists(name.to_ascii_lowercase()));
+    }
+    // Reject a non-existent / non-dir / non-canonicalizable source up front.
+    let canonical_src = src_dir
+        .canonicalize()
+        .map_err(|_| ProfileOpError::UnsafePath {
+            path: src_dir.display().to_string(),
+            reason: "source path does not exist or cannot be resolved",
+        })?;
+    if !canonical_src.is_dir() {
+        return Err(ProfileOpError::UnsafePath {
+            path: src_dir.display().to_string(),
+            reason: "import source must be a directory",
+        });
+    }
+    // copy_tree_filtered with skip_secrets=false performs a full recursive copy.
+    // It never follows symlinks, so no entry in the source can redirect the
+    // copy outside `canonical_src` (zip-slip / `..` escape defense).
+    copy_tree_filtered(&canonical_src, &dst, false)?;
+    Ok(dst)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -551,5 +956,301 @@ mod tests {
         ]);
         activate_for_launch_impl(argv(&["wcore", "--profile", "../escape"]));
         assert_eq!(std::env::var_os("WAYLAND_HOME"), None);
+    }
+
+    // --- Phase 2 management helpers ----------------------------------------
+
+    /// Set WAYLAND_PROFILES_ROOT to a fresh tempdir and return (guard, dir).
+    /// All Phase-2 tests run serial because they mutate the process env.
+    fn rooted() -> (EnvGuard, tempfile::TempDir) {
+        let dir = tempdir().unwrap();
+        let g = EnvGuard::set(&[
+            ("WAYLAND_PROFILES_ROOT", Some(dir.path().to_str().unwrap())),
+            ("WAYLAND_HOME", None),
+        ]);
+        (g, dir)
+    }
+
+    #[test]
+    #[serial]
+    fn create_lists_and_exists() {
+        let (_g, root) = rooted();
+        assert!(!profile_exists("work"));
+        let dir = create_profile("work", None).unwrap();
+        assert_eq!(dir, root.path().join("work"));
+        assert!(dir.is_dir());
+        assert!(profile_exists("Work")); // case-folds
+        // No secrets / no marker for a base-less create.
+        assert!(!dir.join("profile.toml").exists());
+        assert!(!dir.join("credentials.toml").exists());
+
+        create_profile("client.acme", None).unwrap();
+        assert_eq!(list_profiles(), vec!["client.acme", "work"]); // sorted
+    }
+
+    #[test]
+    #[serial]
+    fn create_rejects_duplicate_and_invalid() {
+        let (_g, _root) = rooted();
+        create_profile("work", None).unwrap();
+        assert!(matches!(
+            create_profile("Work", None), // same on-disk dir
+            Err(ProfileOpError::AlreadyExists(_))
+        ));
+        assert!(matches!(
+            create_profile("../escape", None),
+            Err(ProfileOpError::Name(_))
+        ));
+    }
+
+    #[test]
+    #[serial]
+    fn create_with_base_writes_marker_and_never_copies_secrets() {
+        let (_g, root) = rooted();
+        let base = create_profile("base", None).unwrap();
+        // Plant a secret in the base; create --base must NOT copy it.
+        std::fs::write(base.join("credentials.toml"), "[secrets]\nx='y'\n").unwrap();
+        std::fs::create_dir_all(base.join("oauth")).unwrap();
+        std::fs::write(base.join("oauth/token.json"), "{}").unwrap();
+
+        let child = create_profile("child", Some("base")).unwrap();
+        let marker = std::fs::read_to_string(child.join("profile.toml")).unwrap();
+        assert_eq!(marker, "base = \"base\"\n");
+        // SECURITY: secrets are never inherited at create time.
+        assert!(!child.join("credentials.toml").exists());
+        assert!(!child.join("oauth").exists());
+        let _ = root;
+    }
+
+    #[test]
+    #[serial]
+    fn create_with_missing_base_errors_and_leaves_nothing() {
+        let (_g, root) = rooted();
+        assert!(matches!(
+            create_profile("child", Some("ghost")),
+            Err(ProfileOpError::NotFound(_))
+        ));
+        // The child dir must not have been created.
+        assert!(!root.path().join("child").exists());
+    }
+
+    #[test]
+    #[serial]
+    fn list_skips_pointer_and_nondirs() {
+        let (_g, root) = rooted();
+        create_profile("work", None).unwrap();
+        // The pointer file and a stray loose file must be skipped.
+        std::fs::write(root.path().join("active"), "work\n").unwrap();
+        std::fs::write(root.path().join("README"), "hi").unwrap();
+        // A junk dir with an invalid name must be skipped too.
+        std::fs::create_dir_all(root.path().join("..junk")).ok();
+        assert_eq!(list_profiles(), vec!["work"]);
+    }
+
+    #[test]
+    #[serial]
+    fn set_clear_and_active_name_roundtrip() {
+        let (_g, _root) = rooted();
+        create_profile("work", None).unwrap();
+        assert_eq!(active_profile_name(), None);
+        assert!(!is_active("work"));
+
+        set_active_profile("Work").unwrap(); // case-folds to "work"
+        assert_eq!(active_profile_name(), Some("work".to_string()));
+        assert!(is_active("work"));
+        assert!(is_active("WORK"));
+
+        clear_active_profile().unwrap();
+        assert_eq!(active_profile_name(), None);
+        // Clearing an already-absent pointer is idempotent.
+        clear_active_profile().unwrap();
+    }
+
+    #[test]
+    #[serial]
+    fn set_active_refuses_missing_profile() {
+        let (_g, _root) = rooted();
+        assert!(matches!(
+            set_active_profile("ghost"),
+            Err(ProfileOpError::NotFound(_))
+        ));
+        assert!(matches!(
+            set_active_profile("../escape"),
+            Err(ProfileOpError::Name(_))
+        ));
+    }
+
+    #[test]
+    #[serial]
+    fn rename_moves_dir_and_repoints_active() {
+        let (_g, root) = rooted();
+        create_profile("old", None).unwrap();
+        std::fs::write(root.path().join("old/marker"), "data").unwrap();
+        set_active_profile("old").unwrap();
+
+        rename_profile("old", "new").unwrap();
+        assert!(!root.path().join("old").exists());
+        assert!(root.path().join("new/marker").exists());
+        // Active selection follows the rename.
+        assert_eq!(active_profile_name(), Some("new".to_string()));
+    }
+
+    #[test]
+    #[serial]
+    fn rename_errors_on_missing_and_conflict() {
+        let (_g, _root) = rooted();
+        create_profile("a", None).unwrap();
+        create_profile("b", None).unwrap();
+        assert!(matches!(
+            rename_profile("ghost", "z"),
+            Err(ProfileOpError::NotFound(_))
+        ));
+        assert!(matches!(
+            rename_profile("a", "b"),
+            Err(ProfileOpError::AlreadyExists(_))
+        ));
+        // Case-only rename is a no-op success and leaves the dir intact.
+        rename_profile("a", "A").unwrap();
+        assert!(profile_exists("a"));
+    }
+
+    #[test]
+    #[serial]
+    fn delete_dir_does_not_touch_pointer() {
+        let (_g, root) = rooted();
+        create_profile("work", None).unwrap();
+        set_active_profile("work").unwrap();
+        // Low-level delete leaves the (now dangling) pointer for the CLI to handle.
+        delete_profile_dir("work").unwrap();
+        assert!(!root.path().join("work").exists());
+        assert_eq!(active_profile_name(), Some("work".to_string()));
+        assert!(matches!(
+            delete_profile_dir("work"),
+            Err(ProfileOpError::NotFound(_))
+        ));
+    }
+
+    #[test]
+    #[serial]
+    fn delete_profile_clears_pointer_when_active() {
+        let (_g, _root) = rooted();
+        create_profile("work", None).unwrap();
+        create_profile("other", None).unwrap();
+        set_active_profile("work").unwrap();
+
+        delete_profile("work").unwrap();
+        assert!(!profile_exists("work"));
+        assert_eq!(active_profile_name(), None, "active pointer cleared");
+
+        // Deleting a non-active profile leaves an unrelated pointer alone.
+        set_active_profile("other").unwrap();
+        create_profile("temp", None).unwrap();
+        delete_profile("temp").unwrap();
+        assert_eq!(active_profile_name(), Some("other".to_string()));
+    }
+
+    #[test]
+    #[serial]
+    fn export_excludes_secrets_by_default() {
+        let (_g, root) = rooted();
+        let p = create_profile("work", None).unwrap();
+        std::fs::write(p.join("config.toml"), "model='x'").unwrap();
+        std::fs::write(p.join("credentials.toml"), "secret").unwrap();
+        std::fs::write(p.join("credentials.enc"), "secret").unwrap();
+        std::fs::create_dir_all(p.join("oauth")).unwrap();
+        std::fs::write(p.join("oauth/t.json"), "{}").unwrap();
+        std::fs::create_dir_all(p.join("memory")).unwrap();
+        std::fs::write(p.join("memory/notes.md"), "keep").unwrap();
+
+        let out = tempdir().unwrap();
+        let dst = out.path().join("export");
+        export_profile("work", &dst, false).unwrap();
+
+        assert!(dst.join("config.toml").exists());
+        assert!(
+            dst.join("memory/notes.md").exists(),
+            "non-secret subtree copied"
+        );
+        assert!(!dst.join("credentials.toml").exists(), "secret excluded");
+        assert!(!dst.join("credentials.enc").exists(), "secret excluded");
+        assert!(!dst.join("oauth").exists(), "oauth excluded");
+        let _ = root;
+    }
+
+    #[test]
+    #[serial]
+    fn export_include_secrets_copies_them() {
+        let (_g, _root) = rooted();
+        let p = create_profile("work", None).unwrap();
+        std::fs::write(p.join("credentials.toml"), "secret").unwrap();
+        let out = tempdir().unwrap();
+        let dst = out.path().join("export");
+        export_profile("work", &dst, true).unwrap();
+        assert!(dst.join("credentials.toml").exists());
+    }
+
+    #[test]
+    #[serial]
+    fn import_creates_profile_from_tree() {
+        let (_g, _root) = rooted();
+        let src = tempdir().unwrap();
+        std::fs::write(src.path().join("config.toml"), "model='y'").unwrap();
+        std::fs::create_dir_all(src.path().join("skills")).unwrap();
+        std::fs::write(src.path().join("skills/s.md"), "skill").unwrap();
+
+        let dir = import_profile("imported", src.path()).unwrap();
+        assert!(dir.join("config.toml").exists());
+        assert!(dir.join("skills/s.md").exists());
+        assert!(profile_exists("imported"));
+    }
+
+    #[test]
+    #[serial]
+    fn import_rejects_existing_and_bad_source() {
+        let (_g, _root) = rooted();
+        create_profile("taken", None).unwrap();
+        let src = tempdir().unwrap();
+        assert!(matches!(
+            import_profile("taken", src.path()),
+            Err(ProfileOpError::AlreadyExists(_))
+        ));
+        // Non-existent source path is rejected as unsafe (cannot canonicalize).
+        let missing = src.path().join("does-not-exist");
+        assert!(matches!(
+            import_profile("fresh", &missing),
+            Err(ProfileOpError::UnsafePath { .. })
+        ));
+    }
+
+    #[test]
+    #[serial]
+    fn import_does_not_follow_symlinks() {
+        let (_g, _root) = rooted();
+        let src = tempdir().unwrap();
+        std::fs::write(src.path().join("real.txt"), "ok").unwrap();
+        // A symlink pointing outside the source must NOT be followed (C6).
+        let outside = tempdir().unwrap();
+        std::fs::write(outside.path().join("secret.txt"), "leak").unwrap();
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(outside.path(), src.path().join("escape")).unwrap();
+
+        let dir = import_profile("safe", src.path()).unwrap();
+        assert!(dir.join("real.txt").exists());
+        // The symlink (and thus the outside file) was skipped, never recreated.
+        assert!(!dir.join("escape").exists());
+    }
+
+    #[test]
+    fn is_secret_entry_classification() {
+        assert!(is_secret_entry("credentials.toml"));
+        assert!(is_secret_entry("credentials.enc"));
+        assert!(is_secret_entry("credentials.kdf.json"));
+        assert!(is_secret_entry("credentials"));
+        assert!(is_secret_entry("oauth"));
+        // Not secrets:
+        assert!(!is_secret_entry("config.toml"));
+        assert!(!is_secret_entry("credentials-notes"));
+        assert!(!is_secret_entry("oauth-helper"));
+        assert!(!is_secret_entry("memory"));
     }
 }

--- a/crates/wcore-config/src/profile.rs
+++ b/crates/wcore-config/src/profile.rs
@@ -597,6 +597,19 @@ fn copy_tree_inner(
         if meta.file_type().is_symlink() {
             continue;
         }
+        // On Windows, an NTFS directory JUNCTION (and any other reparse point) is
+        // NOT classified as a symlink by `is_symlink()`, yet it redirects just
+        // like one — and a junction needs no special privilege to create. Skip
+        // any reparse point by its file attribute so a hostile/import tree cannot
+        // redirect the copy out of the source via a junction (C6 / zip-slip).
+        #[cfg(windows)]
+        {
+            use std::os::windows::fs::MetadataExt;
+            const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x400;
+            if meta.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+                continue;
+            }
+        }
         if meta.is_dir() {
             std::fs::create_dir_all(&to).map_err(ProfileOpError::io("create dir"))?;
             copy_tree_inner(&from, &to, skip_secrets, false)?;

--- a/crates/wcore-config/src/profile.rs
+++ b/crates/wcore-config/src/profile.rs
@@ -93,6 +93,11 @@ pub fn validate_profile_name(name: &str) -> Result<(), ProfileError> {
     if name.starts_with('.') {
         return Err(invalid("name must not start with '.'"));
     }
+    if name.starts_with('-') {
+        // A leading '-' makes the name look like a CLI flag (e.g. `--profile
+        // --help` would otherwise resolve the name "--help"); reject it.
+        return Err(invalid("name must not start with '-'"));
+    }
     if name.ends_with('.') {
         return Err(invalid("name must not end with '.'"));
     }
@@ -159,10 +164,106 @@ pub fn active_pointer_path() -> PathBuf {
     profiles_root().join("active")
 }
 
+/// Read the `active` pointer file. This is the SOLE place the pointer is read
+/// for the launch decision (C2 / D2) — the `active_pointer_path` single-reader
+/// CI lint (`tests/active_pointer_single_reader_test.rs`) keeps it that way.
+/// Returns the trimmed profile name, or `None` if the file is absent, empty, or
+/// unreadable (a corrupt pointer must never abort launch — it falls through to
+/// the default home).
+fn read_active_pointer() -> Option<String> {
+    let raw = std::fs::read_to_string(active_pointer_path()).ok()?;
+    let name = raw.trim();
+    if name.is_empty() {
+        None
+    } else {
+        Some(name.to_string())
+    }
+}
+
+/// Extract the value of `--profile <name>` or `--profile=<name>` from a raw
+/// argv iterator, WITHOUT a full clap parse (which cannot run before the home
+/// is resolved). Returns the first occurrence. Scanning stops at `--`
+/// (end-of-options), so a literal `--profile` inside a user prompt after `--`
+/// is not mistaken for the flag.
+fn profile_flag_from_args(args: impl Iterator<Item = String>) -> Option<String> {
+    let mut args = args;
+    // Skip argv[0] (the program name).
+    let _ = args.next();
+    while let Some(arg) = args.next() {
+        if arg == "--" {
+            break;
+        }
+        if let Some(val) = arg.strip_prefix("--profile=") {
+            return Some(val.to_string());
+        }
+        if arg == "--profile" {
+            return args.next();
+        }
+    }
+    None
+}
+
+/// THE single source-of-truth resolver (C2). Resolve the active profile ONCE, at
+/// process entry, and materialize it into `WAYLAND_HOME`. After this returns,
+/// `WAYLAND_HOME` is the only thing any code (or child process) consults; the
+/// `active` pointer is never read again — the precise failure that corrupts
+/// Hermes (#18594), where a sticky pointer and the env var can disagree deep in
+/// the stack.
+///
+/// Resolution order:
+///   1. `WAYLAND_HOME` already set → an explicit override always wins; return.
+///   2. `--profile <name>` / `--profile=<name>` on argv.
+///   3. else the `active` pointer file.
+///
+/// A resolved name whose [`profile_dir`] exists is set as `WAYLAND_HOME`. An
+/// invalid name, or a name whose directory does not exist, warns to stderr and
+/// falls through to the legacy default home (NEVER aborts — `--help` must run).
+///
+/// # Panics / threading
+/// Calls [`std::env::set_var`], which is sound ONLY while the process is
+/// single-threaded. The sole caller is `wcore-cli`'s `main()`, immediately
+/// before `load_wayland_env_file()` and before any thread (or the Tokio
+/// runtime) is spawned.
+pub fn activate_for_launch() {
+    activate_for_launch_impl(std::env::args());
+}
+
+/// Testable core of [`activate_for_launch`] — argv is injected so tests can
+/// exercise the `--profile` path without mutating the real process arguments.
+fn activate_for_launch_impl(args: impl Iterator<Item = String>) {
+    // 1. Explicit WAYLAND_HOME wins — never override it.
+    if std::env::var_os("WAYLAND_HOME").is_some() {
+        return;
+    }
+
+    // 2. --profile on argv, else 3. the active pointer.
+    let Some(name) = profile_flag_from_args(args).or_else(read_active_pointer) else {
+        return;
+    };
+
+    match profile_dir(&name) {
+        Ok(dir) if dir.is_dir() => {
+            // SAFETY: single-threaded at process entry (see the doc comment and
+            // the `main()` call site). No other thread can observe the env race.
+            unsafe { std::env::set_var("WAYLAND_HOME", &dir) };
+        }
+        Ok(dir) => {
+            eprintln!(
+                "warning: profile {name:?} not found at {} — using the default home",
+                dir.display()
+            );
+        }
+        Err(e) => {
+            eprintln!("warning: ignoring invalid profile selection: {e}");
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use serial_test::serial;
+    use tempfile::tempdir;
 
     /// RAII env guard — restores prior values on drop so env-mutating tests stay
     /// hermetic even under a thread-per-test `cargo test` runner.
@@ -212,7 +313,7 @@ mod tests {
     fn rejects_traversal_and_separators() {
         for bad in [
             "", "..", ".", "...", "a/b", "a\\b", "../etc", "a\0b", "a b", "a:b", "foo.", "café",
-            "a/../b", ".hidden", ".", "..foo",
+            "a/../b", ".hidden", ".", "..foo", "-foo", "--help", "-",
         ] {
             assert!(validate_profile_name(bad).is_err(), "should reject {bad:?}");
         }
@@ -323,5 +424,132 @@ mod tests {
         let ptr = active_pointer_path();
         assert_eq!(ptr, PathBuf::from("/tmp/p/active"));
         assert!(!ptr.starts_with("/tmp/some-home"));
+    }
+
+    fn argv(parts: &[&str]) -> std::vec::IntoIter<String> {
+        parts
+            .iter()
+            .map(|s| s.to_string())
+            .collect::<Vec<_>>()
+            .into_iter()
+    }
+
+    #[test]
+    fn profile_flag_parsing() {
+        assert_eq!(
+            profile_flag_from_args(argv(&["wcore", "--profile", "work"])),
+            Some("work".to_string())
+        );
+        assert_eq!(
+            profile_flag_from_args(argv(&["wcore", "--profile=work"])),
+            Some("work".to_string())
+        );
+        assert_eq!(profile_flag_from_args(argv(&["wcore", "run"])), None);
+        // First occurrence wins.
+        assert_eq!(
+            profile_flag_from_args(argv(&["wcore", "--profile", "a", "--profile", "b"])),
+            Some("a".to_string())
+        );
+        // A `--profile` after `--` (end-of-options) is NOT the flag.
+        assert_eq!(
+            profile_flag_from_args(argv(&["wcore", "--", "--profile", "x"])),
+            None
+        );
+        // argv[0] named --profile is skipped.
+        assert_eq!(profile_flag_from_args(argv(&["--profile"])), None);
+        // A trailing --profile with no value resolves to None (falls through).
+        assert_eq!(profile_flag_from_args(argv(&["wcore", "--profile"])), None);
+    }
+
+    #[test]
+    #[serial]
+    fn activate_respects_existing_wayland_home() {
+        let root = tempdir().unwrap();
+        std::fs::create_dir_all(root.path().join("work")).unwrap();
+        let _g = EnvGuard::set(&[
+            ("WAYLAND_PROFILES_ROOT", Some(root.path().to_str().unwrap())),
+            ("WAYLAND_HOME", Some("/explicit/home")),
+        ]);
+        activate_for_launch_impl(argv(&["wcore", "--profile", "work"]));
+        // Explicit WAYLAND_HOME must win — never overridden by --profile.
+        assert_eq!(std::env::var("WAYLAND_HOME").unwrap(), "/explicit/home");
+    }
+
+    #[test]
+    #[serial]
+    fn activate_sets_home_from_profile_flag() {
+        let root = tempdir().unwrap();
+        let work = root.path().join("work");
+        std::fs::create_dir_all(&work).unwrap();
+        let _g = EnvGuard::set(&[
+            ("WAYLAND_PROFILES_ROOT", Some(root.path().to_str().unwrap())),
+            ("WAYLAND_HOME", None),
+        ]);
+        activate_for_launch_impl(argv(&["wcore", "--profile", "Work"])); // case-folds
+        assert_eq!(
+            std::env::var_os("WAYLAND_HOME"),
+            Some(work.into_os_string())
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn activate_reads_pointer_when_no_flag() {
+        let root = tempdir().unwrap();
+        let work = root.path().join("work");
+        std::fs::create_dir_all(&work).unwrap();
+        std::fs::write(root.path().join("active"), "work\n").unwrap();
+        let _g = EnvGuard::set(&[
+            ("WAYLAND_PROFILES_ROOT", Some(root.path().to_str().unwrap())),
+            ("WAYLAND_HOME", None),
+        ]);
+        activate_for_launch_impl(argv(&["wcore"]));
+        assert_eq!(
+            std::env::var_os("WAYLAND_HOME"),
+            Some(work.into_os_string())
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn activate_flag_wins_over_pointer() {
+        let root = tempdir().unwrap();
+        std::fs::create_dir_all(root.path().join("flagged")).unwrap();
+        std::fs::create_dir_all(root.path().join("pointed")).unwrap();
+        std::fs::write(root.path().join("active"), "pointed").unwrap();
+        let _g = EnvGuard::set(&[
+            ("WAYLAND_PROFILES_ROOT", Some(root.path().to_str().unwrap())),
+            ("WAYLAND_HOME", None),
+        ]);
+        activate_for_launch_impl(argv(&["wcore", "--profile", "flagged"]));
+        assert_eq!(
+            std::env::var_os("WAYLAND_HOME"),
+            Some(root.path().join("flagged").into_os_string())
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn activate_falls_through_on_missing_dir() {
+        let root = tempdir().unwrap();
+        let _g = EnvGuard::set(&[
+            ("WAYLAND_PROFILES_ROOT", Some(root.path().to_str().unwrap())),
+            ("WAYLAND_HOME", None),
+        ]);
+        activate_for_launch_impl(argv(&["wcore", "--profile", "ghost"]));
+        // Missing profile dir → warn + fall through; WAYLAND_HOME stays unset.
+        assert_eq!(std::env::var_os("WAYLAND_HOME"), None);
+    }
+
+    #[test]
+    #[serial]
+    fn activate_falls_through_on_invalid_name() {
+        let root = tempdir().unwrap();
+        let _g = EnvGuard::set(&[
+            ("WAYLAND_PROFILES_ROOT", Some(root.path().to_str().unwrap())),
+            ("WAYLAND_HOME", None),
+        ]);
+        activate_for_launch_impl(argv(&["wcore", "--profile", "../escape"]));
+        assert_eq!(std::env::var_os("WAYLAND_HOME"), None);
     }
 }

--- a/crates/wcore-config/tests/active_pointer_single_reader_test.rs
+++ b/crates/wcore-config/tests/active_pointer_single_reader_test.rs
@@ -1,0 +1,117 @@
+//! D2 single-reader lint for the isolated-profile `active` pointer.
+//!
+//! C2/D2: the `active` profile pointer is resolved ONCE, at process entry
+//! (`profile::activate_for_launch`), and materialized into `WAYLAND_HOME`; it is
+//! never consulted again. The Hermes corruption bug (#18594) is precisely what
+//! happens when a sticky pointer is re-read deep in the stack and can disagree
+//! with the env var. To keep that discipline locally reviewable, ALL access to
+//! the pointer — via the path resolver AND via the raw `<root>/active` join —
+//! must stay inside the one module that owns it:
+//! `crates/wcore-config/src/profile.rs`. Phase 2's `profile use` writer lives
+//! there too; the CLI calls named helpers, never the path directly.
+//!
+//! Scope/limits (honest): this is a CALL-SITE regression gate, not a proof of
+//! impossibility. It bans the two realistic proliferation shapes — calling the
+//! `active_pointer_path` resolver, and hand-building the pointer path with a
+//! `join` on the `active` literal — from any file but the allow-listed module.
+//! A determined bypass (capturing the resolver as a fn-pointer, or reconstructing
+//! the path from raw string ops) is not detected; the goal is to stop accidental
+//! copy-paste, which is how the Hermes failure actually crept in.
+//!
+//! Mirrors `hermeticity_audit_test.rs`: shells out to `git grep`
+//! (dependency-free), skips comment-only mentions, and is skipped entirely if
+//! `git`/`.git` is unavailable (no false negative, no flake).
+
+use std::path::PathBuf;
+use std::process::Command;
+
+/// The sole file allowed to touch the `active` pointer path.
+const ALLOWLIST: &[&str] = &["crates/wcore-config/src/profile.rs"];
+
+fn workspace_root() -> PathBuf {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    manifest_dir
+        .parent()
+        .and_then(|p| p.parent())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            panic!(
+                "CARGO_MANIFEST_DIR ({}) has fewer than two ancestors; cannot locate workspace root",
+                manifest_dir.display()
+            )
+        })
+}
+
+/// Non-comment hits, under `crates/`, for either the resolver call form or a raw
+/// `join` on the `active` pointer literal. The regex carries backslashes, so the
+/// pattern string in THIS source file does not match itself (the bytes on disk
+/// here are `…path\(`, not `…path(`).
+fn violation_hits(root: &PathBuf) -> Option<Vec<String>> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .arg("grep")
+        .arg("-nE")
+        .arg(r#"active_pointer_path\(|\.join\("active"\)"#)
+        .arg("--")
+        .arg("crates/")
+        .output()
+        .ok()?;
+
+    // `git grep` exits 1 on zero matches — success for us. Any other non-zero
+    // means git itself failed; skip rather than flake.
+    if !output.status.success() && output.status.code() != Some(1) {
+        eprintln!(
+            "active_pointer_single_reader: `git grep` failed (status {:?}); skipping",
+            output.status.code()
+        );
+        return Some(Vec::new());
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut hits = Vec::new();
+    for raw_line in stdout.lines() {
+        // Line shape: `<path>:<lineno>:<content>`.
+        let mut parts = raw_line.splitn(3, ':');
+        let path = match parts.next() {
+            Some(p) => p,
+            None => continue,
+        };
+        let _lineno = parts.next();
+        let content = match parts.next() {
+            Some(c) => c,
+            None => continue,
+        };
+
+        let trimmed = content.trim_start();
+        // Skip comment-only mentions (`//`, `///`, `//!`, block-comment `*`).
+        if trimmed.starts_with("//") || trimmed.starts_with('*') {
+            continue;
+        }
+        if ALLOWLIST.contains(&path) {
+            continue;
+        }
+        hits.push(format!("{path}: {}", content.trim()));
+    }
+    Some(hits)
+}
+
+#[test]
+fn active_pointer_is_accessed_in_exactly_one_module() {
+    let root = workspace_root();
+    if !root.join(".git").exists() {
+        eprintln!("active_pointer_single_reader: no .git at {root:?}; skipping");
+        return;
+    }
+    let Some(hits) = violation_hits(&root) else {
+        eprintln!("active_pointer_single_reader: git unavailable; skipping");
+        return;
+    };
+    assert!(
+        hits.is_empty(),
+        "the active-pointer path must only be accessed from {ALLOWLIST:?} (C2/D2 \
+         single-reader invariant — resolved once at launch, never re-read). \
+         Offending sites:\n{}",
+        hits.join("\n")
+    );
+}

--- a/crates/wcore-config/tests/credential_isolation_test.rs
+++ b/crates/wcore-config/tests/credential_isolation_test.rs
@@ -1,0 +1,186 @@
+//! Task 0.1 / D1 — per-profile credential isolation.
+//!
+//! When WAYLAND_HOME is set (isolated profile), the Auto backend defaults to
+//! the in-home encrypted vault (not the process-global OS keyring, which bleeds
+//! across profiles). These tests prove cross-profile isolation via the file
+//! backend on every platform (matches the Hetzner empirical run).
+
+use std::path::Path;
+
+use serial_test::serial;
+use tempfile::tempdir;
+use wcore_config::credentials::{CredentialsStorageConfig, open_store};
+
+const PASS: &str = "test-vault-passphrase";
+const KEY: &str = "providers.anthropic.api_key";
+
+/// RAII guard: set/remove env vars, restore prior values on drop (keeps tests
+/// hermetic even on a thread-per-test `cargo test` runner).
+struct EnvGuard {
+    saved: Vec<(&'static str, Option<std::ffi::OsString>)>,
+}
+impl EnvGuard {
+    fn set(pairs: &[(&'static str, &str)]) -> Self {
+        let saved = pairs
+            .iter()
+            .map(|(k, v)| {
+                let prev = std::env::var_os(k);
+                unsafe { std::env::set_var(k, v) };
+                (*k, prev)
+            })
+            .collect();
+        Self { saved }
+    }
+
+    /// Remove the given vars now, restoring whatever was there on drop. Used so
+    /// a test that requires a var ABSENT does not permanently clobber it for
+    /// later tests in the same process (the `cargo test` thread-per-test case).
+    fn remove(keys: &[&'static str]) -> Self {
+        let saved = keys
+            .iter()
+            .map(|k| {
+                let prev = std::env::var_os(k);
+                unsafe { std::env::remove_var(k) };
+                (*k, prev)
+            })
+            .collect();
+        Self { saved }
+    }
+}
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        for (k, prev) in &self.saved {
+            match prev {
+                Some(v) => unsafe { std::env::set_var(k, v) },
+                None => unsafe { std::env::remove_var(k) },
+            }
+        }
+    }
+}
+
+fn put_secret(home: &Path, value: &str) {
+    let _g = EnvGuard::set(&[
+        ("WAYLAND_HOME", home.to_str().unwrap()),
+        ("WAYLAND_VAULT_PASSPHRASE", PASS),
+    ]);
+    let cfg = CredentialsStorageConfig::default(); // Auto
+    let store = open_store(&cfg, &home.join("credentials.toml")).expect("open A");
+    store.put(KEY, value).expect("put");
+}
+
+fn get_secret(home: &Path) -> Option<String> {
+    let _g = EnvGuard::set(&[
+        ("WAYLAND_HOME", home.to_str().unwrap()),
+        ("WAYLAND_VAULT_PASSPHRASE", PASS),
+    ]);
+    let cfg = CredentialsStorageConfig::default();
+    let store = open_store(&cfg, &home.join("credentials.toml")).expect("open get");
+    store.get(KEY).expect("get")
+}
+
+#[test]
+#[serial]
+fn vault_lands_in_home_and_secret_does_not_cross_profiles() {
+    let a = tempdir().unwrap();
+    let b = tempdir().unwrap();
+    put_secret(a.path(), "secret-A");
+
+    // (a) vault materialized in home A — this is the discriminating assertion:
+    // against the OLD keyring-Auto code this file would never appear (old Auto
+    // writes credentials.toml or the OS keyring), so it pins the new behavior.
+    assert!(
+        a.path().join("credentials.enc").exists(),
+        "encrypted vault must land inside WAYLAND_HOME A"
+    );
+    // Pre-condition sanity (nothing has been written to B yet).
+    assert!(
+        !b.path().join("credentials.enc").exists(),
+        "home B must have no vault yet"
+    );
+
+    // Same passphrase, different home → secret is NOT resolvable.
+    assert_eq!(
+        get_secret(b.path()),
+        None,
+        "secret written under home A must not resolve under home B"
+    );
+    // Sanity: it IS resolvable under home A (per-home salt, same passphrase).
+    assert_eq!(get_secret(a.path()).as_deref(), Some("secret-A"));
+}
+
+#[test]
+#[serial]
+fn deleting_profile_dir_leaves_zero_residual_secret() {
+    let c = tempdir().unwrap();
+    put_secret(c.path(), "secret-C");
+    assert!(c.path().join("credentials.enc").exists());
+
+    // Delete the whole profile home.
+    std::fs::remove_dir_all(c.path()).unwrap();
+    assert!(!c.path().join("credentials.enc").exists());
+
+    // A fresh isolated home at the same path resolves nothing.
+    std::fs::create_dir_all(c.path()).unwrap();
+    assert_eq!(
+        get_secret(c.path()),
+        None,
+        "no residual secret after profile dir deletion"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+#[serial]
+fn vault_files_are_0600() {
+    use std::os::unix::fs::PermissionsExt;
+    let h = tempdir().unwrap();
+    put_secret(h.path(), "secret-perms");
+    for name in ["credentials.enc", "credentials.kdf.json"] {
+        let p = h.path().join(name);
+        let mode = std::fs::metadata(&p).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "{name} must be 0o600, got {mode:#o}");
+    }
+}
+
+#[test]
+#[serial]
+fn no_passphrase_falls_back_to_plaintext_not_keyring() {
+    // WAYLAND_HOME set but NO passphrase material → plaintext-0600 in-home,
+    // round-trips, and writes credentials.toml (not credentials.enc).
+    let h = tempdir().unwrap();
+    let _g = EnvGuard::set(&[("WAYLAND_HOME", h.path().to_str().unwrap())]);
+    // Ensure no stray passphrase from the ambient environment — routed through
+    // the guard so it is restored for later tests in the same process.
+    let _g2 = EnvGuard::remove(&["WAYLAND_VAULT_PASSPHRASE", "WAYLAND_VAULT_PASSPHRASE_FD"]);
+
+    let cfg = CredentialsStorageConfig::default();
+    let store = open_store(&cfg, &h.path().join("credentials.toml")).expect("open");
+    store.put(KEY, "secret-plain").expect("put");
+    assert_eq!(
+        store.get(KEY).expect("get").as_deref(),
+        Some("secret-plain")
+    );
+    assert!(
+        h.path().join("credentials.toml").exists(),
+        "plaintext fallback must write credentials.toml"
+    );
+    assert!(
+        !h.path().join("credentials.enc").exists(),
+        "must NOT create an encrypted vault without unlock material"
+    );
+
+    // The plaintext fallback must still be 0o600 (D1: warned, but never loose).
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = std::fs::metadata(h.path().join("credentials.toml"))
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(
+            mode, 0o600,
+            "plaintext fallback must be 0o600, got {mode:#o}"
+        );
+    }
+}

--- a/crates/wcore-cua/src/policy.rs
+++ b/crates/wcore-cua/src/policy.rs
@@ -22,7 +22,7 @@
 //! skip the prompt.
 
 use std::collections::HashSet;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use parking_lot::Mutex;
@@ -147,16 +147,27 @@ impl CuaPolicy {
         self
     }
 
-    /// Default on-disk path for the seen-apps store.
-    /// `<data_dir>/wayland/cua/seen-apps.json` — falls back to
-    /// `<tmp_dir>/wayland/cua/seen-apps.json` when `dirs::data_dir`
-    /// returns None (rare; sandboxed test environments).
+    /// Default on-disk path for the seen-apps store, rooted under the
+    /// profile home so `WAYLAND_HOME` sandboxes it:
+    /// `<profile_home>/cua/seen-apps.json`.
+    ///
+    /// On first access a one-time, best-effort migration
+    /// ([`migrate_legacy_seen_apps`]) copies the pre-isolation
+    /// `<data_dir>/wayland/cua/seen-apps.json` here — but ONLY when
+    /// `WAYLAND_HOME` is unset. Under an explicit `WAYLAND_HOME` the user
+    /// opted into an isolated profile and MUST NOT inherit another
+    /// profile's HITL approval grants.
+    ///
+    /// NOTE (open risk O1): no production code currently calls this — the
+    /// host builds `CuaTool` without setting `seen_apps_path`, so the
+    /// store is in-memory only today. This function is the correct home
+    /// for the path + migration the moment persistence is wired.
     pub fn default_seen_apps_path() -> PathBuf {
-        dirs::data_dir()
-            .unwrap_or_else(std::env::temp_dir)
-            .join("wayland")
+        let path = wcore_config::config::profile_home()
             .join("cua")
-            .join("seen-apps.json")
+            .join("seen-apps.json");
+        migrate_legacy_seen_apps(&path);
+        path
     }
 
     /// Compose the composite key used in the seen-apps set:
@@ -467,10 +478,118 @@ fn matches_combo(forbidden: &str, normalized: &str) -> bool {
     }
 }
 
+/// One-time best-effort migration of the pre-isolation CUA seen-apps store
+/// into the `WAYLAND_HOME`-rooted location.
+///
+/// Gated, idempotent, atomic:
+///   * **Gate:** if `WAYLAND_HOME` is set, return immediately — an isolated
+///     profile must NOT inherit shared legacy approval grants;
+///   * if `new_path` already exists → no-op;
+///   * if the legacy `<data_dir>/wayland/cua/seen-apps.json` is absent or
+///     resolves to `new_path` → no-op;
+///   * otherwise copy legacy → a temp sibling, then atomic-`rename` into
+///     place so a concurrent reader never observes a torn file.
+///
+/// Every failure logs at `warn` and returns — a missing grant just
+/// re-prompts the user; it must never crash the engine.
+fn migrate_legacy_seen_apps(new_path: &Path) {
+    // Explicit-isolation profiles never inherit shared legacy state.
+    if std::env::var_os("WAYLAND_HOME").is_some() {
+        return;
+    }
+    if new_path.exists() {
+        return;
+    }
+    let Some(legacy) =
+        dirs::data_dir().map(|d| d.join("wayland").join("cua").join("seen-apps.json"))
+    else {
+        return;
+    };
+    if legacy == new_path || !legacy.exists() {
+        return;
+    }
+    let Some(parent) = new_path.parent() else {
+        return;
+    };
+    if let Err(e) = std::fs::create_dir_all(parent) {
+        tracing::warn!(error = %e, path = %new_path.display(),
+            "cua: failed to create dir for seen-apps migration");
+        return;
+    }
+    // Re-check after dir creation: a concurrent migrator may have won.
+    if new_path.exists() {
+        return;
+    }
+    // Atomic publish: copy to a temp sibling, then rename onto new_path so a
+    // reader sees either absent-or-complete, never a half-written file.
+    let tmp = parent.join(".seen-apps.json.migrating");
+    if let Err(e) = std::fs::copy(&legacy, &tmp) {
+        tracing::warn!(error = %e, from = %legacy.display(), to = %tmp.display(),
+            "cua: failed to stage legacy seen-apps migration");
+        let _ = std::fs::remove_file(&tmp);
+        return;
+    }
+    if let Err(e) = std::fs::rename(&tmp, new_path) {
+        tracing::warn!(error = %e, to = %new_path.display(),
+            "cua: failed to publish migrated seen-apps store");
+        let _ = std::fs::remove_file(&tmp);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::backend::{KeyMods, MouseButton};
+
+    #[test]
+    #[serial_test::serial]
+    fn default_seen_apps_path_roots_under_wayland_home() {
+        let tmp = tempfile::tempdir().unwrap();
+        let prev = std::env::var_os("WAYLAND_HOME");
+        unsafe { std::env::set_var("WAYLAND_HOME", tmp.path()) };
+        let p = CuaPolicy::default_seen_apps_path();
+        match prev {
+            Some(v) => unsafe { std::env::set_var("WAYLAND_HOME", v) },
+            None => unsafe { std::env::remove_var("WAYLAND_HOME") },
+        }
+        assert_eq!(p, tmp.path().join("cua").join("seen-apps.json"));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn migration_skipped_when_wayland_home_set() {
+        // With WAYLAND_HOME set, migration must be an unconditional no-op
+        // (no inheritance of shared legacy grants) — even though new_path
+        // is absent.
+        let tmp = tempfile::tempdir().unwrap();
+        let new_path = tmp.path().join("cua").join("seen-apps.json");
+        let prev = std::env::var_os("WAYLAND_HOME");
+        unsafe { std::env::set_var("WAYLAND_HOME", tmp.path()) };
+        super::migrate_legacy_seen_apps(&new_path);
+        match prev {
+            Some(v) => unsafe { std::env::set_var("WAYLAND_HOME", v) },
+            None => unsafe { std::env::remove_var("WAYLAND_HOME") },
+        }
+        assert!(!new_path.exists());
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn migration_is_idempotent_and_does_not_clobber() {
+        // WAYLAND_HOME unset (single-profile upgrade case); new_path present
+        // → migration must be a no-op and must not overwrite existing data.
+        let tmp = tempfile::tempdir().unwrap();
+        let new_path = tmp.path().join("cua").join("seen-apps.json");
+        std::fs::create_dir_all(new_path.parent().unwrap()).unwrap();
+        std::fs::write(&new_path, br#"["existing"]"#).unwrap();
+        let prev = std::env::var_os("WAYLAND_HOME");
+        unsafe { std::env::remove_var("WAYLAND_HOME") };
+        super::migrate_legacy_seen_apps(&new_path);
+        if let Some(v) = prev {
+            unsafe { std::env::set_var("WAYLAND_HOME", v) }
+        }
+        assert_eq!(std::fs::read(&new_path).unwrap(), br#"["existing"]"#);
+    }
 
     fn click() -> CuaOp {
         CuaOp::LeftClick {

--- a/crates/wcore-mcp/src/transport/stdio.rs
+++ b/crates/wcore-mcp/src/transport/stdio.rs
@@ -36,6 +36,14 @@ const FORWARDED_ENV_VARS: &[&str] = &[
     "LC_NUMERIC",
     "LC_TIME",
     "TMPDIR", // macOS: per-user temp dir used by many npm CLIs
+    // C3: the isolated-profile home. A wayland-aware MCP child (e.g. the IJFW
+    // memory server) must resolve the SAME profile as the parent — without this
+    // it falls back to the default ~/.wayland (cross-profile leak). Non-secret
+    // path; the vault passphrase (WAYLAND_VAULT_*) is never forwarded. This is
+    // distinct from the WAYLAND_PROFILE_HOME contract below (a resolved path for
+    // plugins that read it); WAYLAND_HOME drives the child's own
+    // wayland_config_dir() resolution.
+    "WAYLAND_HOME",
     // Windows essentials. Without these, cmd.exe / powershell.exe / .NET-based
     // MCP servers fail to initialise on Windows and the spawned child dies in
     // ~15ms before the first JSON-RPC request reaches it — diagnosed via
@@ -1180,6 +1188,10 @@ mod tests {
         assert!(
             FORWARDED_ENV_VARS.contains(&"LANG"),
             "LANG must be in the allowlist"
+        );
+        assert!(
+            FORWARDED_ENV_VARS.contains(&"WAYLAND_HOME"),
+            "WAYLAND_HOME must be forwarded for C3 profile propagation"
         );
 
         // Sensitive vars must NOT appear in the allowlist.

--- a/crates/wcore-plugin-api/Cargo.toml
+++ b/crates/wcore-plugin-api/Cargo.toml
@@ -43,3 +43,4 @@ toml = { workspace = true }
 [dev-dependencies]
 rstest.workspace = true
 tempfile.workspace = true
+serial_test.workspace = true

--- a/crates/wcore-plugin-api/src/manifest.rs
+++ b/crates/wcore-plugin-api/src/manifest.rs
@@ -135,14 +135,20 @@ impl PluginIdentity {
         })
     }
 
-    /// Default trusted root for dynamic plugins:
-    /// `<data_dir>/wayland/plugins/`. Falls back to the system temp
-    /// dir when `dirs::data_dir()` returns None.
+    /// Default trusted root for dynamic plugins, rooted under the profile
+    /// home so `WAYLAND_HOME` sandboxes it: `<profile_home>/plugins/`.
+    ///
+    /// SECURITY: this is a trust anchor — it becomes an `allowed_roots`
+    /// entry for path-prefix manifest validation
+    /// ([`PluginIdentity::from_path_prefix`]). `wcore-plugin-api` is the
+    /// plugin-isolation boundary and MUST NOT depend on `wcore-config`
+    /// (enforced by `build.rs` FORBIDDEN_CORE_IMPORTS), so the resolution
+    /// is replicated inline in [`profile_home_local`]. It MUST stay
+    /// byte-for-byte equivalent to `wcore_config::config::profile_home()`;
+    /// the cross-crate test `default_plugin_root_matches_canonical_resolver`
+    /// in `wcore-agent` pins that equality.
     pub fn default_plugin_root() -> PathBuf {
-        dirs::data_dir()
-            .unwrap_or_else(std::env::temp_dir)
-            .join("wayland")
-            .join("plugins")
+        profile_home_local().join("plugins")
     }
 
     /// True when this identity is anchored to the engine binary
@@ -481,5 +487,63 @@ fn validate_partition(p: &str, side: &str, plugin: &str) -> PluginResult<()> {
                 "{plugin}: memory_partitions_{side} contains invalid partition `{p}` (valid: P1..=P5)"
             ),
         }),
+    }
+}
+
+/// Inline mirror of `wcore_config::config::profile_home()`. Kept in sync by
+/// hand because the plugin-api isolation boundary forbids a `wcore-config`
+/// dep (`build.rs` FORBIDDEN_CORE_IMPORTS). MUST stay byte-for-byte equal:
+/// same env var, same control-char filter, same `~/.wayland` default, same
+/// CWD-relative last-resort fallback. Pinned by the cross-crate equality test
+/// `default_plugin_root_matches_canonical_resolver` in `wcore-agent`.
+fn profile_home_local() -> PathBuf {
+    // Reject an override carrying an ASCII control char (NUL/newline) — it
+    // can't be passed safely to a child env. Fall through to the default.
+    if let Ok(wh) = std::env::var("WAYLAND_HOME")
+        && !wh.chars().any(|c| c.is_control())
+    {
+        return PathBuf::from(wh);
+    }
+    dirs::home_dir()
+        .map(|h| h.join(".wayland"))
+        .unwrap_or_else(|| {
+            std::env::current_dir()
+                .map(|d| d.join(".wayland"))
+                .unwrap_or_else(|_| PathBuf::from(".wayland"))
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[serial_test::serial]
+    fn default_plugin_root_honours_wayland_home() {
+        let tmp = tempfile::tempdir().unwrap();
+        let prev = std::env::var_os("WAYLAND_HOME");
+        unsafe { std::env::set_var("WAYLAND_HOME", tmp.path()) };
+        let root = PluginIdentity::default_plugin_root();
+        match prev {
+            Some(v) => unsafe { std::env::set_var("WAYLAND_HOME", v) },
+            None => unsafe { std::env::remove_var("WAYLAND_HOME") },
+        }
+        assert_eq!(root, tmp.path().join("plugins"));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn default_plugin_root_rejects_control_char_override() {
+        let prev = std::env::var_os("WAYLAND_HOME");
+        unsafe { std::env::set_var("WAYLAND_HOME", "bad\nvalue") };
+        let root = PluginIdentity::default_plugin_root();
+        match prev {
+            Some(v) => unsafe { std::env::set_var("WAYLAND_HOME", v) },
+            None => unsafe { std::env::remove_var("WAYLAND_HOME") },
+        }
+        // Control-char override rejected → falls back to ~/.wayland/plugins,
+        // never the literal "bad\nvalue".
+        assert!(root.ends_with("plugins"));
+        assert!(!root.to_string_lossy().contains('\n'));
     }
 }

--- a/crates/wcore-plugin-api/tests/manifest_identity_test.rs
+++ b/crates/wcore-plugin-api/tests/manifest_identity_test.rs
@@ -81,7 +81,8 @@ fn path_prefix_refuses_nonexistent_path() {
 }
 
 #[test]
-fn default_plugin_root_is_under_data_dir() {
+fn default_plugin_root_is_under_profile_home() {
+    // Post-isolation-sweep the default root is `<WAYLAND_HOME or ~/.wayland>/plugins`.
     let root = PluginIdentity::default_plugin_root();
     let s = root.to_string_lossy();
     assert!(

--- a/crates/wcore-plugin-subprocess/src/mcp_bridge.rs
+++ b/crates/wcore-plugin-subprocess/src/mcp_bridge.rs
@@ -109,7 +109,9 @@ const MCP_PROTOCOL_VERSION: &str = "2025-03-26";
 
 /// Minimal env vars forwarded to MCP-bridge child processes after
 /// [`std::process::Command::env_clear`]. Everything else — including
-/// `OPENAI_API_KEY`, `WAYLAND_*`, `ANTHROPIC_*`, etc. — is withheld.
+/// `OPENAI_API_KEY`, `WAYLAND_VAULT_*`, `ANTHROPIC_*`, etc. — is withheld
+/// (`WAYLAND_HOME` is an intentional exception below, forwarded so the child
+/// resolves the same isolated profile — C3; the vault secret stays withheld).
 /// Kept minimal: just enough for CLI tools to locate executables and
 /// behave correctly under different locales on every supported OS.
 ///
@@ -133,6 +135,11 @@ const FORWARDED_ENV_VARS: &[&str] = &[
     "LC_NUMERIC",
     "LC_TIME",
     "TMPDIR",
+    // C3: the isolated-profile home. Engine-controlled children must resolve the
+    // SAME profile as the parent — without this they fall back to the default
+    // ~/.wayland (cross-profile leak). Non-secret path; the vault passphrase
+    // (WAYLAND_VAULT_*) is never forwarded.
+    "WAYLAND_HOME",
     // Windows essentials
     "SYSTEMROOT",
     "WINDIR",
@@ -749,6 +756,8 @@ mod tests {
         assert!(FORWARDED_ENV_VARS.contains(&"HOME"));
         assert!(FORWARDED_ENV_VARS.contains(&"USER"));
         assert!(FORWARDED_ENV_VARS.contains(&"LANG"));
+        // C3 profile propagation.
+        assert!(FORWARDED_ENV_VARS.contains(&"WAYLAND_HOME"));
     }
 
     /// Audit rel-panic-68/M-21: a hostile MCP server that streams an endless

--- a/crates/wcore-plugin-subprocess/src/runner.rs
+++ b/crates/wcore-plugin-subprocess/src/runner.rs
@@ -132,7 +132,9 @@ pub const CRASH_THRESHOLD: u8 = 3;
 
 /// Minimal env vars forwarded to subprocess plugin child processes after
 /// [`std::process::Command::env_clear`]. Everything else — including
-/// `OPENAI_API_KEY`, `WAYLAND_*`, `ANTHROPIC_*`, etc. — is withheld.
+/// `OPENAI_API_KEY`, `WAYLAND_VAULT_*`, `ANTHROPIC_*`, etc. — is withheld
+/// (`WAYLAND_HOME` is an intentional exception below, forwarded so the child
+/// resolves the same isolated profile — C3; the vault secret stays withheld).
 /// Kept minimal: just enough for CLI tools to locate executables and
 /// behave correctly under different locales on every supported OS.
 ///
@@ -156,6 +158,11 @@ pub(crate) const FORWARDED_ENV_VARS: &[&str] = &[
     "LC_NUMERIC",
     "LC_TIME",
     "TMPDIR",
+    // C3: the isolated-profile home. Engine-controlled children must resolve the
+    // SAME profile as the parent — without this they fall back to the default
+    // ~/.wayland (cross-profile leak). Non-secret path; the vault passphrase
+    // (WAYLAND_VAULT_*) is never forwarded.
+    "WAYLAND_HOME",
     // Windows essentials
     "SYSTEMROOT",
     "WINDIR",
@@ -1058,12 +1065,51 @@ mod tests {
         unsafe { std::env::remove_var(secret_var) };
     }
 
+    /// C3: WAYLAND_HOME is forwarded so an engine-spawned child resolves the
+    /// SAME isolated profile as the parent. Spawns a real `/bin/sh` that prints
+    /// $WAYLAND_HOME and asserts the child sees the parent's value.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn subprocess_forwards_wayland_home() {
+        use std::path::Path;
+        use tokio::io::AsyncReadExt;
+
+        // SAFETY: single-threaded serial test context; no concurrent env mutation.
+        unsafe { std::env::set_var("WAYLAND_HOME", "/tmp/isolated-profile-c3") };
+
+        let mut result = super::spawn_binary(
+            Path::new("/bin/sh"),
+            &[
+                "-c".to_string(),
+                "printf '%s' \"$WAYLAND_HOME\"".to_string(),
+            ],
+        )
+        .await
+        .expect("spawn /bin/sh failed");
+
+        let mut stdout_buf = String::new();
+        result.stdout.read_to_string(&mut stdout_buf).await.unwrap();
+        if let Some(mut child) = result.child {
+            let _ = child.wait().await;
+        }
+
+        // SAFETY: single-threaded serial test context.
+        unsafe { std::env::remove_var("WAYLAND_HOME") };
+
+        assert_eq!(
+            stdout_buf, "/tmp/isolated-profile-c3",
+            "child must inherit the parent's WAYLAND_HOME (C3)"
+        );
+    }
+
     #[test]
     fn forwarded_env_vars_contains_expected_minimum() {
         assert!(FORWARDED_ENV_VARS.contains(&"PATH"));
         assert!(FORWARDED_ENV_VARS.contains(&"HOME"));
         assert!(FORWARDED_ENV_VARS.contains(&"USER"));
         assert!(FORWARDED_ENV_VARS.contains(&"LANG"));
+        // C3 profile propagation.
+        assert!(FORWARDED_ENV_VARS.contains(&"WAYLAND_HOME"));
     }
 
     /// Audit rel-panic-68/M-21: the stdout reader must NOT buffer an unbounded

--- a/crates/wcore-tools/src/env_passthrough.rs
+++ b/crates/wcore-tools/src/env_passthrough.rs
@@ -68,6 +68,13 @@ const BASE_SANDBOX_ENV_ALLOWLIST: &[&str] = &[
     "XDG_CACHE_HOME",
     "XDG_CONFIG_HOME",
     "XDG_DATA_HOME",
+    // C3: the isolated-profile home, so a sandboxed command that itself invokes
+    // `wayland-core` (or reads its config) resolves the SAME profile as the
+    // parent rather than the default ~/.wayland. A non-secret path — exactly
+    // like HOME / XDG_*_HOME already forwarded above, from which the default
+    // home path is already inferable, so this exposes nothing new. The vault
+    // passphrase (`WAYLAND_VAULT_*`) is still dropped by `is_sensitive_env_var`.
+    "WAYLAND_HOME",
     // SSL trust-store discovery — needed by curl / git / CLIs to verify
     // TLS; the file *paths*, never a secret.
     "SSL_CERT_FILE",
@@ -490,6 +497,30 @@ mod tests {
                 "secret-shaped var {k} leaked into sandboxed env"
             );
         }
+    }
+
+    #[test]
+    #[serial]
+    fn build_sandboxed_env_forwards_wayland_home_not_vault() {
+        let _g = guard();
+        // C3: WAYLAND_HOME must reach a sandboxed child so a nested wayland-core
+        // invocation resolves the ACTIVE profile, not the default home. The
+        // vault passphrase must still be dropped by the secret filter.
+        unsafe {
+            std::env::set_var("WAYLAND_HOME", "/tmp/isolated-profile");
+            std::env::set_var("WAYLAND_VAULT_PASSPHRASE", "supersecret");
+        }
+        let env = build_sandboxed_env(&[]);
+        assert!(
+            env.iter()
+                .any(|(k, v)| k == "WAYLAND_HOME" && v == "/tmp/isolated-profile"),
+            "WAYLAND_HOME must be forwarded into the sandbox (C3 profile propagation)"
+        );
+        assert!(
+            !env.iter()
+                .any(|(k, _)| k.eq_ignore_ascii_case("WAYLAND_VAULT_PASSPHRASE")),
+            "the vault passphrase must never reach a sandboxed child"
+        );
     }
 
     #[test]

--- a/crates/wcore-tools/src/workspace_policy.rs
+++ b/crates/wcore-tools/src/workspace_policy.rs
@@ -308,6 +308,35 @@ fn compute_secret_deny(
         }
     }
 
+    // Wayland's OWN per-profile credential + OAuth stores (both modes). The
+    // active profile home is often inside $HOME, so it is mountable into a
+    // Trusted sandbox — and an LLM-driven bash command must not be able to
+    // `cat` the profile's secrets. Covers the plaintext-0600 fallback
+    // (credentials.toml), the encrypted vault blob + KDF params
+    // (credentials.enc / credentials.kdf.json — the passphrase is never
+    // forwarded, but deny the blob so it cannot be exfiltrated for offline
+    // attack), and the OAuth token dir. Resolves via the same WAYLAND_HOME-aware
+    // helpers the credential store itself uses, so non-default profile homes are
+    // covered too. `under_mounted` keeps homes outside readable roots out of the
+    // list (they are not reachable from the sandbox anyway).
+    let cred_dir = wcore_config::config::wayland_config_dir();
+    for name in [
+        "credentials.toml",
+        "credentials.enc",
+        "credentials.kdf.json",
+    ] {
+        if let Ok(c) = std::fs::canonicalize(cred_dir.join(name))
+            && under_mounted(&c)
+        {
+            out.push(c);
+        }
+    }
+    if let Ok(c) = std::fs::canonicalize(wcore_config::config::profile_home().join("oauth"))
+        && under_mounted(&c)
+    {
+        out.push(c);
+    }
+
     // Always-mounted system credential stores (both modes). Emit if they
     // exist on disk; canonicalize so the path is exact.
     for s in &system_roots {
@@ -545,6 +574,44 @@ mod tests {
         assert!(
             !deny.contains(&env_canon),
             "Trusted must NOT deny project .env; deny={deny:?}"
+        );
+    }
+
+    /// The active profile's OWN credential + OAuth stores (the Task 0.1 vault /
+    /// plaintext fallback / OAuth tokens) are denied so an LLM-driven bash
+    /// command cannot read them out of a Trusted sandbox, even though the
+    /// profile home sits inside a mounted root.
+    #[test]
+    #[serial_test::serial]
+    fn trusted_denies_wayland_profile_credentials() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        // Profile home inside the (readable) workspace root → mounted.
+        let wh = root.join("profile-home");
+        std::fs::create_dir_all(wh.join("oauth")).unwrap();
+        std::fs::write(wh.join("credentials.toml"), b"secrets = {}").unwrap();
+        std::fs::write(wh.join("oauth/chatgpt.json"), b"{}").unwrap();
+
+        let prev = std::env::var_os("WAYLAND_HOME");
+        // SAFETY: serial test; single-threaded env mutation.
+        unsafe { std::env::set_var("WAYLAND_HOME", &wh) };
+        let p = WorkspacePolicy::trusted_local(root);
+        // SAFETY: serial test; restore prior value (deny is already computed).
+        match &prev {
+            Some(v) => unsafe { std::env::set_var("WAYLAND_HOME", v) },
+            None => unsafe { std::env::remove_var("WAYLAND_HOME") },
+        }
+        let deny = p.secret_deny_paths();
+
+        let cred = std::fs::canonicalize(wh.join("credentials.toml")).unwrap();
+        assert!(
+            deny.contains(&cred),
+            "profile credentials.toml must be denied; deny={deny:?}"
+        );
+        let oauth = std::fs::canonicalize(wh.join("oauth")).unwrap();
+        assert!(
+            deny.contains(&oauth),
+            "profile oauth dir must be denied; deny={deny:?}"
         );
     }
 


### PR DESCRIPTION
Makes the **isolated profile** (a self-contained `WAYLAND_HOME`-rooted home: own config, credentials, OAuth, memory, skills) the single standard profile concept — so a user can run multiple isolated identities/accounts on one box. This is the complete, self-contained CLI-isolation slice (the desktop multi-account experience is a separate, gated follow-up — see Phase D / `needs:desktop`).

Board-ratified decisions (do not relitigate): **D1** secrets → in-home encrypted vault (not the shared OS keyring); **D2** read-once `active` pointer + a CI single-reader lint; **D3** ship CLI isolation now with a fail-closed `--json-stream` guard.

## What's here (10 commits)

**Phase 0 — close the isolation escapes** (state that bypassed `WAYLAND_HOME`):
- trusted-keys + piper voices → `profile_home()`
- browser PIDs, CUA seen-apps, plugin data/install → `profile_home()` (gated atomic migrations; isolated profiles never inherit legacy state)
- **D1**: isolated-profile credentials default to the in-home encrypted vault (Argon2id + XChaCha20-Poly1305), never the constant-service keyring that bleeds across profiles

**Phase 1 — isolation primitive + launch wiring:**
- `wcore-config::profile` control plane (`profiles_root` never reads `WAYLAND_HOME`; name validation, case-fold)
- `activate_for_launch()` read-once resolver + the **D2 single-reader CI lint** (`tests/active_pointer_single_reader_test.rs`)
- `WAYLAND_HOME` propagation to every engine-spawned child (MCP stdio / subprocess runner / sandbox allowlist)
- sandbox denies the active profile's own credential + OAuth stores

**Task 3A / D3** — fail-closed `--json-stream` profile guard (host must set `WAYLAND_HOME` per spawn; never silently writes the default home).

**Phase 2 — the `wcore profile` command family:**
- `create` / `use` / `list` / `show` / `rename` / `delete` / `export` / `import`
- All CRUD + active-pointer writers live in `wcore-config::profile` (so the D2 lint's "all pointer access in one module" invariant holds); the CLI is a thin surface and never touches the pointer file directly.
- Security: `create --base` records an inheritance marker and **never copies secrets**; `export` excludes `credentials*`/`oauth` by default (warns on `--include-secrets`); `import` canonicalizes the source and never follows symlinks (zip-slip defense); `delete` refuses the active profile without `--force` and requires `--yes`/an interactive confirm; `show` never prints secret values.
- `adopt` is intentionally **deferred to Phase 4** (it manipulates the `[profiles.*]` overlay machinery that Phase 4 owns).

## Not in this PR (follow-ups)
- **Phase 3** `--base` inheritance (the create-marker is already written) and **Phase 4** back-compat dual-semantics + `adopt` + #228 Hermes retarget.
- **needs:desktop**: the desktop must set `WAYLAND_HOME` per `--json-stream` spawn before any profile UI (filed separately).

## Verification
Every commit was Hetzner-gated green (Linux): `cargo fmt` + `clippy -D warnings --all-targets` clean; the D2 single-reader lint passes; profile + credential-isolation + full `wcore-config`/`wcore-cli` suites pass. Built via an adversarial builder→red-team→apply swarm; CI here validates all platforms (incl. Windows `#[cfg(windows)]` paths I can't gate locally).