### PR TITLE
feat(#279): JSON-stream observability — active-window %, agent-run correlation, structured traces

### DIFF
--- a/crates/wcore-agent/src/agents/channel_sink.rs
+++ b/crates/wcore-agent/src/agents/channel_sink.rs
@@ -183,6 +183,7 @@ impl OutputSink for ChannelSink {
             msg_id: msg_id.to_string(),
             finish_reason,
             usage: None,
+            agent_run_id: None,
         });
     }
     fn emit_error(&self, msg: &str, retryable: bool) {

--- a/crates/wcore-agent/src/bin/tool_token_bench.rs
+++ b/crates/wcore-agent/src/bin/tool_token_bench.rs
@@ -239,6 +239,7 @@ async fn drain_scripted_usage(provider: &ScriptedProvider) -> Usage {
         } else {
             None
         },
+        active_window_percent: None,
     }
 }
 

--- a/crates/wcore-agent/src/engine.rs
+++ b/crates/wcore-agent/src/engine.rs
@@ -977,6 +977,10 @@ pub struct AgentEngine {
     current_session: Option<Session>,
     output: Arc<dyn OutputSink>,
     current_msg_id: String,
+    /// #279(c): stable per-agent-run id, minted once per run() entry and
+    /// held across the run's turns. Distinct from internal spawn/workflow
+    /// run ids. None until the first run() of the session.
+    current_agent_run_id: Option<String>,
     approval_manager: Option<Arc<wcore_protocol::ToolApprovalManager>>,
     /// W7.1 S4-3.2: shared `ApprovalBridge` instance used to round-trip
     /// `approval_required` Script steps. `AgentBootstrap` creates one bridge
@@ -1477,6 +1481,7 @@ impl AgentEngine {
             current_session: None,
             output,
             current_msg_id: String::new(),
+            current_agent_run_id: None,
             approval_manager: None,
             approval_bridge: Arc::new(ApprovalBridge::new()),
             protocol_writer: None,
@@ -1641,6 +1646,7 @@ impl AgentEngine {
             current_session: Some(session),
             output,
             current_msg_id: String::new(),
+            current_agent_run_id: None,
             approval_manager: None,
             approval_bridge: Arc::new(ApprovalBridge::new()),
             protocol_writer: None,
@@ -2388,6 +2394,9 @@ impl AgentEngine {
     /// is preserved; only the user/assistant message buffer is cleared.
     pub fn clear_conversation(&mut self) {
         self.messages.clear();
+        // #279(c): a cleared session is a new agent run — drop the correlation
+        // id so the next run() mints a fresh one.
+        self.current_agent_run_id = None;
         // D014: a fresh conversation re-baselines the model. The prior
         // explicit `/model` pin no longer applies, so hook/skill switches
         // are honoured again until the user pins anew.
@@ -3341,7 +3350,28 @@ impl AgentEngine {
             finish_reason: FinishReason::Length,
             usage: self.total_usage.clone(),
             turns: turn,
+            active_window_percent: self.active_window_percent_now(&self.model, 0),
+            agent_run_id: self.current_agent_run_id.clone(),
         })
+    }
+
+    /// #279(a): the sole place the engine sources the active-window gauge.
+    /// Constructs the #255 ContextWindow kernel from the POST-swap effective
+    /// model and the per-turn `used_tokens` watermark the run loop already
+    /// computes, then returns `percent()` (0..=100), or `None` when the window
+    /// is unknown. The protocol/TUI NEVER recompute this.
+    ///
+    /// Real #255 kernel API: `ContextWindow::resolve(used_tokens, provider,
+    /// model, config_window) -> Self`, then `percent(&self) -> Option<u32>`.
+    fn active_window_percent_now(&self, effective_model: &str, used_tokens: u64) -> Option<u32> {
+        use wcore_config::context_window::ContextWindow;
+        ContextWindow::resolve(
+            used_tokens,
+            self.compat.provider_type(),
+            effective_model,
+            self.compact_config.context_window as u64,
+        )
+        .percent()
     }
 
     /// Run the agent loop with user input
@@ -3398,6 +3428,13 @@ impl AgentEngine {
             }
         }
         self.current_msg_id = msg_id.to_string();
+        // #279(c): mint a stable per-run correlation id on the first run()
+        // of the session and reuse it for every subsequent turn/message.
+        // Re-minted only when None (fresh engine / cleared session); persists
+        // across --resume because the resumed engine keeps the field.
+        if self.current_agent_run_id.is_none() {
+            self.current_agent_run_id = Some(format!("agent-run-{}", uuid::Uuid::new_v4()));
+        }
         self.output.emit_stream_start(msg_id);
         // Cross-session recall (v2 memory gap fix): on a cold first turn,
         // pre-inject durable facts relevant to this message BEFORE the user
@@ -4340,6 +4377,8 @@ impl AgentEngine {
                     // partial: populated in a future pass when a streaming-drain trigger exists
                     hook_actions: std::mem::take(&mut self.pending_hook_actions),
                     source_product: SOURCE_PRODUCT.to_string(),
+                    // #279(b)+(c): correlate this turn's trace to the run.
+                    agent_run_id: self.current_agent_run_id.clone().unwrap_or_default(),
                 };
                 if let Ok(trace_json) = serde_json::to_value(&trace) {
                     self.output.emit_trace(&self.current_msg_id, &trace_json);
@@ -4389,6 +4428,9 @@ impl AgentEngine {
                     finish_reason,
                     usage: self.total_usage.clone(),
                     turns: turn + 1,
+                    active_window_percent: self
+                        .active_window_percent_now(&effective_model, input_token_estimate as u64),
+                    agent_run_id: self.current_agent_run_id.clone(),
                 });
             }
 
@@ -4864,6 +4906,8 @@ impl AgentEngine {
                 // partial: populated in a future pass when a streaming-drain trigger exists
                 hook_actions: std::mem::take(&mut self.pending_hook_actions),
                 source_product: SOURCE_PRODUCT.to_string(),
+                // #279(b)+(c): correlate this turn's trace to the run.
+                agent_run_id: self.current_agent_run_id.clone().unwrap_or_default(),
             };
             if let Ok(trace_json) = serde_json::to_value(&trace) {
                 self.output.emit_trace(&self.current_msg_id, &trace_json);
@@ -5247,6 +5291,8 @@ impl AgentEngine {
             finish_reason: FinishReason::from_stop_reason(StopReason::EndTurn),
             usage: self.total_usage.clone(),
             turns: turn + 1,
+            active_window_percent: self.active_window_percent_now(&self.model, 0),
+            agent_run_id: self.current_agent_run_id.clone(),
         }
     }
 
@@ -5421,6 +5467,8 @@ impl AgentEngine {
                         "Autocompact: summarized {} messages ({} tokens → compact)",
                         result.messages_summarized, result.pre_compact_tokens
                     ));
