### PR TITLE
feat(#282): Flux context-routing contract — client side V1

### DIFF
--- a/crates/wcore-agent/src/bin/tool_token_bench.rs
+++ b/crates/wcore-agent/src/bin/tool_token_bench.rs
@@ -217,6 +217,8 @@ async fn drain_scripted_usage(provider: &ScriptedProvider) -> Usage {
         routing_hint: None,
         stop_sequences: Vec::new(),
         web_search: false,
+        conversation_id: None,
+        client_context_tokens: None,
     };
     let mut rx = provider.stream(&req).await.expect("scripted stream");
     let mut tu = TokenUsage::default();

--- a/crates/wcore-agent/src/compact/auto.rs
+++ b/crates/wcore-agent/src/compact/auto.rs
@@ -127,6 +127,8 @@ pub async fn autocompact(
             routing_hint: None,
             stop_sequences: Vec::new(),
             web_search: false,
+            conversation_id: None,
+            client_context_tokens: None,
         };
 
         match provider.stream(&request).await {

--- a/crates/wcore-agent/src/engine.rs
+++ b/crates/wcore-agent/src/engine.rs
@@ -1310,6 +1310,12 @@ pub struct AgentEngine {
     /// post-tool-use, and turn-end hook phases. Drained into the next
     /// `TurnTrace.hook_actions` via `std::mem::take` at each emission site.
     pending_hook_actions: Vec<wcore_observability::trace::HookActionRecord>,
+    /// #282 contract V1: stable per-session conversation id for Flux sticky
+    /// routing. Minted ONCE at construction with a v4 UUID and threaded onto
+    /// every `LlmRequest` as `conversation_id`; the Flux provider emits it as
+    /// the `x-wl-conversation-id` request header on tier-alias turns. Survives
+    /// `/clear` and `/resume` so a continued session keeps routing affinity.
+    conversation_id: String,
 }
 
 impl Drop for AgentEngine {
@@ -1562,6 +1568,8 @@ impl AgentEngine {
             // No hook actions have fired before the first turn.
             web_search: false,
             pending_hook_actions: Vec::new(),
+            // #282: mint the stable Flux conversation id once per engine.
+            conversation_id: uuid::Uuid::new_v4().to_string(),
         }
     }
 
@@ -1724,6 +1732,9 @@ impl AgentEngine {
             // No hook actions have fired before the first turn.
             web_search: false,
             pending_hook_actions: Vec::new(),
+            // #282: mint the stable Flux conversation id once per engine. A
+            // resumed session gets a fresh id (sticky routing is best-effort).
+            conversation_id: uuid::Uuid::new_v4().to_string(),
         }
     }
 
@@ -3658,6 +3669,11 @@ impl AgentEngine {
                 routing_hint: None,
                 stop_sequences,
                 web_search: self.web_search,
+                // #282: thread the stable conversation id + assembled-prompt
+                // token estimate so the Flux provider can emit the x-wl-*
+                // context-routing headers on tier-alias turns.
+                conversation_id: Some(self.conversation_id.clone()),
+                client_context_tokens: Some(input_token_estimate as u64),
             };
 
             // Cache-stability (token-opt): inject the per-turn skill-router
@@ -3862,6 +3878,13 @@ impl AgentEngine {
             let finish_reason: FinishReason;
             let turn_usage: TokenUsage;
             let mut stream_attempt: u32 = 0;
+            // #282 contract V1: a managed Flux client that overflows the routed
+            // model's window gets a typed 409 `ProviderError::ContextOverflow`.
+            // We compact the conversation and retry the SAME turn EXACTLY ONCE;
+            // this guard bounds it so a persistently-overflowing turn cannot
+            // infinite-loop. After the single retry, a recurring overflow is
+            // surfaced as a clean terminal error below.
+            let mut overflow_retried = false;
             'stream: loop {
                 // Reset per-attempt accumulators so a retry never
                 // double-commits text/tool-calls from a failed attempt.
@@ -3925,6 +3948,39 @@ impl AgentEngine {
                         // An already-closed empty receiver makes the
                         // `while rx.recv()` loop below a no-op.
                         tokio::sync::mpsc::channel(1).1
+                    }
+                    // #282: hard context overflow from a managed Flux route.
+                    // Compact the conversation, rebuild the request from the
+                    // compacted history, and retry this same turn ONCE. The
+                    // compaction itself hardens the tool-pair invariant (#285);
+                    // we only call `run_compaction` here, never duplicate it.
+                    Err(ProviderError::ContextOverflow {
+                        required_tokens,
+                        model_window,
+                        routed_model,
+                        ..
+                    }) if !overflow_retried => {
+                        overflow_retried = true;
+                        self.output.emit_info(&format!(
+                            "context overflow on {routed_model} ({required_tokens} tokens > \
+                             {model_window} window) — compacted and retrying"
+                        ));
+                        if let Err(e) = self.run_compaction().await {
+                            self.fire_on_session_end(turn).await;
+                            self.save_session();
+                            return Err(e);
+                        }
+                        // Rebuild the volatile request inputs from the compacted
+                        // history; the cached system/tool prefix is unchanged by
+                        // compaction, so only messages + the token estimate move.
+                        request.messages = self.messages.clone();
+                        let recount = estimate::estimate_request_tokens(
+                            &self.messages,
+                            &request.system,
+                            &request.tools,
+                        ) as u64;
+                        request.client_context_tokens = Some(recount);
+                        continue 'stream;
                     }
                     Err(e) => return Err(e.into()),
                 };
@@ -7327,6 +7383,7 @@ mod set_config_tests {
             session_start_injected_len: 0,
             web_search: false,
             pending_hook_actions: Vec::new(),
+            conversation_id: String::new(),
         }
     }
 
@@ -8144,6 +8201,7 @@ mod phase6_tests {
             session_start_injected_len: 0,
             web_search: false,
             pending_hook_actions: Vec::new(),
+            conversation_id: String::new(),
         }
     }
 
@@ -8428,6 +8486,7 @@ mod compact_tests {
             session_start_injected_len: 0,
             web_search: false,
             pending_hook_actions: Vec::new(),
+            conversation_id: String::new(),
         }
     }
 
@@ -9587,6 +9646,7 @@ mod plan_mode_tests {
             session_start_injected_len: 0,
             web_search: false,
             pending_hook_actions: Vec::new(),
+            conversation_id: String::new(),
         }
     }
 
@@ -10004,6 +10064,7 @@ mod hook_integration_tests {
             session_start_injected_len: 0,
             web_search: false,
             pending_hook_actions: Vec::new(),
+            conversation_id: String::new(),
         }
     }
 
@@ -10712,6 +10773,7 @@ mod approval_bridge_engine_tests {
             session_start_injected_len: 0,
             web_search: false,
             pending_hook_actions: Vec::new(),
+            conversation_id: String::new(),
         }
     }
 
@@ -10934,6 +10996,7 @@ mod user_model_writeback_tests {
             session_start_injected_len: 0,
             web_search: false,
             pending_hook_actions: Vec::new(),
+            conversation_id: String::new(),
         }
     }
 

--- a/crates/wcore-agent/src/engine.rs
+++ b/crates/wcore-agent/src/engine.rs
@@ -1316,6 +1316,15 @@ pub struct AgentEngine {
     /// the `x-wl-conversation-id` request header on tier-alias turns. Survives
     /// `/clear` and `/resume` so a continued session keeps routing affinity.
     conversation_id: String,
+    /// #282 contract V1: the REAL context window of the model Flux routed the
+    /// LAST turn to (`x-flux-model-window`). `None` until Flux signals back.
+    /// Used to reconcile the #255 pre-flight overflow guard against the actual
+    /// served-model window instead of the pre-route guess.
+    flux_served_window: Option<u64>,
+    /// #282 contract V1: the LAST-seen Flux context pressure
+    /// (`x-flux-context-pressure`, `0.0..=1.0` = required / window). Captured
+    /// for future #280 pressure-driven scheduling; not yet acted upon.
+    flux_context_pressure: Option<f32>,
 }
 
 impl Drop for AgentEngine {
@@ -1570,6 +1579,9 @@ impl AgentEngine {
             pending_hook_actions: Vec::new(),
             // #282: mint the stable Flux conversation id once per engine.
             conversation_id: uuid::Uuid::new_v4().to_string(),
+            // #282: no Flux signal-back seen yet at construction.
+            flux_served_window: None,
+            flux_context_pressure: None,
         }
     }
 
