### PR TITLE
fix(#282): tolerate live Flux context-overflow shapes (found by live E2E)

### DIFF
--- a/crates/wcore-providers/src/openai.rs
+++ b/crates/wcore-providers/src/openai.rs
@@ -525,11 +525,14 @@ impl OpenAIProvider {
                 return Err(err);
             }
             // #282 contract V1: a managed Flux client that overflows the routed
-            // model's window gets a typed 409 `context_overflow`. Surface it as
-            // a typed error so the engine can compact-then-retry this same turn;
-            // an unrecognised 409 body falls through to the generic `Api` error.
-            if status.as_u16() == 409
-                && let Some(err) = parse_flux_409(&body_text)
+            // model's window gets a typed context-overflow error. Surface it as
+            // `ProviderError::ContextOverflow` so the engine can compact-then-retry
+            // this same turn. Live Flux has shipped this as BOTH 409
+            // (`context_overflow`) and 413 (`context_window_exceeded`) across
+            // versions, so accept either status; an unrecognised body still falls
+            // through to the generic `Api` error.
+            if matches!(status.as_u16(), 409 | 413)
+                && let Some(err) = parse_flux_overflow(&body_text)
             {
                 return Err(err);
             }
@@ -1758,41 +1761,140 @@ pub(crate) fn parse_flux_402(body: &str) -> Option<ProviderError> {
     }
 }
 
-/// Parse a FluxRouter 409 `context_overflow` body into a typed
+/// Parse a FluxRouter hard-context-overflow body into a typed
 /// [`ProviderError::ContextOverflow`] (#282 contract V1, hard-overflow path).
 ///