+                    // #279(d): capture before `result` is moved into `folded`.
+                    let result_pre_compact_tokens = result.pre_compact_tokens;
                     // AUDIT A7 — `autocompact` returns `[boundary(User),
                     // summary(User)]`; appending the live user turn
                     // would then yield three consecutive `User`
@@ -5450,6 +5498,26 @@ impl AgentEngine {
                     self.compaction_floor += collapsed;
                     self.messages = vec![Message::now(Role::User, folded)];
                     compacted = true;
+                    // #279(d): signal the host a compaction fired. Gated host-side
+                    // by capabilities.non_destructive_compact; dormant unless the
+                    // sink was built with with_non_destructive_compact(true).
+                    //
+                    // tokens_freed is the ACTUAL delta: the API-reported
+                    // pre-compaction total minus a post-compaction estimate of the
+                    // folded buffer (the only post count available here — the
+                    // autocompact result carries no post_compact_tokens).
+                    // saturating_sub floors it at 0 ("0 when not measurable"),
+                    // never going negative if the estimate overshoots.
+                    let post_compact_tokens =
+                        estimate::estimate_tokens_from_messages(&self.messages);
+                    let tokens_freed =
+                        result_pre_compact_tokens.saturating_sub(post_compact_tokens);
+                    self.output.emit_compaction(
+                        &self.current_msg_id,
+                        "window_pressure",
+                        tokens_freed,
+                        self.active_window_percent_now(&self.model, post_compact_tokens),
+                    );
                     // Token-opt (diff-resend): autocompact collapsed the leading
                     // prefix, so any read base cached before now is no longer in
                     // the visible transcript. Invalidate diff bases.
@@ -7252,6 +7320,7 @@ mod set_config_tests {
             current_session: None,
             output: Arc::new(NullOutput),
             current_msg_id: String::new(),
+            current_agent_run_id: None,
             approval_manager: None,
             approval_bridge: Arc::new(ApprovalBridge::new()),
             protocol_writer: None,
@@ -8068,6 +8137,7 @@ mod phase6_tests {
             current_session: None,
             output: Arc::new(NullOutput),
             current_msg_id: String::new(),
+            current_agent_run_id: None,
             approval_manager: None,
             approval_bridge: Arc::new(ApprovalBridge::new()),
             protocol_writer: None,
@@ -8352,6 +8422,7 @@ mod compact_tests {
             current_session: None,
             output: Arc::new(NullOutput),
             current_msg_id: String::new(),
+            current_agent_run_id: None,
             approval_manager: None,
             approval_bridge: Arc::new(ApprovalBridge::new()),
             protocol_writer: None,
@@ -9511,6 +9582,7 @@ mod plan_mode_tests {
             current_session: None,
             output: Arc::new(NullOutput),
             current_msg_id: String::new(),
+            current_agent_run_id: None,
             approval_manager: None,
             approval_bridge: Arc::new(ApprovalBridge::new()),
             protocol_writer: None,
@@ -9928,6 +10000,7 @@ mod hook_integration_tests {
             current_session: None,
             output: Arc::new(NullOutput),
             current_msg_id: String::new(),
+            current_agent_run_id: None,
             approval_manager: None,
             approval_bridge: Arc::new(ApprovalBridge::new()),
             protocol_writer: None,
@@ -10558,6 +10631,11 @@ pub struct AgentResult {
     pub finish_reason: FinishReason,
     pub usage: TokenUsage,
     pub turns: usize,
+    /// #279(a): active-window fill (0..=100) from ContextWindow::percent()
+    /// on the post-swap effective model. None when the window is unknown.
+    pub active_window_percent: Option<u32>,
+    /// #279(c): the run's stable correlation id (clone of current_agent_run_id).
+    pub agent_run_id: Option<String>,
 }
 
 #[cfg(test)]
@@ -10636,6 +10714,7 @@ mod approval_bridge_engine_tests {
             current_session: None,
             output: Arc::new(NullOutput),
             current_msg_id: String::new(),
+            current_agent_run_id: None,
             approval_manager: None,
             approval_bridge: Arc::new(ApprovalBridge::new()),
             protocol_writer: None,
@@ -10865,6 +10944,7 @@ mod user_model_writeback_tests {
             current_session: None,
             output: Arc::new(NullOutput),
             current_msg_id: String::new(),
+            current_agent_run_id: None,
             approval_manager: None,
             approval_bridge: Arc::new(ApprovalBridge::new()),
             protocol_writer: None,

--- a/crates/wcore-agent/src/output/mod.rs
+++ b/crates/wcore-agent/src/output/mod.rs
@@ -38,6 +38,33 @@ pub trait OutputSink: Send + Sync {
         cache_read_tokens: u64,
         finish_reason: FinishReason,
     );
+    /// #279(a)+(c): enriched stream-end carrying the engine-computed gauge
+    /// and run-correlation id. Default delegates to emit_stream_end (dropping
+    /// the extras) so existing sinks/mocks need no change; ProtocolSink
+    /// overrides to populate Usage.active_window_percent + StreamEnd.agent_run_id.
+    #[allow(clippy::too_many_arguments)]
+    fn emit_stream_end_full(
+        &self,
+        msg_id: &str,
+        turns: usize,
+        input_tokens: u64,
+        output_tokens: u64,
+        cache_creation_tokens: u64,
+        cache_read_tokens: u64,
+        finish_reason: FinishReason,
+        _active_window_percent: Option<u32>,
+        _agent_run_id: Option<&str>,
+    ) {
+        self.emit_stream_end(
+            msg_id,
+            turns,
+            input_tokens,
+            output_tokens,
+            cache_creation_tokens,
+            cache_read_tokens,
+            finish_reason,
+        );
+    }
     /// Display error.
     ///
     /// `retryable` is the protocol contract's honest signal to the host: `true`
@@ -173,6 +200,19 @@ pub trait OutputSink: Send + Sync {
         _surface: &str,
         _error_kind: &str,
         _message: &str,
+    ) {
+    }
+
+    /// #279(d) + #280: a context compaction occurred. Default no-op;
+    /// ProtocolSink overrides and gates on with_non_destructive_compact(true).
+    /// tokens_freed 0 when unmeasurable; active_window_percent is the
+    /// post-compaction fill from ContextWindow::percent() (None when unknown).
+    fn emit_compaction(
+        &self,
+        _msg_id: &str,
+        _reason: &str,
+        _tokens_freed: u64,
+        _active_window_percent: Option<u32>,
     ) {
     }
 }

--- a/crates/wcore-agent/src/output/protocol_sink.rs
+++ b/crates/wcore-agent/src/output/protocol_sink.rs
@@ -167,6 +167,8 @@ pub struct ProtocolSink {
     /// W7 S4: gates Suspend / ApprovalRequired / ApprovalResume emission.
     /// Off by default.
     hitl_suspend_enabled: bool,
+    /// #279(d): gates CompactOffload emission. Off by default.
+    non_destructive_compact_enabled: bool,
     /// W6 F7 single-source authority for the cost-attribution gate
     /// (audit rev-2 finding 5). Bootstrap flips
     /// `AdvertisedCapabilitiesConfig.cost_attribution = true` when
@@ -203,6 +205,7 @@ impl ProtocolSink {
             sub_agent_traces_enabled: false,
             streaming_tools_enabled: false,
             hitl_suspend_enabled: false,
+            non_destructive_compact_enabled: false,
             advertised: Arc::new(AdvertisedCapabilitiesConfig::default()),
             user_model_backend: std::sync::OnceLock::new(),
             token_redactor: ActiveTokenRedactor::new(),
@@ -286,6 +289,14 @@ impl ProtocolSink {
     /// off per W0 contract.
     pub fn with_hitl_suspend(mut self, enabled: bool) -> Self {
         self.hitl_suspend_enabled = enabled;
+        self
+    }
+
+    /// #279(d) Builder: enable `CompactOffload` emission + advertise
+    /// `capabilities.non_destructive_compact = true`. Default off per W0
+    /// contract.
+    pub fn with_non_destructive_compact(mut self, enabled: bool) -> Self {
+        self.non_destructive_compact_enabled = enabled;
         self
     }
 
@@ -462,6 +473,8 @@ impl ProtocolSink {
             sub_agent_traces: self.sub_agent_traces_enabled,
             streaming_tools: self.streaming_tools_enabled,
             hitl_suspend: self.hitl_suspend_enabled,
+            // #279(d): advertised only when the sink opted in via the builder.
+            non_destructive_compact: self.non_destructive_compact_enabled,
             rpc_tool_script: advertised.rpc_tool_script,
             cost_attribution: advertised.cost_attribution,
             // F-093: surface the resolved backend tag. Cloned from OnceLock;
@@ -550,7 +563,44 @@ impl OutputSink for ProtocolSink {
                 } else {
                     None
                 },
+                active_window_percent: None,
             }),
+            agent_run_id: None,
+        });
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn emit_stream_end_full(
+        &self,
+        msg_id: &str,
+        _turns: usize,
+        input_tokens: u64,
+        output_tokens: u64,
+        cache_creation_tokens: u64,
+        cache_read_tokens: u64,
+        finish_reason: FinishReason,
+        active_window_percent: Option<u32>,
+        agent_run_id: Option<&str>,
+    ) {
+        let _ = self.writer.emit(&ProtocolEvent::StreamEnd {
+            msg_id: msg_id.to_string(),
+            finish_reason,
+            usage: Some(Usage {
+                input_tokens,
+                output_tokens,
+                cache_read_tokens: if cache_read_tokens > 0 {
+                    Some(cache_read_tokens)
+                } else {
+                    None
+                },
+                cache_write_tokens: if cache_creation_tokens > 0 {
+                    Some(cache_creation_tokens)
+                } else {
+                    None
+                },
+                active_window_percent,
+            }),
+            agent_run_id: agent_run_id.map(str::to_string),
         });
     }
 
@@ -681,6 +731,27 @@ impl OutputSink for ProtocolSink {
             reason: reason.to_string(),
             observed: observed.to_string(),
             limit: limit.to_string(),
+        });
+    }
+
+    /// #279(d): emit `ProtocolEvent::CompactOffload`. Gated — a guarded no-op
+    /// unless the sink was built with `with_non_destructive_compact(true)`,
+    /// so the wire shape stays byte-identical until a host opts in.
+    fn emit_compaction(
+        &self,
+        msg_id: &str,
+        reason: &str,
+        tokens_freed: u64,
+        active_window_percent: Option<u32>,
+    ) {
+        if !self.non_destructive_compact_enabled {
+            return;
+        }
+        let _ = self.writer.emit(&ProtocolEvent::CompactOffload {
+            msg_id: msg_id.to_string(),
+            reason: reason.to_string(),
+            tokens_freed,
+            active_window_percent,
         });
     }
 
@@ -1000,5 +1071,29 @@ mod tests {
         ] {
             assert_eq!(auth_error_code(msg), None, "non-auth must be None: {msg:?}");
         }
+    }
+
+    #[test]
+    fn protocol_sink_advertises_non_destructive_compact_only_when_built() {
+        let writer = Arc::new(ProtocolWriter::new());
+        let advertised = AdvertisedCapabilitiesConfig::default();
+        let compat = ProviderCompat::anthropic_defaults();
+        let off = ProtocolSink::new(Arc::clone(&writer));
+        assert!(
+            !off.build_capabilities(&compat, false, "default", false, &advertised)
+                .non_destructive_compact
+        );
+        let on = ProtocolSink::new(writer).with_non_destructive_compact(true);
+        assert!(
+            on.build_capabilities(&compat, false, "default", false, &advertised)
+                .non_destructive_compact
+        );
+    }
+
+    #[test]
+    fn protocol_sink_emit_compaction_noop_when_flag_off() {
+        let writer = Arc::new(ProtocolWriter::new());
+        let sink = ProtocolSink::new(writer);
+        sink.emit_compaction("m1", "window_pressure", 4096, Some(41));
     }
 }

--- a/crates/wcore-agent/src/test_utils/mod.rs
+++ b/crates/wcore-agent/src/test_utils/mod.rs
@@ -203,7 +203,9 @@ impl OutputSink for TestSink {
                 } else {
                     None
                 },
+                active_window_percent: None,
             }),
+            agent_run_id: None,
         });
     }
     fn emit_error(&self, msg: &str, retryable: bool) {

--- a/crates/wcore-agent/tests/turn_trace_shape.rs
+++ b/crates/wcore-agent/tests/turn_trace_shape.rs
@@ -26,6 +26,7 @@ fn turn_trace_provider_field_is_structured_not_family_anthropic() {
         tool_calls: vec![],
         hook_actions: vec![],
         source_product: "wayland-core".into(),
+        agent_run_id: String::new(),
     };
     assert_eq!(trace.provider, "anthropic");
     assert_ne!(

--- a/crates/wcore-cli/src/acp_engine.rs
+++ b/crates/wcore-cli/src/acp_engine.rs
@@ -296,6 +296,7 @@ impl Drop for TerminalGuard {
             msg_id: std::mem::take(&mut self.msg_id),
             finish_reason: FinishReason::Error,
             usage: None,
+            agent_run_id: None,
         });
     }
 }
