### PR TITLE
fix(windows): 4 Windows-only failures (#257 CRLF edit, #262/#263 MCP stdio quoting, #267 sandbox \\?\ path)

### DIFF
--- a/crates/wcore-config/src/shell.rs
+++ b/crates/wcore-config/src/shell.rs
@@ -176,6 +176,46 @@ pub fn hook_shell_command_builder(command_str: &str) -> Command {
     cmd
 }
 
+/// Shell-string mode for the **MCP stdio transport**, whose caller assembles a
+/// command line that is ALREADY escaped for the target shell's parser.
+///
+/// PRECONDITION (load-bearing): on Windows, every token in `command_line` MUST
+/// already be escaped for cmd.exe's parser by the MCP transport
+/// (`windows_program_token` for the program, `windows_cmd_quote` for each arg).
+/// The MCP stdio transport is the ONLY sanctioned caller — do not reuse this
+/// for un-escaped input.
+///
+/// Differs from [`shell_command_builder`] in exactly one Windows-only way: it
+/// appends `command_line` via `raw_arg` instead of `Command::arg`.
+/// `Command::arg` would apply std's `CommandLineToArgvW` quoting ON TOP of the
+/// caller's cmd.exe escaping — a second, incompatible layer that wraps the
+/// spaced line in an outer `"..."` where cmd.exe ignores the caret/`\"`
+/// escaping, breaking quote parity so the child receives a split fragment
+/// (`"C:\Program` for a spaced program path; `pkg^"` for an npx/uvx arg) —
+/// issues #262 and #263. `raw_arg` hands the pre-escaped line to cmd.exe
+/// verbatim, which is cmd's documented non-`CommandLineToArgvW` contract for
+/// `/C`. On Unix the behaviour is byte-identical to [`shell_command_builder`]:
+/// `sh -c` takes the command line as one argument with no second re-quote.
+pub fn mcp_stdio_command_builder(command_line: &str) -> Command {
+    let info = shell_info();
+    let mut cmd = Command::new(info.program);
+    cmd.arg(info.flag);
+    // Append the pre-escaped line LITERALLY so std's CommandLineToArgvW quoting
+    // is not layered on top of the caller's caret/quote escaping (#262/#263).
+    // `raw_arg` is cfg(windows)-gated in tokio, so the call must be compile-time
+    // gated, not a runtime `cfg!(windows)` branch.
+    #[cfg(windows)]
+    {
+        cmd.raw_arg(command_line);
+    }
+    #[cfg(not(windows))]
+    {
+        cmd.arg(command_line);
+    }
+    cmd.kill_on_drop(true);
+    cmd
+}
+
 /// Argv mode: spawn `program` directly with each `arg` passed as a
 /// separate process-arg. No shell interpreter is invoked, so shell
 /// metacharacters in `args` are NEVER interpreted by a shell. The OS

--- a/crates/wcore-mcp/src/transport/stdio.rs
+++ b/crates/wcore-mcp/src/transport/stdio.rs
@@ -1544,7 +1544,7 @@ mod windows_tests {
         )
         .unwrap();
 
-        let parts = vec![
+        let parts = [
             windows_program_token(&bat.to_string_lossy()),
             windows_cmd_quote("@perplexity-ai/mcp-server"),
             windows_cmd_quote("wikipedia-mcp"),

--- a/crates/wcore-mcp/src/transport/stdio.rs
+++ b/crates/wcore-mcp/src/transport/stdio.rs
@@ -9,7 +9,7 @@ use tokio::sync::{Mutex, oneshot};
 use tokio::task::JoinHandle;
 use tokio::time::{Duration, timeout};
 use tracing::{debug, error, warn};
-use wcore_config::shell::shell_command_builder;
+use wcore_config::shell::mcp_stdio_command_builder;
 
 use super::{McpError, McpTransport};
 use crate::protocol::{JsonRpcRequest, JsonRpcResponse};
@@ -432,7 +432,7 @@ impl StdioTransport {
                 parts.push(shell_quote(a));
             }
             let command_str = parts.join(" ");
-            shell_command_builder(&command_str)
+            mcp_stdio_command_builder(&command_str)
         };
         // Audit C8: stderr is `piped()`, not `inherit()`. An inherited stderr
         // writes the MCP server's diagnostics straight onto the parent's
@@ -1489,5 +1489,94 @@ mod windows_tests {
         assert_eq!(resp.result.as_ref().unwrap()["ok"], serde_json::json!(true));
 
         let _ = transport.close().await;
+    }
+
+    // ── #262 / #263: the production `else` branch builds `cmd /C <token>
+    // <args...>` and now hands it to cmd verbatim via `mcp_stdio_command_builder`
+    // (raw_arg). These spawn the SAME helper directly (full env inherited, so a
+    // `.bat` resolves via PATHEXT like npx.cmd/uvx.cmd) and assert the child
+    // sees clean argv. Spawning the helper directly — not `spawn_with_timeout`
+    // — avoids the env_clear/FORWARDED_ENV_VARS gap that the W-5 test documents.
+
+    /// #263 — a spaced absolute program path must resolve and NOT split at the
+    /// space. Before the fix, std's CommandLineToArgvW re-quoted the already
+    /// caret-escaped line, cmd lost quote parity, and the program token split
+    /// into `"C:\dir` + ` with space\...`, so cmd could not find the program.
+    #[tokio::test]
+    async fn w263_spaced_program_path_resolves() {
+        let base = tempfile::tempdir().expect("tempdir");
+        let spaced = base.path().join("dir with space");
+        std::fs::create_dir_all(&spaced).unwrap();
+        let bat = spaced.join("ok.bat");
+        std::fs::write(&bat, "@echo off\r\necho.OK\r\n").unwrap();
+
+        // Same assembly the transport uses: program token only.
+        let line = windows_program_token(&bat.to_string_lossy());
+        let out = mcp_stdio_command_builder(&line)
+            .stdout(std::process::Stdio::piped())
+            .spawn()
+            .expect("spawn spaced-path .bat")
+            .wait_with_output()
+            .await
+            .expect("wait");
+        assert!(
+            out.status.success(),
+            "spaced program path must resolve; stdout={:?}",
+            String::from_utf8_lossy(&out.stdout)
+        );
+        assert!(
+            String::from_utf8_lossy(&out.stdout).contains("OK"),
+            "child must run from the spaced path"
+        );
+    }
+
+    /// #262 — npx/uvx-style package args must reach the child VERBATIM, and
+    /// (Aud-32) a `&` in an arg must stay a literal token, never a command
+    /// separator. The `.bat` echoes each arg inside quotes so the batch line
+    /// re-expansion cannot re-interpret a `&` at echo time.
+    #[tokio::test]
+    async fn w262_args_reach_child_verbatim_and_metachars_neutralized() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let bat = dir.path().join("echo_args.bat");
+        std::fs::write(
+            &bat,
+            "@echo off\r\necho.\"%~1\"\r\necho.\"%~2\"\r\necho.\"%~3\"\r\n",
+        )
+        .unwrap();
+
+        let parts = vec![
+            windows_program_token(&bat.to_string_lossy()),
+            windows_cmd_quote("@perplexity-ai/mcp-server"),
+            windows_cmd_quote("wikipedia-mcp"),
+            windows_cmd_quote("a&b"), // Aud-32: `&` must stay literal
+        ];
+        let line = parts.join(" ");
+        let out = mcp_stdio_command_builder(&line)
+            .stdout(std::process::Stdio::piped())
+            .spawn()
+            .expect("spawn echo .bat")
+            .wait_with_output()
+            .await
+            .expect("wait");
+        let stdout = String::from_utf8_lossy(&out.stdout);
+
+        assert!(
+            stdout.contains("@perplexity-ai/mcp-server"),
+            "scoped-package arg corrupted: {stdout:?}"
+        );
+        assert!(
+            stdout.contains("wikipedia-mcp"),
+            "arg2 corrupted: {stdout:?}"
+        );
+        // The `&` arg arrived as one literal token (no second command ran).
+        assert!(
+            stdout.contains("a&b"),
+            "metachar arg must be one literal token, not split: {stdout:?}"
+        );
+        // No caret leaked into the child's view of the argument.
+        assert!(
+            !stdout.contains('^'),
+            "caret leaked into child argv: {stdout:?}"
+        );
     }
 }