-/// The frozen body shape is a FLAT object whose `error` FIELD is the literal
-/// `"context_overflow"`:
-/// ```json
-/// {"error":"context_overflow","required_tokens":N,"model_window":M,
-///  "routed_model":"…","message":"…"}
-/// ```
-/// We match on the `error` FIELD (never the HTTP status alone, never a substring
-/// of the message) so an unrelated 409 cannot be misread as an overflow. Returns
-/// `None` when the body is not JSON, not the overflow shape, or is missing the
-/// numeric fields — the caller then falls back to [`ProviderError::Api`].
-pub(crate) fn parse_flux_409(body: &str) -> Option<ProviderError> {
-    let obj: Value = serde_json::from_str(body).ok()?;
-    if obj.get("error").and_then(Value::as_str)? != "context_overflow" {
+/// Tolerant by necessity: live Flux has shipped this signal in three shapes
+/// across versions, and the body shape diverged from the frozen spec. We accept
+/// any of them, matching on the overflow `error` CODE (`context_overflow` or
+/// `context_window_exceeded`), never the HTTP status alone:
+///
+/// - A. flat (frozen spec): `{"error":"context_overflow","required_tokens":N,…}`
+/// - A'. FastAPI detail: `{"detail":{"error":"context_window_exceeded",…}}`
+/// - B. live prod envelope: `{"error":{"message":"{'error': 'context_overflow', …}"}}`
+///   — an OpenAI/LiteLLM envelope wrapping a Python dict *repr* with single quotes.
+///
+/// Numbers are also recovered by a digit scan so a quirky `message`/`reason`
+/// value can never hide the overflow. Returns `None` when the body is not an
+/// overflow signal — the caller then falls back to [`ProviderError::Api`].
+pub(crate) fn parse_flux_overflow(body: &str) -> Option<ProviderError> {
+    // Flux signals a hard context overflow under TWO error codes across versions:
+    // `context_overflow` (shipped on 409) and `context_window_exceeded` (the
+    // in-flight 413 path). Accept either; the engine treats both as compact-retry.
+    fn is_overflow(s: &str) -> bool {
+        s == "context_overflow" || s == "context_window_exceeded"
+    }
+    // Build a `ContextOverflow` from a recovered structured object. `message`
+    // falls back to `reason` (the 413 shape names it `reason`); the window /
+    // routed-model fields are absent on some shapes, so they default.
+    fn from_obj(obj: &Value) -> ProviderError {
+        ProviderError::ContextOverflow {
+            required_tokens: obj
+                .get("required_tokens")
+                .and_then(Value::as_u64)
+                .unwrap_or(0),
+            model_window: obj.get("model_window").and_then(Value::as_u64).unwrap_or(0),
+            routed_model: obj
+                .get("routed_model")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string(),
+            message: obj
+                .get("message")
+                .and_then(Value::as_str)
+                .or_else(|| obj.get("reason").and_then(Value::as_str))
+                .unwrap_or("context overflow")
+                .to_string(),
+        }
+    }
+
+    let outer: Value = serde_json::from_str(body).ok()?;
+
+    // Shape A — flat body (frozen spec): a top-level string `error` overflow code
+    // plus sibling fields: {"error":"context_overflow","required_tokens":N,...}.
+    if outer
+        .get("error")
+        .and_then(Value::as_str)
+        .is_some_and(is_overflow)
+    {
+        return Some(from_obj(&outer));
+    }
+    // Shape A' — FastAPI `HTTPException(detail={...})` raw shape, if not re-wrapped:
+    //   {"detail":{"error":"context_window_exceeded","required_tokens":N,...}}
+    if let Some(d) = outer.get("detail")
+        && d.get("error")
+            .and_then(Value::as_str)
+            .is_some_and(is_overflow)
+    {
+        return Some(from_obj(d));
+    }
+
+    // Shape B — what live api.fluxrouter.ai ACTUALLY returns (verified 2026-06-23):
+    // an OpenAI/LiteLLM error envelope wrapping the payload as a Python dict *repr*
+    // (single quotes) inside `error.message`:
+    //   {"error":{"message":"{'error': 'context_overflow', 'required_tokens': N, ...}",
+    //             "type":"None","code":"409"}}
+    // serde can't parse the single-quoted repr, so recover it by normalizing the
+    // Python literals to JSON; numbers are also scanned directly so a quirky
+    // message value can never hide the overflow signal.
+    let inner_str = outer
+        .get("error")
+        .and_then(|e| e.get("message"))
+        .and_then(Value::as_str)
+        .or_else(|| outer.get("error").and_then(Value::as_str))
+        .or_else(|| outer.get("message").and_then(Value::as_str))
+        .or_else(|| outer.get("detail").and_then(Value::as_str))?;
+    if !inner_str.contains("context_overflow") && !inner_str.contains("context_window_exceeded") {
         return None;
     }
-    let required_tokens = obj.get("required_tokens").and_then(Value::as_u64)?;
-    let model_window = obj.get("model_window").and_then(Value::as_u64)?;
-    let routed_model = obj
-        .get("routed_model")
-        .and_then(Value::as_str)
-        .unwrap_or_default()
-        .to_string();
-    let message = obj
-        .get("message")
-        .and_then(Value::as_str)
-        .unwrap_or("context overflow")
-        .to_string();
+    let recovered: Option<Value> = serde_json::from_str::<Value>(inner_str)
+        .ok()
+        .or_else(|| {
+            let normalized = inner_str
+                .replace('\'', "\"")
+                .replace("None", "null")
+                .replace("True", "true")
+                .replace("False", "false");
+            serde_json::from_str::<Value>(&normalized).ok()
+        })
+        .filter(Value::is_object);
+
+    // Digit-scan fallback: find `key` then the first run of ASCII digits after it.
+    let scan_u64 = |key: &str| -> u64 {
+        inner_str
+            .find(key)
+            .and_then(|i| {
+                inner_str[i + key.len()..]
+                    .split(|c: char| !c.is_ascii_digit())
+                    .find(|s| !s.is_empty())
+                    .and_then(|s| s.parse::<u64>().ok())
+            })
+            .unwrap_or(0)
+    };
+    if let Some(obj) = recovered.as_ref() {
+        // Recovered cleanly — but the window/model may still be absent (413
+        // shape), so backfill the numbers from the digit scan when missing.
+        let mut err = from_obj(obj);
+        if let ProviderError::ContextOverflow {
+            required_tokens,
+            model_window,
+            ..
+        } = &mut err
+        {
+            if *required_tokens == 0 {
+                *required_tokens = scan_u64("required_tokens");
+            }
+            if *model_window == 0 {
+                *model_window = scan_u64("model_window");
+            }
+        }
+        return Some(err);
+    }
     Some(ProviderError::ContextOverflow {
-        required_tokens,
-        model_window,
-        routed_model,
-        message,
+        required_tokens: scan_u64("required_tokens"),
+        model_window: scan_u64("model_window"),
+        routed_model: String::new(),
+        message: "context overflow".to_string(),
     })
 }
 
@@ -1944,7 +2046,7 @@ mod tests {
     #[test]
     fn parse_flux_409_context_overflow_full() {
         let body = r#"{"error":"context_overflow","required_tokens":210000,"model_window":200000,"routed_model":"claude-sonnet-4","message":"prompt exceeds routed model window"}"#;
-        match parse_flux_409(body) {
+        match parse_flux_overflow(body) {
             Some(ProviderError::ContextOverflow {
                 required_tokens,
                 model_window,
@@ -1965,21 +2067,99 @@ mod tests {
     #[test]
     fn parse_flux_409_wrong_error_value_returns_none() {
         let body = r#"{"error":"conflict","required_tokens":1,"model_window":2,"routed_model":"x","message":"y"}"#;
-        assert!(parse_flux_409(body).is_none());
+        assert!(parse_flux_overflow(body).is_none());
     }
 
-    /// A `context_overflow` body missing the numeric fields is not the frozen
-    /// shape → `None` (fall back to `Api`), never a partial/zeroed variant.
+    /// A `context_overflow` body missing the numeric fields is STILL an overflow:
+    /// the `error` field is authoritative, so we return `ContextOverflow` (with
+    /// zeroed counts) and let the engine compact-and-retry, rather than falling
+    /// through to a generic `Api` error that would kill the turn.
     #[test]
-    fn parse_flux_409_missing_numeric_fields_returns_none() {
+    fn parse_flux_409_missing_numeric_fields_still_overflows() {
         let body = r#"{"error":"context_overflow","message":"oops"}"#;
-        assert!(parse_flux_409(body).is_none());
+        match parse_flux_overflow(body) {
+            Some(ProviderError::ContextOverflow {
+                required_tokens,
+                model_window,
+                ..
+            }) => {
+                assert_eq!(required_tokens, 0);
+                assert_eq!(model_window, 0);
+            }
+            other => panic!("expected ContextOverflow, got {other:?}"),
+        }
+    }
+
+    /// REGRESSION (live E2E, captured from api.fluxrouter.ai 2026-06-23): the
+    /// production 409 body is NOT the frozen flat shape — it is an OpenAI/LiteLLM
+    /// error envelope wrapping the payload as a Python dict *repr* (single quotes)
+    /// inside `error.message`. The original strict parser silently dropped this
+    /// (so compact-and-retry never fired against live Flux). The parser must
+    /// recover the structured fields from this exact body.
+    #[test]
+    fn parse_flux_409_handles_live_wrapped_python_repr_body() {
+        let body = r#"{"error":{"message":"{'error': 'context_overflow', 'required_tokens': 100000256, 'model_window': 1000000, 'routed_model': 'qwen-3-coder-cerebras', 'message': 'request exceeds the window of every capable model; compact and retry'}","type":"None","param":"None","code":"409"}}"#;
+        match parse_flux_overflow(body) {
+            Some(ProviderError::ContextOverflow {
+                required_tokens,
+                model_window,
+                routed_model,
+                message,
+            }) => {
+                assert_eq!(required_tokens, 100_000_256);
+                assert_eq!(model_window, 1_000_000);
+                assert_eq!(routed_model, "qwen-3-coder-cerebras");
+                assert!(message.contains("compact and retry"));
+            }
+            other => panic!("expected ContextOverflow from live body, got {other:?}"),
+        }
+    }
+
+    /// The in-flight Flux 413 path raises `context_window_exceeded` via FastAPI
+    /// `HTTPException(detail={…})`, which arrives either raw (`{"detail":{…}}`)
+    /// or LiteLLM-wrapped. Both must classify as a context overflow so the
+    /// engine compact-retries when that deploy lands. (413 carries `reason`,
+    /// not `message`, and no window/routed-model — those default.)
+    #[test]
+    fn parse_flux_overflow_handles_413_context_window_exceeded() {
+        // Raw FastAPI detail shape.
+        let raw = r#"{"detail":{"error":"context_window_exceeded","reason":"Request needs ~250000 tokens but exceeds every eligible model.","required_tokens":250000}}"#;
+        match parse_flux_overflow(raw) {
+            Some(ProviderError::ContextOverflow {
+                required_tokens,
+                message,
+                ..
+            }) => {
+                assert_eq!(required_tokens, 250_000);
+                assert!(message.contains("exceeds every eligible model"));
+            }
+            other => panic!("expected ContextOverflow from raw 413 detail, got {other:?}"),
+        }
+        // LiteLLM-wrapped Python-repr of the same.
+        let wrapped = r#"{"error":{"message":"{'error': 'context_window_exceeded', 'reason': 'too big', 'required_tokens': 250000}","code":"413"}}"#;
+        match parse_flux_overflow(wrapped) {
+            Some(ProviderError::ContextOverflow {
+                required_tokens, ..
+            }) => {
+                assert_eq!(required_tokens, 250_000);
+            }
+            other => panic!("expected ContextOverflow from wrapped 413, got {other:?}"),
+        }
+    }
+
+    /// A non-overflow wrapped envelope (e.g. a generic upstream error) must NOT
+    /// be misread as an overflow.
+    #[test]
+    fn parse_flux_409_wrapped_non_overflow_returns_none() {
+        let body =
+            r#"{"error":{"message":"{'error': 'rate_limited', 'retry_after': 5}","code":"409"}}"#;
+        assert!(parse_flux_overflow(body).is_none());
     }
 
     /// A malformed JSON 409 body returns `None`.
     #[test]
     fn parse_flux_409_non_json_returns_none() {
-        assert!(parse_flux_409("not json at all").is_none());
+        assert!(parse_flux_overflow("not json at all").is_none());
     }
 
     /// `ContextOverflow` is NOT provider-retryable: the unchanged request would

--- a/docs/design/flux-282-reference/README.md
+++ b/docs/design/flux-282-reference/README.md
@@ -1,0 +1,38 @@
+# Flux #282 — implementation reference for the Core lane
+
+The Flux side of the context-routing contract (`../2026-06-23-flux-context-routing-contract.md`) is **built, deployed, and ENABLED in production**. This folder is the frozen handshake surface so the Core lane can examine the exact format and behavior while building its side. It is reference material, not a runnable package.
+
+- **`test_context_contract.py`** — the behavior spec *by example* (53 cases). Read this first: it shows exactly how each `x-wl-*` header parses (case-insensitive, defensive), the `REQUIRED` math, the `×1.15` floor, the `409 context_overflow` JSON shape, and the signal-back headers. If your client matches this file's expectations, you interoperate.
+- **`flux-contract-surface.py`** — the actual Flux code (extracted verbatim from the live proxy): the four helper functions, the pre-call filter call site, the post-select backstop, and the signal-back header emission. The surrounding proxy routing is omitted (private + irrelevant to the handshake).
+
+Canonical source of truth (Flux, private): `TradeCanyon/flux-router` @ `master` (`eb6a6b2`, PR #79) — `src/forge_hook.py` + `tests/test_context_contract.py`. Live image `capgw42-ctxcontract-eb6a6b2`, flag `FLUX_CONTEXT_CONTRACT_ENABLED=true`.
+
+## The wire format (frozen)
+
+### Core EMITS — request headers, tier-alias requests only (`flux-auto`/`flux-fast`/`flux-standard`/`flux-reasoning`; a concrete model id opts out)
+| Header | Type | Meaning |
+|---|---|---|
+| `x-wl-context-tokens` | int | assembled prompt tokens you send this turn. **Required** to activate the contract. |
+| `x-wl-expected-output` | int | your output/completion budget. |
+| `x-wl-context-managed` | `true` | send it — gets you the signal-back + 409 path; Flux never silently truncates you. |
+| `x-wl-conversation-id` | string | stable conversation id. |
+
+### Flux SIGNALS BACK — response headers
+| Header | Type | Meaning |
+|---|---|---|
+| `x-flux-routed-model` | string | model actually served *(pre-existing)*. |
+| `x-flux-model-window` | int | real context window of the served model. |
+| `x-flux-context-pressure` | float 0..1 | `REQUIRED / window`. |
+| `x-flux-context-tokens-counted` | int | Flux's authoritative input count — calibrate your estimator. |
+
+### Hard overflow (managed client) → HTTP **409**, match the `error` field (not status/substring)
+```json
+{ "error": "context_overflow", "required_tokens": N, "model_window": M,
+  "routed_model": "…", "message": "request exceeds the window of every capable model; compact and retry" }
+```
+
+## Two implementation facts that make your side simpler
+1. **Flux floors `REQUIRED` at `max(your x-wl-context-tokens + output, Flux's own count + reserve)`.** Your header is the *optimization* signal; Flux's own count is the *safety floor*. Under-counting can never route you onto a too-small model (Flux backstops it). See `_compute_context_required` + the call-site `max(...)` in `flux-contract-surface.py`, and `test_under_declared_*` in the test file.
+2. **`x-flux-context-pressure` is clamped to `0..1`.** Overflow magnitude lives in the 409 body (`required_tokens`/`model_window`). Want an unbounded ratio instead? Say so on #282 and we amend §2 together.
+
+Back-compat: all `x-wl-*` are additive; absent → Flux falls back to body token-counting (today's behavior), so you can ship one header at a time. Test against `https://api.fluxrouter.ai/v1/chat/completions`. Questions → comment on FerroxLabs/wayland #282.

--- a/docs/design/flux-282-reference/flux-contract-surface.py
+++ b/docs/design/flux-282-reference/flux-contract-surface.py
@@ -1,0 +1,281 @@
+"""Flux #282 context-routing contract — IMPLEMENTATION REFERENCE (Flux side, V1).
+
+This is the FROZEN handshake surface extracted from the live Flux proxy
+(src/forge_hook.py @ master eb6a6b2). It is the exact code that parses Core's
+x-wl-* request headers, computes the full-fit floor, raises the structured 409
+context_overflow, and emits the x-flux-* signal-back headers. The full proxy
+routing/bandit logic around it is intentionally omitted (private + irrelevant to
+the handshake). See test_context_contract.py for behavior-by-example. Not runnable
+standalone — reference only.
+"""
+
+# ============================================================================
+# 1) HELPER FUNCTIONS (module-level)
+# ============================================================================
+# ── Wayland #282 context-routing contract helpers (V1) ─────────────────────────
+# Pure functions so the contract's load-bearing math/parse is directly testable
+# without standing up the full pre/post-call hook. All gated by the caller behind
+# _FLUX_CONTEXT_CONTRACT_ENABLED — these helpers themselves never read the flag.
+
+
+def _parse_wl_context_headers(data) -> dict | None:
+    """Parse Core's x-wl-* context gauge from the request headers (contract §2).
+
+    Reads ``data["proxy_server_request"]["headers"]`` (LiteLLM builds this dict
+    with LOWERCASED keys, but we lower-case defensively in case a future caller
+    passes mixed-case). Returns a normalized dict, or ``None`` when the required
+    ``x-wl-context-tokens`` is absent or unparseable (caller then falls back to
+    body token-counting, exactly as today).
+
+    Fully defensive: NEVER raises — any malformed input yields ``None``. A
+    malformed OPTIONAL header degrades to its default without nulling the parse;
+    only the required gauge controls ``None``.
+
+    Returned shape::
+
+        {"context_tokens": int, "expected_output": int,
+         "context_managed": bool, "conversation_id": str | None}
+    """
+    try:
+        psr = data.get("proxy_server_request") if isinstance(data, dict) else None
+        headers = psr.get("headers") if isinstance(psr, dict) else None
+        if not isinstance(headers, dict):
+            return None
+        # Case-insensitive lookup: index by lower-cased key.
+        lower = {}
+        for k, v in headers.items():
+            try:
+                lower[str(k).lower()] = v
+            except Exception:
+                continue
+
+        raw_tokens = lower.get("x-wl-context-tokens")
+        if raw_tokens is None:
+            return None
+        try:
+            context_tokens = int(str(raw_tokens).strip())
+        except (TypeError, ValueError):
+            return None
+
+        try:
+            expected_output = int(str(lower.get("x-wl-expected-output", "")).strip())
+        except (TypeError, ValueError):
+            expected_output = 0
+
+        context_managed = str(lower.get("x-wl-context-managed", "")).strip().lower() == "true"
+
+        conv_raw = lower.get("x-wl-conversation-id")
+        conversation_id = str(conv_raw) if conv_raw not in (None, "") else None
+
+        return {
+            "context_tokens": context_tokens,
+            "expected_output": expected_output,
+            "context_managed": context_managed,
+            "conversation_id": conversation_id,
+        }
+    except Exception:
+        return None
+
+
+def _compute_context_required(wl: dict, data: dict) -> int:
+    """REQUIRED = context_tokens + max(expected_output, request max_tokens) (§3.1).
+
+    The output budget is the larger of Core's declared ``expected_output`` and
+    the request body's own ``max_tokens`` / ``max_completion_tokens`` — whichever
+    Core under-declared still gets room.
+    """
+    # FIX 2: clamp negatives — a hostile/buggy client header must never drive
+    # REQUIRED below zero (which would collapse the routing floor).
+    context_tokens = max(int(wl.get("context_tokens") or 0), 0)
+    expected_output = max(int(wl.get("expected_output") or 0), 0)
+    body_max = int((data.get("max_tokens") or data.get("max_completion_tokens") or 0) if isinstance(data, dict) else 0)
+    return context_tokens + max(expected_output, body_max)
+
+
+def _context_floor(required: int) -> int:
+    """The full-fit floor: ceil(REQUIRED × 1.15) (contract §3.3 headroom)."""
+    return math.ceil(required * _CONTEXT_CONTRACT_HEADROOM)
+
+
+def _context_overflow_detail(required: int, pre_fit: list[str], context_windows: dict) -> dict:
+    """Structured 409 ``context_overflow`` body for a managed client (§2, C5).
+
+    ``model_window`` is the largest KNOWN window among the pre-filter candidates
+    (0 when none are known — never raises). ``routed_model`` is the id of THAT
+    same candidate (FIX 5: window + id must be consistent), "" when none known.
+    """
+    known = [(m, context_windows.get(m)) for m in pre_fit if isinstance(context_windows.get(m), int)]
+    if known:
+        routed_model, model_window = max(known, key=lambda pair: pair[1])
+    else:
+        routed_model, model_window = "", 0
+    return {
+        "error": "context_overflow",
+        "required_tokens": int(required),
+        "model_window": int(model_window),
+        "routed_model": str(routed_model),
+        "message": "request exceeds the window of every capable model; compact and retry",
+    }
+
+
+
+# ============================================================================
+# 2) PRE-CALL FILTER CALL SITE — REQUIRED, x1.15 floor, managed-overflow 409
+#    (inside async pre-call hook, after the eligible-model pool is built;
+#     wl_ctx is None => flag off or no headers => today's additive path)
+# ============================================================================
+                        wl_ctx = None
+                        if _FLUX_CONTEXT_CONTRACT_ENABLED and is_tier_alias(model):
+                            wl_ctx = _parse_wl_context_headers(data)
+
+                        # Token counting is CPU-bound — keep it off the event
+                        # loop (mirrors the select() to_thread call below).
+                        input_tokens = await asyncio.to_thread(_estimate_token_count, messages, "")
+
+                        if wl_ctx is not None:
+                            # FIX 1: the header can only RAISE the floor above
+                            # Flux's own authoritative count, never lower it. A
+                            # client claiming context_tokens=1 on a real 200k
+                            # prompt must not collapse the floor and route the
+                            # huge prompt onto the smallest arm (strictly less
+                            # safe than flag-off). Floor the header-derived
+                            # REQUIRED against (input_tokens + flag-off reserve).
+                            _flagoff_reserve = max(
+                                int(data.get("max_tokens") or data.get("max_completion_tokens") or 0),
+                                CONTEXT_FIT_OUTPUT_HEADROOM,
+                            )
+                            required = max(
+                                _compute_context_required(wl_ctx, data),
+                                input_tokens + _flagoff_reserve,
+                            )
+                            required_tokens = _context_floor(required)
+                            # Stash for the signal-back headers (C6): REQUIRED and
+                            # Flux's own authoritative input count.
+                            metadata[MK_WL_CONTEXT_TOKENS] = wl_ctx["context_tokens"]
+                            metadata[MK_WL_EXPECTED_OUTPUT] = wl_ctx["expected_output"]
+                            metadata[MK_WL_CONTEXT_MANAGED] = wl_ctx["context_managed"]
+                            metadata[MK_WL_CONVERSATION_ID] = wl_ctx["conversation_id"]
+                            metadata[MK_WL_REQUIRED] = required
+                            metadata[MK_WL_INPUT_TOKENS_COUNTED] = input_tokens
+                        else:
+                            # Reserve output room within the model's window: the
+                            # request's own max_tokens when set, else a sane floor.
+                            reserve = max(
+                                int(data.get("max_tokens") or data.get("max_completion_tokens") or 0),
+                                CONTEXT_FIT_OUTPUT_HEADROOM,
+                            )
+                            required_tokens = input_tokens + reserve
+
+                        pre_fit = list(eligible_models)
+                        fit = _filter_by_context_fit(pre_fit, ctx_windows, required_tokens)
+                        if fit and len(fit) < len(pre_fit):
+                            dropped = len(pre_fit) - len(fit)
+                            logger.info(
+                                "context_fit filtered %d/%d eligible models (need~%d tokens)",
+                                dropped,
+                                len(pre_fit),
+                                required_tokens,
+                            )
+                            from src.flux_metrics import flux_context_fit_filter_total  # noqa: PLC0415
+
+                            flux_context_fit_filter_total.labels(result="dropped").inc(dropped)
+                            eligible_models = fit
+                        elif not fit:
+                            # Every eligible model has a known too-small window.
+                            # _filter_by_context_fit fails open on unknown
+                            # windows, so this is reachable only when every
+                            # candidate window is known AND too small — a real
+                            # context-limit error, not a coverage gap.
+                            from src.flux_metrics import flux_context_fit_filter_total  # noqa: PLC0415
+
+                            flux_context_fit_filter_total.labels(result="all_too_small").inc()
+                            logger.warning(
+                                "context_fit: all %d eligible models too small for ~%d tokens — rejecting",
+                                len(pre_fit),
+                                required_tokens,
+                            )
+                            if wl_ctx is not None and wl_ctx["context_managed"]:
+                                # Managed client: never silently truncate. Return
+                                # the structured 409 context_overflow (contract §2)
+                                # so Core compacts-then-retries this turn.
+                                raise HTTPException(
+                                    status_code=409,
+                                    detail=_context_overflow_detail(
+                                        metadata.get(MK_WL_REQUIRED, required_tokens),
+                                        pre_fit,
+                                        ctx_windows,
+                                    ),
+                                )
+                            raise HTTPException(
+                                status_code=413,
+                                detail={
+                                    "error": "context_window_exceeded",
+                                    "reason": (
+                                        f"Request needs ~{required_tokens} tokens (input + "
+                                        f"output headroom) but exceeds the context window of "
+                                        f"every model eligible for this tier."
+                                    ),
+                                    "required_tokens": required_tokens,
+                                },
+                            )
+                except HTTPException:
+                    raise
+                except Exception:
+                    logger.debug("context_fit filter failed", exc_info=True)
+
+
+# ============================================================================
+# 3) POST-SELECT BACKSTOP — managed client never served onto a too-small arm
+# ============================================================================
+    def _assert_served_context_fits(self, data: dict, metadata: dict) -> None:
+        """Wayland #282 (FIX 3): managed-client post-select fit backstop.
+
+        The pre-call context-fit filter runs BEFORE the bandit; the grounding
+        short-circuit and any post-filter re-pick can still land a managed client
+        on a too-small arm, silently overflowing the contract's 409. After the
+        served model is finalized, re-check the ACTUAL served model's real window
+        (the COMPLETE resolver) and refuse with the structured 409 rather than
+        dispatch an overflow.
+
+        FAIL-OPEN on an unknown served window (only 409 when the window is a
+        known int < floor) to avoid false rejects. Gated by the contract flag
+        and the managed marker — inert otherwise (byte-identical to today).
+        """
+        if not (_FLUX_CONTEXT_CONTRACT_ENABLED and metadata.get(MK_WL_CONTEXT_MANAGED)):
+            return
+        from fastapi import HTTPException  # noqa: PLC0415
+
+        _served = data.get("model")
+        _win = self._get_context_window(_served) if _served else None
+        _req = metadata.get(MK_WL_REQUIRED)
+        if isinstance(_win, int) and _win > 0 and isinstance(_req, int) and _win < _context_floor(_req):
+            raise HTTPException(
+                status_code=409,
+                detail=_context_overflow_detail(_context_floor(_req), [_served], {_served: _win}),
+            )
+
+    @staticmethod
+
+# ============================================================================
+# 4) SIGNAL-BACK HEADERS (post-call success hook): window / pressure / counted
+# ============================================================================
+            # ── C6: Wayland #282 context-routing signal-back (gated) ──────
+            # When the contract is on, surface the served model's real window,
+            # the context pressure (REQUIRED / window), and Flux's authoritative
+            # input token count so Core reconciles its #280 gauge against the
+            # model Flux ACTUALLY served. Best-effort: a missing window or an
+            # absent stash simply omits that header — never breaks the response.
+            # When the flag is off none of these emit (byte-identical to today).
+            if _FLUX_CONTEXT_CONTRACT_ENABLED:
+                served_model = metadata.get(MK_SERVED_MODEL) or model
+                served_window = self._get_context_window(served_model) if served_model else None
+                if isinstance(served_window, int) and served_window > 0:
+                    headers["x-flux-model-window"] = str(served_window)
+                    required = metadata.get(MK_WL_REQUIRED)
+                    if isinstance(required, int):
+                        # FIX 4: contract §2 declares pressure as float 0..1;
+                        # genuine-overflow magnitude rides the 409 body, not here.
+                        headers["x-flux-context-pressure"] = f"{min(required / served_window, 1.0):.3f}"
+                counted = metadata.get(MK_WL_INPUT_TOKENS_COUNTED)
+                if isinstance(counted, int):
+                    headers["x-flux-context-tokens-counted"] = str(counted)

--- a/docs/design/flux-282-reference/test_context_contract.py
+++ b/docs/design/flux-282-reference/test_context_contract.py
@@ -1,0 +1,571 @@
+"""Unit tests for the Core<->Flux context-routing contract (Wayland #282, V1).
+
+Mirrors the direct-helper style of tests/test_param_sanitizer.py. The contract's
+load-bearing logic is extracted into pure module-level helpers so it can be
+exercised without standing up the full pre/post-call hook flow:
+
+  - `_parse_wl_context_headers(data)`  — header parse (C2)
+  - `_compute_context_required(wl, data)` — REQUIRED math (C3)
+  - `_context_floor(required)`         — ceil(REQUIRED * 1.15) (C3)
+  - `_context_overflow_detail(...)`    — structured 409 body (C5)
+
+Everything is gated behind FLUX_CONTEXT_CONTRACT_ENABLED. The flag-off-inertness
+tests assert the existing filter formula and the existing 413 are byte-identical
+to today when the flag is off.
+"""
+
+import importlib
+import math
+
+import pytest
+
+import src.forge_hook as fh
+from src.forge_hook import (
+    CONTEXT_FIT_OUTPUT_HEADROOM,
+    _compute_context_required,
+    _context_floor,
+    _context_overflow_detail,
+    _filter_by_context_fit,
+    _parse_wl_context_headers,
+)
+
+
+def _data(headers: dict) -> dict:
+    """A request dict carrying request headers the way LiteLLM delivers them."""
+    return {"proxy_server_request": {"headers": dict(headers)}}
+
+
+# ── C2: header parse ──────────────────────────────────────────────────────
+
+
+def test_parse_all_four_headers():
+    wl = _parse_wl_context_headers(
+        _data(
+            {
+                "x-wl-context-tokens": "120000",
+                "x-wl-expected-output": "4096",
+                "x-wl-context-managed": "true",
+                "x-wl-conversation-id": "conv-abc",
+            }
+        )
+    )
+    assert wl == {
+        "context_tokens": 120000,
+        "expected_output": 4096,
+        "context_managed": True,
+        "conversation_id": "conv-abc",
+    }
+
+
+def test_parse_defaults_when_optionals_absent():
+    # Only the required gauge present: expected_output -> 0, managed -> False,
+    # conversation_id -> None.
+    wl = _parse_wl_context_headers(_data({"x-wl-context-tokens": "5000"}))
+    assert wl == {
+        "context_tokens": 5000,
+        "expected_output": 0,
+        "context_managed": False,
+        "conversation_id": None,
+    }
+
+
+def test_parse_missing_required_token_returns_none():
+    assert _parse_wl_context_headers(_data({"x-wl-expected-output": "100"})) is None
+
+
+def test_parse_garbage_required_token_returns_none():
+    assert _parse_wl_context_headers(_data({"x-wl-context-tokens": "not-an-int"})) is None
+    assert _parse_wl_context_headers(_data({"x-wl-context-tokens": ""})) is None
+
+
+def test_parse_garbage_expected_output_falls_back_to_zero():
+    # A malformed optional must not nuke the whole parse — only the required
+    # gauge controls None. expected_output degrades to its default.
+    wl = _parse_wl_context_headers(_data({"x-wl-context-tokens": "9000", "x-wl-expected-output": "xxx"}))
+    assert wl is not None
+    assert wl["context_tokens"] == 9000
+    assert wl["expected_output"] == 0
+
+
+def test_parse_case_insensitive():
+    wl = _parse_wl_context_headers(
+        _data(
+            {
+                "X-WL-Context-Tokens": "7000",
+                "X-Wl-Expected-Output": "512",
+                "X-WL-CONTEXT-MANAGED": "TRUE",
+                "X-Wl-Conversation-Id": "C1",
+            }
+        )
+    )
+    assert wl == {
+        "context_tokens": 7000,
+        "expected_output": 512,
+        "context_managed": True,
+        "conversation_id": "C1",
+    }
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("true", True),
+        ("TRUE", True),
+        ("True", True),
+        ("  true  ", True),
+        ("false", False),
+        ("0", False),
+        ("1", False),
+        ("yes", False),
+        ("", False),
+    ],
+)
+def test_parse_managed_bool_variants(raw, expected):
+    wl = _parse_wl_context_headers(_data({"x-wl-context-tokens": "100", "x-wl-context-managed": raw}))
+    assert wl["context_managed"] is expected
+
+
+# ── C2 defensive: never raise on malformed proxy_server_request ────────────
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        {},  # no proxy_server_request at all
+        {"proxy_server_request": None},
+        {"proxy_server_request": "garbage"},
+        {"proxy_server_request": {"headers": None}},
+        {"proxy_server_request": {"headers": "garbage"}},
+        {"proxy_server_request": {}},  # no headers key
+        "not-even-a-dict",
+        None,
+    ],
+)
+def test_parse_never_raises_on_malformed_input(data):
+    # Must return None, never raise.
+    assert _parse_wl_context_headers(data) is None
+
+
+# ── C3: REQUIRED math + floor ──────────────────────────────────────────────
+
+
+def test_required_tokens_plus_expected_output():
+    wl = {"context_tokens": 100000, "expected_output": 8000}
+    assert _compute_context_required(wl, {}) == 108000
+
+
+def test_required_uses_max_of_expected_output_and_max_tokens():
+    # data.max_tokens larger than expected_output -> max_tokens wins.
+    wl = {"context_tokens": 100000, "expected_output": 2000}
+    assert _compute_context_required(wl, {"max_tokens": 9000}) == 109000
+    # expected_output larger than max_tokens -> expected_output wins.
+    wl = {"context_tokens": 100000, "expected_output": 9000}
+    assert _compute_context_required(wl, {"max_tokens": 2000}) == 109000
+
+
+def test_required_honors_max_completion_tokens_alias():
+    wl = {"context_tokens": 50000, "expected_output": 0}
+    assert _compute_context_required(wl, {"max_completion_tokens": 4096}) == 54096
+
+
+def test_required_zero_output_budget():
+    wl = {"context_tokens": 50000, "expected_output": 0}
+    assert _compute_context_required(wl, {}) == 50000
+
+
+def test_required_clamps_negative_context_tokens_to_zero():
+    # FIX 2: a hostile/buggy client header of negative tokens must never
+    # produce a sub-zero REQUIRED (which would collapse the floor).
+    wl = {"context_tokens": -50000, "expected_output": 4096}
+    assert _compute_context_required(wl, {}) == 4096
+
+
+def test_required_clamps_negative_expected_output_to_zero():
+    wl = {"context_tokens": 100000, "expected_output": -9999}
+    # expected_output clamped to 0; body_max absent -> output budget 0.
+    assert _compute_context_required(wl, {}) == 100000
+
+
+def test_required_negative_both_floors_at_zero():
+    wl = {"context_tokens": -10, "expected_output": -10}
+    assert _compute_context_required(wl, {}) == 0
+
+
+def test_floor_applies_1_15_multiplier_with_ceil():
+    assert _context_floor(100000) == math.ceil(100000 * 1.15)
+    assert _context_floor(100000) == 115000
+    # Non-round case must round UP, never down.
+    assert _context_floor(100001) == math.ceil(100001 * 1.15)
+    assert _context_floor(7) == 9  # ceil(8.05)
+
+
+# ── C3: filter drops below floor, keeps >= floor ──────────────────────────
+
+
+def test_filter_drops_models_below_floor():
+    floor = _context_floor(100000)  # 115000
+    windows = {"small": 64000, "mid": 128000, "big": 200000}
+    fit = _filter_by_context_fit(["small", "mid", "big"], windows, floor)
+    assert fit == ["mid", "big"]  # small (64k) < 115k dropped
+
+
+def test_filter_keeps_models_at_or_above_floor():
+    floor = _context_floor(100000)  # 115000
+    windows = {"exact": 115000, "over": 116000}
+    fit = _filter_by_context_fit(["exact", "over"], windows, floor)
+    assert fit == ["exact", "over"]  # exact==floor kept (>=)
+
+
+def test_filter_empty_when_all_too_small():
+    floor = _context_floor(300000)  # 345000
+    windows = {"a": 128000, "b": 200000}
+    assert _filter_by_context_fit(["a", "b"], windows, floor) == []
+
+
+# ── C5: structured overflow body ──────────────────────────────────────────
+
+
+def test_overflow_detail_shape():
+    pre_fit = ["a", "b", "c"]
+    windows = {"a": 64000, "b": 200000, "c": 128000}
+    detail = _context_overflow_detail(345000, pre_fit, windows)
+    assert detail["error"] == "context_overflow"
+    assert detail["required_tokens"] == 345000
+    # largest KNOWN window among the pre-filter candidates
+    assert detail["model_window"] == 200000
+    # FIX 5: routed_model and model_window must refer to the SAME candidate —
+    # the one owning the largest known window ("b" here), not pre_fit[0].
+    assert detail["routed_model"] == "b"
+    assert isinstance(detail["routed_model"], str)
+    assert detail["message"] == ("request exceeds the window of every capable model; compact and retry")
+
+
+def test_overflow_detail_routed_model_owns_reported_window():
+    # FIX 5 consistency invariant: whatever window we report, routed_model is the
+    # id that actually has that window. Largest known window here is "mid".
+    pre_fit = ["small", "mid", "tiny"]
+    windows = {"small": 8000, "mid": 128000, "tiny": 4000}
+    detail = _context_overflow_detail(999999, pre_fit, windows)
+    assert detail["routed_model"] == "mid"
+    assert detail["model_window"] == 128000
+    # The reported window equals the routed model's own window.
+    assert detail["model_window"] == windows[detail["routed_model"]]
+
+
+def test_overflow_detail_model_window_is_int():
+    detail = _context_overflow_detail(999999, ["x"], {"x": 8192})
+    assert detail["model_window"] == 8192
+    assert isinstance(detail["model_window"], int)
+    # Single known candidate: routed_model is that candidate.
+    assert detail["routed_model"] == "x"
+
+
+def test_overflow_detail_handles_unknown_windows():
+    # Candidates with no known window -> model_window falls back to 0 (int),
+    # never raises. routed_model falls back to "" when none are known (FIX 5).
+    detail = _context_overflow_detail(500000, ["x", "y"], {})
+    assert detail["model_window"] == 0
+    assert isinstance(detail["model_window"], int)
+    assert detail["routed_model"] == ""
+
+
+# ── FIX 1: contract floor must never be LOWER than Flux's own count ────────
+#
+# At the filter call site the floor is composed as
+#   required = max(_compute_context_required(wl_ctx, data), input_tokens + reserve)
+# so a client header can only RAISE the floor above Flux's own
+# (input_tokens + reserve), never collapse it below. These tests replicate that
+# exact composition with the real helpers and assert the invariant
+# required_tokens >= input_tokens for a tiny/negative header against a large
+# real prompt.
+
+
+def _callsite_required_tokens(wl_ctx: dict, data: dict, input_tokens: int) -> int:
+    """Replicate the FIX-1 filter call-site floor composition exactly."""
+    flagoff_reserve = max(
+        int(data.get("max_tokens") or data.get("max_completion_tokens") or 0),
+        CONTEXT_FIT_OUTPUT_HEADROOM,
+    )
+    required = max(_compute_context_required(wl_ctx, data), input_tokens + flagoff_reserve)
+    return _context_floor(required)
+
+
+def test_floor_never_below_flux_count_tiny_header():
+    # Client claims context_tokens=1 but Flux counts a 200k prompt: the floor
+    # must NOT collapse to ~2 — it floors against Flux's own count.
+    input_tokens = 200_000
+    wl_ctx = {"context_tokens": 1, "expected_output": 0}
+    required_tokens = _callsite_required_tokens(wl_ctx, {}, input_tokens)
+    assert required_tokens >= input_tokens
+    # And it is at least Flux's own flag-off floor (input + headroom), ×1.15.
+    assert required_tokens == _context_floor(input_tokens + CONTEXT_FIT_OUTPUT_HEADROOM)
+
+
+def test_floor_never_below_flux_count_negative_header():
+    # A negative header (FIX 2) is clamped to 0 by _compute_context_required and
+    # then the max() floors against Flux's own count — never below it.
+    input_tokens = 200_000
+    wl_ctx = {"context_tokens": -50_000, "expected_output": -50_000}
+    required_tokens = _callsite_required_tokens(wl_ctx, {}, input_tokens)
+    assert required_tokens >= input_tokens
+
+
+def test_floor_header_can_still_raise_above_flux_count():
+    # When the header's REQUIRED legitimately exceeds Flux's own count, the
+    # header WINS (it raises the floor) — the max() is a floor, not a cap.
+    input_tokens = 10_000
+    wl_ctx = {"context_tokens": 180_000, "expected_output": 8_000}
+    required_tokens = _callsite_required_tokens(wl_ctx, {}, input_tokens)
+    assert required_tokens == _context_floor(188_000)
+    assert required_tokens > input_tokens
+
+
+# ── FIX 3: post-select managed-client backstop (_assert_served_context_fits) ─
+#
+# The pre-call filter runs before the bandit; the grounding short-circuit and
+# any re-pick can still land a managed client on a too-small arm. After the
+# served model is finalized, _assert_served_context_fits re-checks the ACTUAL
+# served model's real window (complete resolver) and 409s rather than overflow.
+# Fail-OPEN on unknown served window (only 409 when the window is a known int <
+# floor) to avoid false rejects.
+
+
+@pytest.fixture
+def hook():
+    return fh.ForgeProxy()
+
+
+def _served_fits(hook, served_model, required, *, managed=True, flag_on=True):
+    """Drive the FIX-3 backstop and report whether it raised a 409."""
+    from fastapi import HTTPException
+
+    import src.forge_hook as mod
+
+    data = {"model": served_model}
+    metadata = {fh.MK_WL_CONTEXT_MANAGED: managed, fh.MK_WL_REQUIRED: required}
+    orig = mod._FLUX_CONTEXT_CONTRACT_ENABLED
+    mod._FLUX_CONTEXT_CONTRACT_ENABLED = flag_on
+    try:
+        hook._assert_served_context_fits(data, metadata)
+        return None  # no 409
+    except HTTPException as exc:
+        return exc
+    finally:
+        mod._FLUX_CONTEXT_CONTRACT_ENABLED = orig
+
+
+def test_served_fit_409_when_known_window_too_small(hook, monkeypatch):
+    # Served model resolves to a known window smaller than the floor -> 409.
+    monkeypatch.setattr(fh.ForgeProxy, "_get_context_window", staticmethod(lambda m: 8000))
+    exc = _served_fits(hook, "too-small", required=100_000)
+    assert exc is not None
+    assert exc.status_code == 409
+    assert exc.detail["error"] == "context_overflow"
+
+
+def test_served_fit_no_409_when_window_fits(hook, monkeypatch):
+    # Served model window comfortably exceeds the floor -> no 409.
+    monkeypatch.setattr(fh.ForgeProxy, "_get_context_window", staticmethod(lambda m: 2_000_000))
+    assert _served_fits(hook, "big", required=100_000) is None
+
+
+def test_served_fit_fail_open_on_unknown_window(hook, monkeypatch):
+    # Unknown served window (None) -> fail OPEN, never 409 (avoids false reject).
+    monkeypatch.setattr(fh.ForgeProxy, "_get_context_window", staticmethod(lambda m: None))
+    assert _served_fits(hook, "mystery", required=100_000) is None
+
+
+def test_served_fit_skipped_for_unmanaged_client(hook, monkeypatch):
+    # Non-managed client is never subject to the backstop even on a tiny window.
+    monkeypatch.setattr(fh.ForgeProxy, "_get_context_window", staticmethod(lambda m: 8000))
+    assert _served_fits(hook, "too-small", required=100_000, managed=False) is None
+
+
+def test_served_fit_skipped_when_flag_off(hook, monkeypatch):
+    # Flag off -> backstop inert (byte-identical to today).
+    monkeypatch.setattr(fh.ForgeProxy, "_get_context_window", staticmethod(lambda m: 8000))
+    assert _served_fits(hook, "too-small", required=100_000, flag_on=False) is None
+
+
+# ── C1 / flag wiring ───────────────────────────────────────────────────────
+
+
+def test_flag_default_off():
+    # In a clean env the contract flag must default to False.
+    assert isinstance(fh._FLUX_CONTEXT_CONTRACT_ENABLED, bool)
+
+
+def test_flag_reads_env(monkeypatch):
+    monkeypatch.setenv("FLUX_CONTEXT_CONTRACT_ENABLED", "true")
+    reloaded = importlib.reload(fh)
+    try:
+        assert reloaded._FLUX_CONTEXT_CONTRACT_ENABLED is True
+    finally:
+        monkeypatch.delenv("FLUX_CONTEXT_CONTRACT_ENABLED", raising=False)
+        importlib.reload(fh)
+
+
+# ── C4: fit-on-pin (select() restricts the pin to the passed pool) ─────────
+#
+# FINDING (Case 1 — pin cannot override a filtered pool): ThompsonRouter.select()
+# at src/thompson_router.py:366 returns a pin ONLY when `pinned in
+# eligible_models`. The context-fit filter (C3) runs at the call site BEFORE
+# select() and rewrites `eligible_models` to the fitting set. So a conversation
+# pinned to a model whose window < floor is dropped from `eligible_models` and
+# can never be returned by select() — fit-on-pin is satisfied by C3's filter,
+# no extra guard needed. These tests prove that invariant.
+
+
+def _make_router():
+    from src.bandit_state import BanditState
+    from src.thompson_router import ThompsonRouter
+    from src.ts_config import TSConfig
+
+    config = TSConfig(
+        enabled=True,
+        shadow_mode=False,
+        kill_switch=False,
+        fast_path_threshold=0.7,
+        decay_factor=0.999,
+        prior_strength=20,
+        prior_strength_new_model=5,
+        l1_cache_ttl_seconds=30,
+        redis_flush_interval_s=5,
+        personalization_threshold=1000,
+        reward_rate_limit_per_hour=100,
+        conversation_pin_ttl_s=14400,
+        allow_upgrade=False,
+        allow_cross_provider=False,
+        upgrade_cost_ceiling=2.0,
+        optimization_modes={"balanced": {"latency_weight": 0.5, "cost_weight": 0.5}},
+        model_costs={"small-win": 1.0, "big-win": 2.0},
+        provider_families={"p": ["small-win", "big-win"]},
+        virtual_models={"flux-standard": None},
+        benchmark_priors={
+            "source": "test",
+            "models": {
+                "small-win": {"overall": 1200},
+                "big-win": {"overall": 1280},
+            },
+        },
+    )
+    state = BanditState(redis_client=None, config=config)
+    return ThompsonRouter(state=state, config=config)
+
+
+def test_pin_returned_when_in_eligible_pool():
+    # Baseline: a pinned model that IS in the eligible pool is returned (proves
+    # the pin path is live and the test below is meaningful).
+    router = _make_router()
+    router._set_conversation_pin("conv-1", "small-win", customer_id="cust-1")
+    decision = router.select(
+        requested_model="flux-standard",
+        messages=[{"role": "user", "content": "hello"}],
+        customer_id="cust-1",
+        eligible_models=["small-win", "big-win"],
+        conversation_id="conv-1",
+    )
+    assert decision.selected_model == "small-win"
+    assert decision.method == "conversation_pinned"
+
+
+def test_pin_dropped_from_pool_is_not_served():
+    # Fit-on-pin: when the context-fit filter has removed the too-small pinned
+    # model from eligible_models (simulated by excluding it), select() must NOT
+    # return the pin — it re-picks from the fitting pool.
+    router = _make_router()
+    router._set_conversation_pin("conv-2", "small-win", customer_id="cust-1")
+    decision = router.select(
+        requested_model="flux-standard",
+        messages=[{"role": "user", "content": "hello"}],
+        customer_id="cust-1",
+        eligible_models=["big-win"],  # small-win filtered out by C3
+        conversation_id="conv-2",
+    )
+    assert decision.selected_model != "small-win"
+    assert decision.method != "conversation_pinned"
+    assert decision.selected_model == "big-win"
+
+
+# ── C6: signal-back headers via the post-call hook ─────────────────────────
+
+
+class _Resp:
+    """Minimal stand-in for the LiteLLM response object the post-call hook sees."""
+
+    def __init__(self):
+        self._hidden_params = {}
+
+
+def _emit_headers(hook, metadata, *, flag_on):
+    """Drive the post-call success hook and return the additional_headers dict."""
+    import src.forge_hook as mod
+
+    data = {"model": "flux-standard", "metadata": metadata}
+    resp = _Resp()
+
+    class _KeyAuth:
+        metadata = {}
+
+    orig = mod._FLUX_CONTEXT_CONTRACT_ENABLED
+    mod._FLUX_CONTEXT_CONTRACT_ENABLED = flag_on
+    try:
+        import asyncio as _asyncio
+
+        _asyncio.get_event_loop().run_until_complete(hook.async_post_call_success_hook(data, _KeyAuth(), resp))
+    finally:
+        mod._FLUX_CONTEXT_CONTRACT_ENABLED = orig
+    return resp._hidden_params.get("additional_headers", {})
+
+
+def test_signal_back_headers_emitted_when_flag_on(hook):
+    # A served model with a known window + stashed REQUIRED/input-count emits all
+    # three context headers. Use a real served model id Flux can resolve a window
+    # for; if the test env can't resolve a window the header is simply absent, so
+    # we drive _get_context_window directly to keep the assertion deterministic.
+    served = "flux-standard"
+    window = hook._get_context_window(served)
+    if not isinstance(window, int) or window <= 0:
+        pytest.skip("no resolvable window for served model in test config")
+    metadata = {
+        fh.MK_SERVED_MODEL: served,
+        fh.MK_WL_REQUIRED: window // 2,
+        fh.MK_WL_INPUT_TOKENS_COUNTED: 4321,
+    }
+    headers = _emit_headers(hook, metadata, flag_on=True)
+    assert headers.get("x-flux-model-window") == str(window)
+    assert headers.get("x-flux-context-pressure") == f"{(window // 2) / window:.3f}"
+    assert headers.get("x-flux-context-tokens-counted") == "4321"
+
+
+def test_pressure_header_clamped_to_one(hook):
+    # FIX 4: contract §2 declares x-flux-context-pressure as float 0..1. When the
+    # stashed REQUIRED exceeds the served window, pressure must emit "1.000",
+    # never a >1 value — the genuine-overflow magnitude rides the 409 body.
+    served = "flux-standard"
+    window = hook._get_context_window(served)
+    if not isinstance(window, int) or window <= 0:
+        pytest.skip("no resolvable window for served model in test config")
+    metadata = {
+        fh.MK_SERVED_MODEL: served,
+        fh.MK_WL_REQUIRED: window * 3,  # far beyond the window
+        fh.MK_WL_INPUT_TOKENS_COUNTED: 100,
+    }
+    headers = _emit_headers(hook, metadata, flag_on=True)
+    assert headers.get("x-flux-context-pressure") == "1.000"
+
+
+def test_signal_back_headers_absent_when_flag_off(hook):
+    served = "flux-standard"
+    window = hook._get_context_window(served)
+    if not isinstance(window, int) or window <= 0:
+        pytest.skip("no resolvable window for served model in test config")
+    metadata = {
+        fh.MK_SERVED_MODEL: served,
+        fh.MK_WL_REQUIRED: window // 2,
+        fh.MK_WL_INPUT_TOKENS_COUNTED: 4321,
+    }
+    headers = _emit_headers(hook, metadata, flag_on=False)
+    assert "x-flux-model-window" not in headers
+    assert "x-flux-context-pressure" not in headers
+    assert "x-flux-context-tokens-counted" not in headers


### PR DESCRIPTION
**Found by a live end-to-end test against `api.fluxrouter.ai`** (not by the green gates — the unit tests used the frozen-spec body shape, which diverges from what live Flux actually returns).

## The bug
The merged #282 `parse_flux_409` matched a **flat** body whose top-level `error` field equals `"context_overflow"`. But live prod returns the payload **wrapped + stringified as a Python dict repr** inside `error.message` (LiteLLM re-serializes Flux's `HTTPException(409, detail={…})` into the OpenAI error envelope):

```
spec / Flux's _context_overflow_detail():  {"error":"context_overflow","required_tokens":N,...}     (flat)
live wire (captured 2026-06-23):           {"error":{"message":"{'error': 'context_overflow', ...}"}} (wrapped repr)
```

So the strict parser fell through to a generic `Api` error and **compact-and-retry never fired against live Flux**. The Flux source also carries an in-flight **413 `context_window_exceeded`** variant.

## The fix
`parse_flux_409` → `parse_flux_overflow`, tolerant of every observed shape:
- accepts both overflow codes (`context_overflow`, `context_window_exceeded`);
- parses the flat body, the FastAPI `detail` envelope, and the wrapped single-quoted Python-repr (normalized to JSON);
- a digit-scan fallback recovers `required_tokens`/`model_window` even if the structured parse fails, so the numbers can never be hidden by a quirky `message`;
- the engine now treats **409 or 413** as the overflow trigger.

`ProviderError::ContextOverflow` is still non-retryable; the engine's existing compact-and-retry path is unchanged.

## Verified against the authoritative source
This branch also adds `docs/design/flux-282-reference/` — the frozen Flux handshake surface (README + the 53-case `test_context_contract.py` + `flux-contract-surface.py`, from TradeCanyon/flux-router PR #79). Confirmed: Flux's `_context_overflow_detail()` returns the flat dict, LiteLLM wraps it on the wire — exactly the two shapes this parser now bridges.

## Tests
Regression tests use the **exact captured live 409 body** + the flat spec shape + both 413 forms (raw `detail` and wrapped). Hetzner gate: `fmt`/`clippy -D warnings` clean, `nextest -p wcore-providers` **757 passed**.

Refs #282. Follow-up to PR #77 (merged). Cross-lane: recommend Flux freeze the overflow body to one shape (3 observed) — `needs:flux` note to follow on #282.