### PR TITLE
feat(#280): smart auto-compaction at active-window threshold (default-off, Flux-aware, memory handoff)

### DIFF
--- a/crates/wcore-agent/src/engine.rs
+++ b/crates/wcore-agent/src/engine.rs
@@ -1327,8 +1327,28 @@ pub struct AgentEngine {
     flux_served_window: Option<u64>,
     /// #282 contract V1: the LAST-seen Flux context pressure
     /// (`x-flux-context-pressure`, `0.0..=1.0` = required / window). Captured
-    /// for future #280 pressure-driven scheduling; not yet acted upon.
+    /// for #280 pressure-driven scheduling (see `smart_compact_fraction`).
     flux_context_pressure: Option<f32>,
+    /// #280 smart auto-compaction — anti-thrash + one-shot wiring. ALL inert
+    /// unless `compact_config.smart_enabled` (the single chokepoint is
+    /// `smart_compact_fraction`, which returns `None` before touching any of
+    /// these when the gate is off).
+    ///
+    /// HYSTERESIS arm flag: true = a proactive compact may fire when the
+    /// fraction crosses the trigger. Flips false on a fire and re-arms only
+    /// once a later turn's fraction drops below the release low-water.
+    smart_compact_armed: bool,
+    /// COOLDOWN watermark: the last turn index a smart compact fired, so two
+    /// fires are spaced at least `smart_cooldown_turns` apart (absorbs the
+    /// post-stream watermark refresh lag).
+    smart_compact_last_turn: Option<u32>,
+    /// TERMINAL cannot-shrink latch: once a smart-forced compact frees fewer
+    /// than `smart_min_shrink_tokens`, smart compaction is OFF for the session.
+    smart_compact_exhausted: bool,
+    /// One-shot: set true by the turn-top pre-gate when a smart compact should
+    /// fire, then consumed via `std::mem::take` inside `run_compaction` so the
+    /// existing autocompact path runs even though the static threshold is unmet.
+    smart_compact_force: bool,
 }
 
 impl Drop for AgentEngine {
@@ -1587,6 +1607,11 @@ impl AgentEngine {
             // #282: no Flux signal-back seen yet at construction.
             flux_served_window: None,
             flux_context_pressure: None,
+            // #280: smart auto-compaction starts armed; latches seeded clear.
+            smart_compact_armed: true,
+            smart_compact_last_turn: None,
+            smart_compact_exhausted: false,
+            smart_compact_force: false,
         }
     }
 
@@ -1756,6 +1781,11 @@ impl AgentEngine {
             // #282: no Flux signal-back seen yet at construction.
             flux_served_window: None,
             flux_context_pressure: None,
+            // #280: smart auto-compaction starts armed; latches seeded clear.
+            smart_compact_armed: true,
+            smart_compact_last_turn: None,
+            smart_compact_exhausted: false,
+            smart_compact_force: false,
         }
     }
 
@@ -3476,6 +3506,181 @@ impl AgentEngine {
         .percent()
     }
 