@@ -326,7 +327,9 @@ fn stream_end_event(msg_id: &str, result: &AgentResult) -> ProtocolEvent {
                 .then_some(result.usage.cache_read_tokens),
             cache_write_tokens: (result.usage.cache_creation_tokens > 0)
                 .then_some(result.usage.cache_creation_tokens),
+            active_window_percent: result.active_window_percent,
         }),
+        agent_run_id: result.agent_run_id.clone(),
     }
 }
 
@@ -612,6 +615,7 @@ impl EngineSession {
                         msg_id: msg_id.clone(),
                         finish_reason: FinishReason::Error,
                         usage: None,
+                        agent_run_id: None,
                     });
                     term.disarm();
                 }
@@ -1018,6 +1022,7 @@ mod tests {
                 msg_id: "m".into(),
                 finish_reason: FinishReason::Length,
                 usage: None,
+                agent_run_id: None,
             },
             // Anything after the terminal frame must NOT appear.
             ProtocolEvent::TextDelta {
@@ -1072,6 +1077,7 @@ mod tests {
                 msg_id: "m".into(),
                 finish_reason: FinishReason::Stop,
                 usage: None,
+                agent_run_id: None,
             },
         ];
         let out = project_all(events).await;
@@ -1143,6 +1149,7 @@ mod tests {
                 msg_id: "m".into(),
                 finish_reason: FinishReason::Stop,
                 usage: None,
+                agent_run_id: None,
             })
             .unwrap();
 