--- a/crates/wcore-sandbox/src/backends/appcontainer.rs
+++ b/crates/wcore-sandbox/src/backends/appcontainer.rs
@@ -240,6 +240,21 @@ mod windows_impl {
         p.starts_with("\\\\") || p.starts_with("//")
     }
 
+    /// True only for the Windows VERBATIM DISK form `\\?\X:\...` — an
+    /// extended-length spelling of an ordinary local drive-letter path.
+    /// `std::fs::canonicalize` returns this form for EVERY local path on
+    /// Windows, so the fs-allowlist guard must treat it as local, not as a
+    /// UNC/device path. Genuine UNC (`\\?\UNC\...`), device (`\\.\...`),
+    /// and other verbatim (`\\?\...`) prefixes are NOT VerbatimDisk and stay
+    /// rejected. The OS path parser handles slash/case variants for us.
+    fn is_verbatim_disk_path(path: &std::path::Path) -> bool {
+        use std::path::{Component, Prefix};
+        matches!(
+            path.components().next(),
+            Some(Component::Prefix(p)) if matches!(p.kind(), Prefix::VerbatimDisk(_))
+        )
+    }
+
     /// Resolve a program reference into an absolute UTF-16 path suitable for
     /// `lpApplicationName`. Hard-fails on any failure — the caller must
     /// propagate the error rather than fall back to a NULL `lpApplicationName`