+    /// #280 — the SINGLE chokepoint for smart auto-compaction. Returns the
+    /// Flux-aware active-window fraction (0.0..) of the CURRENTLY-active model,
+    /// or `None` when the feature is disabled OR the window is unknown.
+    ///
+    /// Default-OFF guarantee: when `smart_enabled` is false this returns `None`
+    /// on its first line, before reading any state — so the turn-top pre-gate
+    /// never touches memory or the force flag and `run_compaction` is byte-for-
+    /// byte unchanged.
+    ///
+    /// Re-eval-on-swap is STRUCTURAL: this reads `self.model` /
+    /// `flux_served_window` / `flux_context_pressure` fresh each turn (the model
+    /// swap was already applied by `apply_pre_turn_outcome`), so there is no
+    /// stored trigger state to invalidate.
+    fn smart_compact_fraction(&self) -> Option<f64> {
+        // Chokepoint: nothing below runs unless explicitly enabled.
+        if !self.compact_config.smart_enabled {
+            return None;
+        }
+        use wcore_config::context_window::ContextWindow;
+        // Finding #174 — the same REAL-pressure watermark the static auto
+        // trigger trusts. On turn 1 it is 0 → fraction 0.0 → never fires before
+        // any stream completes.
+        let used_tokens = self.compact_state.last_real_input_tokens;
+
+        // Flux-aware denominator, mirroring the pre-flight guard + #282
+        // reconciliation: prefer the REAL served-model window when Flux signalled
+        // it back for a tier alias; else the #255 kernel resolution.
+        let kernel_fraction: Option<f64> = if wcore_providers::is_flux_tier_alias(&self.model)
+            && self.flux_served_window.is_some()
+        {
+            ContextWindow {
+                used_tokens,
+                window: self.flux_served_window,
+            }
+            .fraction()
+        } else {
+            ContextWindow::resolve(
+                used_tokens,
+                self.compat.provider_type(),
+                &self.model,
+                self.compact_config.context_window as u64,
+            )
+            .fraction()
+        };
+
+        // The Flux-signalled pressure header is served-model ground truth; it
+        // only ADDS fires via max() so an overload trips even when the local
+        // token estimate lags.
+        let pressure_candidate: Option<f64> = self.flux_context_pressure.map(|p| p as f64);
+
+        match (kernel_fraction, pressure_candidate) {
+            (Some(k), Some(p)) => Some(k.max(p)),
+            (Some(k), None) => Some(k),
+            // Kernel window unknown but Flux gave pressure → use pressure alone.
+            (None, Some(p)) => Some(p),
+            // Fail open: never fabricate a denominator.
+            (None, None) => None,
+        }
+    }
+
+    /// #280 — anti-thrash decision. Three independent latches; ALL must clear to
+    /// re-fire. The arm flag flips and the cooldown watermark stamps HERE (at the
+    /// decision point), not inside `run_compaction`, so a circuit-broken or
+    /// erroring autocompact cannot hot-loop the failing summarization every turn.
+    fn smart_compact_should_fire(&mut self, turn: u32, frac: f64) -> bool {
+        // TERMINAL cannot-shrink latch.
+        if self.smart_compact_exhausted {
+            return false;
+        }
+        let trigger = self.compact_config.smart_trigger_fraction.clamp(0.60, 0.70);
+        // A mis-set release >= trigger can never collapse hysteresis.
+        let release = self
+            .compact_config
+            .smart_release_fraction
+            .min(trigger - 0.05);
+
+        // HYSTERESIS RE-ARM: while disarmed we only re-arm (never fire the same
+        // turn, since release < trigger).
+        if !self.smart_compact_armed {
+            if frac < release {
+                self.smart_compact_armed = true;
+            }
+            return false;
+        }
+
+        // COOLDOWN: min completed turns between two fires.
+        if let Some(last) = self.smart_compact_last_turn
+            && turn.saturating_sub(last) < self.compact_config.smart_cooldown_turns
+        {
+            return false;
+        }
+
+        // FIRE TEST.
+        if self.smart_compact_armed && frac >= trigger {
+            self.smart_compact_armed = false;
+            self.smart_compact_last_turn = Some(turn);
+            return true;
+        }
+        false
+    }
+
+    /// #280 — record ONE additive, non-destructive handoff Episode to long-term
+    /// memory BEFORE `run_compaction` mutates the buffer, so the verbatim
+    /// pre-compaction transcript survives even if the LLM summary rewords prose.
+    ///
+    /// Non-destructive by construction: `record_episode` is a pure INSERT that
+    /// never touches `self.messages`; a failure is logged-and-swallowed (never
+    /// propagated) so a memory outage cannot abort or alter the turn. With
+    /// `NullMemory` installed this is a no-op stub.
+    async fn write_smart_handoff(&self) {
+        use wcore_memory::v2_types::{Episode, EpisodeId, EpisodeStatus, Tier};
+
+        // VERBATIM role-tagged concatenation of the current buffer's text blocks
+        // (the live conversation about to be summarized) — captured from the
+        // LIVE buffer, not the post-fold result, so nothing is lost.
+        let mut summary = String::new();
+        let mut live_user_text: Option<String> = None;
+        for m in &self.messages {
+            let role = match m.role {
+                Role::User => "user",
+                Role::Assistant => "assistant",
+                Role::System => "system",
+                Role::Tool => "tool",
+            };
+            for block in &m.content {
+                if let ContentBlock::Text { text } = block {
+                    summary.push_str(role);
+                    summary.push_str(": ");
+                    summary.push_str(text);
+                    summary.push('\n');
+                    if matches!(m.role, Role::User) {
+                        live_user_text = Some(text.clone());
+                    }
+                }
+            }
+        }
+
+        // Cheap heuristic bullets — NO extra LLM call.
+        let mut atomic_facts: Vec<String> = Vec::new();
+        if let Some(t) = live_user_text {
+            atomic_facts.push(t);
+        }
+        let pre_estimate = self.compact_state.last_real_input_tokens;
+        atomic_facts.push(format!("pre_compact_estimate: {pre_estimate}"));
+        if let Some(pct) = self.active_window_percent_now(&self.model, pre_estimate) {
+            atomic_facts.push(format!("active_window_percent: {pct}"));
+        }
+
+        let ep = Episode {
+            id: EpisodeId::new(),
+            tier: Tier::Session,
+            ts: wcore_memory::audit::now_secs(),
+            episode_type: "compaction_handoff".into(),
+            summary,
+            atomic_facts,
+            source: "smart_compact".into(),
+            source_product: "wcore-compact".into(),
+            session_id: Some(self.conversation_id.clone()),
+            project_root: None,
+            decay_score: 1.0,
+            status: EpisodeStatus::Active,
+        };
+        if let Err(e) = self
+            .memory_api
+            .record_episode(ep, wcore_memory::AccessToken::MainAgent)
+            .await
+        {
+            tracing::warn!(
+                target: "wcore_agent::memory",
+                error = %e,
+                "#280 smart handoff record_episode failed; continuing"
+            );
+        }
+    }
+
     /// Run the agent loop with user input
     pub async fn run(&mut self, user_input: &str, msg_id: &str) -> Result<AgentResult, AgentError> {
         // methodology #27: production caller for StyleDetector::observe (Task 1.B.3)
@@ -3668,6 +3873,30 @@ impl AgentEngine {
                 let outcome = hook_engine.run_pre_compact(turn, self.messages.len()).await;
                 for line in outcome.hook_trace {
                     tracing::debug!(target: "wcore_agent::hooks", "{line}");
+                }
+            }
+
+            // #280 — smart auto-compaction pre-gate. Boundary-fire ONLY: this is
+            // the turn-loop top (the tool loop lives below provider.stream in the
+            // same iteration), and the model swap was already applied above, so
+            // the Flux-aware fraction is computed against the CURRENTLY-active
+            // model. Default-OFF: `smart_compact_fraction` returns `None` on its
+            // first line when disabled, so neither memory nor the force flag is
+            // touched and `run_compaction` below behaves exactly as before. On a
+            // fire we (1) persist a non-destructive handoff Episode, then (2) set
+            // the one-shot force flag and fall straight through into the existing
+            // `run_compaction` — no new summarization / fold / emit code.
+            let smart_fired = match self.smart_compact_fraction() {
+                Some(frac) => self.smart_compact_should_fire(turn as u32, frac),
+                None => false,
+            };
+            if smart_fired {
+                self.smart_compact_force = true;
+                if self.compact_config.smart_handoff_to_memory {
+                    // Persist BEFORE run_compaction mutates the buffer so the
+                    // verbatim pre-compaction transcript is durable; errors are
+                    // swallowed and never abort the turn.
+                    self.write_smart_handoff().await;
                 }
             }
 
@@ -5629,10 +5858,17 @@ impl AgentEngine {
         // (provider-reported billed input, thinking excluded for non-
         // replaying providers), NOT the conservative `last_input_tokens`
         // the EMERGENCY hard-stop uses. This stops premature compaction.
-        let should_compact = auto::should_autocompact(
-            self.compact_state.last_real_input_tokens,
-            &self.compact_config,
-        );
+        // #280 — consume the one-shot smart force flag (set by the turn-top
+        // pre-gate). `std::mem::take` makes it strictly one-shot per arming and
+        // consumes it whether or not the circuit breaker lets the compact run,
+        // so a tripped breaker can't latch it. `smart_drove` is reused below for
+        // the CompactOffload reason string and the cannot-shrink latch.
+        let smart_drove = std::mem::take(&mut self.smart_compact_force);
+        let should_compact = smart_drove
+            || auto::should_autocompact(
+                self.compact_state.last_real_input_tokens,
+                &self.compact_config,
+            );
         if should_compact && !self.compact_state.is_circuit_broken(&self.compact_config) {
             let provider = Arc::clone(&self.provider);
             // AUDIT A4 — `run_compaction` runs at the TOP of the turn
@@ -5735,9 +5971,21 @@ impl AgentEngine {
                         estimate::estimate_tokens_from_messages(&self.messages);
                     let tokens_freed =
                         result_pre_compact_tokens.saturating_sub(post_compact_tokens);
+                    // #280 — when the smart trigger drove this pass, tag the host
+                    // chip with smart provenance (free-form String field, forward-
+                    // compatible) and arm the cannot-shrink terminal latch if the
+                    // compaction freed less than the configured floor.
+                    if smart_drove && tokens_freed < self.compact_config.smart_min_shrink_tokens {
+                        self.smart_compact_exhausted = true;
+                    }
+                    let reason = if smart_drove {
+                        "smart_window_pressure"
+                    } else {
+                        "window_pressure"
+                    };
                     self.output.emit_compaction(
                         &self.current_msg_id,
-                        "window_pressure",
+                        reason,
                         tokens_freed,
                         self.active_window_percent_now(&self.model, post_compact_tokens),
                     );
@@ -7622,6 +7870,10 @@ mod set_config_tests {
             conversation_id: String::new(),
             flux_served_window: None,
             flux_context_pressure: None,
+            smart_compact_armed: true,
+            smart_compact_last_turn: None,
+            smart_compact_exhausted: false,
+            smart_compact_force: false,
         }
     }
 
@@ -8443,6 +8695,10 @@ mod phase6_tests {
             conversation_id: String::new(),
             flux_served_window: None,
             flux_context_pressure: None,
+            smart_compact_armed: true,
+            smart_compact_last_turn: None,
+            smart_compact_exhausted: false,
+            smart_compact_force: false,
         }
     }
 
@@ -8731,6 +8987,10 @@ mod compact_tests {
             conversation_id: String::new(),
             flux_served_window: None,
             flux_context_pressure: None,
+            smart_compact_armed: true,
+            smart_compact_last_turn: None,
+            smart_compact_exhausted: false,
+            smart_compact_force: false,
         }
     }
 
@@ -10049,6 +10309,10 @@ mod plan_mode_tests {
             conversation_id: String::new(),
             flux_served_window: None,
             flux_context_pressure: None,
+            smart_compact_armed: true,
+            smart_compact_last_turn: None,
+            smart_compact_exhausted: false,
+            smart_compact_force: false,
         }
     }
 