--- a/crates/wcore-cli/src/main.rs
+++ b/crates/wcore-cli/src/main.rs
@@ -2806,7 +2806,7 @@ async fn run_json_stream_mode(
                                                 false,
                                             );
                                         }
-                                        output.emit_stream_end(
+                                        output.emit_stream_end_full(
                                             &msg_id,
                                             result.turns,
                                             result.usage.input_tokens,
@@ -2814,6 +2814,8 @@ async fn run_json_stream_mode(
                                             result.usage.cache_creation_tokens,
                                             result.usage.cache_read_tokens,
                                             result.finish_reason,
+                                            result.active_window_percent,
+                                            result.agent_run_id.as_deref(),
                                         );
                                     }
                                     Err(e) => {

--- a/crates/wcore-cli/src/tui/engine_bridge.rs
+++ b/crates/wcore-cli/src/tui/engine_bridge.rs
@@ -282,7 +282,9 @@ impl OutputSink for ChannelSink {
                 output_tokens,
                 cache_read_tokens: (cache_read_tokens > 0).then_some(cache_read_tokens),
                 cache_write_tokens: (cache_creation_tokens > 0).then_some(cache_creation_tokens),
+                active_window_percent: None,
             }),
+            agent_run_id: None,
         });
     }
 
@@ -523,6 +525,7 @@ impl Drop for TerminalGuard {
             msg_id: std::mem::take(&mut self.msg_id),
             finish_reason: FinishReason::Error,
             usage: None,
+            agent_run_id: None,
         });
     }
 }
