### PR TITLE
chore: remove predecessor "wayland-hermes" naming from source comments + THIRD-PARTY-NOTICES

### DIFF
--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -1,0 +1,46 @@
+# Third-Party Notices
+
+wayland-core includes code ported from third-party open-source projects. Their
+copyright notices and license texts are reproduced below, as their licenses
+require.
+
+---
+
+## Nous Research — Hermes (MIT)
+
+Portions of wayland-core are ported from Nous Research's Hermes agent
+(MIT-licensed). The following modules contain code that derives from it:
+
+- `crates/wcore-tools/src/todo.rs` — todo tool
+- `crates/wcore-tools/src/yuanbao_tools.rs` — Yuanbao tools
+- `crates/wcore-tools/src/discord_tool.rs` — Discord tool
+- `crates/wcore-tools/src/send_message.rs` — send-message tool
+- `crates/wcore-tools/src/session_search.rs` — session-search tool
+- `crates/wcore-tools/src/homeassistant_tool.rs` — Home Assistant tool
+- `crates/wcore-tools/src/transcription_tools.rs` — transcription tools
+- `crates/wcore-tools/src/vision_tools.rs` — vision tools
+- `crates/wcore-types/src/cache_tier.rs` — cache-tier definitions
+
+```
+MIT License
+
+Copyright (c) Nous Research
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```

--- a/crates/wcore-agent/src/auto_skill/mod.rs
+++ b/crates/wcore-agent/src/auto_skill/mod.rs
@@ -14,7 +14,7 @@
 //! hydrates the draft as a seed pair. The two paths are complementary:
 //! the detector captures execution patterns, U6 captures intent patterns.
 //!
-//! Hermes-parity bet: self-learning from runtime observation without RL.
+//! Self-learning from runtime observation without RL.
 
 pub mod bucketer;
 pub mod drafter;

--- a/crates/wcore-agent/src/bootstrap.rs
+++ b/crates/wcore-agent/src/bootstrap.rs
@@ -595,7 +595,7 @@ impl AgentBootstrap {
         // T11: JsonlTool — large-file-friendly JSON Lines streaming tool.
         registry.register(Box::new(wcore_tools::jsonl_tool::JsonlTool::default()));
         // T3-3.1.1: ClarifyTool — structured user-clarification prompt
-        // (ported from wayland-hermes). The host layer intercepts
+        // (ported from the prior Wayland Python engine). The host layer intercepts
         // tool calls named `clarify` to perform the real UI interaction.
         registry.register(Box::new(wcore_tools::clarify::ClarifyTool::new()));
         // v0.9.3 W0.4: AskUserQuestionTool — structured multi-choice question.
@@ -608,7 +608,7 @@ impl AgentBootstrap {
             wcore_tools::ask_user_question::AskUserQuestionTool::new(),
         ));
         // T3-3.1.2: TodoTool — in-memory planning/task list ported from
-        // wayland-hermes. State is per-session (one `TodoTool` instance
+        // the prior Wayland Python engine. State is per-session (one `TodoTool` instance
         // per bootstrap → one list per agent session).
         registry.register(Box::new(wcore_tools::todo::TodoTool::new()));
         // T3-3.1.4: SendMessageTool — registered with the fail-loud
@@ -1743,7 +1743,7 @@ impl AgentBootstrap {
                 .with_parent_output(Arc::clone(&self.output)),
         ));
         // T3-3.1.3: DelegateTool — focused single-task / batch delegation
-        // surface ported from wayland-hermes. Sibling to SpawnTool (the
+        // surface ported from the prior Wayland Python engine. Sibling to SpawnTool (the
         // existing registry-aware multi-agent fan-out): Delegate provides
         // structured-JSON output + per-task `toolsets` whitelist + max
         // turns 50 default, while Spawn exposes registry-resolved named

--- a/crates/wcore-agent/src/oauth/chatgpt.rs
+++ b/crates/wcore-agent/src/oauth/chatgpt.rs
@@ -598,7 +598,7 @@ struct DeviceUserCode {
 }
 
 /// Parse the Step-1 usercode JSON. Accepts `user_code` or the `usercode`