@@ -10470,6 +10734,10 @@ mod hook_integration_tests {
             conversation_id: String::new(),
             flux_served_window: None,
             flux_context_pressure: None,
+            smart_compact_armed: true,
+            smart_compact_last_turn: None,
+            smart_compact_exhausted: false,
+            smart_compact_force: false,
         }
     }
 
@@ -11044,6 +11312,8 @@ mod approval_bridge_engine_tests {
     use wcore_tools::registry::ToolRegistry;
     use wcore_types::llm::{LlmEvent, LlmRequest};
     use wcore_types::message::FinishReason;
+    // #280 smart-compaction tests construct conversation messages directly.
+    use wcore_types::message::{ContentBlock, Message, Role};
 
     use crate::approval::{ApprovalBridge, ApprovalOutcome, ApprovalRequest};
     use crate::compact::state::CompactState;
@@ -11187,6 +11457,10 @@ mod approval_bridge_engine_tests {
             conversation_id: String::new(),
             flux_served_window: None,
             flux_context_pressure: None,
+            smart_compact_armed: true,
+            smart_compact_last_turn: None,
+            smart_compact_exhausted: false,
+            smart_compact_force: false,
         }
     }
 
@@ -11247,6 +11521,421 @@ mod approval_bridge_engine_tests {
             )
             .await;
         assert!(!resolved);