@@ -978,7 +981,9 @@ impl TuiEngine {
                                 .then_some(result.usage.cache_read_tokens),
                             cache_write_tokens: (result.usage.cache_creation_tokens > 0)
                                 .then_some(result.usage.cache_creation_tokens),
+                            active_window_percent: result.active_window_percent,
                         }),
+                        agent_run_id: result.agent_run_id.clone(),
                     });
                     term.disarm();
                 }
@@ -995,6 +1000,7 @@ impl TuiEngine {
                         msg_id: msg_id.clone(),
                         finish_reason: FinishReason::Error,
                         usage: None,
+                        agent_run_id: None,
                     });
                     term.disarm();
                 }
@@ -1036,6 +1042,7 @@ impl TuiEngine {
                 msg_id: String::new(),
                 finish_reason: FinishReason::Error,
                 usage: None,
+                agent_run_id: None,
             });
         }
     }
@@ -2811,6 +2818,7 @@ mod tests {
                 msg_id,
                 finish_reason,
                 usage,
+                ..
             } => {
                 assert_eq!(msg_id, "m1");
                 assert_eq!(finish_reason, FinishReason::Stop);

--- a/crates/wcore-cli/src/tui/fixtures.rs
+++ b/crates/wcore-cli/src/tui/fixtures.rs
@@ -46,7 +46,9 @@ pub fn full_conversation() -> Vec<ProtocolEvent> {
                 output_tokens: 17,
                 cache_read_tokens: None,
                 cache_write_tokens: None,
+                active_window_percent: None,
             }),
+            agent_run_id: None,
         },
     ]
 }

--- a/crates/wcore-cli/src/tui/protocol_bridge.rs
+++ b/crates/wcore-cli/src/tui/protocol_bridge.rs
@@ -885,6 +885,7 @@ fn apply_event_inner(app: &mut App, event: ProtocolEvent) {
         | ProtocolEvent::CuaEvent { .. }
         | ProtocolEvent::Suspend { .. }
         | ProtocolEvent::ApprovalResume { .. }
+        | ProtocolEvent::CompactOffload { .. }
         | ProtocolEvent::Pong => {}
     }
 }
@@ -2017,6 +2018,7 @@ mod tests {
                 msg_id: "m1".into(),
                 finish_reason: wcore_protocol::events::FinishReason::Stop,
                 usage: None,
+                agent_run_id: None,
             },
         );
         assert!(!app.session.streaming_active);
@@ -2070,6 +2072,7 @@ mod tests {
                 msg_id: "m1".into(),
                 finish_reason: wcore_protocol::events::FinishReason::Stop,
                 usage: None,
+                agent_run_id: None,
             },
         );
         assert!(app.session.thinking.is_empty());
@@ -2114,7 +2117,9 @@ mod tests {
                     output_tokens: 42,
                     cache_read_tokens: None,
                     cache_write_tokens: None,
+                    active_window_percent: None,
                 }),
+                agent_run_id: None,
             },
         );
         assert_eq!(app.session.turns.len(), 1, "one assistant turn flushed");
@@ -2167,6 +2172,7 @@ mod tests {
                 msg_id: "m1".into(),
                 finish_reason: wcore_protocol::events::FinishReason::Stop,
                 usage: None,
+                agent_run_id: None,
             },
         );
         let elements = &app.session.turns[0].elements;
@@ -3005,6 +3011,7 @@ mod tests {
                 msg_id: "m1".into(),
                 finish_reason: wcore_protocol::events::FinishReason::Stop,
                 usage: None,
+                agent_run_id: None,
             },
         );
         assert!(
@@ -3066,6 +3073,7 @@ mod tests {
                 msg_id: "m1".into(),
                 finish_reason: wcore_protocol::events::FinishReason::Stop,
                 usage: None,
+                agent_run_id: None,
             },
         );
         apply_event(
@@ -3454,6 +3462,7 @@ mod tests {
                 msg_id: "m1".into(),
                 finish_reason: wcore_protocol::events::FinishReason::Stop,
                 usage: None,
+                agent_run_id: None,
             },
         );
     }
@@ -3538,6 +3547,7 @@ mod tests {
                 msg_id: "m1".into(),
                 finish_reason: wcore_protocol::events::FinishReason::Stop,
                 usage: None,
+                agent_run_id: None,
             },
         );
         let turn = app
@@ -3640,6 +3650,7 @@ mod tests {
                 msg_id: "m1".into(),
                 finish_reason: wcore_protocol::events::FinishReason::Stop,
                 usage: None,
+                agent_run_id: None,
             },
         );
         let turn = app
@@ -3720,6 +3731,7 @@ mod tests {
                 msg_id: "m1".into(),
                 finish_reason: wcore_protocol::events::FinishReason::Stop,
                 usage: None,
+                agent_run_id: None,
             },
         );
         let turn = app
@@ -3791,6 +3803,7 @@ mod tests {
                 msg_id: "m1".into(),
                 finish_reason: wcore_protocol::events::FinishReason::Stop,
                 usage: None,
+                agent_run_id: None,
             },
         );
         let turn = app
@@ -3859,6 +3872,7 @@ mod tests {
                 msg_id: "m1".into(),
                 finish_reason: wcore_protocol::events::FinishReason::Stop,
                 usage: None,
+                agent_run_id: None,
             },
         );
         // v0.9.1.2 F12: a `ToolRequest` opens an in-flight assistant
@@ -4054,6 +4068,7 @@ mod tests {
                 msg_id: "m1".into(),
                 finish_reason: wcore_protocol::events::FinishReason::Stop,
                 usage: None,
+                agent_run_id: None,
             },
         );
         assert_eq!(app.session.turns.len(), 1);
@@ -4146,6 +4161,7 @@ mod tests {
                 msg_id: "m1".into(),
                 finish_reason: wcore_protocol::events::FinishReason::Stop,
                 usage: None,
+                agent_run_id: None,
             },
         );
         // Now inject an EXTRA unreferenced card in `tool_cards` (the