@@ -1735,6 +1747,9 @@ impl AgentEngine {
             // #282: mint the stable Flux conversation id once per engine. A
             // resumed session gets a fresh id (sticky routing is best-effort).
             conversation_id: uuid::Uuid::new_v4().to_string(),
+            // #282: no Flux signal-back seen yet at construction.
+            flux_served_window: None,
+            flux_context_pressure: None,
         }
     }
 
@@ -3809,12 +3824,21 @@ impl AgentEngine {
             // to the old `window > 0` skip; `size_output_cap`'s UNKNOWN_CAP and
             // the provider 400 are the backstops.
             {
-                let ctx = wcore_config::context_window::ContextWindow::resolve(
+                let mut ctx = wcore_config::context_window::ContextWindow::resolve(
                     input_token_estimate as u64,
                     self.compat.provider_type(),
                     &request.model,
                     self.compact_config.context_window as u64,
                 );
+                // #282 contract V1: once Flux has SIGNALLED-BACK the real served
+                // window (`x-flux-model-window`) on a prior turn of THIS Flux
+                // route, prefer it over the alias's pre-route guess so the guard
+                // measures against the model that will actually serve the turn.
+                if wcore_providers::is_flux_tier_alias(&request.model)
+                    && let Some(window) = self.flux_served_window
+                {
+                    ctx.window = Some(window);
+                }
                 if let Some(ceiling) = ctx.input_ceiling(
                     self.compact_config.output_reserve as u64,
                     self.compact_config.emergency_buffer as u64,
@@ -4038,6 +4062,38 @@ impl AgentEngine {
                         }
                         LlmEvent::SearchResults(results) => {
                             grounding_search_results = results;
+                        }
+                        LlmEvent::ProviderMeta {
+                            routed_model,
+                            model_window,
+                            context_pressure,
+                            tokens_counted,
+                        } => {
+                            // #282 contract V1: Flux SIGNALS-BACK. Capture the
+                            // pressure for future #280 scheduling (not yet acted
+                            // on) and the REAL served-model window so the #255
+                            // overflow guard measures against the model that
+                            // actually served this turn, not the pre-route guess.
+                            self.flux_context_pressure = context_pressure;
+                            self.flux_served_window = model_window;
+                            if let Some(window) = model_window {
+                                // Reconcile the #255 gauge through the kernel:
+                                // recompute the active-window fraction against the
+                                // REAL served window. `tokens_counted` is Flux's
+                                // own prompt count when present; fall back to our
+                                // pre-flight estimate otherwise.
+                                let used = tokens_counted.unwrap_or(input_token_estimate as u64);
+                                let ctx = wcore_config::context_window::ContextWindow {
+                                    used_tokens: used,
+                                    window: Some(window),
+                                };
+                                if let Some(pct) = ctx.percent() {
+                                    let routed = routed_model.as_deref().unwrap_or("flux-routed");
+                                    self.output.emit_info(&format!(
+                                        "Flux routed to {routed} ({pct}% of {window}-token window)"
+                                    ));
+                                }
+                            }
                         }
                     }
                 }
@@ -7384,6 +7440,8 @@ mod set_config_tests {
             web_search: false,
             pending_hook_actions: Vec::new(),
             conversation_id: String::new(),
+            flux_served_window: None,
+            flux_context_pressure: None,
         }
     }
 
@@ -8202,6 +8260,8 @@ mod phase6_tests {
             web_search: false,
             pending_hook_actions: Vec::new(),
             conversation_id: String::new(),
+            flux_served_window: None,
+            flux_context_pressure: None,
         }
     }
 
@@ -8487,6 +8547,8 @@ mod compact_tests {
             web_search: false,
             pending_hook_actions: Vec::new(),
             conversation_id: String::new(),
+            flux_served_window: None,
+            flux_context_pressure: None,
         }
     }
 
@@ -9647,6 +9709,8 @@ mod plan_mode_tests {
             web_search: false,
             pending_hook_actions: Vec::new(),
             conversation_id: String::new(),
+            flux_served_window: None,
+            flux_context_pressure: None,
         }
     }
 
@@ -10065,6 +10129,8 @@ mod hook_integration_tests {
             web_search: false,
             pending_hook_actions: Vec::new(),
             conversation_id: String::new(),
+            flux_served_window: None,
+            flux_context_pressure: None,
         }
     }
 
@@ -10774,6 +10840,8 @@ mod approval_bridge_engine_tests {
             web_search: false,
             pending_hook_actions: Vec::new(),
             conversation_id: String::new(),
+            flux_served_window: None,
+            flux_context_pressure: None,
         }
     }
 
@@ -10997,6 +11065,8 @@ mod user_model_writeback_tests {
             web_search: false,
             pending_hook_actions: Vec::new(),
             conversation_id: String::new(),
+            flux_served_window: None,
+            flux_context_pressure: None,
         }
     }
 
@@ -13199,6 +13269,156 @@ mod ijfw_session_start_e2e_tests {
         assert!(
             engine.messages.is_empty(),
             "an unmapped plugin must contribute no prelude"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// #282 contract V1 — engine compact-and-retry on a Flux 409 context_overflow.
+//
+// A managed Flux client that overflows the routed window gets a typed
+// `ProviderError::ContextOverflow` from `provider.stream()`. The engine must
+// run ONE compaction pass and retry the SAME turn EXACTLY ONCE: a transient
+// overflow recovers, a persistent one terminates cleanly (no infinite loop).
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod overflow_retry_tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use async_trait::async_trait;
+    use wcore_config::config::{Config, ProviderType};
+    use wcore_providers::{LlmProvider, ProviderError};
+    use wcore_tools::registry::ToolRegistry;
+    use wcore_types::llm::{LlmEvent, LlmRequest};
+    use wcore_types::message::{FinishReason, StopReason, TokenUsage};
+
+    use crate::output::OutputSink;
+
+    struct NullOutput;
+    impl OutputSink for NullOutput {
+        fn emit_text_delta(&self, _: &str, _: &str) {}
+        fn emit_thinking(&self, _: &str, _: &str) {}
+        fn emit_tool_call(&self, _: &str, _: &str) {}
+        fn emit_tool_result(&self, _: &str, _: bool, _: &str) {}
+        fn emit_stream_start(&self, _: &str) {}
+        fn emit_stream_end(
+            &self,
+            _: &str,
+            _: usize,
+            _: u64,
+            _: u64,
+            _: u64,
+            _: u64,
+            _: FinishReason,
+        ) {
+        }
+        fn emit_error(&self, _: &str, _: bool) {}
+        fn emit_info(&self, _: &str) {}
+    }
+
+    /// A provider that returns `ContextOverflow` for its first `overflow_for`
+    /// `stream()` calls, then a clean one-line turn. The shared call counter
+    /// lets a test assert EXACTLY how many times the engine dispatched.
+    struct OverflowProvider {
+        calls: Arc<AtomicUsize>,
+        overflow_for: usize,
+    }
+
+    #[async_trait]
+    impl LlmProvider for OverflowProvider {
+        async fn stream(
+            &self,
+            _request: &LlmRequest,
+        ) -> Result<tokio::sync::mpsc::Receiver<LlmEvent>, ProviderError> {
+            let n = self.calls.fetch_add(1, Ordering::SeqCst);
+            if n < self.overflow_for {
+                return Err(ProviderError::ContextOverflow {
+                    required_tokens: 210_000,
+                    model_window: 200_000,
+                    routed_model: "claude-sonnet-4".into(),
+                    message: "prompt exceeds routed window".into(),
+                });
+            }
+            let (tx, rx) = tokio::sync::mpsc::channel(2);
+            tokio::spawn(async move {
+                let _ = tx.send(LlmEvent::TextDelta("ok".into())).await;
+                let _ = tx
+                    .send(LlmEvent::Done {
+                        stop_reason: StopReason::EndTurn,
+                        finish_reason: FinishReason::Stop,
+                        usage: TokenUsage::default(),
+                    })
+                    .await;
+            });
+            Ok(rx)
+        }
+    }
+
+    fn flux_config() -> Config {
+        Config {
+            provider_label: "flux-router".into(),
+            provider: ProviderType::FluxRouter,
+            api_key: "sk-flux-test".into(),
+            base_url: "http://localhost:0".into(),
+            model: "flux-auto".into(),
+            max_tokens: 1024,
+            max_turns: Some(1),
+            ..Default::default()
+        }
+    }
+
+    /// A SINGLE overflow recovers: the engine compacts and retries once, the
+    /// retry succeeds, and `run` returns Ok. The provider is dispatched exactly
+    /// twice (the overflowing attempt + the recovered retry).
+    #[tokio::test]
+    async fn single_overflow_compacts_and_retries_then_succeeds() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let provider = OverflowProvider {
+            calls: Arc::clone(&calls),
+            overflow_for: 1,
+        };
+        let mut engine = super::AgentEngine::new_with_provider(
+            Arc::new(provider),
+            flux_config(),
+            ToolRegistry::new(),
+            Arc::new(NullOutput),
+        );
+        let result = engine.run("hello", "m-overflow-ok").await;
+        assert!(result.is_ok(), "a single overflow must recover: {result:?}");
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            2,
+            "exactly one overflow-retry: one failed dispatch + one recovered"
+        );
+    }
+
+    /// A PERSISTENT overflow terminates: the engine retries exactly ONCE, and
+    /// when the retry still overflows it surfaces a terminal error instead of
+    /// looping forever. The provider is dispatched exactly twice.
+    #[tokio::test]
+    async fn persistent_overflow_retries_once_then_terminal_error() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let provider = OverflowProvider {
+            calls: Arc::clone(&calls),
+            overflow_for: usize::MAX,
+        };
+        let mut engine = super::AgentEngine::new_with_provider(
+            Arc::new(provider),
+            flux_config(),
+            ToolRegistry::new(),
+            Arc::new(NullOutput),
+        );
+        let result = engine.run("hello", "m-overflow-loop").await;
+        assert!(
+            result.is_err(),
+            "a persistent overflow must terminate, not loop"
+        );
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            2,
+            "the overflow-retry is bounded to ONE: one initial + one retry, then terminal"
         );
     }
 }