@@ -1465,7 +1480,17 @@ mod windows_impl {
     /// relative paths are ambiguous, and UNC / `\\?\` / `\\.\` paths could name
     /// a network share whose DACL we must never touch.
     fn acl_path_is_safe(path: &std::path::Path) -> bool {
-        path.is_absolute() && !is_unc_or_device_path(&path.to_string_lossy())
+        if !path.is_absolute() {
+            return false;
+        }
+        // A canonicalized local path arrives as `\\?\X:\...` (verbatim disk),
+        // which `is_unc_or_device_path` would otherwise reject. Accept that
+        // form explicitly; everything else still goes through the UNC/device
+        // rejection.
+        if is_verbatim_disk_path(path) {
+            return true;
+        }
+        !is_unc_or_device_path(&path.to_string_lossy())
     }
 
     /// Build one `EXPLICIT_ACCESS_W` for the AppContainer `sid` with `mask`
@@ -1704,14 +1729,46 @@ mod windows_impl {
         #[test]
         fn acl_path_is_safe_rejects_unc_and_device() {
             // UNC/device paths are absolute but must never have their DACL
-            // touched (could be a remote share).
+            // touched (could be a remote share). The verbatim-disk form
+            // `\\?\X:\...` is the one exception and is covered by its own test.
             assert!(!acl_path_is_safe(std::path::Path::new(
                 r"\\server\share\file"
             )));
-            assert!(!acl_path_is_safe(std::path::Path::new(r"\\?\C:\x")));
             assert!(!acl_path_is_safe(std::path::Path::new(
                 r"\\.\PhysicalDrive0"
             )));
+            // Verbatim UNC stays rejected — it names a network share, not a
+            // local disk, so it is NOT VerbatimDisk.
+            assert!(!acl_path_is_safe(std::path::Path::new(
+                r"\\?\UNC\server\share"
+            )));
+        }
+
+        #[test]
+        fn acl_path_is_safe_accepts_verbatim_disk() {
+            // `std::fs::canonicalize` returns the verbatim-disk form for local
+            // paths on Windows (issue #267: a USB drive canonicalizes to
+            // `\\?\E:\...`). These must be accepted, not rejected as UNC.
+            assert!(acl_path_is_safe(std::path::Path::new(
+                r"\\?\E:\AIWorkspace\Wayland\wcore-temp-1782166469597"
+            )));
+            assert!(acl_path_is_safe(std::path::Path::new(
+                r"\\?\C:\Users\Public\work"
+            )));
+        }
+
+        #[test]
+        fn is_verbatim_disk_path_classifies_prefixes() {
+            assert!(is_verbatim_disk_path(std::path::Path::new(r"\\?\D:\data")));
+            // Verbatim-UNC, device, and genuine UNC are NOT verbatim-disk.
+            assert!(!is_verbatim_disk_path(std::path::Path::new(r"\\?\UNC\s\h")));
+            assert!(!is_verbatim_disk_path(std::path::Path::new(r"\\.\COM1")));
+            assert!(!is_verbatim_disk_path(std::path::Path::new(
+                r"\\server\share"
+            )));
+            // A plain drive path is Prefix::Disk, not VerbatimDisk; it is
+            // accepted by acl_path_is_safe via the is_absolute branch instead.
+            assert!(!is_verbatim_disk_path(std::path::Path::new(r"C:\plain")));
         }
 
         #[test]

--- a/crates/wcore-tools/src/edit.rs
+++ b/crates/wcore-tools/src/edit.rs
@@ -83,6 +83,43 @@ impl EditTool {
             return Ok((new_content, match_count));
         }
 
+        // CRLF reconciliation (issue #257). The Read tool emits file content via
+        // `str::lines()`, which strips the trailing `\r` of every CRLF line, so the
+        // model's `old_string` is LF-only even when the file on disk is CRLF. An
+        // LF pattern can never exact-match `\r\n` content, producing a spurious
+        // "old_string not found" loop on Windows-authored files. When the file is
+        // CRLF and the supplied pattern is LF-only, retry the match against a
+        // CRLF-translated copy of the pattern. The replacement is translated the
+        // same way so the file keeps its original line endings; we operate on the
+        // raw `content` (never re-normalized) so the surrounding bytes are intact.
+        if old_string.contains('\n') && !old_string.contains('\r') && content.contains("\r\n") {
+            let crlf_old = old_string.replace('\n', "\r\n");
+            let crlf_match_count = content.matches(crlf_old.as_str()).count();
+            if crlf_match_count == 1 || (crlf_match_count > 1 && replace_all) {
+                // Mirror the model's LF intent into CRLF for the replacement text
+                // so inserted/edited lines match the file's existing endings.
+                let crlf_new = if new_string.contains('\n') && !new_string.contains('\r') {
+                    new_string.replace('\n', "\r\n")
+                } else {
+                    new_string.to_string()
+                };
+                let new_content = if replace_all {
+                    content.replace(crlf_old.as_str(), &crlf_new)
+                } else {
+                    content.replacen(crlf_old.as_str(), &crlf_new, 1)
+                };
+                return Ok((new_content, crlf_match_count));
+            }
+            // Multiple CRLF matches without `replace_all`: mirror the exact-path
+            // "multiple matches" error rather than falling through to the
+            // misleading "old_string not found" (the LF `match_count` is 0).
+            if crlf_match_count > 1 {
+                return Err(format!(
+                    "Multiple matches found ({crlf_match_count}). Use replace_all or provide more context."
+                ));
+            }
+        }
+
         // Exact match failed. Fall back to fuzzy only when the gate is on.
         if self.fuzzy_fallback {
             let res = fuzzy_find_and_replace(content, old_string, new_string, replace_all);
@@ -726,5 +763,58 @@ mod tests {
         let mut c = cache.write().unwrap();
         let cached = c.get(&file_path).expect("file should be in cache");
         assert_eq!(cached.mtime_ms, disk_mtime);
+    }
+
+    // ── CRLF reconciliation (issue #257) ─────────────────────────────────
+    // The Read tool normalizes CRLF to LF via `str::lines()`, so the model's
+    // `old_string` is LF-only against a CRLF file on disk. compute_edit must
+    // still match, and must preserve the file's CRLF endings.
+
+    #[test]
+    fn compute_edit_matches_lf_pattern_against_crlf_file() {
+        let tool = EditTool::new(None);
+        let content = "line one\r\nline two\r\nline three\r\n";
+        // old_string as the Read tool would have shown it: LF-only.
+        let (out, count) = tool
+            .compute_edit(content, "line one\nline two", "line ONE\nline TWO", false)
+            .expect("LF pattern must match the CRLF file");
+        assert_eq!(count, 1);
+        assert_eq!(out, "line ONE\r\nline TWO\r\nline three\r\n");
+    }
+
+    #[test]
+    fn compute_edit_lf_file_unaffected_by_crlf_retry() {
+        let tool = EditTool::new(None);
+        let (out, count) = tool
+            .compute_edit("a\nb\nc\n", "a\nb", "X\nY", false)
+            .expect("LF happy path");
+        assert_eq!(count, 1);
+        assert_eq!(out, "X\nY\nc\n");
+    }
+
+    #[test]
+    fn compute_edit_crlf_missing_pattern_still_errors() {
+        let tool = EditTool::new(None);
+        let err = tool
+            .compute_edit("a\r\nb\r\n", "zzz\nyyy", "q", false)
+            .expect_err("genuinely-absent pattern must still error");
+        assert!(err.contains("not found"), "got: {err}");
+    }
+
+    #[test]
+    fn compute_edit_crlf_replace_all_multi() {
+        let tool = EditTool::new(None);
+        let content = "x\r\ny\r\nx\r\ny\r\n";
+        let (out, count) = tool
+            .compute_edit(content, "x\ny", "p\nq", true)
+            .expect("replace_all through the CRLF path");
+        assert_eq!(count, 2);
+        assert_eq!(out, "p\r\nq\r\np\r\nq\r\n");
+        // Same input without replace_all: the CRLF path reports multiple
+        // matches (not the misleading "old_string not found").
+        let err = tool
+            .compute_edit(content, "x\ny", "p\nq", false)
+            .expect_err("multiple CRLF matches without replace_all must error");
+        assert!(err.contains("Multiple matches"), "got: {err}");
     }
 }


### PR DESCRIPTION
Fixes four Windows-only defects, each diagnosed + adversarially red-teamed before implementation.

### #257 — Edit "old_string not found" loop → Bash fallback → timeouts
The Read tool normalizes CRLF→LF via `str::lines()`, so the model's `old_string` is LF-only against a CRLF file on disk. The exact match could never hit, the agent looped then fell back to Bash (which times out on the reporter's box). `compute_edit` now retries an LF pattern against a CRLF-translated copy, **preserving the file's CRLF endings**, and returns a proper "multiple matches" error on the CRLF path instead of the misleading "not found". Byte-level fix — **verified on Linux** (4 cross-platform tests).

### #262 / #263 — MCP stdio launch corrupts args / spaced program paths
The Windows launch path caret-escaped the command line for cmd.exe, then passed it through `Command::arg`, which layered std's `CommandLineToArgvW` quoting on top — a second, incompatible layer that broke quote parity. Result: npx/uvx args corrupted (#262) and `"C:\Program Files\..."` split at the space (#263).

New `wcore_config::shell::mcp_stdio_command_builder` appends the pre-escaped line via `raw_arg` (verbatim), the documented non-`CommandLineToArgvW` contract for `cmd /C`. **The reconciliation rejected the obvious "rebuild as argv" alternative** because it silently regresses the Aud-32 metacharacter neutralization (`cmd /C npx a&calc` would run `calc`). The per-token caret escaping is unchanged — it just reaches cmd un-re-quoted now.

### #267 — Bash sandbox rejects canonicalized local paths
`std::fs::canonicalize` returns the verbatim-disk form `\\?\X:\...` for **every** local path on Windows (e.g. a USB drive), which the AppContainer fs-allowlist guard misclassified as UNC/device and rejected. `acl_path_is_safe` now accepts `Prefix::VerbatimDisk` while still rejecting genuine UNC / device / verbatim-UNC paths.

---
**Verification.** Hetzner Linux gate green: fmt, clippy `-D warnings` (wcore-config/tools/mcp/sandbox), nextest 154/154 incl. the CRLF tests. The Windows-specific code (`#267` guard, the `raw_arg` arm, the stdio `.bat` behavioral tests) is `#[cfg(windows)]` and verifies on **CI (Array)** — that leg must be green before merge.

Addresses FerroxLabs/wayland#257, #262, #263, #267.