--- a/crates/wcore-cli/src/tui/surfaces/workspace.rs
+++ b/crates/wcore-cli/src/tui/surfaces/workspace.rs
@@ -8346,6 +8346,7 @@ mod tests {
                 msg_id: "m1".into(),
                 finish_reason: FinishReason::Stop,
                 usage: None,
+                agent_run_id: None,
             },
         ];
 

--- a/crates/wcore-cli/src/tui/widgets/streaming_status.rs
+++ b/crates/wcore-cli/src/tui/widgets/streaming_status.rs
@@ -564,7 +564,9 @@ mod tests {
                     output_tokens: 439,
                     cache_read_tokens: None,
                     cache_write_tokens: None,
+                    active_window_percent: None,
                 }),
+                agent_run_id: None,
             },
         );
         assert_eq!(app.session.phase, StreamingPhase::Idle);

--- a/crates/wcore-eval/src/scorer.rs
+++ b/crates/wcore-eval/src/scorer.rs
@@ -295,6 +295,7 @@ mod tests {
             tool_calls: vec![],
             hook_actions: vec![],
             source_product: "test".into(),
+            agent_run_id: String::new(),
         };
         assert_eq!(s.score_cost(&t), 1.0);
         t.cost_usd = 0.0;

--- a/crates/wcore-eval/tests/scoring_determinism.rs
+++ b/crates/wcore-eval/tests/scoring_determinism.rs
@@ -50,6 +50,7 @@ fn baseline_trace() -> TurnTrace {
         tool_calls: vec![ToolCallTrace::new("c1".into(), "Read".into(), json!({}))],
         hook_actions: vec![],
         source_product: "wayland-core".into(),
+        agent_run_id: String::new(),
     }
 }
 

--- a/crates/wcore-evolve/src/schema_reward.rs
+++ b/crates/wcore-evolve/src/schema_reward.rs
@@ -467,6 +467,7 @@ mod tests {
             tool_calls,
             hook_actions: vec![],
             source_product: "test".into(),
+            agent_run_id: String::new(),
         }
     }
 

--- a/crates/wcore-memory/tests/p5_user_model_inference.rs
+++ b/crates/wcore-memory/tests/p5_user_model_inference.rs
@@ -32,6 +32,7 @@ fn turn_with_calls(turn: usize, tools: Vec<&str>) -> TurnTrace {
             .collect(),
         hook_actions: vec![],
         source_product: "wcore-agent".into(),
+        agent_run_id: String::new(),
     }
 }
 

--- a/crates/wcore-observability/src/trace.rs
+++ b/crates/wcore-observability/src/trace.rs
@@ -262,6 +262,12 @@ pub struct TurnTrace {
     /// an empty vector.
     pub hook_actions: Vec<HookActionRecord>,
     pub source_product: String,
+    /// #279(b)+(c): stable per-run id mirroring StreamEnd.agent_run_id.
+    /// #[serde(default)] so trace JSON written before this field existed
+    /// still deserializes; skip_serializing_if keeps the shape unchanged
+    /// when unset.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub agent_run_id: String,
 }
 
 impl TurnTrace {
@@ -956,5 +962,29 @@ mod tests {
         let s = summarize_workflow_detection(&[]);
         assert_eq!(s.count, 0);
         assert_eq!(s.mean_confidence, 0.0);
+    }
+
+    #[test]
+    fn turn_trace_without_agent_run_id_deserializes_to_empty_279() {
+        let old = serde_json::json!({
+            "turn": 0, "model": "claude-opus-4", "provider": "anthropic",
+            "input_tokens": 100, "output_tokens": 50, "cache_read": 0, "cache_write": 0,
+            "cache_hit_rate": 0.0, "cost_usd": 0.0, "tool_calls": [], "hook_actions": [],
+            "source_product": "wcore"
+        });
+        let parsed: TurnTrace =
+            serde_json::from_value(old).expect("old trace must still deserialize");
+        assert_eq!(
+            parsed.agent_run_id, "",
+            "missing agent_run_id defaults to empty"
+        );
+        let mut t = parsed.clone();
+        t.agent_run_id = "agent-run-abc".into();
+        assert!(serde_json::to_string(&t).unwrap().contains("agent-run-abc"));
+        assert!(
+            !serde_json::to_string(&parsed)
+                .unwrap()
+                .contains("agent_run_id")
+        );
     }
 }

--- a/crates/wcore-observability/tests/golden_trace_v1.rs
+++ b/crates/wcore-observability/tests/golden_trace_v1.rs
@@ -67,6 +67,7 @@ fn golden_turn_trace_full_shape() {
         tool_calls: vec![tcc_full()],
         hook_actions: vec![],
         source_product: SOURCE_PRODUCT.to_string(),
+        agent_run_id: String::new(),
     };
     let got = serde_json::to_value(&turn).unwrap();
     let want = json!({

--- a/crates/wcore-protocol/src/events.rs
+++ b/crates/wcore-protocol/src/events.rs
@@ -74,6 +74,11 @@ pub enum ProtocolEvent {
         finish_reason: FinishReason,
         #[serde(skip_serializing_if = "Option::is_none")]
         usage: Option<Usage>,
+        /// #279(c): stable per-run correlation handle grouping every event of
+        /// one agent run (survives multi-message / --resume). None on synthetic
+        /// stream-ends (slash/exit/stop) that aren't a model run.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        agent_run_id: Option<String>,
     },
     Error {
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -406,6 +411,20 @@ pub enum ProtocolEvent {
         app: String,
         reason: String,
     },
+    /// W5 M6 / #279(d) + #280: a context compaction occurred. Gated by
+    /// capabilities.non_destructive_compact; hosts that don't recognise
+    /// compact_offload MUST drop it per the host decoder contract.
+    CompactOffload {
+        msg_id: String,
+        /// Why compaction fired (e.g. "window_pressure", "manual").
+        reason: String,
+        /// Tokens reclaimed. 0 when not measurable.
+        tokens_freed: u64,
+        /// Active-window fill AFTER compaction, same opaque 0..=100 u32 as
+        /// Usage.active_window_percent (from ContextWindow::percent()).
+        #[serde(skip_serializing_if = "Option::is_none")]
+        active_window_percent: Option<u32>,
+    },
     Pong,
 }
 
@@ -627,6 +646,12 @@ pub struct Usage {
     pub cache_read_tokens: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cache_write_tokens: Option<u64>,
+    /// #279(a): active-window fill 0..=100, sourced by the engine from
+    /// wcore_config::context_window::ContextWindow::percent() on the
+    /// POST-swap effective model. Opaque u32; wcore-protocol takes NO
+    /// wcore-config dep. None (omitted) when the window is unknown.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub active_window_percent: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -746,7 +771,9 @@ mod tests {
                 output_tokens: 50,
                 cache_read_tokens: Some(20),
                 cache_write_tokens: None,
+                active_window_percent: None,
             }),
+            agent_run_id: None,
         };
         let json = serde_json::to_value(&event).unwrap();
         assert_eq!(json["type"], "stream_end");