--- a/crates/wcore-agent/src/test_utils/mod.rs
+++ b/crates/wcore-agent/src/test_utils/mod.rs
@@ -266,6 +266,8 @@ mod tests {
             routing_hint: None,
             stop_sequences: Vec::new(),
             web_search: false,
+            conversation_id: None,
+            client_context_tokens: None,
         };
         let mut rx = p.stream(&req).await.unwrap();
         let first = rx.recv().await.unwrap();

--- a/crates/wcore-agent/tests/bootstrap_test.rs
+++ b/crates/wcore-agent/tests/bootstrap_test.rs
@@ -423,6 +423,8 @@ mod resilience_wrap {
                 routing_hint: None,
                 stop_sequences: Vec::new(),
                 web_search: false,
+                conversation_id: None,
+                client_context_tokens: None,
             };
             let _ = result.provider.stream(&req).await;
         }
@@ -471,6 +473,8 @@ mod resilience_wrap {
                 routing_hint: None,
                 stop_sequences: Vec::new(),
                 web_search: false,
+                conversation_id: None,
+                client_context_tokens: None,
             };
             let _ = result.provider.stream(&req).await;
         }

--- a/crates/wcore-agent/tests/ollama_e2e_test.rs
+++ b/crates/wcore-agent/tests/ollama_e2e_test.rs
@@ -104,6 +104,8 @@ async fn ollama_provider_streams_text_delta_and_done() {
         routing_hint: None,
         stop_sequences: Vec::new(),
         web_search: false,
+        conversation_id: None,
+        client_context_tokens: None,
     };
 
     let mut rx = provider
@@ -225,6 +227,8 @@ async fn ollama_provider_maps_length_done_reason() {
         routing_hint: None,
         stop_sequences: Vec::new(),
         web_search: false,
+        conversation_id: None,
+        client_context_tokens: None,
     };
     let mut rx = provider.stream(&request).await.unwrap();
     while let Some(event) = rx.recv().await {
@@ -267,6 +271,8 @@ async fn ollama_provider_5xx_surfaces_as_api_error() {
         routing_hint: None,
         stop_sequences: Vec::new(),
         web_search: false,
+        conversation_id: None,
+        client_context_tokens: None,
     };
     let err = provider.stream(&request).await.unwrap_err();
     match err {
@@ -309,6 +315,8 @@ async fn ollama_live_smoke() {
         routing_hint: None,
         stop_sequences: Vec::new(),
         web_search: false,
+        conversation_id: None,
+        client_context_tokens: None,
     };
     let mut rx = provider.stream(&request).await.expect("ollama stream");
     let mut text = String::new();

--- a/crates/wcore-cli/tests/harness_mock_llm.rs
+++ b/crates/wcore-cli/tests/harness_mock_llm.rs
@@ -55,6 +55,8 @@ fn minimal_request() -> LlmRequest {
         routing_hint: None,
         stop_sequences: Vec::new(),
         web_search: false,
+        conversation_id: None,
+        client_context_tokens: None,
     }
 }
 

--- a/crates/wcore-evolve/src/mutator/llm_paraphrase_provider.rs
+++ b/crates/wcore-evolve/src/mutator/llm_paraphrase_provider.rs
@@ -216,7 +216,8 @@ async fn collect_text(
             LlmEvent::ThinkingDelta(_)
             | LlmEvent::ToolUse { .. }
             | LlmEvent::Citations(_)
-            | LlmEvent::SearchResults(_) => {}
+            | LlmEvent::SearchResults(_)
+            | LlmEvent::ProviderMeta { .. } => {}
         }
     }
     Err(LlmParaphraseError::StreamEndedEarly)

--- a/crates/wcore-evolve/src/mutator/llm_paraphrase_provider.rs
+++ b/crates/wcore-evolve/src/mutator/llm_paraphrase_provider.rs
@@ -137,6 +137,8 @@ impl LlmParaphraseProvider {
             routing_hint: None,
             stop_sequences: Vec::new(),
             web_search: false,
+            conversation_id: None,
+            client_context_tokens: None,
         }
     }
 

--- a/crates/wcore-observability/src/cache.rs
+++ b/crates/wcore-observability/src/cache.rs
@@ -58,6 +58,8 @@ mod tests {
             routing_hint: None,
             stop_sequences: Vec::new(),
             web_search: false,
+            conversation_id: None,
+            client_context_tokens: None,
         }
     }
 

--- a/crates/wcore-observability/tests/cache_boundaries_test.rs
+++ b/crates/wcore-observability/tests/cache_boundaries_test.rs
@@ -21,6 +21,8 @@ fn req_with_messages(messages: Vec<Message>) -> LlmRequest {
         routing_hint: None,
         stop_sequences: Vec::new(),
         web_search: false,
+        conversation_id: None,
+        client_context_tokens: None,
     }
 }
 

--- a/crates/wcore-providers/src/anthropic.rs
+++ b/crates/wcore-providers/src/anthropic.rs
@@ -830,6 +830,8 @@ mod tests {
             routing_hint: None,
             stop_sequences: Vec::new(),
             web_search: false,
+            conversation_id: None,
+            client_context_tokens: None,
         }
     }
 

--- a/crates/wcore-providers/src/azure_openai.rs
+++ b/crates/wcore-providers/src/azure_openai.rs
@@ -383,6 +383,8 @@ mod tests {
             routing_hint: None,
             stop_sequences: Vec::new(),
             web_search: false,
+            conversation_id: None,
+            client_context_tokens: None,
         }
     }
 

--- a/crates/wcore-providers/src/bedrock.rs
+++ b/crates/wcore-providers/src/bedrock.rs
@@ -1999,6 +1999,8 @@ mod tests {
                 routing_hint: None,
                 stop_sequences: Vec::new(),
                 web_search: false,
+                conversation_id: None,
+                client_context_tokens: None,
             }
         }
 