+    }
+
+    // --- #280 smart auto-compaction ---------------------------------------
+
+    /// Default-OFF: with `smart_enabled` false, `smart_compact_fraction` returns
+    /// `None` even at extreme pressure — the single chokepoint that keeps the
+    /// whole feature inert and `run_compaction` byte-for-byte unchanged.
+    #[test]
+    fn smart_default_off_fraction_is_none_at_any_pressure() {
+        let mut engine = make_engine();
+        // Slam the watermark well past any window; gate is still off by default.
+        engine.compact_state.last_real_input_tokens = 10_000_000;
+        assert!(!engine.compact_config.smart_enabled);
+        assert_eq!(engine.smart_compact_fraction(), None);
+    }
+
+    /// When enabled, the fraction is computed against the active model's window.
+    /// "test-model" is unknown → resolves to the config window (200k), so 130k
+    /// used ≈ 0.65. At a small fill it must be well under the trigger.
+    #[test]
+    fn smart_fraction_uses_config_window_for_unknown_model() {
+        let mut engine = make_engine();
+        engine.compact_config.smart_enabled = true;
+        engine.compact_config.context_window = 200_000;
+        engine.compact_state.last_real_input_tokens = 130_000;
+        let frac = engine.smart_compact_fraction().expect("window known");
+        assert!((frac - 0.65).abs() < 0.01, "frac was {frac}");
+        engine.compact_state.last_real_input_tokens = 60_000;
+        let low = engine.smart_compact_fraction().expect("window known");
+        assert!(low < 0.35, "low frac was {low}");
+    }
+
+    /// Flux-aware denominator: a tier-alias model with a served window prefers
+    /// that window; a Flux pressure header forces a higher effective fraction
+    /// via the max() path even when the local estimate lags.
+    #[test]
+    fn smart_fraction_prefers_flux_served_window_and_pressure() {
+        let mut engine = make_engine();
+        engine.compact_config.smart_enabled = true;
+        // A Flux tier alias so the served-window branch is taken.
+        engine.model = "flux-auto".into();
+        engine.flux_served_window = Some(280_000);
+        engine.compact_state.last_real_input_tokens = 200_000;
+        // 200k / 280k ≈ 0.714.
+        let frac = engine.smart_compact_fraction().expect("served window set");
+        assert!((frac - 0.714).abs() < 0.01, "frac was {frac}");
+
+        // Larger served window lowers the fraction.
+        engine.flux_served_window = Some(400_000);
+        let lower = engine.smart_compact_fraction().expect("served window set");
+        assert!(lower < 0.55, "lower frac was {lower}");
+
+        // A high pressure header forces a higher effective fraction via max()
+        // even though the kernel fraction (200k/400k = 0.5) is lower.
+        engine.flux_context_pressure = Some(0.70);
+        let forced = engine.smart_compact_fraction().expect("pressure set");
+        // The f32 pressure header (≈0.70) wins over the kernel fraction (0.50)
+        // via max(); allow for f32→f64 rounding.
+        assert!(forced > 0.69, "forced frac was {forced}");
+    }
+
+    /// Fire test + the band clamp: an out-of-band trigger (0.95) is clamped to
+    /// 0.70; a fraction at/above the clamped trigger fires once and disarms.
+    #[test]
+    fn smart_should_fire_clamps_trigger_and_disarms() {
+        let mut engine = make_engine();
+        engine.compact_config.smart_trigger_fraction = 0.95; // → clamped 0.70
+        // 0.69 is below the clamped 0.70 trigger → no fire.
+        assert!(!engine.smart_compact_should_fire(1, 0.69));
+        assert!(engine.smart_compact_armed);
+        // 0.72 >= clamped 0.70 → fire, then disarm.
+        assert!(engine.smart_compact_should_fire(1, 0.72));
+        assert!(!engine.smart_compact_armed);
+        assert_eq!(engine.smart_compact_last_turn, Some(1));
+    }
+
+    /// Hysteresis: across turns the trigger fires, stays disarmed through the
+    /// dead band, re-arms only once the fraction drops below release, then fires
+    /// again — exactly two fires.
+    #[test]
+    fn smart_hysteresis_two_fires_across_turns() {
+        let mut engine = make_engine();
+        engine.compact_config.smart_trigger_fraction = 0.65;
+        engine.compact_config.smart_release_fraction = 0.50;
+        engine.compact_config.smart_cooldown_turns = 0; // isolate hysteresis
+        let fracs = [0.66_f64, 0.62, 0.55, 0.48, 0.66];
+        let mut fires = 0;
+        for (i, f) in fracs.iter().enumerate() {
+            if engine.smart_compact_should_fire(i as u32 + 1, *f) {
+                fires += 1;
+            }
+        }
+        assert_eq!(fires, 2, "expected fires at turns 1 and 5 only");
+    }
+
+    /// Cooldown: with cooldown 2 and the fraction held above the trigger, fires
+    /// are spaced at least 2 turns apart. Re-arm each turn to isolate cooldown
+    /// from hysteresis.
+    #[test]
+    fn smart_cooldown_spaces_fires() {
+        let mut engine = make_engine();
+        engine.compact_config.smart_trigger_fraction = 0.65;
+        engine.compact_config.smart_cooldown_turns = 2;
+        let mut fire_turns = Vec::new();
+        for turn in 1..=6u32 {
+            engine.smart_compact_armed = true; // bypass hysteresis
+            if engine.smart_compact_should_fire(turn, 0.80) {
+                fire_turns.push(turn);
+            }
+        }
+        // First fire at turn 1; next allowed at turn >= 3, then >= 5.
+        assert_eq!(fire_turns, vec![1, 3, 5]);
+    }
+
+    /// Cannot-shrink terminal latch: once exhausted, the trigger never fires
+    /// again even at extreme pressure and after release would otherwise re-arm.
+    #[test]
+    fn smart_exhausted_latch_is_terminal() {
+        let mut engine = make_engine();
+        engine.compact_config.smart_trigger_fraction = 0.65;
+        engine.compact_config.smart_cooldown_turns = 0;
+        engine.smart_compact_exhausted = true;
+        for turn in 1..=5u32 {
+            engine.smart_compact_armed = true;
+            assert!(!engine.smart_compact_should_fire(turn, 0.99));
+        }
+    }
+
+    /// Giant-buffer / stays-above-release case: a fraction permanently above
+    /// release fires exactly once, then the trigger stays disarmed forever.
+    #[test]
+    fn smart_stays_disarmed_when_above_release() {
+        let mut engine = make_engine();
+        engine.compact_config.smart_trigger_fraction = 0.65;
+        engine.compact_config.smart_release_fraction = 0.50;
+        engine.compact_config.smart_cooldown_turns = 0;
+        let mut fires = 0;
+        for turn in 1..=6u32 {
+            // Held at 0.80: above both trigger and release every turn.
+            if engine.smart_compact_should_fire(turn, 0.80) {
+                fires += 1;
+            }
+        }
+        assert_eq!(fires, 1, "must fire once then stay disarmed");
+    }
+
+    /// Handoff write: a smart handoff records exactly one Episode tagged
+    /// compaction_handoff/Session/smart_compact via MainAgent, and the
+    /// conversation buffer is left intact (non-destructive).
+    #[tokio::test]
+    async fn smart_handoff_records_one_session_episode_non_destructively() {
+        use std::sync::Mutex as StdMutex;
+        use wcore_memory::v2_types::Episode;
+
+        // Capture episodes; delegate every other MemoryApi method to NullMemory
+        // so the stub stays a complete, correct impl without re-stubbing 13
+        // methods.
+        #[derive(Default)]
+        struct CapturingMemory {
+            episodes: StdMutex<Vec<Episode>>,
+            inner: wcore_memory::NullMemory,
+        }
+        #[async_trait::async_trait]
+        impl wcore_memory::MemoryApi for CapturingMemory {
+            async fn record_episode(
+                &self,
+                ep: Episode,
+                tok: wcore_memory::AccessToken,
+            ) -> wcore_memory::error::Result<wcore_memory::v2_types::EpisodeId> {
+                self.episodes.lock().unwrap().push(ep.clone());
+                self.inner.record_episode(ep, tok).await
+            }
+            async fn assert_fact(
+                &self,
+                f: wcore_memory::v2_types::Fact,
+                tok: wcore_memory::AccessToken,
+            ) -> wcore_memory::error::Result<wcore_memory::v2_types::FactId> {
+                self.inner.assert_fact(f, tok).await
+            }
+            async fn upsert_procedure(
+                &self,
+                p: wcore_memory::v2_types::Procedure,
+                tok: wcore_memory::AccessToken,
+            ) -> wcore_memory::error::Result<wcore_memory::v2_types::ProcedureId> {
+                self.inner.upsert_procedure(p, tok).await
+            }
+            async fn list_procedures(
+                &self,
+                tier: wcore_memory::v2_types::Tier,
+                tok: wcore_memory::AccessToken,
+            ) -> wcore_memory::error::Result<Vec<wcore_memory::v2_types::Procedure>> {
+                self.inner.list_procedures(tier, tok).await
+            }
+            async fn update_user_model(
+                &self,
+                key: &str,
+                val: serde_json::Value,
+                tok: wcore_memory::AccessToken,
+            ) -> wcore_memory::error::Result<()> {
+                self.inner.update_user_model(key, val, tok).await
+            }
+            async fn search(
+                &self,
+                q: wcore_memory::v2_types::Query,
+                tok: wcore_memory::AccessToken,
+            ) -> wcore_memory::error::Result<Vec<wcore_memory::v2_types::Hit>> {
+                self.inner.search(q, tok).await
+            }
+            async fn get_episode(
+                &self,
+                id: &wcore_memory::v2_types::EpisodeId,
+                tok: wcore_memory::AccessToken,
+            ) -> wcore_memory::error::Result<Episode> {
+                self.inner.get_episode(id, tok).await
+            }
+            async fn user_model(
+                &self,
+                tok: wcore_memory::AccessToken,
+            ) -> wcore_memory::error::Result<wcore_memory::v2_types::UserModel> {
+                self.inner.user_model(tok).await
+            }
+            async fn dream_now(
+                &self,
+            ) -> wcore_memory::error::Result<wcore_memory::v2_types::DreamReport> {
+                self.inner.dream_now().await
+            }
+            async fn compact(
+                &self,
+                target_tokens: u64,
+            ) -> wcore_memory::error::Result<wcore_memory::v2_types::CompactReport> {
+                self.inner.compact(target_tokens).await
+            }
+            async fn record_skill_use(
+                &self,
+                name: &str,
+                succeeded: bool,
+                latency_ms: u64,
+            ) -> wcore_memory::error::Result<()> {
+                self.inner
+                    .record_skill_use(name, succeeded, latency_ms)
+                    .await
+            }
+            async fn top_procedures(
+                &self,
+                tier: wcore_memory::v2_types::Tier,
+                k: usize,
+                min_uses: u64,
+                tok: wcore_memory::AccessToken,
+            ) -> wcore_memory::error::Result<Vec<wcore_memory::v2_types::Procedure>> {
+                self.inner.top_procedures(tier, k, min_uses, tok).await
+            }
+            async fn kg_ingest_facts(
+                &self,
+                transcript: &str,
+            ) -> wcore_memory::error::Result<usize> {
+                self.inner.kg_ingest_facts(transcript).await
+            }
+        }
+
+        let mut engine = make_engine();
+        let mem = Arc::new(CapturingMemory::default());
+        engine.memory_api = mem.clone();
+        engine.conversation_id = "conv-280".into();
+        engine.messages = vec![
+            Message::now(
+                Role::User,
+                vec![ContentBlock::Text {
+                    text: "fix the failing test".into(),
+                }],
+            ),
+            Message::now(
+                Role::Assistant,
+                vec![ContentBlock::Text {
+                    text: "looking into it".into(),
+                }],
+            ),
+        ];
+        let before = engine.messages.len();
+
+        engine.write_smart_handoff().await;
+
+        let eps = mem.episodes.lock().unwrap();
+        assert_eq!(eps.len(), 1, "exactly one episode recorded");
+        let ep = &eps[0];
+        assert_eq!(ep.episode_type, "compaction_handoff");
+        assert_eq!(ep.source, "smart_compact");
+        assert_eq!(ep.tier, wcore_memory::v2_types::Tier::Session);
+        assert_eq!(ep.session_id.as_deref(), Some("conv-280"));
+        assert!(ep.summary.contains("fix the failing test"));
+        assert!(ep.summary.contains("looking into it"));
+        // Non-destructive: the buffer was not touched.
+        assert_eq!(engine.messages.len(), before);
+    }
+
+    /// A memory backend that errors must NOT abort the handoff path — the error
+    /// is swallowed so the turn proceeds.
+    #[tokio::test]
+    async fn smart_handoff_swallows_memory_errors() {
+        // record_episode errors; everything else delegates to NullMemory. The
+        // handoff path must swallow the error and never abort the turn.
+        #[derive(Default)]
+        struct FailingMemory {
+            inner: wcore_memory::NullMemory,
+        }
+        #[async_trait::async_trait]
+        impl wcore_memory::MemoryApi for FailingMemory {
+            async fn record_episode(
+                &self,
+                _ep: wcore_memory::v2_types::Episode,
+                _tok: wcore_memory::AccessToken,
+            ) -> wcore_memory::error::Result<wcore_memory::v2_types::EpisodeId> {
+                Err(wcore_memory::error::MemoryError::AccessDenied {
+                    partition: "test".into(),
+                    tier: "session".into(),
+                    reason: "boom".into(),
+                })
+            }
+            async fn assert_fact(
+                &self,
+                f: wcore_memory::v2_types::Fact,
+                tok: wcore_memory::AccessToken,
+            ) -> wcore_memory::error::Result<wcore_memory::v2_types::FactId> {
+                self.inner.assert_fact(f, tok).await
+            }
+            async fn upsert_procedure(
+                &self,
+                p: wcore_memory::v2_types::Procedure,
+                tok: wcore_memory::AccessToken,
+            ) -> wcore_memory::error::Result<wcore_memory::v2_types::ProcedureId> {
+                self.inner.upsert_procedure(p, tok).await
+            }
+            async fn list_procedures(
+                &self,
+                tier: wcore_memory::v2_types::Tier,
+                tok: wcore_memory::AccessToken,
+            ) -> wcore_memory::error::Result<Vec<wcore_memory::v2_types::Procedure>> {
+                self.inner.list_procedures(tier, tok).await
+            }
+            async fn update_user_model(
+                &self,
+                key: &str,
+                val: serde_json::Value,
+                tok: wcore_memory::AccessToken,
+            ) -> wcore_memory::error::Result<()> {
+                self.inner.update_user_model(key, val, tok).await
+            }
+            async fn search(
+                &self,
+                q: wcore_memory::v2_types::Query,
+                tok: wcore_memory::AccessToken,
+            ) -> wcore_memory::error::Result<Vec<wcore_memory::v2_types::Hit>> {
+                self.inner.search(q, tok).await
+            }
+            async fn get_episode(
+                &self,
+                id: &wcore_memory::v2_types::EpisodeId,
+                tok: wcore_memory::AccessToken,
+            ) -> wcore_memory::error::Result<wcore_memory::v2_types::Episode> {
+                self.inner.get_episode(id, tok).await
+            }
+            async fn user_model(
+                &self,
+                tok: wcore_memory::AccessToken,
+            ) -> wcore_memory::error::Result<wcore_memory::v2_types::UserModel> {
+                self.inner.user_model(tok).await
+            }
+            async fn dream_now(
+                &self,
+            ) -> wcore_memory::error::Result<wcore_memory::v2_types::DreamReport> {
+                self.inner.dream_now().await
+            }
+            async fn compact(
+                &self,
+                target_tokens: u64,
+            ) -> wcore_memory::error::Result<wcore_memory::v2_types::CompactReport> {
+                self.inner.compact(target_tokens).await
+            }
+            async fn record_skill_use(
+                &self,
+                name: &str,
+                succeeded: bool,
+                latency_ms: u64,
+            ) -> wcore_memory::error::Result<()> {
+                self.inner
+                    .record_skill_use(name, succeeded, latency_ms)
+                    .await
+            }
+            async fn top_procedures(
+                &self,
+                tier: wcore_memory::v2_types::Tier,
+                k: usize,
+                min_uses: u64,
+                tok: wcore_memory::AccessToken,
+            ) -> wcore_memory::error::Result<Vec<wcore_memory::v2_types::Procedure>> {
+                self.inner.top_procedures(tier, k, min_uses, tok).await
+            }
+            async fn kg_ingest_facts(
+                &self,
+                transcript: &str,
+            ) -> wcore_memory::error::Result<usize> {
+                self.inner.kg_ingest_facts(transcript).await
+            }
+        }
+
+        let mut engine = make_engine();
+        engine.memory_api = Arc::new(FailingMemory::default());
+        engine.messages = vec![Message::now(
+            Role::User,
+            vec![ContentBlock::Text {
+                text: "hello".into(),
+            }],
+        )];
+        // Must not panic / propagate.
+        engine.write_smart_handoff().await;
+        assert_eq!(engine.messages.len(), 1);
     }
 }
 