@@ -767,6 +794,7 @@ mod tests {
                 msg_id: "m1".to_string(),
                 finish_reason: variant,
                 usage: None,
+                agent_run_id: None,
             };
             let json = serde_json::to_value(&event).unwrap();
             assert_eq!(json["finish_reason"], expected, "variant {variant:?}");
@@ -780,6 +808,7 @@ mod tests {
             msg_id: "m1".to_string(),
             finish_reason: FinishReason::Length,
             usage: None,
+            agent_run_id: None,
         };
         let json = serde_json::to_value(&event).unwrap();
         assert!(

--- a/crates/wcore-protocol/tests/golden_v0_1_21.rs
+++ b/crates/wcore-protocol/tests/golden_v0_1_21.rs
@@ -106,7 +106,9 @@ fn golden_stream_end_stop_v0_1_21() {
             output_tokens: 50,
             cache_read_tokens: None,
             cache_write_tokens: None,
+            active_window_percent: None,
         }),
+        agent_run_id: None,
     };
     assert_eq!(
         serialize(&event),
@@ -129,6 +131,7 @@ fn golden_stream_end_length_v0_1_21() {
         msg_id: "m-1".into(),
         finish_reason: FinishReason::Length,
         usage: None,
+        agent_run_id: None,
     };
     assert_eq!(
         serialize(&event),
@@ -148,6 +151,7 @@ fn golden_stream_end_error_v0_1_21() {
         msg_id: "m-1".into(),
         finish_reason: FinishReason::Error,
         usage: None,
+        agent_run_id: None,
     };
     assert_eq!(
         serialize(&event),
@@ -175,6 +179,7 @@ fn golden_stream_end_every_finish_reason_serializes_snake_case() {
             msg_id: "m".into(),
             finish_reason: fr,
             usage: None,
+            agent_run_id: None,
         };
         let got = serialize(&event);
         assert_eq!(
@@ -197,7 +202,9 @@ fn golden_usage_with_full_cache_fields_v0_1_21() {
             output_tokens: 500,
             cache_read_tokens: Some(800),
             cache_write_tokens: Some(200),
+            active_window_percent: None,
         }),
+        agent_run_id: None,
     };
     assert_eq!(
         serialize(&event),
@@ -212,6 +219,68 @@ fn golden_usage_with_full_cache_fields_v0_1_21() {
                 "cache_write_tokens": 200
             }
         })
+    );
+}
+
+#[test]
+fn golden_stream_end_no_new_keys_when_unset_279() {
+    let event = ProtocolEvent::StreamEnd {
+        msg_id: "m-1".into(),
+        finish_reason: FinishReason::Stop,
+        usage: Some(Usage {
+            input_tokens: 1000,
+            output_tokens: 500,
+            cache_read_tokens: Some(800),
+            cache_write_tokens: Some(200),
+            active_window_percent: None,
+        }),
+        agent_run_id: None,
+    };
+    assert_eq!(
+        serialize(&event),
+        json!({
+            "type": "stream_end",
+            "msg_id": "m-1",
+            "finish_reason": "stop",
+            "usage": {
+                "input_tokens": 1000,
+                "output_tokens": 500,
+                "cache_read_tokens": 800,
+                "cache_write_tokens": 200
+            }
+        }),
+        "unset #279 fields must not appear on the wire"
+    );
+}
+
+#[test]
+fn golden_stream_end_with_new_keys_when_set_279() {
+    let event = ProtocolEvent::StreamEnd {
+        msg_id: "m-1".into(),
+        finish_reason: FinishReason::Stop,
+        usage: Some(Usage {
+            input_tokens: 1000,
+            output_tokens: 500,
+            cache_read_tokens: None,
+            cache_write_tokens: None,
+            active_window_percent: Some(73),
+        }),
+        agent_run_id: Some("agent-run-abc".into()),
+    };
+    assert_eq!(
+        serialize(&event),
+        json!({
+            "type": "stream_end",
+            "msg_id": "m-1",
+            "finish_reason": "stop",
+            "usage": {
+                "input_tokens": 1000,
+                "output_tokens": 500,
+                "active_window_percent": 73
+            },
+            "agent_run_id": "agent-run-abc"
+        }),
+        "set #279 fields appear only when present; rest unchanged"
     );
 }
 

--- a/crates/wcore-protocol/tests/host_decoder_contract.rs
+++ b/crates/wcore-protocol/tests/host_decoder_contract.rs
@@ -114,6 +114,71 @@ fn host_drops_unknown_event_type_silently() {
     }
 }
 
