### PR TITLE
fix(#293): authenticate openai-chatgpt from ~/.codex/auth.json

### DIFF
--- a/crates/wcore-agent/src/oauth/chatgpt.rs
+++ b/crates/wcore-agent/src/oauth/chatgpt.rs
@@ -866,6 +866,34 @@ mod tests {
         ChatGptTokenManager::new(OAuthStorage::at_root(root).expect("storage"))
     }
 
+    /// Point `CODEX_HOME` at a guaranteed-empty (but existing) dir for the
+    /// guard's lifetime, restoring the prior value on drop. A "no engine token"
+    /// assertion must not be contaminated by a real `~/.codex/auth.json` on the
+    /// host — CI runners can carry a live Codex login, which the #293 fallback
+    /// would (correctly, in production) import. Pair with
+    /// `#[serial_test::serial]` since it mutates process-global env.
+    struct CodexHomeGuard {
+        _dir: TempDir,
+        saved: Option<std::ffi::OsString>,
+    }
+    impl CodexHomeGuard {
+        fn empty() -> Self {
+            let dir = TempDir::new().unwrap();
+            let saved = std::env::var_os("CODEX_HOME");
+            // SAFETY: serial test; reverted on drop.
+            unsafe { std::env::set_var("CODEX_HOME", dir.path()) };
+            Self { _dir: dir, saved }
+        }
+    }
+    impl Drop for CodexHomeGuard {
+        fn drop(&mut self) {
+            match &self.saved {
+                Some(v) => unsafe { std::env::set_var("CODEX_HOME", v) },
+                None => unsafe { std::env::remove_var("CODEX_HOME") },
+            }
+        }
+    }
+
     fn token(access: &str, refresh: Option<&str>, expires_at: Option<u64>) -> OAuthTokens {
         OAuthTokens {
             access_token: access.to_string(),
@@ -1047,7 +1075,11 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn errors_when_no_tokens_stored() {
+        // Isolate CODEX_HOME so the empty engine store can't be backfilled by a
+        // real Codex login on the host (the #293 fallback).
+        let _codex = CodexHomeGuard::empty();
         let tmp = TempDir::new().unwrap();
         let mgr = manager_at(tmp.path().join("oauth"));
         let err = mgr.get().await.unwrap_err();
@@ -1055,7 +1087,11 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn clear_cache_drops_in_memory_tokens() {
+        // After the backing file is removed the re-load must miss; isolate
+        // CODEX_HOME so the #293 Codex fallback can't satisfy it instead.
+        let _codex = CodexHomeGuard::empty();
         let tmp = TempDir::new().unwrap();
         let mgr = manager_at(tmp.path().join("oauth"));
         mgr.storage

--- a/crates/wcore-agent/src/oauth/chatgpt.rs
+++ b/crates/wcore-agent/src/oauth/chatgpt.rs
@@ -416,20 +416,37 @@ impl ChatGptTokenManager {
         exp <= now
     }
 
-    /// Load the cached token from disk on first call, then keep it in memory.
-    /// A cache miss returns `Ok(None)` so the caller can surface login
-    /// guidance rather than an opaque error.
+    /// Load the active token on first call, then keep it in memory. Reads the
+    /// engine store first and, ONLY when it holds no token, falls back to the
+    /// Codex CLI's `~/.codex/auth.json`. A miss on both returns `Ok(None)` so
+    /// the caller can surface login guidance rather than an opaque error.
+    ///
+    /// The Codex-CLI fallback is the non-interactive desktop contract (#293):
+    /// "Sign in with ChatGPT" in the Wayland app writes a valid login to
+    /// `~/.codex/auth.json` but does not populate the engine store, and there is
+    /// no `auth login chatgpt` subcommand to trigger an import — so a present,
+    /// valid Codex auth doc must authenticate `--provider openai-chatgpt` on its
+    /// own. (The xAI manager has the twin fallback for the Grok CLI file.)
+    /// Store-first, rather than xAI's "fresher of the two", keeps a token the
+    /// engine already owns authoritative and consults the CLI file only as the
+    /// genuine no-engine-token fallback this contract requires.
     async fn load_cached(&self) -> Result<Option<OAuthTokens>, String> {
         let mut guard = self.cached.lock().await;
         if guard.is_some() {
             return Ok(guard.clone());
         }
-        let from_disk = self
+        let mut tokens = self
             .storage
             .load(PROVIDER)
             .map_err(|e| format!("oauth storage load failed: {e}"))?;
-        *guard = from_disk.clone();
-        Ok(from_disk)
+        if tokens.is_none() {
+            // A malformed/absent/untrusted Codex file is "no CLI token", not a
+            // hard error: fall through to the not-signed-in guidance instead of
+            // failing the load.
+            tokens = import_codex_cli_tokens().ok();
+        }
+        *guard = tokens.clone();
+        Ok(tokens)
     }
 
     /// Clear the in-memory token cache. Logout calls this so a live manager
@@ -1130,6 +1147,87 @@ mod tests {
         assert_eq!(tokens.refresh_token.as_deref(), Some("rt-codex"));
         assert_eq!(tokens.id_token.as_deref(), Some("id-codex"));
         assert_eq!(tokens.expires_at_unix_secs, Some(exp));
+    }
+
+    /// #293: with an EMPTY engine store but a valid `~/.codex/auth.json`, the
+    /// manager authenticates non-interactively from the Codex CLI file instead
+    /// of failing `--provider openai-chatgpt` with "not signed in". This is the
+    /// desktop contract (the app writes the Codex file; there is no interactive
+    /// `auth login chatgpt` to populate the engine store).
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn get_falls_back_to_codex_cli_when_engine_store_empty() {
+        let tmp = TempDir::new().unwrap();
+        // Empty engine store — nothing ever persisted to it.
+        let mgr = manager_at(tmp.path().join("oauth"));
+
+        let home = tmp.path().join("codex");
+        let access = jwt_with_account_and_exp("acct_codex", far_future());
+        write_codex_auth(
+            &home,
+            serde_json::json!({
+                "OPENAI_API_KEY": serde_json::Value::Null,
+                "tokens": {
+                    "access_token": access,
+                    "refresh_token": "rt-codex",
+                    "id_token": "id-codex",
+                }
+            }),
+        );
+
+        // SAFETY: serial test; env reverted before the assertions run.
+        let saved = std::env::var_os("CODEX_HOME");
+        unsafe { std::env::set_var("CODEX_HOME", &home) };
+        let result = mgr.get().await;
+        match saved {
+            Some(v) => unsafe { std::env::set_var("CODEX_HOME", v) },
+            None => unsafe { std::env::remove_var("CODEX_HOME") },
+        }
+
+        let (token, account_id) = result.expect("codex-CLI fallback should authenticate");
+        assert_eq!(token, access);
+        assert_eq!(account_id, "acct_codex");
+    }
+
+    /// Guard the store-first precedence: a token in the engine store is used
+    /// as-is and the Codex CLI file is NOT consulted (so existing engine logins
+    /// keep working and can't be silently shadowed by a stale Codex file).
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn engine_store_token_takes_precedence_over_codex_cli() {
+        let tmp = TempDir::new().unwrap();
+        let mut mgr = manager_at(tmp.path().join("oauth"));
+        // Fresh stored token → get() must return it without refreshing, so a
+        // dead token_url proves no network/refresh happened.
+        mgr.flow = Arc::new(build_chatgpt_flow_with_token_url(
+            "http://127.0.0.1:1/never",
+        ));
+        let stored = jwt_with_account_and_exp("acct_store", far_future());
+        mgr.storage
+            .store(PROVIDER, &token(&stored, Some("rt"), Some(far_future())))
+            .unwrap();
+
+        let home = tmp.path().join("codex");
+        let codex = jwt_with_account_and_exp("acct_codex", far_future());
+        write_codex_auth(
+            &home,
+            serde_json::json!({ "tokens": { "access_token": codex, "refresh_token": "rt-codex" } }),
+        );
+
+        let saved = std::env::var_os("CODEX_HOME");
+        unsafe { std::env::set_var("CODEX_HOME", &home) };
+        let result = mgr.get().await;
+        match saved {
+            Some(v) => unsafe { std::env::set_var("CODEX_HOME", v) },
+            None => unsafe { std::env::remove_var("CODEX_HOME") },
+        }
+
+        let (token, account_id) = result.expect("engine store token");
+        assert_eq!(
+            token, stored,
+            "engine store must win over the Codex CLI file"
+        );
+        assert_eq!(account_id, "acct_store");
     }
 
     #[test]

--- a/crates/wcore-agent/tests/chatgpt_oauth_e2e.rs
+++ b/crates/wcore-agent/tests/chatgpt_oauth_e2e.rs
@@ -352,6 +352,7 @@ async fn end_to_end_response_done_terminal_closes_cleanly() {
 /// "not signed in" guidance as a `ProviderError::Connection` BEFORE any HTTP
 /// request is attempted (the Codex mock is mounted with `expect(0)`).
 #[tokio::test]
+#[serial_test::serial]
 async fn end_to_end_no_token_surfaces_login_guidance() {
     let codex = MockServer::start().await;
     Mock::given(method("POST"))
@@ -363,15 +364,27 @@ async fn end_to_end_no_token_surfaces_login_guidance() {
 
     let tmp = TempDir::new().unwrap();
     let storage = OAuthStorage::at_root(tmp.path().join("oauth")).unwrap();
-    // Nothing stored.
+    // Nothing stored. Isolate CODEX_HOME to an empty dir so the #293 Codex-CLI
+    // fallback can't backfill the empty store from a real host login (CI runners
+    // may carry a live ~/.codex/auth.json). Restored before the assertions so a
+    // failure can't leak the env var to other serial tests.
+    let codex_home = tmp.path().join("codex-empty");
+    std::fs::create_dir_all(&codex_home).unwrap();
+    let saved_codex_home = std::env::var_os("CODEX_HOME");
+    // SAFETY: serial test; reverted below before any assertion.
+    unsafe { std::env::set_var("CODEX_HOME", &codex_home) };
 
     let mgr = Arc::new(ChatGptTokenManager::new(storage));
     let provider = provider_against(codex.uri(), bearer_over_manager(mgr));
 
-    let err = provider
-        .stream(&make_request())
-        .await
-        .expect_err("missing token must error before any HTTP call");
+    let result = provider.stream(&make_request()).await;
+
+    match saved_codex_home {
+        Some(v) => unsafe { std::env::set_var("CODEX_HOME", v) },
+        None => unsafe { std::env::remove_var("CODEX_HOME") },
+    }
+
+    let err = result.expect_err("missing token must error before any HTTP call");
     match err {
         ProviderError::Connection(msg) => {
             assert!(msg.contains("not signed in"), "msg={msg}");


### PR DESCRIPTION
## Problem
`--provider openai-chatgpt` failed with `Connection error: not signed in to ChatGPT — run \`wayland auth login chatgpt\`` **even when a valid Codex CLI auth file was present** (`~/.codex/auth.json`). This is the **engine half of #243** — the desktop half (model selectable, correct `--provider openai-chatgpt` spawn, valid auth file written) is already fixed and confirmed live on Windows.

## Root cause
`ChatGptTokenManager::load_cached()` read **only** the engine's own OAuth store and never fell back to `import_codex_cli_tokens()`. The Wayland desktop's "Sign in with ChatGPT" writes a valid login to `~/.codex/auth.json` (the documented contract) but does **not** populate the engine store, and there is **no `auth login chatgpt` subcommand** to trigger an import — so the file-import path is the only way a present, valid auth doc can authenticate non-interactively. A Codex-only login therefore surfaced as "not signed in".

The xAI manager already has the twin fallback (`read_grok_cli_tokens()` for `~/.grok/auth.json`); the ChatGPT manager was simply never given the equivalent.

## Fix
Add a **store-first, Codex-CLI fallback** in `load_cached()`: when the engine store holds no token, import `~/.codex/auth.json` via the existing (C6-hardened, ownership/containment-checked) `import_codex_cli_tokens()`. A malformed/absent/untrusted Codex file is treated as "no CLI token" (not a hard error), falling through to the existing not-signed-in guidance.

Store-first precedence (vs xAI's "fresher of the two") keeps an engine-owned token authoritative and ensures it can't be silently shadowed by a stale Codex file.

## Tests (new, both green on the Hetzner gate)
- `get_falls_back_to_codex_cli_when_engine_store_empty` — empty engine store + valid `~/.codex/auth.json` → `get()` authenticates (the #293 acceptance scenario).
- `engine_store_token_takes_precedence_over_codex_cli` — a stored engine token is used as-is and the Codex file is not consulted (dead refresh URL proves no network).

## Verification
Gated on Hetzner (`wcore-agent` scope): `cargo fmt --check` ✓ · `cargo clippy --all-targets -D warnings` ✓ · `cargo nextest` 1895 passed (only the 2 documented pre-existing flakes failed). Both new tests PASS.

## Acceptance (desktop, post-release)
```
wayland-core --provider openai-chatgpt --model gpt-5.2 --max-turns 1 "Reply with exactly: PONG"
```
on a box with a fresh in-app ChatGPT sign-in → completes a turn (was FAIL on 0.12.5/0.12.6).

Closes the engine half of #243; unblocks the desktop #243 full E2E. Related: #272 (Doctor reconnect — `login_status()` has the same store-only gap; deliberately out of scope here), #290 (Windows CODEX_HOME test path).