--- a/crates/wcore-providers/src/cerebras.rs
+++ b/crates/wcore-providers/src/cerebras.rs
@@ -144,6 +144,8 @@ mod tests {
             routing_hint: None,
             stop_sequences: Vec::new(),
             web_search: false,
+            conversation_id: None,
+            client_context_tokens: None,
         };
         let result = p.stream(&req).await;
         assert!(result.is_err(), "expected error from unreachable host");

--- a/crates/wcore-providers/src/chain.rs
+++ b/crates/wcore-providers/src/chain.rs
@@ -54,6 +54,9 @@ fn is_chain_retryable(e: &ProviderError) -> bool {
         ProviderError::Parse(_) => false,
         // Request too large — won't shrink on a different provider
         ProviderError::PromptTooLong(_) => false,
+        // Flux 409 context_overflow — recovery is compact-then-retry on the
+        // SAME provider (the engine drives it), never failover. Terminal here.
+        ProviderError::ContextOverflow { .. } => false,
         // Missing credential is a config error the user must fix; failing over
         // would only mask it. Terminal.
         ProviderError::MissingApiKey => false,

--- a/crates/wcore-providers/src/chain.rs
+++ b/crates/wcore-providers/src/chain.rs
@@ -204,6 +204,8 @@ mod tests {
             routing_hint: None,
             stop_sequences: Vec::new(),
             web_search: false,
+            conversation_id: None,
+            client_context_tokens: None,
         }
     }
 

--- a/crates/wcore-providers/src/classify.rs
+++ b/crates/wcore-providers/src/classify.rs
@@ -174,6 +174,9 @@ fn classify_by_provider_error(err: &ProviderError) -> FailoverReason {
         // compact/route-to-larger-context-model, NOT swap provider. Per the
         // FailoverReason taxonomy doc at the top of this module.
         ProviderError::PromptTooLong(_) => FailoverReason::ContextOverflow,
+        // Flux 409 context_overflow — same recovery as PromptTooLong: compact
+        // and retry on the same provider, never swap.
+        ProviderError::ContextOverflow { .. } => FailoverReason::ContextOverflow,
         ProviderError::Connection(_) => FailoverReason::Timeout,
         ProviderError::Parse(_) => FailoverReason::Format,
         ProviderError::Http(_) => FailoverReason::Timeout,

--- a/crates/wcore-providers/src/cohere.rs
+++ b/crates/wcore-providers/src/cohere.rs
@@ -530,6 +530,8 @@ mod tests {
             routing_hint: None,
             stop_sequences: Vec::new(),
             web_search: false,
+            conversation_id: None,
+            client_context_tokens: None,
         }
     }
 

--- a/crates/wcore-providers/src/deepseek.rs
+++ b/crates/wcore-providers/src/deepseek.rs
@@ -140,6 +140,8 @@ mod tests {
             routing_hint: None,
             stop_sequences: Vec::new(),
             web_search: false,
+            conversation_id: None,
+            client_context_tokens: None,
         };
         let result = p.stream(&req).await;
         assert!(result.is_err(), "expected error from unreachable host");

--- a/crates/wcore-providers/src/fireworks.rs
+++ b/crates/wcore-providers/src/fireworks.rs
@@ -156,6 +156,8 @@ mod tests {
             routing_hint: None,
             stop_sequences: Vec::new(),
             web_search: false,
+            conversation_id: None,
+            client_context_tokens: None,
         };
         let result = p.stream(&req).await;
         assert!(result.is_err(), "expected error from unreachable host");

--- a/crates/wcore-providers/src/flux_router.rs
+++ b/crates/wcore-providers/src/flux_router.rs
@@ -147,6 +147,8 @@ mod tests {
             routing_hint: None,
             stop_sequences: Vec::new(),
             web_search: false,
+            conversation_id: None,
+            client_context_tokens: None,
         };
         let result = p.stream(&req).await;
         assert!(result.is_err(), "expected error from unreachable host");

--- a/crates/wcore-providers/src/gemini.rs
+++ b/crates/wcore-providers/src/gemini.rs
@@ -1009,6 +1009,8 @@ mod tests {
             routing_hint: None,
             stop_sequences: Vec::new(),
             web_search: false,
+            conversation_id: None,
+            client_context_tokens: None,
         }
     }
 

--- a/crates/wcore-providers/src/groq.rs
+++ b/crates/wcore-providers/src/groq.rs
@@ -137,6 +137,8 @@ mod tests {
             routing_hint: None,
             stop_sequences: Vec::new(),
             web_search: false,
+            conversation_id: None,
+            client_context_tokens: None,
         };
         let result = p.stream(&req).await;
         assert!(result.is_err(), "expected error from unreachable host");

--- a/crates/wcore-providers/src/lib.rs
+++ b/crates/wcore-providers/src/lib.rs
@@ -190,6 +190,23 @@ pub enum ProviderError {
         reason: String,
         upgrade_url: Option<String>,
     },