+#[test]
+fn host_drops_compact_offload_when_capability_unknown_279() {
+    let line = json!({
+        "type": "compact_offload",
+        "msg_id": "m-1",
+        "reason": "window_pressure",
+        "tokens_freed": 4096,
+        "active_window_percent": 41
+    })
+    .to_string();
+    match host_decode(&line) {
+        DecodeOutcome::UnknownType(t) => assert_eq!(t, "compact_offload"),
+        other => panic!("expected UnknownType, got {other:?}"),
+    }
+}
+
+#[test]
+fn host_tolerates_unknown_fields_on_stream_end_279() {
+    let line = json!({
+        "type": "stream_end",
+        "msg_id": "m-1",
+        "finish_reason": "stop",
+        "usage": {"input_tokens": 10, "output_tokens": 5, "active_window_percent": 88},
+        "agent_run_id": "agent-run-xyz"
+    })
+    .to_string();
+    match host_decode(&line) {
+        DecodeOutcome::Known(v) => {
+            assert_eq!(v["type"], "stream_end");
+            assert_eq!(v["finish_reason"], "stop");
+            assert_eq!(v["usage"]["input_tokens"], 10);
+        }
+        other => panic!("expected Known(stream_end), got {other:?}"),
+    }
+}
+
+#[test]
+fn capability_aware_host_parses_compact_offload_279() {
+    fn decode_with_caps(line: &str, known_extra: &[&str]) -> DecodeOutcome {
+        let v: Value = serde_json::from_str(line).unwrap();
+        let t = v["type"].as_str().unwrap();
+        if V0_1_21_KNOWN_TYPES.contains(&t) || known_extra.contains(&t) {
+            DecodeOutcome::Known(v)
+        } else {
+            DecodeOutcome::UnknownType(t.to_string())
+        }
+    }
+    let line = json!({
+        "type": "compact_offload",
+        "msg_id": "m-1",
+        "reason": "window_pressure",
+        "tokens_freed": 4096,
+        "active_window_percent": 41
+    })
+    .to_string();
+    match decode_with_caps(&line, &["compact_offload"]) {
+        DecodeOutcome::Known(v) => {
+            assert_eq!(v["reason"], "window_pressure");
+            assert_eq!(v["tokens_freed"], 4096);
+            assert_eq!(v["active_window_percent"], 41);
+        }
+        other => panic!("capability-aware host must parse compact_offload, got {other:?}"),
+    }
+}
+
 /// W8a A.7 — `BudgetExceeded` ships as a host-tolerated additive variant
 /// per audit F5: no dedicated capability flag, always-emitted, dropped
 /// silently by hosts that don't know the `budget_exceeded` `type`

--- a/crates/wcore-skills/tests/draft_pattern_detector.rs
+++ b/crates/wcore-skills/tests/draft_pattern_detector.rs
@@ -36,6 +36,7 @@ fn turn_with_calls(turn: usize, calls: Vec<(&str, serde_json::Value)>) -> TurnTr
             .collect(),
         hook_actions: vec![],
         source_product: "wcore-agent".into(),
+        agent_run_id: String::new(),
     }
 }
 

--- a/crates/wcore-skills/tests/w9_acceptance.rs
+++ b/crates/wcore-skills/tests/w9_acceptance.rs
@@ -28,6 +28,7 @@ fn turn(i: usize, tools: &[(&str, serde_json::Value)]) -> TurnTrace {
             .collect(),
         hook_actions: vec![],
         source_product: "wcore-agent".into(),
+        agent_run_id: String::new(),
     }
 }
 

--- a/crates/wcore-tools/tests/git_commit_message.rs
+++ b/crates/wcore-tools/tests/git_commit_message.rs
@@ -17,6 +17,7 @@ fn synth_trace(touched: &[&str]) -> TurnTrace {
         tool_calls: vec![],
         hook_actions: vec![],
         source_product: "wayland-core".into(),
+        agent_run_id: String::new(),
     };
     for p in touched {
         t.tool_calls.push(ToolCallTrace::new(


### PR DESCRIPTION
Unblocks desktop **#252**. Four **additive, backward-compatible** surfaces on the JSON-stream protocol — every field gated by serde `skip_serializing_if`/`default`, so old hosts and old engine builds stay compatible, and `wcore-protocol` takes **no** new dep on `wcore-config` (the percent is transported as an opaque integer).

## Surfaces
- **(a) `Usage.active_window_percent: Option<u32>`** — the post-swap active model's context fill, sourced by the engine from the #255 `ContextWindow::resolve(..).percent()` kernel. Lives on `wcore_protocol::events::Usage` only (`wcore_types` `TokenUsage` is untouched).
- **(b) Structured traces** over the existing `ProtocolEvent::TraceEvent` (gated; no new surface).
- **(c) `StreamEnd.agent_run_id: Option<String>`** — stable per-run correlation handle, minted once per run in the engine; `None` on synthetic stream-ends (slash/exit/stop). `OutputSink` gains a defaulted `emit_stream_end_full` that delegates to the legacy `emit_stream_end`, so every sink stays source-compatible.
- **(d) `ProtocolEvent::CompactOffload`** — compaction event (reason, `tokens_freed`, post-compact `active_window_percent`), gated by the reserved `Capabilities.non_destructive_compact`; hosts that don't recognise it MUST drop it per the host-decoder contract. Pairs with #280.

## Tests
Golden (`golden_v0_1_21`) + `host_decoder_contract` backward-compat assertions: old-shape decode unchanged, `None` fields elided.

## Verification (Hetzner gate, workspace scope)
`cargo fmt --all --check` clean · `clippy --workspace --all-targets -D warnings` clean · `nextest --workspace` **9124 passed**. The `release_binary_smoke` suite (incl. `release_binary_ready_event_advertises_plugin_capabilities`) **passes** against a freshly built release binary — confirming (d)'s capability gating does not alter advertised plugin capabilities.

Refs #279. Built on the #255 kernel (#74).