-/// alias (OpenClaw observed both), requires a non-empty `device_auth_id`, and
+/// alias (both observed in the wild), requires a non-empty `device_auth_id`, and
 /// floors `interval` at [`DEVICE_POLL_MIN_INTERVAL`]. A missing/zero interval
 /// falls back to the floor.
 fn parse_device_usercode(body: &str) -> Result<DeviceUserCode, String> {
@@ -754,8 +754,7 @@ async fn poll_device_authorization(
             return Err("ChatGPT device sign-in timed out after 15 minutes".to_string());
         }
         // Wait BEFORE the first poll — the user needs time to type the code,
-        // and the server returns pending immediately otherwise (mirrors the
-        // Hermes/OpenClaw references).
+        // and the server returns pending immediately otherwise.
         tokio::time::sleep(user_code.interval).await;
 
         let res = tokio::time::timeout(
@@ -1265,7 +1264,7 @@ mod tests {
 
     #[test]
     fn parse_device_usercode_accepts_usercode_alias_and_string_interval() {
-        // OpenClaw observed the `usercode` alias; some servers send interval as a string.
+        // The `usercode` alias is observed in the wild; some servers send interval as a string.
         let parsed =
             parse_device_usercode(r#"{"usercode":"BBBB","device_auth_id":"dev","interval":"7"}"#)
                 .expect("parse");

--- a/crates/wcore-agent/src/tool_backends/mod.rs
+++ b/crates/wcore-agent/src/tool_backends/mod.rs
@@ -214,7 +214,7 @@ fn disclose_parallel_once() {
 }
 
 /// Pick the active `WebBackend`. Explicit `WAYLAND_WEB_BACKEND` wins; otherwise
-/// the first configured key (Hermes preference order) is used. Every selected
+/// the first configured key (the provider preference order) is used. Every selected
 /// primary is wrapped so it falls back to DuckDuckGo on failure — DDG is the
 /// floor for all tiers except an explicit `off`.
 ///
@@ -252,7 +252,7 @@ pub fn build_web_search_backend() -> Arc<dyn WebBackend> {
         WebBackendChoice::Auto => {}
     }
 
-    // 1..6 — Hermes preference order, first key present wins; each floors on DDG.
+    // 1..6 — the provider preference order, first key present wins; each floors on DDG.
     if let Some(key) = read_env_key("FIRECRAWL_API_KEY") {
         tracing::info!("web search: Firecrawl (FIRECRAWL_API_KEY found)");
         return chain(Arc::new(FirecrawlWebBackend::new(key)));

--- a/crates/wcore-agent/src/tool_backends/piper.rs
+++ b/crates/wcore-agent/src/tool_backends/piper.rs
@@ -72,7 +72,7 @@ const DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(120);
 
 /// Default voice id used when neither the request nor `PIPER_VOICE`
 /// supplies one. Matches the Python `DEFAULT_VOICE` constant in the
-/// Hermes original.
+/// original implementation.
 pub const DEFAULT_PIPER_VOICE: &str = "en_US-amy-medium";
 
 // ---------------------------------------------------------------------

--- a/crates/wcore-agent/src/tool_backends/searxng_web.rs
+++ b/crates/wcore-agent/src/tool_backends/searxng_web.rs
@@ -2,7 +2,7 @@
 //! instance) — wayland-core ships the connector, not the instance.
 //!
 //! GETs `<SEARXNG_URL>/search?q=<query>&format=json` and maps the JSON
-//! `results[]` (sorted by `score` desc, per Hermes) into the engine shape.
+//! `results[]` (sorted by `score` desc) into the engine shape.
 //!
 //! ⚠️ The instance must be **publicly resolvable**: requests go through the
 //! SSRF-safe client, so a `SEARXNG_URL` pointing at `localhost`/a private IP is

--- a/crates/wcore-agent/src/tool_backends/video_analyze.rs
+++ b/crates/wcore-agent/src/tool_backends/video_analyze.rs
@@ -3,8 +3,8 @@
 //! that produces a coherent video summary.
 //!
 //! No vendor exposes a viable "send-a-video, get-a-summary" REST API at
-//! a price point compatible with a free default. Hermes does not ship
-//! `video_analyze` at all. The Wayland strategy is a three-step pipeline:
+//! a price point compatible with a free default. The predecessor did not
+//! ship `video_analyze` at all. The Wayland strategy is a three-step pipeline:
 //!
 //! 1. Validate the input path under a strict whitelist (closes S-H5).
 //! 2. Extract N evenly-spaced frames via local `ffmpeg` into a

--- a/crates/wcore-cli/src/main.rs
+++ b/crates/wcore-cli/src/main.rs
@@ -590,7 +590,7 @@ fn open_tui_log_file() -> std::io::Result<std::fs::File> {
 /// [`wcore_config::profile::activate_for_launch`] could not resolve the profile
 /// to an existing home), refusing is the only safe choice: silently falling
 /// through to the SHARED default home would cross-write another account's
-/// credentials and memory — the Hermes #18594 corruption reproduced at the host
+/// credentials and memory — the credential/memory corruption bug reproduced at the host
 /// boundary. Interactive CLI/TUI use is intentionally tolerant (it warns and
 /// falls through); only the host protocol is held to the strict contract.
 ///

--- a/crates/wcore-cli/src/tui/theme_detect.rs
+++ b/crates/wcore-cli/src/tui/theme_detect.rs
@@ -2,8 +2,8 @@
 //!
 //! `detect_light_mode()` decides whether the host terminal is painting on a
 //! LIGHT background so `Theme::for_mode(ThemeMode::Auto)` can pick the light
-//! Hearth palette. The decision is a 5-tier fallback modelled on hermes
-//! `theme.ts:415-475`:
+//! Hearth palette. The decision is a 5-tier fallback modelled on the prior
+//! Wayland Python engine's theme detection:
 //!
 //! 1. **Explicit `/theme` setting** — handled by the caller (a `ThemeMode`
 //!    of `Light`/`Dark` never reaches this module; only `Auto` does).

--- a/crates/wcore-compact/src/semantic.rs
+++ b/crates/wcore-compact/src/semantic.rs
@@ -1,7 +1,7 @@
 //! Semantic chunk-priority compression core.
 //!
-//! Ports the head/tail-protected, budget-bounded chunk selection from
-//! `wayland-hermes/agent/agent/context_compressor.py`. This module is the
+//! Ports the head/tail-protected, budget-bounded chunk selection from the
+//! prior Wayland Python engine. This module is the
 //! T2-B1 *core* lift: chunk-priority scoring, stable selection within a token
 //! budget, retention policies, and a `compress()` entry point.
 //!

--- a/crates/wcore-config/src/profile.rs
+++ b/crates/wcore-config/src/profile.rs
@@ -207,7 +207,7 @@ fn profile_flag_from_args(args: impl Iterator<Item = String>) -> Option<String> 
 /// process entry, and materialize it into `WAYLAND_HOME`. After this returns,
 /// `WAYLAND_HOME` is the only thing any code (or child process) consults; the
 /// `active` pointer is never read again — the precise failure that corrupts
-/// Hermes (#18594), where a sticky pointer and the env var can disagree deep in
+/// that corruption bug, where a sticky pointer and the env var can disagree deep in
 /// the stack.
 ///
 /// Resolution order:

--- a/crates/wcore-config/tests/active_pointer_single_reader_test.rs
+++ b/crates/wcore-config/tests/active_pointer_single_reader_test.rs
@@ -2,7 +2,7 @@
 //!
 //! C2/D2: the `active` profile pointer is resolved ONCE, at process entry
 //! (`profile::activate_for_launch`), and materialized into `WAYLAND_HOME`; it is
-//! never consulted again. The Hermes corruption bug (#18594) is precisely what
+//! never consulted again. The credential/memory corruption bug is precisely what
 //! happens when a sticky pointer is re-read deep in the stack and can disagree
 //! with the env var. To keep that discipline locally reviewable, ALL access to
 //! the pointer — via the path resolver AND via the raw `<root>/active` join —
@@ -16,7 +16,7 @@
 //! `join` on the `active` literal — from any file but the allow-listed module.
 //! A determined bypass (capturing the resolver as a fn-pointer, or reconstructing
 //! the path from raw string ops) is not detected; the goal is to stop accidental
-//! copy-paste, which is how the Hermes failure actually crept in.
+//! copy-paste, which is how that failure actually crept in.
 //!
 //! Mirrors `hermeticity_audit_test.rs`: shells out to `git grep`
 //! (dependency-free), skips comment-only mentions, and is skipped entirely if

--- a/crates/wcore-config/tests/memory_config_test.rs
+++ b/crates/wcore-config/tests/memory_config_test.rs
@@ -10,7 +10,7 @@
 //
 // F-091 (HIGH, D4 decision): `memory.enabled` default flipped from
 // `false` → `true`. Memory is the core value proposition ("memory is
-// the whole pitch" — Aud-6 HERMES-FANBOY-4). Users who want to opt out
+// the whole pitch"). Users who want to opt out
 // set `memory.enabled = false` in wcore.toml or pass `--no-memory`.
 // Test updated to reflect the new opt-out-by-config contract.
 

--- a/crates/wcore-providers/src/openai_chatgpt.rs
+++ b/crates/wcore-providers/src/openai_chatgpt.rs
@@ -18,8 +18,7 @@
 //!
 //! ## Reference
 //!
-//! Wire details mirrored from OpenClaw (OpenAI-maintained Codex client) and
-//! Hermes — see `.planning/2026-06-16-CHATGPT-OAUTH-SPEC.md` §2.
+//! Wire details mirrored from the OpenAI-maintained Codex client.
 //!
 //! [`stream`]: OpenAIChatGptProvider::stream
 
@@ -67,7 +66,7 @@ pub const CODEX_BASE_URL: &str = "https://chatgpt.com/backend-api/codex";
 
 /// Default `instructions` injected when a request carries no system prompt.
 ///
-/// Codex (per both OpenClaw and Hermes) always sends a non-empty
+/// Codex always sends a non-empty
 /// `instructions` field; `build_responses_body` omits it when `request.system`
 /// is empty. D4: ensure it is always present.
 const DEFAULT_INSTRUCTIONS: &str = "You are a helpful assistant.";
@@ -165,7 +164,7 @@ impl OpenAIChatGptProvider {
     ///   the encrypted blob paired with each function_call) is a follow-up.
     /// * D4 — ensure `instructions` is always present.
     /// * D5 — when tools are present, send `tool_choice: "auto"` +
-    ///   `parallel_tool_calls: true` (matches both references).
+    ///   `parallel_tool_calls: true` (matches the reference client).
     fn build_codex_body(&self, request: &LlmRequest) -> serde_json::Value {
         let mut body = build_responses_body(request, &self.compat);
         if let Some(obj) = body.as_object_mut() {

--- a/crates/wcore-providers/src/routing.rs
+++ b/crates/wcore-providers/src/routing.rs
@@ -23,7 +23,7 @@
 //! The higher-level [`route`] returns a [`RoutingDecision`] that names the rule
 //! that fired, so the picker's behavior is visible in trace observability.
 //!
-//! Ported from `wayland-hermes/agent/agent/smart_model_routing.py`. The Python
+//! Ported from the prior Wayland Python engine's smart model routing. The Python
 //! version routed by parsing the raw user message; this Rust port lifts the
 //! decision to a typed request shape so callers — provider chain, agent
 //! engine — can supply structured inputs (token counts, vision flag) instead

--- a/crates/wcore-safety/src/halluci_guard.rs
+++ b/crates/wcore-safety/src/halluci_guard.rs
@@ -1,7 +1,7 @@
 //! Hallucination guard for assistant outputs.
 //!
 //! Wayland v0.6.2 Tier-2 lift **T2-A1**. Ports the deterministic claim
-//! extractor + cross-ref shape from `wayland-hermes/agent/agent/hallucination_guard.py`
+//! extractor + cross-ref shape from the prior Wayland Python engine
 //! and generalises it from "delegation claims vs. Kanban DB" to
 //! "factual claims vs. `ToolCallTrace::result_snippet`" (T2-A0).
 //!

--- a/crates/wcore-safety/src/pii.rs
+++ b/crates/wcore-safety/src/pii.rs
@@ -22,7 +22,7 @@ static PATTERNS: &[(&str, &str)] = &[
     ),
     // Bearer token (header value style, >=20 chars of token material)
     ("BEARER_TOKEN", r"Bearer [A-Za-z0-9._\-]{20,}"),
-    // ── Hermes redact.py port — additional credential prefixes ──
+    // ── Prior Wayland Python engine redaction port — additional credential prefixes ──
     // GitHub personal access tokens (classic) and fine-grained.
     ("GITHUB_PAT", r"ghp_[A-Za-z0-9]{20,}"),
     ("GITHUB_PAT_FG", r"github_pat_[A-Za-z0-9_]{20,}"),
@@ -136,7 +136,7 @@ impl PIIScrubber {
 #[cfg(test)]
 mod tests {
     //! Per-pattern positive + negative coverage for the patterns ported from
-    //! the Hermes ``redact.py`` library (T3-4). Existing patterns
+    //! the prior Wayland Python engine's redaction library (T3-4). Existing patterns
     //! (AWS_*, OPENAI_API_KEY, ANTHROPIC_API_KEY, JWT, BEARER_TOKEN) are
     //! covered by ``crates/wcore-safety/tests/safety_tests.rs``.
     use super::PIIScrubber;

--- a/crates/wcore-safety/src/validator.rs
+++ b/crates/wcore-safety/src/validator.rs
@@ -140,7 +140,7 @@ impl OutputValidator {
 }
 
 // ---------------------------------------------------------------------------
-// LLM-judge validator (T2-A2 port of wayland-hermes output_validator.py)
+// LLM-judge validator (T2-A2 port of the prior Wayland Python engine)
 //
 // Adds an LLM-as-judge layer over the existing regex/PII checks: scores an
 // output against a configurable set of criteria, charges spend against a
@@ -185,7 +185,7 @@ pub struct BudgetExhausted {
 
 /// What axis the LLM-judge scores the output against.
 ///
-/// Mirrors the hermes scoring axes (factuality / grounding / consistency)
+/// Mirrors the scoring axes (factuality / grounding / consistency)
 /// but generalised so callers can request a single axis or a custom one
 /// without needing to ship a code change. Serde-derived so judge prompts
 /// can embed the list verbatim.

--- a/crates/wcore-tools/src/aws_cli_tool.rs
+++ b/crates/wcore-tools/src/aws_cli_tool.rs
@@ -1,6 +1,6 @@
 //! v0.6.3 Tier 2B T14 — read-only AWS CLI wrapper tool.
 //!
-//! Ported from `wayland-hermes/agent/tools/aws_cli_tool.py`. Wraps the
+//! Ported from the prior Wayland Python engine. Wraps the
 //! host `aws` CLI binary, restricted to **read-only** operations. The
 //! AWS CLI command form is `aws <service> <operation> [args...]`, e.g.
 //! `aws s3 ls`, `aws ec2 describe-instances`, `aws iam get-user`.

--- a/crates/wcore-tools/src/binary_extensions.rs
+++ b/crates/wcore-tools/src/binary_extensions.rs
@@ -1,6 +1,6 @@
 //! T3-3.2.1 — Binary file extensions to skip for text-based operations.
 //!
-//! Ported from `wayland-hermes/agent/tools/binary_extensions.py`, which is
+//! Ported from the prior Wayland Python engine, which is
 //! itself a port of `free-code src/constants/files.ts`.
 //!
 //! These files can't be meaningfully compared as text and are often large.

--- a/crates/wcore-tools/src/clarify.rs
+++ b/crates/wcore-tools/src/clarify.rs
@@ -1,4 +1,4 @@
-//! T3-3.1.1 — clarify_tool port from `wayland-hermes/agent/tools/clarify_tool.py`.
+//! T3-3.1.1 — clarify_tool port from the prior Wayland Python engine.
 //!
 //! The `clarify` tool lets the agent surface a structured question (with up
 //! to 4 multiple-choice options, plus an implicit "Other" the UI appends)

--- a/crates/wcore-tools/src/cronjob_tools.rs
+++ b/crates/wcore-tools/src/cronjob_tools.rs
@@ -1,6 +1,6 @@
 //! T3-3.7 — `cronjob` scheduled-task management tool.
 //!
-//! Ported from `wayland-hermes/agent/tools/cronjob_tools.py`. The Python
+//! Ported from the prior Wayland Python engine. The Python
 //! original is a thin dispatch surface over `cron.jobs` (a JSON-file
 //! scheduler ticked by the gateway daemon). The engine has no such
 //! daemon, so this port covers the **dispatch surface** only — schema,

--- a/crates/wcore-tools/src/debug_helpers.rs
+++ b/crates/wcore-tools/src/debug_helpers.rs
@@ -1,5 +1,5 @@
-//! T3-3.1.8 — Per-tool opt-in debug session (port of
-//! `hermes/agent/tools/debug_helpers.py`).
+//! T3-3.1.8 — Per-tool opt-in debug session (ported from the prior
+//! Wayland Python engine).
 //!
 //! This is intentionally narrow: a developer-debug shim that lets a
 //! specific tool (e.g. a future web_tools, vision_tools, or MOA port)
@@ -13,7 +13,7 @@
 //!
 //! Disabled-by-default discipline: every method is a no-op unless the
 //! configured env var is set to `"true"` (case-insensitive), matching
-//! the Hermes semantics. Construction is cheap (one `env::var` lookup,
+//! the predecessor's semantics. Construction is cheap (one `env::var` lookup,
 //! no allocation when disabled past the empty `Vec`).
 //!
 //! Log files land in `wayland_config_dir()/logs/` (e.g.
@@ -43,7 +43,7 @@ fn default_log_dir() -> Option<PathBuf> {
     Some(wcore_config::config::wayland_config_dir().join("logs"))
 }
 
-/// One recorded tool-call entry. Mirrors the Hermes JSON shape:
+/// One recorded tool-call entry. Mirrors the predecessor's JSON shape:
 /// `{ "timestamp": ..., "tool_name": ..., ...call_data }`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DebugCall {
@@ -57,8 +57,8 @@ pub struct DebugCall {
 }
 
 /// Summary returned by `DebugSession::session_info()`. Matches the
-/// shape the Hermes `get_debug_session_info()` helper exposed so the
-/// downstream protocol surface stays compatible if/when those tools
+/// shape the predecessor's `get_debug_session_info()` helper exposed so
+/// the downstream protocol surface stays compatible if/when those tools
 /// land in Rust.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DebugSessionInfo {

--- a/crates/wcore-tools/src/delegate.rs
+++ b/crates/wcore-tools/src/delegate.rs
@@ -1,8 +1,8 @@
-//! T3-3.1.3 — `DelegateTool` ported from hermes `delegate_tool.py`.
+//! T3-3.1.3 — `DelegateTool` ported from the prior Wayland Python engine.
 //!
-//! Hermes's `delegate_task` spawns one or more child `AIAgent` instances
-//! with isolated context, restricted toolsets, and their own terminal
-//! sessions; the parent only sees the final summary. Wayland already
+//! The predecessor's `delegate_task` spawns one or more child `AIAgent`
+//! instances with isolated context, restricted toolsets, and their own
+//! terminal sessions; the parent only sees the final summary. Wayland already
 //! exposes the same primitive via [`wcore_types::spawner::Spawner`],
 //! whose concrete implementation `AgentSpawner` lives in `wcore-agent`
 //! (one layer above this crate). The trait is intentionally hosted in
@@ -14,16 +14,16 @@
 //! construction time (the CLI bootstrap wires the concrete `AgentSpawner`
 //! through). The tool itself owns:
 //!   * input parsing (single `goal`/`context` mode and batch `tasks` mode),
-//!   * the focused child-prompt template (mirrors hermes
+//!   * the focused child-prompt template (mirrors the predecessor's
 //!     `_build_child_system_prompt`),
-//!   * fan-out via `futures::future::join_all` (mirrors hermes's
+//!   * fan-out via `futures::future::join_all` (mirrors the predecessor's
 //!     `ThreadPoolExecutor`), and
 //!   * the JSON result envelope returned to the parent agent.
 //!
 //! The Wayland `Spawner` trait exposes a single-task `spawn_fork`
 //! entry point; batch parallelism is implemented here by joining one
 //! call per task. The blocked-tools / depth-limit / credential-pool
-//! machinery from hermes does NOT cross the boundary in this port —
+//! machinery from the predecessor does NOT cross the boundary in this port —
 //! those concerns are already enforced inside `wcore-agent`
 //! (`SpawnTool` + `AgentSpawner`) so duplicating them here would be
 //! redundant and risk drift.
@@ -44,7 +44,7 @@ use crate::Tool;
 /// consistent across the two surfaces.
 pub const DELEGATE_MAX_TASKS: usize = 5;
 
-/// Default per-child conversation turn budget (mirrors hermes
+/// Default per-child conversation turn budget (mirrors the predecessor's
 /// `DEFAULT_MAX_ITERATIONS = 50`).
 pub const DELEGATE_DEFAULT_MAX_TURNS: usize = 50;
 
@@ -59,7 +59,7 @@ pub const DELEGATE_DEFAULT_MAX_TOKENS: u32 = 4096;
 /// The tool stays callable even when no spawner is wired (e.g. tests
 /// that construct the tool without an engine) — invocations in that
 /// state return an `is_error: true` `ToolResult` whose `content`
-/// surfaces the configuration gap, matching hermes's
+/// surfaces the configuration gap, matching the predecessor's
 /// "delegate_task requires a parent agent context" error shape.
 pub struct DelegateTool {
     spawner: Option<Arc<dyn Spawner>>,
@@ -92,7 +92,7 @@ struct Task {
 }
 
 fn parse_input(input: &Value) -> Result<(Vec<Task>, usize), String> {
-    // Batch mode wins when both are present (matches hermes contract).
+    // Batch mode wins when both are present (matches the predecessor contract).
     let max_turns = input
         .get("max_iterations")
         .and_then(|v| v.as_u64())
@@ -173,7 +173,7 @@ fn parse_input(input: &Value) -> Result<(Vec<Task>, usize), String> {
     Err("Provide either 'goal' (single task) or 'tasks' (batch).".to_string())
 }
 
-/// Mirror of hermes `_build_child_system_prompt`. Kept intentionally
+/// Mirror of the predecessor's `_build_child_system_prompt`. Kept intentionally
 /// terse — the persona / workspace-hint extensions live in
 /// `wcore-agent` where the engine knows the real session cwd.
 ///
@@ -469,7 +469,7 @@ mod tests {
         );
 
         // 2c: unwired tool surfaces the configuration-gap error
-        // (analogue of hermes "requires a parent agent context").
+        // (analogue of the predecessor's "requires a parent agent context").
         let unwired = DelegateTool::unwired();
         let result = unwired.execute(json!({"goal": "noop"})).await;
         assert!(result.is_error);

--- a/crates/wcore-tools/src/discord_tool.rs
+++ b/crates/wcore-tools/src/discord_tool.rs
@@ -1,7 +1,7 @@
 //! T3-3.7 — Discord server introspection / management tool.
 //!
-//! Ported from `wayland-hermes/agent/tools/discord_tool.py` (MIT
-//! © Nous Research). The Python original talks to Discord's REST API
+//! Ported from an upstream MIT-licensed library (see THIRD-PARTY-NOTICES.md).
+//! The Python original talks to Discord's REST API
 //! directly (urllib + bot token). Wayland's engine MUST NOT initiate
 //! HTTP from inside `wcore-tools` (HTTP is a `wcore-providers` /
 //! plugin / host concern), so this port covers the **dispatch surface

--- a/crates/wcore-tools/src/env_passthrough.rs
+++ b/crates/wcore-tools/src/env_passthrough.rs
@@ -1,5 +1,5 @@
 //! T3-3.4 (sub-wave 4): environment variable passthrough registry
-//! ported from `wayland-hermes/agent/tools/env_passthrough.py`.
+//! ported from the prior Wayland Python engine.
 //!
 //! Skills that declare `required_environment_variables` in their
 //! frontmatter need those vars available in sandboxed execution

--- a/crates/wcore-tools/src/file_safety.rs
+++ b/crates/wcore-tools/src/file_safety.rs
@@ -1,5 +1,5 @@
-//! T3-3.2.2 — Shared file-safety rules ported from
-//! `wayland-hermes/agent/tools/file_safety.py`.
+//! T3-3.2.2 — Shared file-safety rules ported from the prior Wayland
+//! Python engine.
 //!
 //! This is a *helper* module, not a tool. It exposes:
 //!

--- a/crates/wcore-tools/src/file_state.rs
+++ b/crates/wcore-tools/src/file_state.rs
@@ -1,6 +1,6 @@
 //! T3-3.2.3 — Cross-agent file state coordination registry.
 //!
-//! Port of `agent/tools/file_state.py` from wayland-hermes. Prevents
+//! Ported from the prior Wayland Python engine. Prevents
 //! mangled edits when concurrent subagents (same process, same
 //! filesystem) touch the same file. Complements the single-agent
 //! [`crate::file_cache::FileStateCache`] — that module is a per-process

--- a/crates/wcore-tools/src/fuzzy_match.rs
+++ b/crates/wcore-tools/src/fuzzy_match.rs
@@ -1,6 +1,6 @@
 //! T3-3.2.7: Fuzzy find-and-replace helper for the Edit tool.
 //!
-//! Port of `wayland-hermes/agent/tools/fuzzy_match.py` — an 8/9-strategy
+//! Ported from the prior Wayland Python engine — an 8/9-strategy
 //! matching chain (inspired by OpenCode) used to robustly locate text in
 //! a file even when the LLM-supplied `old_string` differs from the on-disk
 //! content in whitespace, indentation, Unicode punctuation, or escape

--- a/crates/wcore-tools/src/github_tool.rs
+++ b/crates/wcore-tools/src/github_tool.rs
@@ -1,6 +1,6 @@
 //! v0.6.3 Tier 2B T3 — GitHub REST API operations tool.
 //!
-//! Ported from `wayland-hermes/agent/tools/github_tool.py`. The Python
+//! Ported from the prior Wayland Python engine. The Python
 //! original talks to `api.github.com` directly (httpx + a `GITHUB_TOKEN`).
 //! Mirroring the established `wcore-tools` discipline (see
 //! [`discord_tool`](crate::discord_tool), [`web_tools`](crate::web_tools),

--- a/crates/wcore-tools/src/gitlab_tool.rs
+++ b/crates/wcore-tools/src/gitlab_tool.rs
@@ -1,6 +1,6 @@
 //! T4 (v0.6.3 Tier 2B) — GitLab REST API v4 operations tool.
 //!
-//! Ported from `wayland-hermes/agent/tools/gitlab_tool.py` and modeled
+//! Ported from the prior Wayland Python engine and modeled
 //! on `discord_tool.rs`. The Python original talks to GitLab's REST API
 //! directly (an HTTP client + a `PRIVATE-TOKEN` header). Wayland's
 //! engine MUST NOT initiate HTTP from inside `wcore-tools` — HTTP is a

--- a/crates/wcore-tools/src/google_meet_tool.rs
+++ b/crates/wcore-tools/src/google_meet_tool.rs
@@ -1,7 +1,7 @@
 //! T3-3.7 (sub-wave 7): `meet_*` tools — Google Meet integration via a
 //! pluggable [`GoogleMeetBackend`].
 //!
-//! Ported from `wayland-hermes/agent/tools/google_meet_tool.py` (754 LOC).
+//! Ported from the prior Wayland Python engine (754 LOC).
 //!
 //! The Python original spawns a detached Playwright + headless-Chromium
 //! subprocess that joins a Google Meet URL, scrapes live captions into a

--- a/crates/wcore-tools/src/homeassistant_tool.rs
+++ b/crates/wcore-tools/src/homeassistant_tool.rs
@@ -1,6 +1,6 @@
 //! T3-3.7 -- `homeassistant` smart-home tool.
 //!
-//! Ported from `wayland-hermes/agent/tools/homeassistant_tool.py` (MIT).
+//! Ported from an upstream MIT-licensed library (see THIRD-PARTY-NOTICES.md).
 //! The Python original exposes four LLM-callable tools -- `ha_list_entities`,
 //! `ha_get_state`, `ha_list_services`, `ha_call_service` -- that each talk
 //! directly to the Home Assistant REST API via `aiohttp`. Wayland's

--- a/crates/wcore-tools/src/image_generation_tool.rs
+++ b/crates/wcore-tools/src/image_generation_tool.rs
@@ -1,6 +1,6 @@
 //! T3-3.6 (sub-wave 6): `image_generate` tool — text-to-image generation.
 //!
-//! Ported from `wayland-hermes/agent/tools/image_generation_tool.py` (506 LOC).
+//! Ported from the prior Wayland Python engine.
 //!
 //! Sends a text prompt to a multimodal image-generation backend through a
 //! **pluggable [`ImageGenerationBackend`]**. The engine binds the real

--- a/crates/wcore-tools/src/lib.rs
+++ b/crates/wcore-tools/src/lib.rs
@@ -17,20 +17,20 @@ pub mod bash;
 // Native per-command Bash output compaction (cargo/git/test/grep) — engine-owned,
 // fail-open, size-gated. See `.planning/2026-06-11-NATIVE-BASH-COMPACTION-DESIGN.md`.
 pub mod bash_compact;
-// T3-3.2.1: pure-string binary extension filter ported from hermes (sub-wave 2).
+// T3-3.2.1: pure-string binary extension filter ported from the prior Wayland Python engine (sub-wave 2).
 pub mod binary_extensions;
-// T3-3.1.1: clarify_tool ported from wayland-hermes (sub-wave 1).
+// T3-3.1.1: clarify_tool ported from the prior Wayland Python engine (sub-wave 1).
 pub mod clarify;
 // W8a A.3: ToolContext threaded into every tool dispatch (cancel + vfs + sink).
 pub mod context;
-// T3-3.1.8: per-tool opt-in JSON call log (port of hermes debug_helpers).
+// T3-3.1.8: per-tool opt-in JSON call log (port of the prior Wayland Python engine).
 pub mod debug_helpers;
-// T3-3.4 (sub-wave 4): env var passthrough registry — HELPER. Ports
-// `wayland-hermes/agent/tools/env_passthrough.py`. Skill-declared
+// T3-3.4 (sub-wave 4): env var passthrough registry — HELPER. Ported
+// from the prior Wayland Python engine. Skill-declared
 // `required_environment_variables` (plus host config) survive
 // sandboxed sub-process env stripping in BashTool / ScriptTool.
 pub mod env_passthrough;
-// T3-3.1.3: delegate tool ported from hermes — bridges to wcore-types `Spawner`
+// T3-3.1.3: delegate tool ported from the prior Wayland Python engine — bridges to wcore-types `Spawner`
 // trait so the actual sub-agent dispatch stays in wcore-agent.
 pub mod delegate;
 pub mod dispatcher;
@@ -41,12 +41,12 @@ pub mod edit;
 pub mod email_parse_tool;
 pub mod file_cache;
 // T3-3.2.2: shared file-safety policy (write deny list + skill-hub read
-// block) ported from `wayland-hermes/agent/tools/file_safety.py`.
+// block) ported from the prior Wayland Python engine.
 pub mod file_safety;
-// T3-3.2.3: cross-agent file state coordination (port of hermes file_state.py).
+// T3-3.2.3: cross-agent file state coordination (port of the prior Wayland Python engine).
 pub mod file_state;
-// T3-3.2.7: 9-strategy fuzzy find-and-replace helper (port of hermes
-// fuzzy_match.py). Wired into EditTool as an opt-in fallback (Rank 41):
+// T3-3.2.7: 9-strategy fuzzy find-and-replace helper (port of the prior
+// Wayland Python engine). Wired into EditTool as an opt-in fallback (Rank 41):
 // `EditTool::with_fuzzy_fallback(true)` retries an exact-match failure
 // through this chain; default OFF so the exact path is byte-identical.
 pub mod fuzzy_match;
@@ -61,14 +61,14 @@ pub mod git_commit_message;
 // T4 (v0.6.3 Tier 2B): GitLab REST API v4 tool — issue/MR/file read +
 // note posts via a pluggable GitLabBackend (NullGitLabBackend fails
 // loud, NO-STUBS). Configurable base URL for self-hosted GitLab.
-// Ported from `wayland-hermes/agent/tools/gitlab_tool.py`.
+// Ported from the prior Wayland Python engine.
 pub mod gitlab_tool;
 pub mod glob;
 // T3-3.7.3 (sub-wave 7): Google Meet conferencing tool ported from
-// `wayland-hermes/agent/tools/google_meet_tool.py`.
+// the prior Wayland Python engine.
 pub mod google_meet_tool;
 pub mod grep;
-// T3-3.1.5: per-thread interrupt signaling (port of hermes interrupt.py).
+// T3-3.1.5: per-thread interrupt signaling (port of the prior Wayland Python engine).
 pub mod interrupt;
 // T11 (Plan v2 Tier 2B): JSON Lines streaming tool — large-file-friendly
 // ranged slice / count / key filter / per-line JSON validation via a
@@ -91,25 +91,25 @@ pub mod moa;
 // (NullNotionBackend fails loud, NO-STUBS). Mirrors github_tool.
 pub mod notion_tool;
 // T3-3.3.4 (sub-wave 4): Office-side skill enable/disable runtime (HELPER)
-// ported from `wayland-hermes/agent/tools/office_runtime.py`. Manages
+// ported from the prior Wayland Python engine. Manages
 // materialization of optional skill bundles under the user's skills
 // directory in response to Desktop-driven enable/disable toggles.
 pub mod office_runtime;
 // T3-3.8.4: OSV malware advisory check before launching MCP package-runner
-// shims (`npx` / `uvx`) — ported from hermes (sub-wave 8).
+// shims (`npx` / `uvx`) — ported from the prior Wayland Python engine (sub-wave 8).
 pub mod osv_check;
 // Wave SD: path validation for legacy `execute()` entry points (closes
 // SECURITY MAJOR #14 — top-level Read/Write/Edit without sandbox).
 pub mod path_validation;
-// T3-3.2.8: V4A patch-format parser (HELPER) ported from hermes (sub-wave 2).
+// T3-3.2.8: V4A patch-format parser (HELPER) ported from the prior Wayland Python engine (sub-wave 2).
 pub mod patch_parser;
-// T15: read-only PDF text-extraction tool (port of hermes pdf_tool.py).
+// T15: read-only PDF text-extraction tool (port of the prior Wayland Python engine).
 // Pure-Rust `pdf-extract` backend gated behind the default-on `pdf`
 // cargo feature; PdfTool degrades to an honest error when the feature
 // is off so the schema stays stable across build configs.
 pub mod pdf_tool;
 // T3-3.8 (sub-wave 8): Piper TTS voice + binary downloader (HELPER) ported
-// from `wayland-hermes/agent/tools/piper_download.py`. Pluggable
+// from the prior Wayland Python engine. Pluggable
 // ModelDownloader + BinaryExtractor traits (Null = fail-loud,
 // Capturing = test double); not surfaced as a tool because `tts_tool`
 // explicitly delegates Piper voice/binary acquisition to the backend.
@@ -130,15 +130,15 @@ pub mod record_episode;
 pub mod registry;
 pub mod repomap;
 // T3-3.3.2: HELPER — broad JSON-Schema sanitizer for llama.cpp / strict
-// backend compat (port of hermes `schema_sanitizer.py`). Distinct from
+// backend compat (port of the prior Wayland Python engine). Distinct from
 // the Bedrock-targeted `wcore_config::compat::sanitize_json_schema`.
 pub mod schema_sanitizer;
 pub mod script;
 // T3-3.1.4: cross-channel `send_message` tool (port of
-// wayland-hermes/agent/tools/send_message_tool.py).
+// the prior Wayland Python engine).
 pub mod send_message;
 // T3-3.7 (sub-wave 7): Discord server tool — port of
-// `wayland-hermes/agent/tools/discord_tool.py`. Dispatch surface only;
+// the prior Wayland Python engine. Dispatch surface only;
 // host wires a `DiscordBackend` implementation for real REST I/O.
 // NullDiscordBackend fails loud (NO-STUBS). Composes url_safety for
 // defense-in-depth on string fields that could carry URLs.
@@ -150,7 +150,7 @@ pub mod discord_tool;
 pub mod github_tool;
 // T3-3.7 (sub-wave 7): cronjob scheduled-task management tool —
 // pluggable CronScheduler seam (NullCronScheduler fails loud). Ported
-// from `wayland-hermes/agent/tools/cronjob_tools.py`.
+// from the prior Wayland Python engine.
 pub mod cronjob_tools;
 // T3-3.1.7: SessionSearchTool — past-session recall via MemoryApi.
 pub mod session_search;
@@ -158,27 +158,27 @@ pub mod session_search;
 // truncation. Postgres/MySQL are out of scope (would be `sql-extra`-gated).
 pub mod sql_query_tool;
 // T3-3.7 (sub-wave 7): Tencent Yuanbao platform toolset
-// (port of `wayland-hermes/agent/tools/yuanbao_tools.py`). Single
+// (port of the prior Wayland Python engine). Single
 // `YuanbaoTool` with an `action` discriminator dispatches all five
-// hermes operations (group_info / group_members / search_sticker /
+// operations (group_info / group_members / search_sticker /
 // send_sticker / send_dm) through a host-supplied YuanbaoBackend.
 pub mod yuanbao_tools;
 // T3-3.3.3: Tirith pre-exec security scanner wrapper (HELPER) ported from
-// hermes tirith_security.py. Auto-installer is documented out-of-scope.
+// the prior Wayland Python engine. Auto-installer is documented out-of-scope.
 pub mod tirith_security;
-// T3-3.1.2: in-memory planning/task list tool ported from wayland-hermes.
+// T3-3.1.2: in-memory planning/task list tool ported from the prior Wayland Python engine.
 pub mod todo;
 // T3-3.3.3: configurable tool-output truncation limits (HELPER) — port of
-// `wayland-hermes/agent/tools/tool_output_limits.py`. Adds user-tunable
+// the prior Wayland Python engine. Adds user-tunable
 // `max_bytes` / `max_lines` / `max_line_length` knobs that complement the
 // existing per-tool `max_result_size()` and `truncate_utf8()` primitives.
 pub mod tool_output_limits;
 // T3-3.3.3: tool-result persistence helper (port of
-// wayland-hermes/agent/tools/tool_result_storage.py).
+// the prior Wayland Python engine).
 pub mod tool_result_storage;
 pub mod tool_search;
-// T3-3.3.3: SSRF / private-network URL safety helper (port of hermes
-// `url_safety.py`). HELPER module — callers wire it into HTTP-client
+// T3-3.3.3: SSRF / private-network URL safety helper (port of the prior
+// Wayland Python engine). HELPER module — callers wire it into HTTP-client
 // redirect hooks and tool pre-flight checks.
 pub mod url_safety;
 // W8a A.3: VirtualFs trait + RealFs / InMemoryFs / SandboxedFs (X2).
@@ -188,7 +188,7 @@ pub mod vfs;
 pub mod video_analyze_tool;
 // T3-3.6 (sub-wave 6): image_generate tool — text-to-image generation
 // via a pluggable ImageGenerationBackend (NullImageGenerationBackend
-// fails loud). Ported from `wayland-hermes/agent/tools/image_generation_tool.py`.
+// fails loud). Ported from the prior Wayland Python engine.
 pub mod image_generation_tool;
 // T8 (v0.6.3 Tier 2B): image_inspect tool — read-only image metadata
 // (dimensions / format / color type via `image`; EXIF via
@@ -197,17 +197,17 @@ pub mod image_generation_tool;
 pub mod image_inspect_tool;
 // T3-3.6 (sub-wave 6): text_to_speech tool — multi-provider TTS via a
 // pluggable TtsBackend (NullTtsBackend fails loud). Ported from
-// `wayland-hermes/agent/tools/tts_tool.py`.
+// the prior Wayland Python engine.
 pub mod tts_tool;
 // T3-3.3.3: website blocklist helper ported from
-// `wayland-hermes/agent/tools/website_policy.py` (sub-wave 3).
+// the prior Wayland Python engine (sub-wave 3).
 pub mod website_policy;
 // T3-3.5: vision_analyze tool ported from
-// `wayland-hermes/agent/tools/vision_tools.py` (sub-wave 5).
+// the prior Wayland Python engine (sub-wave 5).
 pub mod vision_tools;
 // T3-3.8 (sub-wave 8): web tool — search/extract/crawl via a pluggable
 // WebBackend (NullWebBackend fails loud). Ported from
-// `wayland-hermes/agent/tools/web_tools.py`. Composes url_safety +
+// the prior Wayland Python engine. Composes url_safety +
 // website_policy for SSRF + blocklist gating before backend dispatch.
 pub mod web_tools;
 // Wave RC (2026-05-23): simple HTTP-GET tool — `WebFetch`. The Browser
@@ -218,26 +218,26 @@ pub mod web_tools;
 // reaches for by default for read-only page fetches now.
 pub mod web_fetch;
 // T3-3.6: transcribe_audio tool ported from
-// `wayland-hermes/agent/tools/transcription_tools.py` (sub-wave 6).
+// the prior Wayland Python engine (sub-wave 6).
 // Pluggable TranscriptionBackend + AudioFetcher seams; NullBackend
 // fails loud (NO-STUBS); composes url_safety + website_policy for
 // URL inputs. Mirrors the vision_tools seam pattern.
 pub mod transcription_tools;
 // T3-3.6 (sub-wave 6): voice_mode session helper — pluggable
 // AudioRecorder / TranscriptionBackend / AudioPlayer seams. Ported
-// from `wayland-hermes/agent/tools/voice_mode.py`.
+// from the prior Wayland Python engine.
 pub mod voice_mode;
 // T3-3.7 (sub-wave 7): Spotify toolset — seven agent-facing tools
 // sharing a pluggable SpotifyBackend (NullSpotifyBackend fails loud).
-// Ported from `wayland-hermes/agent/tools/spotify_tool.py`.
+// Ported from the prior Wayland Python engine.
 pub mod spotify_tool;
 // T3-3.7 (sub-wave 7): homeassistant tool — smart-home control via a
 // pluggable HomeAssistantBackend (NullHomeAssistantBackend fails loud).
-// Ported from `wayland-hermes/agent/tools/homeassistant_tool.py`.
+// Ported from the prior Wayland Python engine.
 pub mod homeassistant_tool;
 // T3-3.8 (sub-wave 8): wayland self-introspection toolset
 // (`wayland_status` + `wayland_telemetry_query`) ported from
-// `wayland-hermes/agent/tools/wayland_introspection.py`.
+// the prior Wayland Python engine.
 // Pluggable WaylandIntrospectionBackend seam; NullBackend fails loud
 // (NO-STUBS). Two tools share one backend so the
 // `wayland_introspection` toolset disables as a unit.

--- a/crates/wcore-tools/src/moa.rs
+++ b/crates/wcore-tools/src/moa.rs
@@ -1,8 +1,7 @@
 //! T2-C2: Mixture-of-Agents tool.
 //!
 //! Port of Wang 2024 ("Mixture-of-Agents Enhances Large Language Model
-//! Capabilities", arXiv:2406.04692) from
-//! `wayland-hermes/agent/tools/mixture_of_agents_tool.py`.
+//! Capabilities", arXiv:2406.04692) from the prior Wayland Python engine.
 //!
 //! The MoA pattern fans a user prompt across N *proposer* providers in
 //! parallel, concatenates their answers, then hands the bundle to an

--- a/crates/wcore-tools/src/office_runtime.rs
+++ b/crates/wcore-tools/src/office_runtime.rs
@@ -1,5 +1,5 @@
-//! T3-3.4: Office-side skill enable/disable runtime — port of
-//! `wayland-hermes/agent/tools/office_runtime.py` (Stage 5 Task 7).
+//! T3-3.4: Office-side skill enable/disable runtime — ported from the
+//! prior Wayland Python engine (Stage 5 Task 7).
 //!
 //! HELPER module. The authoritative source of truth for which optional
 //! skills are enabled lives in the Wayland Desktop's `office.db`; the
@@ -10,7 +10,7 @@
 //!
 //! ## Divergence from the Python source
 //!
-//! The Python module imports three cross-module symbols at import time:
+//! The Python source imports three cross-module symbols at import time:
 //! - `wayland_constants.get_wayland_home()` — global Wayland home path.
 //! - `tools.skills_hub.OptionalSkillSource` — Python class with a
 //!   `fetch(slug) -> SkillBundle | None` method that returns a
@@ -37,8 +37,8 @@
 //! `dirs::home_dir()` cross-platform) but we don't depend on that crate
 //! here to avoid pulling `wcore-skills` into `wcore-tools`.
 //!
-//! Concurrency: hermes runs all four `office_runtime` entry points from
-//! the same `office_sync` async handler, but the in-memory sets are
+//! Concurrency: the Python source runs all four `office_runtime` entry
+//! points from the same `office_sync` async handler, but the in-memory sets are
 //! plain module globals. The Rust port wraps them in [`Mutex`] guards
 //! so a multi-threaded host (e.g. `wcore-agent` on Tokio's multi-thread
 //! runtime) can hit `is_enabled`/`is_office_origin` concurrently without
@@ -59,10 +59,10 @@ pub enum SkillFileContent {
 }
 
 /// A materializable skill bundle. Roughly equivalent to the
-/// `SkillBundle` returned by hermes' `OptionalSkillSource.fetch()` —
-/// just the `files` mapping is required here (other Python attributes
-/// like `version` / `description` are loader concerns that don't
-/// affect on-disk materialization).
+/// `SkillBundle` returned by the Python source's
+/// `OptionalSkillSource.fetch()` — just the `files` mapping is required
+/// here (other Python attributes like `version` / `description` are
+/// loader concerns that don't affect on-disk materialization).
 #[derive(Debug, Clone, Default)]
 pub struct SkillBundle {
     /// Relative path inside the skill dir → file content.
@@ -71,12 +71,12 @@ pub struct SkillBundle {
     pub files: BTreeMap<String, SkillFileContent>,
 }
 
-/// Source-of-bundles seam — mirrors hermes' `OptionalSkillSource.fetch`.
+/// Source-of-bundles seam — mirrors the Python `OptionalSkillSource.fetch`.
 pub trait SkillSource: Send + Sync {
     fn fetch(&self, slug: &str) -> Option<SkillBundle>;
 }
 
-/// Mirror-the-enabled-set seam — hermes calls
+/// Mirror-the-enabled-set seam — the Python source calls
 /// `office_sync.set_enabled(_enabled)` so the `/office/events` snapshot
 /// stays in sync with what the runtime knows about. The Rust port
 /// defaults this to a no-op when the host doesn't wire one in.
@@ -84,7 +84,7 @@ pub trait EnabledMirror: Send + Sync {
     fn mirror_enabled(&self, enabled: &HashSet<String>);
 }
 
-/// Authored-skill broadcast seam — hermes calls
+/// Authored-skill broadcast seam — the Python source calls
 /// `office_sync.emit_skill_authored(slug)` to fan a `skill-authored`
 /// event out to the Desktop Settings pane via the long-poll bridge.
 pub trait SkillAuthoredEmitter: Send + Sync {
@@ -119,10 +119,11 @@ impl LoadOutcome {
     }
 }
 
-/// Per-instance office runtime state. Hermes uses module-level globals;
-/// the Rust port encapsulates them so tests don't need to share state.
+/// Per-instance office runtime state. The Python source uses
+/// module-level globals; the Rust port encapsulates them so tests don't
+/// need to share state.
 pub struct OfficeRuntime {
-    /// Equivalent to hermes' `get_wayland_home() / "skills"` — root
+    /// Equivalent to the Python `get_wayland_home() / "skills"` — root
     /// directory under which `<slug>/` directories get materialized.
     skills_root: PathBuf,
     source: Box<dyn SkillSource>,
@@ -256,7 +257,7 @@ impl OfficeRuntime {
             .expect("office_origin mutex poisoned")
             .contains(slug);
         if !was_office_origin {
-            // Matches hermes' `_office_origin` gate — refuse to unload.
+            // Matches the Python `_office_origin` gate — refuse to unload.
             return;
         }
         let target = self.skills_root.join(slug);
@@ -452,7 +453,7 @@ mod tests {
     #[test]
     fn load_skill_rejects_path_traversal_in_bundle() {
         let tmp = TempDir::new().unwrap();
-        // Hermes is implicitly trusting; the Rust port adds containment.
+        // The Python source is implicitly trusting; the Rust port adds containment.
         let bundle = binary_bundle("../escape.txt", vec![1, 2, 3]);
         let (rt, _, _) = rt_with(tmp.path().to_path_buf(), vec![("evil", bundle)]);
         let outcome = rt.load_skill("evil");

--- a/crates/wcore-tools/src/osv_check.rs
+++ b/crates/wcore-tools/src/osv_check.rs
@@ -1,6 +1,6 @@
 //! T3-3.8 — OSV (Open Source Vulnerabilities) malware check.
 //!
-//! Ported from `wayland-hermes/agent/tools/osv_check.py` (155 LOC).
+//! Ported from the prior Wayland Python engine.
 //!
 //! Before launching an MCP server via `npx` / `uvx` (or any analogous
 //! package-runner shim), this helper queries the OSV API to check

--- a/crates/wcore-tools/src/patch_parser.rs
+++ b/crates/wcore-tools/src/patch_parser.rs
@@ -1,6 +1,6 @@
 //! V4A Patch Format Parser (HELPER module).
 //!
-//! Ported from `wayland-hermes/agent/tools/patch_parser.py` (sub-wave 2 of
+//! Ported from the prior Wayland Python engine (sub-wave 2 of
 //! T3-3). This module only parses the V4A patch format used by codex / cline
 //! and similar coding agents — application of the parsed operations lives
 //! elsewhere (the higher-level edit tooling).

--- a/crates/wcore-tools/src/pdf_tool.rs
+++ b/crates/wcore-tools/src/pdf_tool.rs
@@ -1,6 +1,6 @@
 //! T15: read-only PDF text-extraction tool.
 //!
-//! Ported in spirit from `wayland-hermes/agent/tools/pdf_tool.py`. Extracts
+//! Ported in spirit from the prior Wayland Python engine. Extracts
 //! plain text from a PDF file on the local filesystem — either the whole
 //! document or a contiguous page range.
 //!

--- a/crates/wcore-tools/src/piper_download.rs
+++ b/crates/wcore-tools/src/piper_download.rs
@@ -1,6 +1,6 @@
 //! T3-3.8 (sub-wave 8): Piper voice + binary downloader (HELPER).
 //!
-//! Ported from `wayland-hermes/agent/tools/piper_download.py`.
+//! Ported from the prior Wayland Python engine.
 //!
 //! The Python original performs three jobs:
 //!

--- a/crates/wcore-tools/src/schema_sanitizer.rs
+++ b/crates/wcore-tools/src/schema_sanitizer.rs
@@ -29,7 +29,7 @@
 //! This module walks the final tool schema tree and fixes the broader set of
 //! known-hostile constructs on a deep copy of the input.
 //!
-//! Ported from `wayland-hermes/agent/tools/schema_sanitizer.py`.
+//! Ported from the prior Wayland Python engine.
 
 use serde_json::{Map, Value, json};
 

--- a/crates/wcore-tools/src/send_message.rs
+++ b/crates/wcore-tools/src/send_message.rs
@@ -1,7 +1,7 @@
 //! T3-3.1.4 — `send_message` cross-channel messaging tool.
 //!
-//! Ported from `wayland-hermes/agent/tools/send_message_tool.py` (MIT
-//! © Nous Research). The Python original routes to ~17 external
+//! Ported from an upstream MIT-licensed library (see THIRD-PARTY-NOTICES.md). The Python original
+//! routes to ~17 external
 //! messaging platforms (Telegram, Discord, Slack, Matrix, Signal,
 //! Email, SMS, etc.). Wayland's engine has no adapters for any of
 //! those, so this port covers the **dispatch surface** only — schema,

--- a/crates/wcore-tools/src/session_search.rs
+++ b/crates/wcore-tools/src/session_search.rs
@@ -1,8 +1,8 @@
 // T3-3.1.7: SessionSearchTool — long-term conversation recall.
 //
-// Ported from `wayland-hermes/agent/tools/session_search_tool.py` (MIT ©
-// Nous Research). The Python version uses SQLite FTS5 against a session
-// transcript table, then summarizes the top matches with a cheap LLM.
+// Ported from an upstream MIT-licensed library (see THIRD-PARTY-NOTICES.md). The Python version uses
+// SQLite FTS5 against a session transcript table, then summarizes the top
+// matches with a cheap LLM.
 //
 // In wayland-core the session/episode store lives in `wcore-memory` (v2
 // 5-partition × 3-tier model), and the public `MemoryApi::search` entry

--- a/crates/wcore-tools/src/spotify_tool.rs
+++ b/crates/wcore-tools/src/spotify_tool.rs
@@ -1,9 +1,8 @@
 //! T3-3.7 (sub-wave 7): Spotify toolset — seven agent-facing tools that
 //! share a single pluggable [`SpotifyBackend`].
 //!
-//! Ported from `wayland-hermes/agent/tools/spotify_tool.py` (597 LOC) and
-//! the URI/ID normalization helpers from
-//! `wayland-hermes/agent/tools/providers/spotify_client.py`.
+//! Ported from the prior Wayland Python engine (the 597-LOC Spotify
+//! toolset and the URI/ID normalization helpers from its Spotify client).
 //!
 //! The Python original is built on top of a concrete `SpotifyClient`
 //! (httpx-based, OAuth token from `wayland auth spotify`). Wayland's

--- a/crates/wcore-tools/src/tirith_security.rs
+++ b/crates/wcore-tools/src/tirith_security.rs
@@ -13,9 +13,9 @@
 //! Operational failures (spawn error, timeout, unknown exit code) respect the
 //! `fail_open` config setting.
 //!
-//! # Port divergence vs hermes
+//! # Port divergence vs the prior Wayland Python engine
 //!
-//! The Python source [`tirith_security.py`] additionally contains an
+//! The prior Python source additionally contains an
 //! **auto-installer** that downloads the `tirith` binary from GitHub releases,
 //! verifies it with cosign provenance + SHA-256 checksums, extracts a tarball,
 //! and persists a 24h failure-marker on disk. That heavy supply-chain logic
@@ -25,8 +25,6 @@
 //! needed. This module only resolves an already-present binary via PATH or
 //! `$WAYLAND_HOME/bin/tirith`, and surfaces the [`check_command_security`]
 //! main API.
-//!
-//! [`tirith_security.py`]: https://github.com/sheeki03/wayland-hermes/blob/main/agent/tools/tirith_security.py
 
 use std::env;
 use std::fs;
@@ -56,7 +54,7 @@ pub const MAX_SUMMARY_LEN: usize = 500;
 
 /// Security configuration for the tirith scanner.
 ///
-/// Mirrors the hermes `_load_security_config()` shape. In production callers
+/// Mirrors the prior Python engine's `_load_security_config()` shape. In production callers
 /// should populate this from their config layer; the [`SecurityConfig::from_env`]
 /// helper honours the `TIRITH_*` environment overrides the Python tool used.
 #[derive(Debug, Clone)]
@@ -90,7 +88,7 @@ impl Default for SecurityConfig {
 impl SecurityConfig {
     /// Construct a config with environment variable overrides applied.
     ///
-    /// Recognised vars (match hermes):
+    /// Recognised vars (match the prior Python engine):
     /// * `TIRITH_ENABLED`   (bool: `1`/`true`/`yes` enables)
     /// * `TIRITH_BIN`       (string path)
     /// * `TIRITH_TIMEOUT`   (integer seconds)
@@ -181,7 +179,7 @@ impl SecurityResult {
 /// Return the `$WAYLAND_HOME` directory.
 ///
 /// Honours the `WAYLAND_HOME` env var; falls back to `~/.wayland` (matching
-/// hermes' `wayland_constants.get_wayland_home`).
+/// the prior Python engine's `wayland_constants.get_wayland_home`).
 pub fn wayland_home() -> PathBuf {
     if let Ok(v) = env::var("WAYLAND_HOME") {
         return PathBuf::from(v);
@@ -299,7 +297,7 @@ pub enum PathResolution {
     /// Binary located at this path.
     Found(PathBuf),
     /// Could not locate a usable binary. The string is a short failure tag
-    /// matching the hermes vocabulary (e.g. `"explicit_path_missing"`,
+    /// matching the prior Python engine's vocabulary (e.g. `"explicit_path_missing"`,
     /// `"not_on_path"`).
     Missing(String),
 }
@@ -315,7 +313,7 @@ pub enum PathResolution {
 ///   * `$WAYLAND_HOME/bin/tirith`
 ///
 /// This intentionally does **NOT** trigger the network auto-installer that the
-/// hermes source performs. See the module-level docs.
+/// prior Python engine performs. See the module-level docs.
 pub fn resolve_tirith_path(configured_path: &str) -> PathResolution {
     let expanded = expand_user(configured_path);
     let explicit = is_explicit_path(configured_path);
@@ -350,7 +348,7 @@ pub fn resolve_tirith_path(configured_path: &str) -> PathResolution {
 
 /// Run a tirith security scan on `command` using the supplied configuration.
 ///
-/// Mirrors hermes' `check_command_security`. Returns a [`SecurityResult`]
+/// Mirrors the prior Python engine's `check_command_security`. Returns a [`SecurityResult`]
 /// whose `action` is determined by tirith's exit code; JSON stdout is parsed
 /// for `findings` / `summary` enrichment but never overrides the verdict.
 ///
@@ -436,7 +434,7 @@ pub async fn check_command_security(command: &str, cfg: &SecurityConfig) -> Secu
 }
 
 /// Parse tirith JSON stdout into a [`SecurityResult`], applying the truncation
-/// limits and degradation rules from hermes. The `action` parameter is the
+/// limits and degradation rules from the prior Python engine. The `action` parameter is the
 /// authoritative verdict from the exit code; JSON never overrides it.
 pub fn enrich_with_json(action: Action, stdout: &[u8]) -> SecurityResult {
     let text = std::str::from_utf8(stdout).unwrap_or("").trim();
@@ -561,7 +559,7 @@ mod tests {
         assert!(r.findings.is_empty());
         assert!(r.summary.is_empty());
 
-        // Whitespace-only is also "empty" per hermes' .strip() check.
+        // Whitespace-only is also "empty" per the prior Python engine's .strip() check.
         let r = enrich_with_json(Action::Allow, b"   \n\t  ");
         assert_eq!(r.action, Action::Allow);
         assert!(r.summary.is_empty());
@@ -605,7 +603,7 @@ mod tests {
     #[test]
     fn security_config_default_fail_closed() {
         // v0.6.2 cross-audit Round 1: default flipped from fail-open (matching
-        // hermes) to fail-closed. Operators who need the old behavior set
+        // the prior Python engine) to fail-closed. Operators who need the old behavior set
         // TIRITH_FAIL_OPEN=true.
         let cfg = SecurityConfig::default();
         assert!(cfg.tirith_enabled);

--- a/crates/wcore-tools/src/todo.rs
+++ b/crates/wcore-tools/src/todo.rs
@@ -1,7 +1,6 @@
 //! Todo Tool — Planning & Task Management
 //!
-//! Ports `wayland-hermes/agent/tools/todo_tool.py` (MIT © Nous Research, Rust
-//! port by Sean) into the wcore-tools dispatch surface.
+//! Ported from an upstream MIT-licensed library (see THIRD-PARTY-NOTICES.md) into the wcore-tools dispatch surface.
 //!
 //! Provides an in-memory task list the agent uses to decompose complex tasks,
 //! track progress, and maintain focus across long conversations.

--- a/crates/wcore-tools/src/tool_output_limits.rs
+++ b/crates/wcore-tools/src/tool_output_limits.rs
@@ -1,8 +1,8 @@
 //! T3-3.3.3: Configurable tool-output truncation limits.
 //!
-//! Ported from `wayland-hermes/agent/tools/tool_output_limits.py` (which in
-//! turn ports `anomalyco/opencode` PR #23770 — *"feat(truncate): allow
-//! configuring tool output truncation limits"*).
+//! Ported from the prior Wayland Python engine (which in turn ports
+//! `anomalyco/opencode` PR #23770 — *"feat(truncate): allow configuring tool
+//! output truncation limits"*).
 //!
 //! ## Why a separate helper?
 //!
@@ -11,15 +11,16 @@
 //! truncation primitive. Neither of those is **user-configurable** at runtime,
 //! and neither covers the *per-line length* cap that file-ops tools need.
 //!
-//! Hermes centralises three user-tunable knobs behind a single `tool_output`
-//! config section so power users can tune them without patching the source:
+//! The predecessor centralises three user-tunable knobs behind a single
+//! `tool_output` config section so power users can tune them without patching
+//! the source:
 //!
 //! - `max_bytes` — terminal stdout/stderr cap (default 50_000)
 //! - `max_lines` — read_file pagination + truncation cap (default 2000)
 //! - `max_line_length` — per-line length cap before `... [truncated]`
 //!   (default 2000)
 //!
-//! The hermes Python module reads `tool_output` directly from
+//! The prior Python module reads `tool_output` directly from
 //! `wayland_cli.config.load_config()`. To avoid a circular `wcore-tools ↔
 //! wcore-config` dependency (and to keep this helper trivially testable),
 //! the Rust port accepts a `&serde_json::Value` config section pointer
@@ -55,13 +56,13 @@
 
 use serde_json::Value;
 
-/// Default terminal-tool byte cap (matches hermes `terminal_tool.MAX_OUTPUT_CHARS`).
+/// Default terminal-tool byte cap (matches the prior engine's `terminal_tool.MAX_OUTPUT_CHARS`).
 pub const DEFAULT_MAX_BYTES: usize = 50_000;
 
-/// Default file-ops line cap (matches hermes `file_operations.MAX_LINES`).
+/// Default file-ops line cap (matches the prior engine's `file_operations.MAX_LINES`).
 pub const DEFAULT_MAX_LINES: usize = 2_000;
 
-/// Default per-line length cap (matches hermes `file_operations.MAX_LINE_LENGTH`).
+/// Default per-line length cap (matches the prior engine's `file_operations.MAX_LINE_LENGTH`).
 pub const DEFAULT_MAX_LINE_LENGTH: usize = 2_000;
 
 /// Resolved tool-output truncation limits.
@@ -91,7 +92,7 @@ impl Default for ToolOutputLimits {
 impl ToolOutputLimits {
     /// Build limits from an optional `tool_output` config section.
     ///
-    /// Mirrors hermes `get_tool_output_limits()`:
+    /// Mirrors the prior engine's `get_tool_output_limits()`:
     ///
     /// - `None` (no `tool_output` section in config) → all defaults.
     /// - A non-object section (e.g. a string mistakenly assigned by the user)
@@ -118,8 +119,9 @@ impl ToolOutputLimits {
 /// Coerce a JSON value to a positive `usize`, falling back to `default` on
 /// any failure mode (missing, wrong type, ≤ 0, non-integral float, overflow).
 ///
-/// Mirrors hermes `_coerce_positive_int` but tightened for `usize`: a negative
-/// JSON integer or a `>usize::MAX` integer both fall through to `default`.
+/// Mirrors the prior engine's `_coerce_positive_int` but tightened for `usize`:
+/// a negative JSON integer or a `>usize::MAX` integer both fall through to
+/// `default`.
 fn coerce_positive_usize(value: Option<&Value>, default: usize) -> usize {
     let v = match value {
         Some(v) => v,
@@ -132,7 +134,7 @@ fn coerce_positive_usize(value: Option<&Value>, default: usize) -> usize {
             } else if let Some(i) = n.as_i64() {
                 if i > 0 { Some(i as u64) } else { None }
             } else if let Some(f) = n.as_f64() {
-                // Match hermes: `int(value)` on a float truncates toward zero;
+                // Match the prior engine: `int(value)` on a float truncates toward zero;
                 // values ≤ 0 fall through. Reject non-finite floats explicitly.
                 if f.is_finite() && f >= 1.0 {
                     Some(f as u64)
@@ -168,7 +170,7 @@ mod tests {
 
     #[test]
     fn defaults_when_section_is_not_object() {
-        // Mirrors hermes: non-dict `tool_output` (e.g. a string) is ignored.
+        // Mirrors the prior engine: non-dict `tool_output` (e.g. a string) is ignored.
         let bad = json!("oops not an object");
         let limits = ToolOutputLimits::from_section(Some(&bad));
         assert_eq!(limits, ToolOutputLimits::default());
@@ -213,7 +215,7 @@ mod tests {
 
     #[test]
     fn string_integers_are_coerced() {
-        // hermes uses `int(value)` which accepts numeric strings; mirror that.
+        // The prior engine uses `int(value)` which accepts numeric strings; mirror that.
         let section = json!({
             "max_bytes": "65536",
             "max_lines": "  10000  ",   // whitespace trimmed

--- a/crates/wcore-tools/src/tool_result_storage.rs
+++ b/crates/wcore-tools/src/tool_result_storage.rs
@@ -1,5 +1,5 @@
-//! T3-3.3.3 — Tool-result persistence helper ported from
-//! `wayland-hermes/agent/tools/tool_result_storage.py`.
+//! T3-3.3.3 — Tool-result persistence helper ported from the prior
+//! Wayland Python engine.
 //!
 //! Defense against context-window overflow operates at three layers:
 //!

--- a/crates/wcore-tools/src/transcription_tools.rs
+++ b/crates/wcore-tools/src/transcription_tools.rs
@@ -1,6 +1,6 @@
 //! T3-3.6 — `transcribe_audio` speech-to-text tool.
 //!
-//! Ported from `wayland-hermes/agent/tools/transcription_tools.py` (MIT).
+//! Ported from an upstream MIT-licensed library (see THIRD-PARTY-NOTICES.md).
 //! The Python original supports four backends (faster-whisper local,
 //! Groq Whisper, OpenAI Whisper, Mistral Voxtral) with provider
 //! auto-detection from env vars. Wayland's engine deliberately ships

--- a/crates/wcore-tools/src/tts_tool.rs
+++ b/crates/wcore-tools/src/tts_tool.rs
@@ -1,7 +1,7 @@
 //! T3-3.6 (sub-wave 6): `text_to_speech` tool — multi-provider TTS via a
 //! pluggable [`TtsBackend`].
 //!
-//! Ported from `wayland-hermes/agent/tools/tts_tool.py` (1137 LOC).
+//! Ported from the prior Wayland Python engine.
 //!
 //! The Python original embeds six concrete provider integrations (Edge,
 //! ElevenLabs, OpenAI, MiniMax, xAI, Mistral, Piper) plus an ffmpeg

--- a/crates/wcore-tools/src/url_safety.rs
+++ b/crates/wcore-tools/src/url_safety.rs
@@ -1,6 +1,6 @@
 //! URL safety checks — block requests to private/internal network addresses.
 //!
-//! Ported from `wayland-hermes/agent/tools/url_safety.py` (T3-3.3 sub-wave 3).
+//! Ported from the prior Wayland Python engine (T3-3.3 sub-wave 3).
 //!
 //! Prevents SSRF (Server-Side Request Forgery) where a malicious prompt or
 //! skill could trick the agent into fetching internal resources like cloud

--- a/crates/wcore-tools/src/video_analyze_tool.rs
+++ b/crates/wcore-tools/src/video_analyze_tool.rs
@@ -1,6 +1,6 @@
 //! T3-3.5 (sub-wave 5): `video_analyze` tool — AI video analysis.
 //!
-//! Ported from `wayland-hermes/agent/tools/video_analyze_tool.py` (516 LOC).
+//! Ported from the prior Wayland Python engine.
 //!
 //! Sends a video (HTTP/HTTPS URL or local file) to a multimodal LLM
 //! through a **pluggable [`VideoAnalysisBackend`]**. The engine binds the

--- a/crates/wcore-tools/src/vision_tools.rs
+++ b/crates/wcore-tools/src/vision_tools.rs
@@ -1,6 +1,6 @@
 //! T3-3.5 — `vision_analyze` AI vision tool.
 //!
-//! Ported from `wayland-hermes/agent/tools/vision_tools.py` (MIT).
+//! Ported from an upstream MIT-licensed library (see THIRD-PARTY-NOTICES.md).
 //! The Python original routes image URLs (or local paths) through a
 //! centralized auxiliary LLM router that supports OpenRouter, Codex,
 //! native Anthropic, or any OpenAI-compatible endpoint. Wayland's

--- a/crates/wcore-tools/src/voice_mode.rs
+++ b/crates/wcore-tools/src/voice_mode.rs
@@ -1,6 +1,6 @@
 //! T3-3.6 — `voice_mode` session helper.
 //!
-//! Ported from `wayland-hermes/agent/tools/voice_mode.py` (1017 LOC, MIT).
+//! Ported from the prior Wayland Python engine (1017 LOC).
 //!
 //! ## Classification: **Helper, NOT a Tool**
 //!

--- a/crates/wcore-tools/src/wayland_introspection.rs
+++ b/crates/wcore-tools/src/wayland_introspection.rs
@@ -1,7 +1,7 @@
 //! T3-3.8 — Wayland self-introspection toolset (`wayland_status` +
 //! `wayland_telemetry_query`).
 //!
-//! Ported from `wayland-hermes/agent/tools/wayland_introspection.py`
+//! Ported from the prior Wayland Python engine
 //! (PRD-1 §4.2 + §4.3). The Python original registers two read-only
 //! tools as a single `wayland_introspection` toolset so the model can
 //! reflectively answer "what's the runtime state right now?" and "what

--- a/crates/wcore-tools/src/web_tools.rs
+++ b/crates/wcore-tools/src/web_tools.rs
@@ -1,6 +1,6 @@
 //! T3-3.8 — `web_search` / `web_extract` / `web_crawl` tools.
 //!
-//! Ported from `wayland-hermes/agent/tools/web_tools.py` (2314 LOC). The
+//! Ported from the prior Wayland Python engine. The
 //! Python original is a multi-backend dispatcher across Exa / Firecrawl /
 //! Parallel / Tavily / DuckDuckGo / trafilatura, each with its own HTTP
 //! client, response normalizer, optional LLM-summarization pass, and
@@ -13,7 +13,7 @@
 //! ## What is in the port
 //!
 //! * A single [`WebTool`] with an `operation` discriminator that exposes
-//!   the three hermes entry points (`search`, `extract`, `crawl`) through
+//!   the three entry points (`search`, `extract`, `crawl`) through
 //!   one Tool. Tool name: `"web"`. The same backend instance handles all
 //!   three operations.
 //! * [`WebBackend`] — async trait the host implements once per real
@@ -26,7 +26,7 @@
 //!   `CapturingVisionBackend` / `CapturingTranscriptionBackend`.
 //! * SSRF + website-policy gating happens **before** the backend is
 //!   called, for *every* URL in the inputs. This matches the post-fix
-//!   layout in `web_tools.py` (lines 1236–1264) where the website
+//!   layout in the prior Wayland Python engine where the website
 //!   blocklist was moved out of the firecrawl branch so trafilatura and
 //!   the free fallback couldn't bypass it.
 //! * The two parameter validators ([`validate_search_query`],
@@ -55,10 +55,10 @@
 //! 1. URL list is rejected when **any** URL fails [`is_safe_url`] — the
 //!    backend is never called with a private-network / loopback URL.
 //! 2. URLs are screened by [`check_website_access`] (fail-open on
-//!    malformed config — same semantics as hermes / vision_tools).
+//!    malformed config — same semantics as vision_tools).
 //! 3. URLs are rejected up front if they contain what looks like an API
 //!    key prefix (`sk-`, `pk-`, percent-encoded variants). This mirrors
-//!    the secrets-in-URL guard at hermes lines 1204–1214 and prevents
+//!    the prior engine's secrets-in-URL guard and prevents
 //!    accidental exfiltration via the URL bar.
 //! 4. Search queries are length-bounded (4 KB) so an attacker can't
 //!    force a megabyte-of-junk request through the backend.
@@ -91,11 +91,11 @@ pub const WEB_MAX_URL_BYTES: usize = 4096;
 pub const WEB_DEFAULT_SEARCH_LIMIT: u32 = 5;
 
 /// Upper bound on `limit` accepted from the model. Anything larger is
-/// clamped (matches hermes `_tavily_request` which clamps at 20).
+/// clamped (matches the prior engine's Tavily request which clamps at 20).
 pub const WEB_MAX_SEARCH_LIMIT: u32 = 50;
 
-/// Inline key-prefix sniff. The full hermes redactor lives in
-/// `agent/redact.py`; here we keep a conservative subset that catches
+/// Inline key-prefix sniff. The full redactor lives in the prior
+/// Wayland Python engine; here we keep a conservative subset that catches
 /// the most common exfiltration vectors. Backends + the redact crate
 /// remain responsible for content-side scrubbing.
 fn url_contains_apparent_secret(url: &str) -> bool {
@@ -162,7 +162,7 @@ pub fn validate_search_query(query: &str) -> Result<&str, String> {
 /// Run every URL through SSRF + secret + length + website-policy gates
 /// and return the filtered safe list plus a parallel list of structured
 /// rejections (so the caller can return them as failed-row entries in
-/// the response — matching hermes' partial-success shape).
+/// the response — matching the prior engine's partial-success shape).
 ///
 /// `config_path = None` reads the cached website-policy bundle.
 pub fn validate_url_list(urls: &[String]) -> (Vec<String>, Vec<UrlRejection>) {
@@ -237,7 +237,7 @@ pub struct UrlRejection {
     pub reason: String,
 }
 
-/// Which hermes-original operation a [`WebTool::execute`] call should
+/// Which operation a [`WebTool::execute`] call should
 /// dispatch.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum WebOperation {
@@ -268,14 +268,15 @@ impl WebOperation {
     }
 }
 
-/// Outcome of a backend call. Mirrors the JSON shape the hermes tool
-/// emits — the backend returns a structured value and the Tool wraps
+/// Outcome of a backend call. Mirrors the JSON shape the prior engine's
+/// tool emits — the backend returns a structured value and the Tool wraps
 /// it in `{success, data: …}` / `{success, results: …}`.
 #[derive(Debug, Clone)]
 pub enum WebOutcome {
     /// Successful response. `payload` is splice-merged into the final
     /// result object — backends should return `{"web":[…]}` for search
-    /// and `{"results":[…]}` for extract/crawl to match hermes shapes.
+    /// and `{"results":[…]}` for extract/crawl to match the prior engine's
+    /// shapes.
     Ok { payload: Value },
     /// Structured error. Becomes `{success:false, error:<message>}`.
     Err { message: String },
@@ -439,7 +440,8 @@ impl WebBackend for CapturingWebBackend {
     }
 }
 
-/// `web` tool — Wayland engine port of hermes' three web entry points.
+/// `web` tool — Wayland engine port of the prior engine's three web entry
+/// points.
 ///
 /// Single Tool with an `operation` discriminator (search / extract /
 /// crawl) that dispatches through a host-supplied [`WebBackend`]. Use
@@ -534,7 +536,7 @@ impl WebTool {
 
         let (safe, rejected) = validate_url_list(&urls);
         // If every URL was rejected, short-circuit without calling the
-        // backend — mirrors hermes returning a results-only response.
+        // backend — mirrors the prior engine returning a results-only response.
         if safe.is_empty() {
             return ok_result(json!({
                 "success": true,
@@ -550,7 +552,7 @@ impl WebTool {
         match self.backend.extract(req).await {
             WebOutcome::Ok { mut payload } => {
                 // Merge rejected URLs as failure rows into the backend
-                // results, mirroring hermes' partial-success format.
+                // results, mirroring the prior engine's partial-success format.
                 if !rejected.is_empty()
                     && let Some(results) = payload
                         .as_object_mut()
@@ -575,7 +577,7 @@ impl WebTool {
             Some(s) => s,
             None => return err_result("Missing required parameter: 'url'"),
         };
-        // Normalize scheme — hermes prepends https:// for bare hosts.
+        // Normalize scheme — the prior engine prepends https:// for bare hosts.
         let url_owned;
         let url = if raw_url.starts_with("http://") || raw_url.starts_with("https://") {
             raw_url
@@ -602,7 +604,7 @@ impl WebTool {
             .and_then(Value::as_str)
             .unwrap_or("basic")
             .to_string();
-        // Bound depth to the two values hermes recognizes.
+        // Bound depth to the two values the prior engine recognizes.
         if depth != "basic" && depth != "advanced" {
             return err_result("Parameter 'depth' must be 'basic' or 'advanced'");
         }
@@ -883,7 +885,7 @@ mod tests {
             }))
             .await;
         // All blocked → backend never called, response is success with
-        // every row marked as error (matches hermes partial-results).
+        // every row marked as error (matches the prior engine's partial-results).
         assert!(!r.is_error);
         assert_no_backend_calls(&backend);
         let v = parse(&r);

--- a/crates/wcore-tools/src/website_policy.rs
+++ b/crates/wcore-tools/src/website_policy.rs
@@ -1,6 +1,6 @@
 //! T3-3.3.3 — Website access policy helpers for URL-capable tools.
 //!
-//! Ported from `wayland-hermes/agent/tools/website_policy.py` (296 LOC).
+//! Ported from the prior Wayland Python engine.
 //!
 //! Loads a user-managed website blocklist from `~/.wayland-core/config.yaml`
 //! plus any referenced shared list files, and enforces it on URLs the

--- a/crates/wcore-tools/src/yuanbao_tools.rs
+++ b/crates/wcore-tools/src/yuanbao_tools.rs
@@ -1,7 +1,6 @@
 //! T3-3.7 — `yuanbao_tools`: Tencent Yuanbao platform toolset.
 //!
-//! Ported from `wayland-hermes/agent/tools/yuanbao_tools.py` (MIT
-//! © Nous Research). The Python original registers five separate
+//! Ported from an upstream MIT-licensed library (see THIRD-PARTY-NOTICES.md). The Python original registers five separate
 //! tools — `yb_query_group_info`, `yb_query_group_members`,
 //! `yb_search_sticker`, `yb_send_sticker`, `yb_send_dm` — against a
 //! gateway-side Yuanbao adapter (`gateway.platforms.yuanbao`).
@@ -18,7 +17,7 @@
 //!
 //! Divergences from the Python original (intentional):
 //!
-//!   * Five separate hermes registry entries collapse into one engine
+//!   * Five separate registry entries collapse into one engine
 //!     `YuanbaoTool` with an `action` field. Schema parity holds:
 //!     every required parameter the Python tools declared is required
 //!     here for the matching action.
@@ -120,7 +119,7 @@ pub struct YuanbaoMedia {
 // ---------------------------------------------------------------------------
 
 /// Host-supplied Yuanbao adapter boundary. Mirrors the methods the
-/// hermes tool invokes against `gateway.platforms.yuanbao.get_active_adapter()`.
+/// Python tool invokes against `gateway.platforms.yuanbao.get_active_adapter()`.
 /// The engine never talks to Yuanbao directly; the host implements
 /// this trait and binds it at registration time.
 #[async_trait]
@@ -520,7 +519,7 @@ impl YuanbaoAction {
 // YuanbaoTool
 // ---------------------------------------------------------------------------
 
-/// `yuanbao` tool — Wayland engine port of the five hermes
+/// `yuanbao` tool — Wayland engine port of the five
 /// `yb_*` tools collapsed under a single `action` discriminator.
 pub struct YuanbaoTool {
     backend: Arc<dyn YuanbaoBackend>,
@@ -1129,7 +1128,7 @@ impl YuanbaoTool {
 }
 
 /// Parse the `media_files` parameter. Accepts either an array of
-/// objects `{"path": str, "is_voice": bool}` (the Python hermes
+/// objects `{"path": str, "is_voice": bool}` (the Python
 /// handler's primary shape) or an array of `[path, is_voice]` tuples
 /// (its fallback shape).
 fn parse_media_files(raw: Option<&Value>) -> Vec<YuanbaoMedia> {
@@ -1203,7 +1202,7 @@ mod tests {
             YuanbaoAction::from_name("query_group_info"),
             Some(YuanbaoAction::QueryGroupInfo)
         );
-        // Hermes registry-style names also accepted.
+        // Legacy `yb_*` registry-style names also accepted.
         assert_eq!(
             YuanbaoAction::from_name("yb_send_dm"),
             Some(YuanbaoAction::SendDm)

--- a/crates/wcore-types/src/cache_tier.rs
+++ b/crates/wcore-types/src/cache_tier.rs
@@ -1,10 +1,10 @@
 //! Anthropic prompt cache tier picker (5m vs 1h ephemeral cache_control).
 //!
-//! Ported from wayland-hermes (MIT, Nous Research):
-//!   `agent/agent/prompt_caching.py` :: `apply_anthropic_cache_control`
+//! Ported from an upstream MIT-licensed library's (see THIRD-PARTY-NOTICES.md)
+//! `apply_anthropic_cache_control`.
 //!
-//! Hermes hard-codes `cache_ttl: "5m"` or `"1h"` at call sites. This module
-//! lifts the *selection* of the tier into a pure decision function so the
+//! The predecessor hard-codes `cache_ttl: "5m"` or `"1h"` at call sites. This
+//! module lifts the *selection* of the tier into a pure decision function so the
 //! Anthropic adapter (`anthropic.rs`) can choose the right marker per request
 //! based on expected reuse window and prompt size.
 //!
@@ -57,7 +57,7 @@ impl CacheTier {
 
 /// Tunable thresholds for [`pick_with_config`].
 ///
-/// Defaults match Anthropic's published minimums and Hermes' implicit
+/// Defaults match Anthropic's published minimums and the predecessor's implicit
 /// "longer than 5 minutes -> 1h" heuristic.
 #[derive(Debug, Clone, Copy)]
 pub struct CacheTierConfig {


### PR DESCRIPTION
The Rust engine was ported from an earlier author-owned Python project named
**wayland-hermes**. The token "hermes" collides with an unrelated third party,
so a casual `grep hermes` over the source misreads the port-provenance
comments as a clone. This reword removes that footprint.

### What changed
- **Comment-only.** Every `wayland-hermes` / `hermes` port-provenance note and
  design name-drop reworded to a neutral descriptor ("the prior Wayland Python
  engine", or the behavior stated directly). **No code, identifier, string
  literal, enum, match arm, or test assertion changed** — behavior is identical.
- **Interop values kept:** the A2A agent-kind list (`"…|hermes|openclaw|…"`) is
  a wire-protocol enumeration of agent kinds that may connect, not attribution —
  left intact.

### Third-party attribution (the important part)
Several ported tools genuinely derive from a third party's **MIT-licensed**
code — their `© Nous Research` copyright notices were in the file headers.
Stripping those would breach MIT, so per the license the attribution is
**retained**: moved to a new root **`THIRD-PARTY-NOTICES.md`** (full MIT text +
copyright + the list of derived modules), and those file headers now point
there. This is both the compliant and the stronger posture — "used their MIT
code with attribution" is a complete answer.

### Verification
Hetzner Linux gate: `cargo fmt --all --check` clean, `cargo clippy --workspace
--all-targets -D warnings` clean (comment-only diff, so this guards the
doc-comment lints). No test changes.