+    /// FluxRouter 409 `context_overflow` (#282 contract V1) — a managed client's
+    /// assembled prompt exceeds the routed model's context window even after
+    /// Flux's server-side structuring. This is NOT a provider-level retry: the
+    /// engine must compact the conversation, then retry the SAME turn. Marked
+    /// non-retryable in [`ProviderError::is_retryable`] so the generic
+    /// retry/backoff loop does not resend the unchanged (still-overflowing)
+    /// request; the engine handles the compact-then-retry explicitly.
+    #[error(
+        "Flux context overflow: {required_tokens} tokens required > {model_window} window \
+         on {routed_model}: {message}"
+    )]
+    ContextOverflow {
+        required_tokens: u64,
+        model_window: u64,
+        routed_model: String,
+        message: String,
+    },
 }
 
 impl ProviderError {
@@ -221,7 +238,10 @@ impl ProviderError {
             // must change plan / clear a charge / add a payment method first.
             | ProviderError::PremiumLocked { .. }
             | ProviderError::UpgradeRequired { .. }
-            | ProviderError::SpendCeilingUnresolved { .. } => false,
+            | ProviderError::SpendCeilingUnresolved { .. }
+            // #282: context overflow is resolved by engine-side compaction +
+            // an explicit single retry, NOT by a blind provider-level resend.
+            | ProviderError::ContextOverflow { .. } => false,
             // Egress transport timeouts/connects are pre-mapped to Connection
             // by provider code (like Http); a Denied is terminal. Both false here.
             ProviderError::Egress(_) => false,

--- a/crates/wcore-providers/src/lib.rs
+++ b/crates/wcore-providers/src/lib.rs
@@ -56,7 +56,7 @@ pub use classify::classify_failover;
 pub use cooldown::{CooldownClass, CooldownState, CooldownTracker};
 pub use failover::{FailoverError, FailoverReason, wrap_provider_error};
 pub use key_rotation::{KeyPool, split_keys};
-pub use openai::{AsyncTokenSource, OpenAIProvider};
+pub use openai::{AsyncTokenSource, OpenAIProvider, is_flux_tier_alias};
 pub use openai_chatgpt::{AsyncBearerSource, BearerCreds, OpenAIChatGptProvider};
 pub use registry::{ProviderFactory, ProviderRegistry, RegistryError, WaylandProviderRegistry};
 pub use resilient::{

--- a/crates/wcore-providers/src/mistral.rs
+++ b/crates/wcore-providers/src/mistral.rs
@@ -138,6 +138,8 @@ mod tests {
             routing_hint: None,
             stop_sequences: Vec::new(),
             web_search: false,
+            conversation_id: None,
+            client_context_tokens: None,
         };
         let result = p.stream(&req).await;
         assert!(result.is_err(), "expected error from unreachable host");

--- a/crates/wcore-providers/src/moonshot.rs
+++ b/crates/wcore-providers/src/moonshot.rs
@@ -147,6 +147,8 @@ mod tests {
             routing_hint: None,
             stop_sequences: Vec::new(),
             web_search: false,
+            conversation_id: None,
+            client_context_tokens: None,
         };
         let result = p.stream(&req).await;
         assert!(result.is_err(), "expected error from unreachable host");

--- a/crates/wcore-providers/src/nvidia.rs
+++ b/crates/wcore-providers/src/nvidia.rs
@@ -150,6 +150,8 @@ mod tests {
             routing_hint: None,
             stop_sequences: Vec::new(),
             web_search: false,
+            conversation_id: None,
+            client_context_tokens: None,
         };
         let result = p.stream(&req).await;
         assert!(result.is_err(), "expected error from unreachable host");

--- a/crates/wcore-providers/src/openai.rs
+++ b/crates/wcore-providers/src/openai.rs
@@ -3,7 +3,7 @@ use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
-use reqwest::header::{AUTHORIZATION, CONTENT_TYPE, HeaderMap, HeaderValue};
+use reqwest::header::{AUTHORIZATION, CONTENT_TYPE, HeaderMap, HeaderName, HeaderValue};
 use serde_json::{Value, json};
 use tokio::sync::mpsc;
 
@@ -133,6 +133,44 @@ impl OpenAIProvider {
         headers.insert(AUTHORIZATION, auth);
         headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
         Ok(headers)
+    }
+
+    /// #282 contract V1 — append the Core→Flux context-aware-routing request
+    /// headers to `headers`, but ONLY when this turn targets a Flux **tier
+    /// alias** (`flux-auto`/`flux-fast`/`flux-standard`/`flux-reasoning`). A
+    /// concrete model id opts OUT (the customer pinned the upstream), so non-Flux
+    /// and concrete-model requests are left byte-for-byte unchanged.
+    ///
+    /// `OpenAIProvider` is shared by every OpenAI-compatible provider; the
+    /// `is_flux_tier_alias` gate is the one place that quirk lives, so the
+    /// headers can never leak onto a non-Flux deployment.
+    ///
+    /// Emits (all `x-wl-*`):
+    /// - `x-wl-context-tokens`  — assembled-prompt token estimate (skipped if absent)
+    /// - `x-wl-expected-output` — the output budget (`request.max_tokens`)
+    /// - `x-wl-context-managed` — literal `true` (opts into the managed path)
+    /// - `x-wl-conversation-id` — stable conversation id (skipped if absent)
+    fn apply_flux_context_headers(headers: &mut HeaderMap, request: &LlmRequest) {
+        if !is_flux_tier_alias(&request.model) {
+            return;
+        }
+        if let Some(tokens) = request.client_context_tokens
+            && let Ok(v) = HeaderValue::from_str(&tokens.to_string())
+        {
+            headers.insert(HeaderName::from_static("x-wl-context-tokens"), v);
+        }
+        if let Ok(v) = HeaderValue::from_str(&request.max_tokens.to_string()) {
+            headers.insert(HeaderName::from_static("x-wl-expected-output"), v);
+        }
+        headers.insert(
+            HeaderName::from_static("x-wl-context-managed"),
+            HeaderValue::from_static("true"),
+        );
+        if let Some(id) = request.conversation_id.as_deref()
+            && let Ok(v) = HeaderValue::from_str(id)
+        {
+            headers.insert(HeaderName::from_static("x-wl-conversation-id"), v);
+        }
     }
 
     fn build_messages(messages: &[Message], system: &str, compat: &ProviderCompat) -> Vec<Value> {
@@ -447,15 +485,15 @@ impl OpenAIProvider {
         body: &Value,
         key: &str,
         using_bearer: bool,
+        request: &LlmRequest,
     ) -> Result<reqwest::Response, ProviderError> {
         let url = self.url_for(base_url, use_responses);
-        let response = builder_send_with_retry(
-            self.client
-                .post(&url)
-                .headers(self.build_headers(key)?)
-                .json(body),
-        )
-        .await?;
+        // #282: attach the Core→Flux context-routing headers (gated to Flux
+        // tier aliases inside the helper); non-Flux requests are unchanged.
+        let mut headers = self.build_headers(key)?;
+        Self::apply_flux_context_headers(&mut headers, request);
+        let response =
+            builder_send_with_retry(self.client.post(&url).headers(headers).json(body)).await?;
 
         let status = response.status();
         if !status.is_success() {
@@ -483,6 +521,15 @@ impl OpenAIProvider {
             // state distinctly; unrecognised 402s fall through to `Api`.
             if status.as_u16() == 402
                 && let Some(err) = parse_flux_402(&body_text)
+            {
+                return Err(err);
+            }
+            // #282 contract V1: a managed Flux client that overflows the routed
+            // model's window gets a typed 409 `context_overflow`. Surface it as
+            // a typed error so the engine can compact-then-retry this same turn;
+            // an unrecognised 409 body falls through to the generic `Api` error.
+            if status.as_u16() == 409
+                && let Some(err) = parse_flux_409(&body_text)
             {
                 return Err(err);
             }
@@ -1027,7 +1074,7 @@ impl LlmProvider for OpenAIProvider {
 
         let primary = self.effective_base_url();
         let response = match self
-            .try_send(&primary, use_responses, &body, &key, using_bearer)
+            .try_send(&primary, use_responses, &body, &key, using_bearer, request)
             .await
         {
             Ok(resp) => resp,
@@ -1050,7 +1097,7 @@ impl LlmProvider for OpenAIProvider {
                     .clone()
                     .expect("is_some_and guarantees Some");
                 let resp = self
-                    .try_send(&fallback, use_responses, &body, &key, using_bearer)
+                    .try_send(&fallback, use_responses, &body, &key, using_bearer, request)
                     .await?;
                 self.pin_base_url(&fallback);
                 resp
@@ -1700,6 +1747,44 @@ pub(crate) fn parse_flux_402(body: &str) -> Option<ProviderError> {
     }
 }
 
+/// Parse a FluxRouter 409 `context_overflow` body into a typed
+/// [`ProviderError::ContextOverflow`] (#282 contract V1, hard-overflow path).
+///
+/// The frozen body shape is a FLAT object whose `error` FIELD is the literal
+/// `"context_overflow"`:
+/// ```json
+/// {"error":"context_overflow","required_tokens":N,"model_window":M,
+///  "routed_model":"…","message":"…"}
+/// ```
+/// We match on the `error` FIELD (never the HTTP status alone, never a substring
+/// of the message) so an unrelated 409 cannot be misread as an overflow. Returns
+/// `None` when the body is not JSON, not the overflow shape, or is missing the
+/// numeric fields — the caller then falls back to [`ProviderError::Api`].
+pub(crate) fn parse_flux_409(body: &str) -> Option<ProviderError> {
+    let obj: Value = serde_json::from_str(body).ok()?;
+    if obj.get("error").and_then(Value::as_str)? != "context_overflow" {
+        return None;
+    }
+    let required_tokens = obj.get("required_tokens").and_then(Value::as_u64)?;
+    let model_window = obj.get("model_window").and_then(Value::as_u64)?;
+    let routed_model = obj
+        .get("routed_model")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+    let message = obj
+        .get("message")
+        .and_then(Value::as_str)
+        .unwrap_or("context overflow")
+        .to_string();
+    Some(ProviderError::ContextOverflow {
+        required_tokens,
+        model_window,
+        routed_model,
+        message,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1804,6 +1889,65 @@ mod tests {
     #[test]
     fn parse_flux_402_non_json_returns_none() {
         assert!(parse_flux_402("not json at all").is_none());
+    }
+
+    // --- #282 FluxRouter typed 409 context_overflow parsing ----------------
+
+    /// A well-formed `context_overflow` body parses into the typed variant with
+    /// every field recovered (contract V1 hard-overflow path).
+    #[test]
+    fn parse_flux_409_context_overflow_full() {
+        let body = r#"{"error":"context_overflow","required_tokens":210000,"model_window":200000,"routed_model":"claude-sonnet-4","message":"prompt exceeds routed model window"}"#;
+        match parse_flux_409(body) {
+            Some(ProviderError::ContextOverflow {
+                required_tokens,
+                model_window,
+                routed_model,
+                message,
+            }) => {
+                assert_eq!(required_tokens, 210_000);
+                assert_eq!(model_window, 200_000);
+                assert_eq!(routed_model, "claude-sonnet-4");
+                assert_eq!(message, "prompt exceeds routed model window");
+            }
+            other => panic!("expected ContextOverflow, got {other:?}"),
+        }
+    }
+
+    /// We match on the `error` FIELD, never the status. A 409 whose `error` is
+    /// something else returns `None` so it falls through to the generic `Api`.
+    #[test]
+    fn parse_flux_409_wrong_error_value_returns_none() {
+        let body = r#"{"error":"conflict","required_tokens":1,"model_window":2,"routed_model":"x","message":"y"}"#;
+        assert!(parse_flux_409(body).is_none());
+    }
+
+    /// A `context_overflow` body missing the numeric fields is not the frozen
+    /// shape → `None` (fall back to `Api`), never a partial/zeroed variant.
+    #[test]
+    fn parse_flux_409_missing_numeric_fields_returns_none() {
+        let body = r#"{"error":"context_overflow","message":"oops"}"#;
+        assert!(parse_flux_409(body).is_none());
+    }
+
+    /// A malformed JSON 409 body returns `None`.
+    #[test]
+    fn parse_flux_409_non_json_returns_none() {
+        assert!(parse_flux_409("not json at all").is_none());
+    }
+
+    /// `ContextOverflow` is NOT provider-retryable: the unchanged request would
+    /// overflow again. The engine resolves it via compaction + an explicit
+    /// single retry, so the generic retry/backoff loop must skip it.
+    #[test]
+    fn context_overflow_is_not_retryable() {
+        let err = ProviderError::ContextOverflow {
+            required_tokens: 210_000,
+            model_window: 200_000,
+            routed_model: "claude-sonnet-4".into(),
+            message: "overflow".into(),
+        };
+        assert!(!err.is_retryable());
     }
 
     /// The typed variants render DISTINCT Display messages: the two feature
@@ -2159,6 +2303,8 @@ mod tests {
             routing_hint: None,
             stop_sequences: Vec::new(),
             web_search: false,
+            conversation_id: None,
+            client_context_tokens: None,
         };
         let body = provider.build_request_body(&req);
         assert_eq!(body["max_tokens"], 1024);
@@ -2189,6 +2335,8 @@ mod tests {
             routing_hint: None,
             stop_sequences: Vec::new(),
             web_search: false,
+            conversation_id: None,
+            client_context_tokens: None,
         }
     }
 
@@ -2262,6 +2410,81 @@ mod tests {
                 "{concrete} must NOT be treated as a tier alias"
             );
         }
+    }
+
+    // --- #282 Core→Flux context-routing request headers -------------------
+
+    /// On a Flux **tier alias** the x-wl-* context-routing headers are emitted:
+    /// context tokens + expected output (= max_tokens) + the literal managed
+    /// opt-in + the conversation id. (#282 contract V1, emit side.)
+    #[test]
+    fn flux_context_headers_emitted_for_tier_alias() {
+        let mut req = stop_req();
+        req.model = "flux-auto".into();
+        req.max_tokens = 4096;
+        req.conversation_id = Some("conv-abc".into());
+        req.client_context_tokens = Some(123_456);
+
+        let mut headers = HeaderMap::new();
+        OpenAIProvider::apply_flux_context_headers(&mut headers, &req);
+
+        assert_eq!(
+            headers.get("x-wl-context-tokens").unwrap(),
+            "123456",
+            "context tokens header carries the assembled-prompt estimate"
+        );
+        assert_eq!(
+            headers.get("x-wl-expected-output").unwrap(),
+            "4096",
+            "expected-output header carries request.max_tokens"
+        );
+        assert_eq!(
+            headers.get("x-wl-context-managed").unwrap(),
+            "true",
+            "managed opt-in is the literal `true`"
+        );
+        assert_eq!(headers.get("x-wl-conversation-id").unwrap(), "conv-abc");
+    }
+
+    /// A CONCRETE model id (the customer pinned the upstream) opts OUT: NONE of
+    /// the x-wl-* headers are emitted, so non-Flux / pinned requests are
+    /// byte-for-byte unchanged. (#282 gating proof.)
+    #[test]
+    fn flux_context_headers_absent_for_concrete_model() {
+        let mut req = stop_req();
+        req.model = "gpt-4o".into();
+        req.conversation_id = Some("conv-abc".into());
+        req.client_context_tokens = Some(123_456);
+
+        let mut headers = HeaderMap::new();
+        OpenAIProvider::apply_flux_context_headers(&mut headers, &req);
+
+        assert!(headers.get("x-wl-context-tokens").is_none());
+        assert!(headers.get("x-wl-expected-output").is_none());
+        assert!(headers.get("x-wl-context-managed").is_none());
+        assert!(headers.get("x-wl-conversation-id").is_none());
+        assert!(
+            headers.is_empty(),
+            "a concrete-model request must carry no x-wl-* headers at all"
+        );
+    }
+
+    /// When the optional values are absent the header is SKIPPED (not emitted
+    /// empty), but the always-present managed opt-in + expected-output remain.
+    #[test]
+    fn flux_context_headers_skip_absent_optionals() {
+        let mut req = stop_req();
+        req.model = "flux-reasoning".into();
+        req.conversation_id = None;
+        req.client_context_tokens = None;
+
+        let mut headers = HeaderMap::new();
+        OpenAIProvider::apply_flux_context_headers(&mut headers, &req);
+
+        assert!(headers.get("x-wl-context-tokens").is_none());
+        assert!(headers.get("x-wl-conversation-id").is_none());
+        assert_eq!(headers.get("x-wl-context-managed").unwrap(), "true");
+        assert!(headers.get("x-wl-expected-output").is_some());
     }
 
     /// web_search on a tier-alias model injects the `{"type":"web_search"}`
@@ -2452,6 +2675,8 @@ mod tests {
             routing_hint: None,
             stop_sequences: Vec::new(),
             web_search: false,
+            conversation_id: None,
+            client_context_tokens: None,
         };
         let body = provider.build_request_body(&req);
         assert_eq!(body["max_completion_tokens"], 2048);
@@ -2487,6 +2712,8 @@ mod tests {
             routing_hint: None,
             stop_sequences: Vec::new(),
             web_search: false,
+            conversation_id: None,
+            client_context_tokens: None,
         };
         let body = provider.build_request_body(&req);
         assert_eq!(body["max_completion_tokens"], 1024);
@@ -2518,6 +2745,8 @@ mod tests {
             routing_hint: None,
             stop_sequences: Vec::new(),
             web_search: false,
+            conversation_id: None,
+            client_context_tokens: None,
         };
         let body = provider.build_request_body(&req);
         assert_eq!(body["max_tokens"], 1024);
@@ -2547,6 +2776,8 @@ mod tests {
             routing_hint: None,
             stop_sequences: Vec::new(),
             web_search: false,
+            conversation_id: None,
+            client_context_tokens: None,
         };
         let body = provider.build_request_body(&req);
         assert!(
@@ -2576,6 +2807,8 @@ mod tests {
             routing_hint: None,
             stop_sequences: Vec::new(),
             web_search: false,
+            conversation_id: None,
+            client_context_tokens: None,
         };
         let body = provider.build_request_body(&req);
         assert_eq!(body["reasoning_effort"], "medium");

--- a/crates/wcore-providers/src/openai.rs
+++ b/crates/wcore-providers/src/openai.rs
@@ -1108,7 +1108,18 @@ impl LlmProvider for OpenAIProvider {
         let (tx, rx) = mpsc::channel(64);
         let debug = self.debug.clone();
 
+        // #282 contract V1: Flux SIGNALS-BACK via `x-flux-*` response headers on
+        // every response. Read them BEFORE `response` is moved into the body
+        // task (and before `bytes_stream()` consumes it), then emit a single
+        // `ProviderMeta` event at stream start. Non-Flux providers send none of
+        // these headers, so the parse yields `None` and nothing is emitted —
+        // the SSE body path is entirely unchanged.
+        let provider_meta = parse_flux_response_meta(response.headers());
+
         tokio::spawn(async move {
+            if let Some(meta) = provider_meta {
+                let _ = tx.send(meta).await;
+            }
             let result = if use_responses {
                 process_responses_sse_stream(response, &tx, &debug).await
             } else {
@@ -1649,7 +1660,7 @@ pub(crate) fn map_openai_finish_reason(raw: &str) -> FinishReason {
 /// Matched case-insensitively against the four documented aliases. This is the
 /// one place that quirk lives; callers consult it rather than string-matching
 /// inline.
-pub(crate) fn is_flux_tier_alias(model: &str) -> bool {
+pub fn is_flux_tier_alias(model: &str) -> bool {
     matches!(
         model.to_ascii_lowercase().as_str(),
         "flux-auto" | "flux-fast" | "flux-standard" | "flux-reasoning"
@@ -1782,6 +1793,41 @@ pub(crate) fn parse_flux_409(body: &str) -> Option<ProviderError> {
         model_window,
         routed_model,
         message,
+    })
+}
+
+/// Parse the FluxRouter SIGNALS-BACK `x-flux-*` response headers (#282 contract
+/// V1) into a single [`LlmEvent::ProviderMeta`]. Returns `None` only when NONE
+/// of the four headers is present (a non-Flux provider), so the engine emits
+/// nothing on those routes. Each field is parsed independently — an absent or
+/// unparsable single header is `None`, never an error.
+///
+/// Headers:
+/// - `x-flux-routed-model`           → `routed_model`     (str)
+/// - `x-flux-model-window`           → `model_window`     (int)
+/// - `x-flux-context-pressure`       → `context_pressure` (float, REQUIRED/window)
+/// - `x-flux-context-tokens-counted` → `tokens_counted`   (int)
+fn parse_flux_response_meta(headers: &HeaderMap) -> Option<LlmEvent> {
+    let as_str = |name: &str| headers.get(name).and_then(|v| v.to_str().ok());
+    let routed_model = as_str("x-flux-routed-model").map(str::to_string);
+    let model_window = as_str("x-flux-model-window").and_then(|s| s.parse::<u64>().ok());
+    let context_pressure = as_str("x-flux-context-pressure").and_then(|s| s.parse::<f32>().ok());
+    let tokens_counted =
+        as_str("x-flux-context-tokens-counted").and_then(|s| s.parse::<u64>().ok());
+
+    // No Flux signal present at all → nothing to emit (non-Flux response).
+    if routed_model.is_none()
+        && model_window.is_none()
+        && context_pressure.is_none()
+        && tokens_counted.is_none()
+    {
+        return None;
+    }
+    Some(LlmEvent::ProviderMeta {
+        routed_model,
+        model_window,
+        context_pressure,
+        tokens_counted,
     })
 }
 
@@ -1948,6 +1994,77 @@ mod tests {
             message: "overflow".into(),
         };
         assert!(!err.is_retryable());
+    }
+
+    // --- #282 Flux SIGNALS-BACK x-flux-* response header parsing -----------
+
+    /// All four `x-flux-*` headers present → a fully-populated `ProviderMeta`.
+    #[test]
+    fn parse_flux_response_meta_full() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            HeaderName::from_static("x-flux-routed-model"),
+            HeaderValue::from_static("claude-sonnet-4"),
+        );
+        headers.insert(
+            HeaderName::from_static("x-flux-model-window"),
+            HeaderValue::from_static("200000"),
+        );
+        headers.insert(
+            HeaderName::from_static("x-flux-context-pressure"),
+            HeaderValue::from_static("0.42"),
+        );
+        headers.insert(
+            HeaderName::from_static("x-flux-context-tokens-counted"),
+            HeaderValue::from_static("84000"),
+        );
+        match parse_flux_response_meta(&headers) {
+            Some(LlmEvent::ProviderMeta {
+                routed_model,
+                model_window,
+                context_pressure,
+                tokens_counted,
+            }) => {
+                assert_eq!(routed_model.as_deref(), Some("claude-sonnet-4"));
+                assert_eq!(model_window, Some(200_000));
+                assert_eq!(context_pressure, Some(0.42));
+                assert_eq!(tokens_counted, Some(84_000));
+            }
+            other => panic!("expected ProviderMeta, got {other:?}"),
+        }
+    }
+
+    /// A non-Flux response (NONE of the headers) yields `None`, so the engine
+    /// emits nothing on non-Flux routes.
+    #[test]
+    fn parse_flux_response_meta_absent_returns_none() {
+        let headers = HeaderMap::new();
+        assert!(parse_flux_response_meta(&headers).is_none());
+    }
+
+    /// A partial signal (only the window) still emits a `ProviderMeta`; the
+    /// missing fields are `None`, never a parse error.
+    #[test]
+    fn parse_flux_response_meta_partial_window_only() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            HeaderName::from_static("x-flux-model-window"),
+            HeaderValue::from_static("128000"),
+        );
+        match parse_flux_response_meta(&headers) {
+            Some(LlmEvent::ProviderMeta {
+                routed_model,
+                model_window,
+                context_pressure,
+                tokens_counted,
+            }) => {
+                assert_eq!(model_window, Some(128_000));
+                assert!(routed_model.is_none());
+                assert!(context_pressure.is_none());
+                assert!(tokens_counted.is_none());
+            }
+            other => panic!("expected ProviderMeta, got {other:?}"),
+        }
     }
 
     /// The typed variants render DISTINCT Display messages: the two feature

--- a/crates/wcore-providers/src/openai_compatible.rs
+++ b/crates/wcore-providers/src/openai_compatible.rs
@@ -151,6 +151,8 @@ mod tests {
             routing_hint: None,
             stop_sequences: Vec::new(),
             web_search: false,
+            conversation_id: None,
+            client_context_tokens: None,
         };
         let result = p.stream(&req).await;
         assert!(result.is_err(), "expected error from unreachable host");

--- a/crates/wcore-providers/src/openrouter.rs
+++ b/crates/wcore-providers/src/openrouter.rs
@@ -188,6 +188,8 @@ mod tests {
             routing_hint: None,
             stop_sequences: Vec::new(),
             web_search: false,
+            conversation_id: None,
+            client_context_tokens: None,
         };
         let result = p.stream(&req).await;
         assert!(result.is_err(), "expected error from unreachable host");
@@ -254,6 +256,8 @@ mod tests {
             routing_hint: None,
             stop_sequences: Vec::new(),
             web_search: false,
+            conversation_id: None,
+            client_context_tokens: None,
         };
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()

--- a/crates/wcore-providers/src/perplexity.rs
+++ b/crates/wcore-providers/src/perplexity.rs
@@ -150,6 +150,8 @@ mod tests {
             routing_hint: None,
             stop_sequences: Vec::new(),
             web_search: false,
+            conversation_id: None,
+            client_context_tokens: None,
         };
         let result = p.stream(&req).await;
         assert!(result.is_err(), "expected error from unreachable host");

--- a/crates/wcore-providers/src/qwen.rs
+++ b/crates/wcore-providers/src/qwen.rs
@@ -157,6 +157,8 @@ mod tests {
             routing_hint: None,
             stop_sequences: Vec::new(),
             web_search: false,
+            conversation_id: None,
+            client_context_tokens: None,
         };
         let result = p.stream(&req).await;
         assert!(result.is_err(), "expected error from unreachable host");

--- a/crates/wcore-providers/src/resilient.rs
+++ b/crates/wcore-providers/src/resilient.rs
@@ -393,6 +393,8 @@ mod tests {
             routing_hint: None,
             stop_sequences: Vec::new(),
             web_search: false,
+            conversation_id: None,
+            client_context_tokens: None,
         }
     }
 

--- a/crates/wcore-providers/src/together.rs
+++ b/crates/wcore-providers/src/together.rs
@@ -141,6 +141,8 @@ mod tests {
             routing_hint: None,
             stop_sequences: Vec::new(),
             web_search: false,
+            conversation_id: None,
+            client_context_tokens: None,
         };
         let result = p.stream(&req).await;
         assert!(result.is_err(), "expected error from unreachable host");

--- a/crates/wcore-providers/src/xai.rs
+++ b/crates/wcore-providers/src/xai.rs
@@ -153,6 +153,8 @@ mod tests {
             routing_hint: None,
             stop_sequences: Vec::new(),
             web_search: false,
+            conversation_id: None,
+            client_context_tokens: None,
         };
         let result = p.stream(&req).await;
         assert!(result.is_err(), "expected error from unreachable host");

--- a/crates/wcore-providers/tests/bedrock_http_errors.rs
+++ b/crates/wcore-providers/tests/bedrock_http_errors.rs
@@ -73,6 +73,8 @@ fn cohere_request() -> LlmRequest {
         routing_hint: None,
         stop_sequences: Vec::new(),
         web_search: false,
+        conversation_id: None,
+        client_context_tokens: None,
     }
 }
 
@@ -95,6 +97,8 @@ fn anthropic_request() -> LlmRequest {
         routing_hint: None,
         stop_sequences: Vec::new(),
         web_search: false,
+        conversation_id: None,
+        client_context_tokens: None,
     }
 }
 

--- a/crates/wcore-providers/tests/gemini_test.rs
+++ b/crates/wcore-providers/tests/gemini_test.rs
@@ -44,6 +44,8 @@ fn minimal_request() -> LlmRequest {
         routing_hint: None,
         stop_sequences: Vec::new(),
         web_search: false,
+        conversation_id: None,
+        client_context_tokens: None,
     }
 }
 
@@ -617,6 +619,8 @@ async fn gemini_live_api_smoke_test() {
         routing_hint: None,
         stop_sequences: Vec::new(),
         web_search: false,
+        conversation_id: None,
+        client_context_tokens: None,
     };
 
     let rx = provider

--- a/crates/wcore-providers/tests/provider_anthropic_test.rs
+++ b/crates/wcore-providers/tests/provider_anthropic_test.rs
@@ -32,6 +32,8 @@ fn minimal_request() -> LlmRequest {
         routing_hint: None,
         stop_sequences: Vec::new(),
         web_search: false,
+        conversation_id: None,
+        client_context_tokens: None,
     }
 }
 

--- a/crates/wcore-providers/tests/provider_fallback_e2e.rs
+++ b/crates/wcore-providers/tests/provider_fallback_e2e.rs
@@ -62,6 +62,8 @@ fn dummy_request() -> LlmRequest {
         routing_hint: None,
         stop_sequences: Vec::new(),
         web_search: false,
+        conversation_id: None,
+        client_context_tokens: None,
     }
 }
 

--- a/crates/wcore-providers/tests/provider_openai_test.rs
+++ b/crates/wcore-providers/tests/provider_openai_test.rs
@@ -31,6 +31,8 @@ fn make_request() -> LlmRequest {
         routing_hint: None,
         stop_sequences: Vec::new(),
         web_search: false,
+        conversation_id: None,
+        client_context_tokens: None,
     }
 }
 

--- a/crates/wcore-types/src/llm.rs
+++ b/crates/wcore-types/src/llm.rs
@@ -129,6 +129,23 @@ pub enum LlmEvent {
     /// FluxRouter web_search grounding (contract §5.4): the richer per-source
     /// cards accompanying [`LlmEvent::Citations`]. Emitted once at end-of-stream.
     SearchResults(Vec<FluxSearchResult>),
+    /// #282 contract V1 — Flux SIGNALS-BACK response metadata, parsed from the
+    /// `x-flux-*` response headers and emitted ONCE at stream start (before any
+    /// text deltas). Every field is `Option` because a non-Flux provider never
+    /// sends these headers, so a missing/unparsable header is `None` rather than
+    /// a stream error. Consumed by the engine to reconcile the #255 context
+    /// gauge against the REAL served-model window and to stash live context
+    /// pressure for future scheduling (#280).
+    ProviderMeta {
+        /// `x-flux-routed-model` — the upstream model Flux actually routed to.
+        routed_model: Option<String>,
+        /// `x-flux-model-window` — the routed model's context window (tokens).
+        model_window: Option<u64>,
+        /// `x-flux-context-pressure` — `0.0..=1.0` = required / window.
+        context_pressure: Option<f32>,
+        /// `x-flux-context-tokens-counted` — Flux's own count of the prompt.
+        tokens_counted: Option<u64>,
+    },
 }
 
 /// A single FluxRouter / Perplexity-Sonar web_search source card (contract

--- a/crates/wcore-types/src/llm.rs
+++ b/crates/wcore-types/src/llm.rs
@@ -72,6 +72,20 @@ pub struct LlmRequest {
     /// the provider skips injection for a concrete model id. `Default` is
     /// `false`, so all existing construction sites stay ungrounded.
     pub web_search: bool,
+    /// #282 contract V1: stable, per-session conversation id for Flux sticky
+    /// routing. Emitted as the `x-wl-conversation-id` request header ONLY on a
+    /// Flux tier-alias request; `None` (the default) skips the header, so all
+    /// existing `..Default::default()` construction sites stay back-compatible.
+    /// Minted once at engine construction with a v4 UUID and threaded onto every
+    /// request the engine builds.
+    pub conversation_id: Option<String>,
+    /// #282 contract V1: the full assembled-prompt token estimate for this turn
+    /// (system + tools + messages), as computed by the engine before the stream
+    /// call. Emitted as the `x-wl-context-tokens` request header ONLY on a Flux
+    /// tier-alias request; `None` (the default) skips the header. Kept as an
+    /// `Option` so providers/tests that don't supply an estimate stay
+    /// back-compatible via `..Default::default()`.
+    pub client_context_tokens: Option<u64>,
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
The **wcore client half** of the Core↔Flux context-aware routing contract (#282). Flux's server half is live + enabled in prod (`api.fluxrouter.ai`); this builds Core's side against the frozen spec. Client owns compaction, router routes, provider enforces the window.

## What it does (tier-alias Flux requests only — `flux-auto`/`flux-fast`/`flux-standard`/`flux-reasoning`; a concrete model id opts out)
**Emit (request headers)** — gated strictly on `is_flux_tier_alias(&request.model)`, so every non-Flux request is byte-for-byte unchanged:
- `x-wl-context-tokens` (assembled prompt estimate) · `x-wl-expected-output` (max_tokens) · `x-wl-context-managed: true` · `x-wl-conversation-id` (stable per-engine UUID).

**Handle overflow (HTTP 409)** — `parse_flux_409` matches the structured body's `error == "context_overflow"` field (never a substring/status alone) → new non-retryable `ProviderError::ContextOverflow { required_tokens, model_window, routed_model, message }`. The engine catches it, runs one compaction pass, and retries the same turn **once** (hard-bounded by an `overflow_retried` guard — a persistently-overflowing turn terminates cleanly, no loop). The retry-compaction reuses `run_compaction` (hardened against orphaned tool pairs by #285).

**Consume signal-back (response headers)** — new `LlmEvent::ProviderMeta { routed_model, model_window, context_pressure, tokens_counted }` captured from the response before the SSE body is read; the engine reconciles the #255 active-window denominator against the *real served-model* window (`x-flux-model-window`) and stashes pressure for #280.

## Scope
V1 only. V2 (cost-decision states, cache-sticky routing, compaction-summary routing) is explicitly HELD. No `#280` scheduling yet (it doesn't exist) — pressure is captured, not acted on. The gauge reconciliation feeds the #255 pre-flight guard; once #279's gauge emitter lands it should also consume `flux_served_window`.

## Design notes
- All new `LlmRequest`/`LlmEvent`/engine fields are additive (`Option` + derived `Default`); no provider-quirk hardcoding — gated on `is_flux_tier_alias` + provider type, the existing pattern.
- `ProviderError::ContextOverflow` classified as `FailoverReason::ContextOverflow` (compact/retry same provider, never failover), mirroring `PromptTooLong`.

## Verification (Hetzner gate, workspace)
`fmt --check` clean · `clippy --workspace --all-targets -D warnings` clean · `nextest --workspace` **9130 passed** (1 known flake: `http_fetch_honors_per_call_timeout`, unrelated timing test). New tests: `parse_flux_409` shapes, header gating (alias vs concrete model), `context_overflow_is_not_retryable`, `parse_flux_response_meta`, and two engine tests (single-overflow compacts+retries+succeeds; persistent-overflow retries once then terminal).

Refs #282. Coupled to #285 (no-orphan compaction). Built on #255 (#74).