@@ -11413,6 +12102,10 @@ mod user_model_writeback_tests {
             conversation_id: String::new(),
             flux_served_window: None,
             flux_context_pressure: None,
+            smart_compact_armed: true,
+            smart_compact_last_turn: None,
+            smart_compact_exhausted: false,
+            smart_compact_force: false,
         }
     }
 

--- a/crates/wcore-agent/src/engine.rs
+++ b/crates/wcore-agent/src/engine.rs
@@ -3610,6 +3610,10 @@ impl AgentEngine {
     /// #280 — record ONE additive, non-destructive handoff Episode to long-term
     /// memory BEFORE `run_compaction` mutates the buffer, so the verbatim
     /// pre-compaction transcript survives even if the LLM summary rewords prose.
+    /// The transcript captures every load-bearing block — assistant/user text,
+    /// the `tool_use` name + args, the `tool_result` bodies (which carry the
+    /// bulk of a coding session's context), and thinking — so the spec's
+    /// "nothing lost" intent holds, not just prose.
     ///
     /// Non-destructive by construction: `record_episode` is a pure INSERT that
     /// never touches `self.messages`; a failure is logged-and-swallowed (never
@@ -3618,11 +3622,15 @@ impl AgentEngine {
     async fn write_smart_handoff(&self) {
         use wcore_memory::v2_types::{Episode, EpisodeId, EpisodeStatus, Tier};
 
-        // VERBATIM role-tagged concatenation of the current buffer's text blocks
-        // (the live conversation about to be summarized) — captured from the
-        // LIVE buffer, not the post-fold result, so nothing is lost.
+        // VERBATIM role-tagged concatenation of the current buffer (the live
+        // conversation about to be summarized), captured from the LIVE buffer
+        // (not the post-fold result). Every content-block kind is preserved —
+        // tool_result bodies are the bulk of real context and MUST survive, so
+        // a text-only handoff would silently drop most of what we promise to
+        // keep.
         let mut summary = String::new();
-        let mut live_user_text: Option<String> = None;
+        // The last USER message's text — the active task — for atomic_facts[0].
+        let mut last_user_text: Option<String> = None;
         for m in &self.messages {
             let role = match m.role {
                 Role::User => "user",
@@ -3630,18 +3638,42 @@ impl AgentEngine {
                 Role::System => "system",
                 Role::Tool => "tool",
             };
+            let mut this_user_text: Option<String> = None;
             for block in &m.content {
-                if let ContentBlock::Text { text } = block {
+                let line = match block {
+                    ContentBlock::Text { text } => {
+                        if matches!(m.role, Role::User) {
+                            this_user_text = Some(text.clone());
+                        }
+                        Some(text.clone())
+                    }
+                    ContentBlock::ToolUse { name, input, .. } => {
+                        Some(format!("tool_use({name}): {input}"))
+                    }
+                    ContentBlock::ToolResult {
+                        tool_use_id,
+                        content,
+                        is_error,
+                    } => Some(format!(
+                        "tool_result({tool_use_id}{}): {content}",
+                        if *is_error { " error" } else { "" }
+                    )),
+                    ContentBlock::Thinking { thinking } => Some(format!("thinking: {thinking}")),
+                };
+                if let Some(line) = line {
                     summary.push_str(role);
                     summary.push_str(": ");
-                    summary.push_str(text);
+                    summary.push_str(&line);
                     summary.push('\n');
-                    if matches!(m.role, Role::User) {
-                        live_user_text = Some(text.clone());
-                    }
                 }
             }
+            // Capture the LAST user message's text (the current task), not the
+            // last text block across all user messages.
+            if this_user_text.is_some() {
+                last_user_text = this_user_text;
+            }
         }
+        let live_user_text = last_user_text;
 
         // Cheap heuristic bullets — NO extra LLM call.
         let mut atomic_facts: Vec<String> = Vec::new();
@@ -11936,6 +11968,174 @@ mod approval_bridge_engine_tests {
         // Must not panic / propagate.
         engine.write_smart_handoff().await;
         assert_eq!(engine.messages.len(), 1);
+    }
+
+    // --- #280 smart compaction through run_compaction() (integration) ------
+
+    /// A provider that always returns a fixed, non-empty summary turn. Reused by
+    /// both run_compaction integration tests so autocompact's summary LLM call
+    /// succeeds deterministically (no live model). Mirrors the `summary_turn`
+    /// shape in `tests/engine_compact_test.rs`.
+    struct SummaryProvider {
+        summary: String,
+    }
+    #[async_trait::async_trait]
+    impl LlmProvider for SummaryProvider {
+        async fn stream(
+            &self,
+            _: &LlmRequest,
+        ) -> Result<tokio::sync::mpsc::Receiver<LlmEvent>, ProviderError> {
+            use wcore_types::message::{StopReason, TokenUsage};
+            let events = vec![
+                LlmEvent::TextDelta(self.summary.clone()),
+                LlmEvent::Done {
+                    stop_reason: StopReason::EndTurn,
+                    finish_reason: FinishReason::from_stop_reason(StopReason::EndTurn),
+                    usage: TokenUsage::default(),
+                },
+            ];
+            let (tx, rx) = tokio::sync::mpsc::channel(16);
+            tokio::spawn(async move {
+                for event in events {
+                    let _ = tx.send(event).await;
+                }
+            });
+            Ok(rx)
+        }
+    }
+
+    /// An OutputSink that captures every `emit_compaction` call so the
+    /// integration tests can read the `CompactOffload` reason string and the
+    /// tokens_freed the engine emitted. Every other method is a no-op.
+    #[derive(Default)]
+    struct CapturingCompactSink {
+        events: std::sync::Mutex<Vec<(String, u64)>>,
+    }
+    impl OutputSink for CapturingCompactSink {
+        fn emit_text_delta(&self, _: &str, _: &str) {}
+        fn emit_thinking(&self, _: &str, _: &str) {}
+        fn emit_tool_call(&self, _: &str, _: &str) {}
+        fn emit_tool_result(&self, _: &str, _: bool, _: &str) {}
+        fn emit_stream_start(&self, _: &str) {}
+        fn emit_stream_end(
+            &self,
+            _: &str,
+            _: usize,
+            _: u64,
+            _: u64,
+            _: u64,
+            _: u64,
+            _: FinishReason,
+        ) {
+        }
+        fn emit_error(&self, _: &str, _: bool) {}
+        fn emit_info(&self, _: &str) {}
+        fn emit_compaction(&self, _: &str, reason: &str, tokens_freed: u64, _: Option<u32>) {
+            self.events
+                .lock()
+                .unwrap()
+                .push((reason.to_string(), tokens_freed));
+        }
+    }
+
+    /// Positive path: `smart_compact_force = true` drives `run_compaction()`
+    /// through the smart branch. The emitted `CompactOffload` carries
+    /// `reason == "smart_window_pressure"`, and because the pre-compaction
+    /// total (`compact_state.last_input_tokens`) dwarfs the post-compaction
+    /// estimate, `tokens_freed >> smart_min_shrink_tokens` and the cannot-shrink
+    /// latch stays clear (`smart_compact_exhausted == false`).
+    #[tokio::test]
+    async fn smart_run_compaction_emits_smart_reason_and_does_not_exhaust() {
+        let mut engine = make_engine();
+        engine.provider = Arc::new(SummaryProvider {
+            summary: "Conversation summary of the prior turns.".into(),
+        });
+        let sink = Arc::new(CapturingCompactSink::default());
+        engine.output = sink.clone();
+
+        // A real, non-User buffer to summarize (a trailing User message would be
+        // popped out as the live turn). pre_compact_tokens == last_input_tokens.
+        engine.messages = vec![Message::now(
+            Role::Assistant,
+            vec![ContentBlock::Text {
+                text: "earlier assistant context that gets summarized".into(),
+            }],
+        )];
+        // Smart drove this pass; pre-compaction total is huge so the freed delta
+        // (pre − tiny post estimate) is far above the 2000-token floor.
+        engine.smart_compact_force = true;
+        engine.compact_state.last_input_tokens = 300_000;
+        assert_eq!(engine.compact_config.smart_min_shrink_tokens, 2_000);
+
+        engine
+            .run_compaction()
+            .await
+            .expect("compaction must succeed");
+
+        let events = sink.events.lock().unwrap();
+        assert_eq!(events.len(), 1, "exactly one CompactOffload emitted");
+        let (reason, tokens_freed) = &events[0];
+        assert_eq!(
+            reason.as_str(),
+            "smart_window_pressure",
+            "smart-driven pass must tag the offload with smart provenance"
+        );
+        assert!(
+            *tokens_freed > engine.compact_config.smart_min_shrink_tokens,
+            "tokens_freed {tokens_freed} must dwarf the {} floor",
+            engine.compact_config.smart_min_shrink_tokens
+        );
+        assert!(
+            !engine.smart_compact_exhausted,
+            "normal shrink must NOT arm the cannot-shrink latch"
+        );
+        // The one-shot force flag is consumed regardless of outcome.
+        assert!(!engine.smart_compact_force);
+    }
+
+    /// Negative path (cannot-shrink latch): a tiny pre-compaction total means the
+    /// freed delta falls below `smart_min_shrink_tokens`, so a smart-driven
+    /// `run_compaction()` arms the terminal `smart_compact_exhausted` latch. The
+    /// offload reason is still the smart string.
+    #[tokio::test]
+    async fn smart_run_compaction_latches_exhausted_when_cannot_shrink() {
+        let mut engine = make_engine();
+        engine.provider = Arc::new(SummaryProvider {
+            summary: "tiny summary".into(),
+        });
+        let sink = Arc::new(CapturingCompactSink::default());
+        engine.output = sink.clone();
+
+        engine.messages = vec![Message::now(
+            Role::Assistant,
+            vec![ContentBlock::Text {
+                text: "small context".into(),
+            }],
+        )];
+        engine.smart_compact_force = true;
+        // pre_compact_tokens far below the 2000 floor → freed delta < floor → the
+        // cannot-shrink latch must arm.
+        engine.compact_state.last_input_tokens = 100;
+        assert!(
+            engine.compact_state.last_input_tokens < engine.compact_config.smart_min_shrink_tokens
+        );
+
+        engine
+            .run_compaction()
+            .await
+            .expect("compaction must succeed");
+
+        assert!(
+            engine.smart_compact_exhausted,
+            "freeing fewer than smart_min_shrink_tokens must latch exhausted"
+        );
+        let events = sink.events.lock().unwrap();
+        assert_eq!(events.len(), 1, "exactly one CompactOffload emitted");
+        assert_eq!(
+            events[0].0.as_str(),
+            "smart_window_pressure",
+            "the cannot-shrink pass is still smart-driven"
+        );
     }
 }
 

--- a/crates/wcore-config/src/compact.rs
+++ b/crates/wcore-config/src/compact.rs
@@ -70,6 +70,43 @@ pub struct CompactConfig {
     /// Default: `None` — use the live model, preserving prior behavior.
     #[serde(default)]
     pub compaction_model: Option<String>,
+
+    // --- #280 smart auto-compaction (default-OFF; soak before enabling) ---
+    /// MASTER GATE for #280 smart auto-compaction. When false (the default),
+    /// NOTHING in the smart path runs: the proactive pre-gate early-returns and
+    /// `run_compaction` behaves byte-for-byte as before this feature landed.
+    /// This is the default-OFF guarantee — flip to true only after a soak.
+    #[serde(default)]
+    pub smart_enabled: bool,
+
+    /// High-water active-window share that ARMS a proactive compact (#280).
+    /// Spec band 0.60–0.70; clamped to that band at the use site so an
+    /// out-of-band TOML value is corrected rather than firing at 1% or never.
+    #[serde(default = "default_smart_trigger_fraction")]
+    pub smart_trigger_fraction: f64,
+
+    /// Hysteresis low-water (#280). After a smart fire the trigger DISARMS and
+    /// re-arms only once a later turn's fraction drops below this. Forced to
+    /// `min(trigger - 0.05)` at the use site so it can never collapse hysteresis.
+    #[serde(default = "default_smart_release_fraction")]
+    pub smart_release_fraction: f64,
+
+    /// Minimum completed turns between two smart fires (#280). Belt-and-
+    /// suspenders for the post-stream watermark refresh lag.
+    #[serde(default = "default_smart_cooldown_turns")]
+    pub smart_cooldown_turns: u32,
+
+    /// Cannot-shrink terminal latch (#280): if a smart-triggered compact frees
+    /// fewer than this many tokens, smart compaction latches OFF for the rest
+    /// of the session (guards against "frees ~nothing, fire forever").
+    #[serde(default = "default_smart_min_shrink_tokens")]
+    pub smart_min_shrink_tokens: u64,
+
+    /// Write the non-destructive handoff Episode to long-term memory on a smart
+    /// fire (#280). Default true, but only reachable when `smart_enabled`. Lets
+    /// the memory write be soaked/disabled independently for NullMemory hosts.
+    #[serde(default = "default_true")]
+    pub smart_handoff_to_memory: bool,
 }
 
 impl Default for CompactConfig {
@@ -88,6 +125,12 @@ impl Default for CompactConfig {
             compaction: wcore_compact::CompactionLevel::default(),
             toon: false,
             compaction_model: None,
+            smart_enabled: false,
+            smart_trigger_fraction: default_smart_trigger_fraction(),
+            smart_release_fraction: default_smart_release_fraction(),
+            smart_cooldown_turns: default_smart_cooldown_turns(),
+            smart_min_shrink_tokens: default_smart_min_shrink_tokens(),
+            smart_handoff_to_memory: true,
         }
     }
 }
@@ -127,6 +170,18 @@ fn default_compactable_tools() -> Vec<String> {
 }
 fn default_true() -> bool {
     true
+}
+fn default_smart_trigger_fraction() -> f64 {
+    0.65
+}
+fn default_smart_release_fraction() -> f64 {
+    0.50
+}
+fn default_smart_cooldown_turns() -> u32 {
+    2
+}
+fn default_smart_min_shrink_tokens() -> u64 {
+    2_000
 }
 
 #[cfg(test)]
@@ -252,6 +307,58 @@ cache_diagnostics = true
         let toml_str = r#"toon = true"#;
         let cfg: CompactConfig = toml::from_str(toml_str).unwrap();
         assert!(cfg.toon);
+    }
+
+    #[test]
+    fn smart_compaction_defaults_off() {
+        // #280: the master gate is OFF by default and the band defaults sit in
+        // the spec band so the use-site clamp is a no-op for the defaults.
+        let cfg = CompactConfig::default();
+        assert!(!cfg.smart_enabled);
+        assert_eq!(cfg.smart_trigger_fraction, 0.65);
+        assert_eq!(cfg.smart_release_fraction, 0.50);
+        assert_eq!(cfg.smart_cooldown_turns, 2);
+        assert_eq!(cfg.smart_min_shrink_tokens, 2_000);
+        assert!(cfg.smart_handoff_to_memory);
+    }
+
+    #[test]
+    fn toml_empty_keeps_smart_off() {
+        // An empty [compact] block must leave smart compaction default-OFF so
+        // existing configs are byte-for-byte unaffected.
+        let cfg: CompactConfig = toml::from_str("").unwrap();
+        assert!(!cfg.smart_enabled);
+        assert!(cfg.smart_handoff_to_memory);
+    }
+
+    #[test]
+    fn toml_smart_partial_override_uses_defaults() {
+        // Only the master gate set; every other smart field keeps its default.
+        let cfg: CompactConfig = toml::from_str("smart_enabled = true").unwrap();
+        assert!(cfg.smart_enabled);
+        assert_eq!(cfg.smart_trigger_fraction, 0.65);
+        assert_eq!(cfg.smart_cooldown_turns, 2);
+        assert_eq!(cfg.smart_min_shrink_tokens, 2_000);
+        assert!(cfg.smart_handoff_to_memory);
+    }
+
+    #[test]
+    fn toml_smart_full_override() {
+        let toml_str = r#"
+smart_enabled = true
+smart_trigger_fraction = 0.68
+smart_release_fraction = 0.45
+smart_cooldown_turns = 4
+smart_min_shrink_tokens = 5000
+smart_handoff_to_memory = false
+"#;
+        let cfg: CompactConfig = toml::from_str(toml_str).unwrap();
+        assert!(cfg.smart_enabled);
+        assert_eq!(cfg.smart_trigger_fraction, 0.68);
+        assert_eq!(cfg.smart_release_fraction, 0.45);
+        assert_eq!(cfg.smart_cooldown_turns, 4);
+        assert_eq!(cfg.smart_min_shrink_tokens, 5_000);
+        assert!(!cfg.smart_handoff_to_memory);
     }
 
     #[test]

--- a/crates/wcore-config/tests/compact_config_test.rs
+++ b/crates/wcore-config/tests/compact_config_test.rs
@@ -67,6 +67,36 @@ context_window = 128000
     assert!(config.compact.enabled);
 }
 
+/// #280: smart auto-compaction is default-OFF and back-compatible. A config
+/// with no smart_* keys must leave the master gate false and the handoff on.
+#[test]
+fn smart_compaction_default_off_in_config_file() {
+    let toml_str = r#"
+[compact]
+context_window = 100000
+"#;
+    let config: ConfigFile = toml::from_str(toml_str).unwrap();
+    assert!(!config.compact.smart_enabled);
+    assert_eq!(config.compact.smart_trigger_fraction, 0.65);
+    assert!(config.compact.smart_handoff_to_memory);
+}
+
+/// #280: an out-of-band smart_trigger_fraction parses verbatim (the spec band
+/// clamp is applied at the engine use site, not at deserialization, to keep
+/// config back-compat — see advanced.md). This documents the raw-parse contract.
+#[test]
+fn smart_trigger_fraction_out_of_band_parses_verbatim() {
+    let toml_str = r#"
+[compact]
+smart_enabled = true
+smart_trigger_fraction = 0.95
+"#;
+    let config: ConfigFile = toml::from_str(toml_str).unwrap();
+    // Raw value is preserved; the engine clamps it into 0.60..=0.70 when it
+    // evaluates the trigger.
+    assert_eq!(config.compact.smart_trigger_fraction, 0.95);
+}
+
 /// TC-2.2-07: Config TOML with [compact] section parses completely.
 #[test]
 fn tc_2_2_07_config_with_compact_section() {

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -328,6 +328,47 @@ max_failures = 3            # Circuit breaker threshold
 micro_keep_recent = 5       # Keep N most recent tool results
 ```
 
+### Smart auto-compaction (#280)
+
+Smart auto-compaction is a **proactive** pre-gate that fires the existing
+autocompact path *early* — when the conversation reaches a configurable share of
+the **currently-active model's** context window (default ~65%), instead of
+waiting for the static `autocompact_buffer` threshold (~91% effective). On a
+fire it (1) writes a non-destructive handoff of the live conversation to
+long-term memory (a `compaction_handoff` Episode — nothing is lost even if the
+LLM summary later rewords prose), then (2) runs the normal autocompact and
+continues the turn seamlessly. It emits the same `CompactOffload` host event as
+ordinary compaction, with the reason `smart_window_pressure` so the host can
+label the "Compacted — kept X of Y" chip with smart provenance.
+
+The trigger is **Flux-aware**: it is computed against the active model's real
+window (preferring the served-model window Flux signals back) and re-evaluated
+every turn, so it tracks model swaps automatically rather than using a fixed
+token count.
+
+**Default-OFF.** Because it fires well below the static threshold, it runs the
+LLM summarizer more often (more cost/latency). Soak it before enabling.
+
+```toml
+[compact]
+smart_enabled = false            # MASTER GATE — default off; enable after a soak
+smart_trigger_fraction = 0.65    # Active-window share that arms a proactive compact
+                                 #   (clamped to the 0.60–0.70 band at runtime)
+smart_release_fraction = 0.50    # Hysteresis low-water: re-arm only after the
+                                 #   fraction drops below this (forced < trigger-0.05)
+smart_cooldown_turns = 2         # Minimum completed turns between two smart fires
+smart_min_shrink_tokens = 2000   # Cannot-shrink latch: if a smart compact frees
+                                 #   fewer tokens than this, smart compaction
+                                 #   latches OFF for the rest of the session
+smart_handoff_to_memory = true   # Write the non-destructive handoff Episode
+```
+
+`smart_trigger_fraction` is **clamped** into the 0.60–0.70 band at the use site,
+so an out-of-band value (e.g. `0.95`) is silently corrected rather than
+disabling the trigger. Anti-thrash is enforced by three independent latches
+(hysteresis arm/release, cooldown, and the terminal cannot-shrink latch); all
+must clear before the trigger can fire again.
+
 ---
 
 ## File State Cache


### PR DESCRIPTION
Smart auto-compaction (#280): when a conversation crosses a configurable share of the **active model's** context window, the engine proactively writes a non-destructive memory handoff, runs a non-destructive compact, and continues the turn seamlessly — no manual `/compact`, no stall, no lost state. **Default-OFF** (soak before enabling).

## Design — a thin pre-gate over the existing machinery
This adds a proactive *trigger*, not a new compaction path. At the turn top (after PreCompact hooks, before `run_compaction`) the engine:
1. Computes a **Flux-aware active-window fraction** — prefers the real served-model window (`flux_served_window`) + Flux pressure header from #282, else the #255 `ContextWindow` kernel; recomputed every turn so it tracks model swaps with no stored state (kills the #255 false-denominator class).
2. If the fraction crosses the threshold **and** the anti-thrash latches allow, sets a one-shot force flag, writes the handoff, and falls through into the **unchanged** `run_compaction` — which does the proven live-turn carve-out, LLM summary, fold, #285 orphan-safety, and the #279 `CompactOffload` emit (reason swapped to `smart_window_pressure`). Zero new summarization/fold/emit code.

## Default-OFF chokepoint
`smart_compact_fraction()` returns `None` on its first line when `smart_enabled == false`, so with the master switch off the feature touches neither memory nor the force flag and `run_compaction` behaves byte-for-byte as before. Soak is airtight.

## Config (all serde-defaulted, back-compat)
`smart_enabled` (bool, **default false**), `smart_trigger_fraction` (0.65, clamped 0.60–0.70 at use), `smart_release_fraction` (0.50, hysteresis low-water), `smart_cooldown_turns` (2), `smart_min_shrink_tokens` (2000, cannot-shrink latch), `smart_handoff_to_memory` (true).

## Anti-thrash (three independent latches)
Hysteresis re-arm (disarms after a fire; re-arms only when the fraction drops below `release`), a turn cooldown, and a terminal cannot-shrink latch (if a smart compact frees < `smart_min_shrink_tokens`, smart compaction latches off for the session) — so it can never hot-loop, even when the conversation is incompressible.

## Non-destructive memory handoff (review-hardened)
Persists ONE `Episode` (`compaction_handoff`, Session tier, keyed by conversation id) with a **verbatim role-tagged transcript of every block** — text, `tool_use` name+args, **`tool_result` bodies** (the bulk of real context), and thinking — so "nothing lost" is honest, not prose-only. Pure INSERT, never touches the buffer; memory errors are logged-and-swallowed.

## Review
Built via a design-panel + adversarial-review workflow; the review's two IMPORTANT findings are fixed in this PR: (1) the handoff now captures tool-result/tool-use/thinking content (was text-only), with an honest doc comment; (2) added an integration test through `run_compaction` asserting the `smart_window_pressure` reason reaches `CompactOffload` and the cannot-shrink latch sets correctly.

## Verification (Hetzner gate, workspace)
`fmt --check` clean · `clippy --workspace --all-targets -D warnings` clean · `nextest --workspace` **9159 passed** (1 known flake: `http_fetch_honors_per_call_timeout`). 18 new tests: config defaults/TOML, the Flux-aware fraction, all three anti-thrash latches, default-off no-op, lossless handoff, error-swallow, and the run_compaction integration test.

Refs #280. Built on #255 (#74), #279 (#76), #282 (#77), #285 (#75). Prevents the #161/#255 runaway-context failure class. Default-off pending soak before enable.