### PR TITLE
feat(providers): add Sakana AI (Fugu) — OpenAI-compatible endpoint

### DIFF
--- a/crates/wcore-cli/src/provider_keys.rs
+++ b/crates/wcore-cli/src/provider_keys.rs
@@ -39,12 +39,13 @@ pub enum Provider {
     Cerebras,
     Perplexity,
     Moonshot,
+    Sakana,
 }
 
 impl Provider {
     /// Every provider, in picker display order. Used to render the
     /// provider picker shown for ambiguous / unrecognized keys.
-    pub const ALL: [Provider; 13] = [
+    pub const ALL: [Provider; 14] = [
         Provider::Anthropic,
         Provider::OpenAi,
         Provider::OpenRouter,
@@ -58,6 +59,7 @@ impl Provider {
         Provider::Cerebras,
         Provider::Perplexity,
         Provider::Moonshot,
+        Provider::Sakana,
     ];
 
     /// Human-readable provider name. Shown on the detect line, the
@@ -77,6 +79,7 @@ impl Provider {
             Provider::Cerebras => "Cerebras",
             Provider::Perplexity => "Perplexity",
             Provider::Moonshot => "Moonshot",
+            Provider::Sakana => "Sakana",
         }
     }
 
@@ -98,6 +101,7 @@ impl Provider {
             Provider::Cerebras => "cerebras",
             Provider::Perplexity => "perplexity",
             Provider::Moonshot => "moonshot",
+            Provider::Sakana => "sakana",
         }
     }
 
@@ -169,6 +173,9 @@ pub fn detect_provider(key: &str) -> Detected {
         Detected::One(Provider::Perplexity)
     } else if key.starts_with("csk-") {
         Detected::One(Provider::Cerebras)
+    } else if key.starts_with("fish_") {
+        // Sakana AI keys are prefixed `fish_` (verified live).
+        Detected::One(Provider::Sakana)
     } else if is_deepseek_key(key) {
         // DeepSeek issues `sk-` + exactly 32 hex chars — a shape precise
         // enough to detect without guessing.
@@ -196,7 +203,7 @@ pub struct EnvKey {
 /// The environment variable → provider map onboarding scans on entry.
 /// Two variables map to Gemini (`GEMINI_API_KEY` and Google's older
 /// `GOOGLE_API_KEY`); the first one set wins.
-pub const ENV_VAR_MAP: [(&str, Provider); 13] = [
+pub const ENV_VAR_MAP: [(&str, Provider); 14] = [
     ("ANTHROPIC_API_KEY", Provider::Anthropic),
     ("OPENAI_API_KEY", Provider::OpenAi),
     ("OPENROUTER_API_KEY", Provider::OpenRouter),
@@ -210,6 +217,7 @@ pub const ENV_VAR_MAP: [(&str, Provider); 13] = [
     ("TOGETHER_API_KEY", Provider::Together),
     ("CEREBRAS_API_KEY", Provider::Cerebras),
     ("PERPLEXITY_API_KEY", Provider::Perplexity),
+    ("SAKANA_API_KEY", Provider::Sakana),
 ];
 
 /// Scan the process environment for known provider API-key variables.
@@ -315,6 +323,10 @@ pub fn validation_endpoint(provider: Provider, key: &str) -> (String, AuthStyle)
         ),
         Provider::Moonshot => (
             "https://api.moonshot.ai/v1/models".to_string(),
+            AuthStyle::Bearer,
+        ),
+        Provider::Sakana => (
+            "https://api.sakana.ai/v1/models".to_string(),
             AuthStyle::Bearer,
         ),
     }
@@ -460,6 +472,11 @@ mod tests {
         assert_eq!(
             detect_provider("csk-abcdef"),
             Detected::One(Provider::Cerebras)
+        );
+        // Sakana AI keys are prefixed `fish_`.
+        assert_eq!(
+            detect_provider("fish_f2570dfe4dac"),
+            Detected::One(Provider::Sakana)
         );
     }
 

--- a/crates/wcore-config/src/compat.rs
+++ b/crates/wcore-config/src/compat.rs
@@ -447,7 +447,9 @@ impl ProviderCompat {
         // route — they leave this `None` (→ "client"). This is the single,
         // vendor-neutral place that classifies a router vs. a direct provider.
         let input_optimization = match provider_id {
-            "flux-router" | "openrouter" => Some("router".to_string()),
+            // Sakana/Fugu is a multi-agent orchestration layer that routes and
+            // optimizes upstream — same class as flux-router/openrouter.
+            "flux-router" | "openrouter" | "sakana" => Some("router".to_string()),
             _ => None,
         };
         Self {
@@ -562,6 +564,17 @@ impl ProviderCompat {
         Self {
             api_path: Some("/chat/completions".into()),
             ..Self::openai_compat_provider("flux-router")
+        }
+    }
+
+    /// Defaults for Sakana AI ("Fugu") — OpenAI-compat orchestration endpoint
+    /// at `https://api.sakana.ai/v1`. The base URL ends in `/v1`, so pin
+    /// `api_path` to avoid `/v1/v1`. Classified as a router (Fugu optimizes
+    /// upstream) via `openai_compat_provider("sakana")`.
+    pub fn sakana_defaults() -> Self {
+        Self {
+            api_path: Some("/chat/completions".into()),
+            ..Self::openai_compat_provider("sakana")
         }
     }
 
@@ -1314,6 +1327,7 @@ mod cache_breakpoint_tests {
             ProviderType::Cohere => ProviderCompat::cohere_defaults(),
             ProviderType::OpenAIChatGpt => ProviderCompat::chatgpt_defaults(),
             ProviderType::MiniMax => ProviderCompat::minimax_defaults(),
+            ProviderType::Sakana => ProviderCompat::sakana_defaults(),
         };
         assert_eq!(
             resolved.cache_message_breakpoints,

--- a/crates/wcore-config/src/config.rs
+++ b/crates/wcore-config/src/config.rs
@@ -980,6 +980,12 @@ pub enum ProviderType {
     /// struct, distinguished only by base URL, `provider_type` cost label, and
     /// the offline model-alias fallback key. Default model: `MiniMax-M2`.
     MiniMax,
+    /// Sakana AI ("Fugu") — OpenAI-compatible chat-completions endpoint at
+    /// `https://api.sakana.ai/v1`. Bearer auth (keys are prefixed `fish_`).
+    /// Fugu is a multi-agent orchestration/routing layer; models: `fugu`
+    /// (default), `fugu-ultra`, `fugu-ultra-20260615`. Thin newtype over
+    /// `OpenAIProvider`.
+    Sakana,
 }
 
 impl ProviderType {
@@ -1009,6 +1015,7 @@ impl ProviderType {
                 // its compat preset is built on `openai_compat_provider`, so it
                 // belongs to the OpenAI-compatible family for plumbing purposes.
                 | ProviderType::OpenAIChatGpt
+                | ProviderType::Sakana
         )
     }
 }
@@ -1071,6 +1078,9 @@ pub(crate) fn default_model_for(provider: ProviderType) -> &'static str {
         ProviderType::Moonshot | ProviderType::Qwen => "",
         // F-025: Mistral + Cohere have heterogeneous model catalogs; user sets model.
         ProviderType::Mistral | ProviderType::Cohere => "",
+        // Sakana has a clear headline default — `fugu` routes across providers,
+        // so `--provider sakana` with no model just works.
+        ProviderType::Sakana => "fugu",
         // ChatGPT Codex default: gpt-5.5 (the headline Codex model). See
         // `wcore_types::model_aliases` codex consts for the full catalog.
         ProviderType::OpenAIChatGpt => "gpt-5.5",
@@ -1139,6 +1149,7 @@ pub fn provider_type_slug(provider: ProviderType) -> &'static str {
         ProviderType::Cerebras => "cerebras",
         ProviderType::OpenRouter => "openrouter",
         ProviderType::FluxRouter => "flux-router",
+        ProviderType::Sakana => "sakana",
         ProviderType::Deepseek => "deepseek",
         ProviderType::Xai => "xai",
         ProviderType::Groq => "groq",
@@ -1311,7 +1322,9 @@ pub fn default_base_url_for(provider: ProviderType) -> String {
         | ProviderType::Perplexity
         | ProviderType::Cerebras
         | ProviderType::OpenRouter
-        | ProviderType::FluxRouter => String::new(),
+        | ProviderType::FluxRouter
+        // Sakana's newtype falls back to SAKANA_DEFAULT_BASE_URL when empty.
+        | ProviderType::Sakana => String::new(),
         ProviderType::Deepseek | ProviderType::Xai | ProviderType::Groq => String::new(),
         ProviderType::Moonshot | ProviderType::Qwen => String::new(),
         // F-025: Mistral + Cohere fall back to their own default base URLs.
@@ -1347,6 +1360,7 @@ pub fn compat_defaults_for(provider: ProviderType) -> ProviderCompat {
         ProviderType::Cerebras => ProviderCompat::cerebras_defaults(),
         ProviderType::OpenRouter => ProviderCompat::openrouter_defaults(),
         ProviderType::FluxRouter => ProviderCompat::flux_router_defaults(),
+        ProviderType::Sakana => ProviderCompat::sakana_defaults(),
         ProviderType::Deepseek => ProviderCompat::deepseek_defaults(),
         ProviderType::Xai => ProviderCompat::xai_defaults(),
         ProviderType::Groq => ProviderCompat::groq_defaults(),
@@ -1700,6 +1714,9 @@ fn parse_builtin_provider(s: &str) -> Option<ProviderType> {
         // v0.8.1 U10a: router-class OpenAI-compatible endpoints.
         "openrouter" => Some(ProviderType::OpenRouter),
         "flux-router" | "flux" => Some(ProviderType::FluxRouter),
+        // Sakana AI ("Fugu") — OpenAI-compatible. "fugu" is the natural
+        // model-brand alias users reach for.
+        "sakana" | "fugu" => Some(ProviderType::Sakana),
         // v0.8.1 U10b: native OpenAI-compatible providers.
         "deepseek" => Some(ProviderType::Deepseek),
         "xai" | "grok" => Some(ProviderType::Xai),
@@ -1734,7 +1751,7 @@ pub const BUILTIN_PROVIDER_NAMES: &str = "anthropic, openai, bedrock, vertex, ge
      azure-openai (alias: azure), together, fireworks, nvidia, perplexity, \
      cerebras, openrouter, flux-router (alias: flux), deepseek, xai (alias: grok), \
      groq, moonshot (alias: kimi), qwen (aliases: alibaba, dashscope), \
-     mistral, cohere, openai-chatgpt (alias: chatgpt)";
+     mistral, cohere, openai-chatgpt (alias: chatgpt), sakana (alias: fugu)";
 
 fn merge_provider_configs(base: ProviderConfig, overlay: ProviderConfig) -> ProviderConfig {
     ProviderConfig {
@@ -1989,6 +2006,11 @@ fn resolve_api_key(
                 return Ok(key);
             }
         }
+        ProviderType::Sakana => {
+            if let Ok(key) = std::env::var("SAKANA_API_KEY") {
+                return Ok(key);
+            }
+        }
     }
 
     Err(MissingApiKey.into())
@@ -2046,6 +2068,7 @@ pub fn credentials_store_key(provider: ProviderType) -> Option<String> {
         ProviderType::Mistral => "providers.mistral.api_key",
         ProviderType::Cohere => "providers.cohere.api_key",
         ProviderType::MiniMax => "providers.minimax.api_key",
+        ProviderType::Sakana => "providers.sakana.api_key",
     };
     Some(key.to_string())
 }

--- a/crates/wcore-providers/src/lib.rs
+++ b/crates/wcore-providers/src/lib.rs
@@ -22,6 +22,7 @@ pub mod groq;
 pub mod http_client;
 pub mod key_rotation;
 pub mod key_validation;
+pub mod sakana;
 // litellm, lmstudio, vllm: deleted per DECISIONS.md §D3 (Sean, 2026-05-23).
 // These were framework-shaped local-inference adapters shipped as code but
 // never wired to ProviderType arms. Revivable as plugins if needed.
@@ -406,6 +407,10 @@ pub fn create_native_provider(config: &Config) -> Arc<dyn LlmProvider> {
         ProviderType::FluxRouter => Arc::new(new_openai_compat(&config.base_url, |b| match b {
             Some(url) => flux_router::FluxRouterProvider::new(&config.api_key, url, compat, debug),
             None => flux_router::FluxRouterProvider::with_defaults(&config.api_key, compat, debug),
+        })),
+        ProviderType::Sakana => Arc::new(new_openai_compat(&config.base_url, |b| match b {
+            Some(url) => sakana::SakanaProvider::new(&config.api_key, url, compat, debug),
+            None => sakana::SakanaProvider::with_defaults(&config.api_key, compat, debug),
         })),
         // v0.8.1 U10b: 3 more OpenAI-compatible providers — DeepSeek, xAI, Groq.
         ProviderType::Deepseek => Arc::new(new_openai_compat(&config.base_url, |b| match b {

--- a/crates/wcore-providers/src/sakana.rs
+++ b/crates/wcore-providers/src/sakana.rs
@@ -1,0 +1,184 @@
+//! Sakana AI provider — the "Fugu" OpenAI-API-compatible endpoint.
+//!
+//! Sakana's `https://api.sakana.ai/v1` surface speaks the standard OpenAI
+//! chat-completions wire format (Bearer auth, `/v1/chat/completions`, SSE
+//! `chat.completion.chunk` frames terminated by `[DONE]`, OpenAI error
+//! envelopes — verified live). Fugu itself is a multi-agent orchestration
+//! layer that routes across upstream frontier models. Like
+//! [`crate::flux_router::FluxRouterProvider`], this adapter is a thin newtype
+//! over [`OpenAIProvider`]; vendor quirks belong in [`OpenAIProvider`] and
+//! [`ProviderCompat`], not here.
+//!
+//! Models: `fugu` (default), `fugu-ultra`, `fugu-ultra-20260615`.
+//! Register via [`register_sakana_in`] against a [`ProviderRegistry`]. The id
+//! is lowercased to `"sakana"`.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use tokio::sync::mpsc;
+
+use wcore_config::compat::ProviderCompat;
+use wcore_config::debug::DebugConfig;
+use wcore_types::llm::{LlmEvent, LlmRequest};
+
+use crate::openai::OpenAIProvider;
+use crate::registry::{ProviderFactory, ProviderRegistry, RegistryError};
+use crate::{LlmProvider, ProviderError};
+
+/// Default Sakana base URL (OpenAI-compat surface). Override via `base_url` in
+/// config or `--base-url`.
+pub const SAKANA_DEFAULT_BASE_URL: &str = "https://api.sakana.ai/v1";
+
+/// Sakana ("Fugu") provider — delegates to [`OpenAIProvider`] over Sakana's
+/// OpenAI-compatible endpoint.
+pub struct SakanaProvider {
+    inner: OpenAIProvider,
+}
+
+impl SakanaProvider {
+    /// Construct with an explicit base URL.
+    pub fn new(api_key: &str, base_url: &str, compat: ProviderCompat, debug: DebugConfig) -> Self {
+        Self {
+            inner: OpenAIProvider::new(api_key, base_url, compat, debug),
+        }
+    }
+
+    /// Construct with Sakana's default base URL ([`SAKANA_DEFAULT_BASE_URL`]).
+    pub fn with_defaults(api_key: &str, compat: ProviderCompat, debug: DebugConfig) -> Self {
+        Self::new(api_key, SAKANA_DEFAULT_BASE_URL, compat, debug)
+    }
+}
+
+#[async_trait]
+impl LlmProvider for SakanaProvider {
+    async fn stream(
+        &self,
+        request: &LlmRequest,
+    ) -> Result<mpsc::Receiver<LlmEvent>, ProviderError> {
+        self.inner.stream(request).await
+    }
+
+    async fn list_models(&self) -> anyhow::Result<Vec<crate::ModelInfo>> {
+        self.inner.list_models().await
+    }
+}
+
+/// Register a Sakana factory in the given registry under the lowercased id
+/// `"sakana"`. The factory captures the provided `api_key`, `base_url`,
+/// `compat`, and `debug` and constructs a fresh provider per call.
+pub fn register_sakana_in<R: ProviderRegistry>(
+    registry: &mut R,
+    api_key: String,
+    base_url: String,
+    compat: ProviderCompat,
+    debug: DebugConfig,
+) -> Result<(), RegistryError> {
+    let factory: ProviderFactory = Arc::new(move || {
+        Arc::new(SakanaProvider::new(
+            &api_key,
+            &base_url,
+            compat.clone(),
+            debug.clone(),
+        )) as Arc<dyn LlmProvider>
+    });
+    registry.register("sakana", factory)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::registry::WaylandProviderRegistry;
+
+    #[test]
+    fn constructs_with_default_url() {
+        let p = SakanaProvider::with_defaults(
+            "fish_test",
+            ProviderCompat::default(),
+            DebugConfig::default(),
+        );
+        let _ = p;
+    }
+
+    #[test]
+    fn constructs_with_custom_url() {
+        let p = SakanaProvider::new(
+            "fish_test",
+            "http://localhost:9999",
+            ProviderCompat::default(),
+            DebugConfig::default(),
+        );
+        let _ = p;
+    }
+
+    #[test]
+    fn default_base_url_is_sakana_v1() {
+        assert_eq!(SAKANA_DEFAULT_BASE_URL, "https://api.sakana.ai/v1");
+    }
+
+    #[tokio::test]
+    async fn stream_errors_on_unreachable_host() {
+        // Point at an unroutable port — stream() must surface a ProviderError,
+        // not panic, and not hang. Reuses OpenAIProvider's error path.
+        let p = SakanaProvider::new(
+            "fish_test",
+            "http://127.0.0.1:1",
+            ProviderCompat::default(),
+            DebugConfig::default(),
+        );
+        let req = LlmRequest {
+            model: "fugu".into(),
+            system: String::new(),
+            messages: vec![],
+            tools: vec![],
+            max_tokens: 16,
+            thinking: None,
+            reasoning_effort: None,
+            cache_tier: None,
+            routing_hint: None,
+            stop_sequences: Vec::new(),
+            web_search: false,
+            conversation_id: None,
+            client_context_tokens: None,
+        };
+        let result = p.stream(&req).await;
+        assert!(result.is_err(), "expected error from unreachable host");
+    }
+
+    #[test]
+    fn register_uses_lowercase_id() {
+        let mut r = WaylandProviderRegistry::new();
+        register_sakana_in(
+            &mut r,
+            "fish_test".into(),
+            SAKANA_DEFAULT_BASE_URL.into(),
+            ProviderCompat::default(),
+            DebugConfig::default(),
+        )
+        .unwrap();
+        assert!(r.get("sakana").is_some());
+        assert!(r.get("Sakana").is_none());
+        assert!(r.get("SAKANA").is_none());
+    }
+
+    #[test]
+    fn register_rejects_duplicate() {
+        let mut r = WaylandProviderRegistry::new();
+        register_sakana_in(
+            &mut r,
+            "fish_test".into(),
+            SAKANA_DEFAULT_BASE_URL.into(),
+            ProviderCompat::default(),
+            DebugConfig::default(),
+        )
+        .unwrap();
+        let second = register_sakana_in(
+            &mut r,
+            "fish_other".into(),
+            SAKANA_DEFAULT_BASE_URL.into(),
+            ProviderCompat::default(),
+            DebugConfig::default(),
+        );
+        assert!(matches!(second, Err(RegistryError::DuplicateId(_))));
+    }
+}

--- a/crates/wcore-types/src/model_aliases.rs
+++ b/crates/wcore-types/src/model_aliases.rs
@@ -240,6 +240,9 @@ pub fn expand_short_form(model: &str) -> Option<&'static str> {
         ("minimax", "m2") => Some(MINIMAX_M2),
         ("minimax", "m2.5") => Some(MINIMAX_M2_5),
         ("minimax", "m3") => Some(MINIMAX_M3),
+        // Sakana ("Fugu") carries NO hardcoded catalog — it relies on the live
+        // `/v1/models` fetch (like flux-router/groq), so there is nothing here
+        // to drift out of date.
         _ => None,
     }
 }
@@ -270,6 +273,12 @@ pub const MINIMAX_M3: &str = "MiniMax-M3";
 pub fn minimax_m3() -> String {
     from_env_or(MINIMAX_M3, "E2E_MINIMAX_M3")
 }
+
+// Sakana ("Fugu") deliberately has NO model-id constants or catalog here: its
+// `/model` picker is driven by the live `https://api.sakana.ai/v1/models`
+// fetch (`OpenAIProvider::list_models`), the same live-source pattern Hermes /
+// OpenClaw / the desktop app use (models.dev) — never a hand-typed list. The
+// per-provider default (`fugu`) lives in `wcore_config::default_model_for`.
 
 /// The selectable models for a provider, as `(short_form, resolved_id)`
 /// pairs in display order (most-capable first). The single source of truth
@@ -343,6 +352,8 @@ pub fn models_for_provider(provider: &str) -> &'static [(&'static str, &'static 
             ("minimax:m2.5", MINIMAX_M2_5),
             ("minimax:m2", MINIMAX_M2),
         ],
+        // NOTE: Sakana is intentionally absent — live `/v1/models` is its
+        // catalog (no hand-typed fallback to drift). Same for flux-router/groq.
         _ => &[],
     }
 }


### PR DESCRIPTION
## What
Adds **Sakana AI** ("Fugu") as a first-class provider. Sakana's `https://api.sakana.ai/v1` speaks the standard OpenAI chat wire format (Bearer auth, `/v1/chat/completions`, OpenAI SSE `chat.completion.chunk` + `[DONE]`, OpenAI error envelopes — all verified live). Fugu is a multi-agent orchestration/routing layer.

## How (follows the FluxRouter pattern)
- `ProviderType::Sakana` + a thin `SakanaProvider` newtype over `OpenAIProvider`, wired through `create_native_provider` + a `sakana_defaults()` compat preset (classified as a `"router"` for input optimization, since Fugu optimizes upstream).
- **Auto-detection** (per request): model alias `sakana` / `fugu` → Sakana provider; **API-key prefix `fish_`** → Sakana in the key recognizer; `SAKANA_API_KEY` env + credentials store.
- Default model `fugu` (so `--provider sakana` works out of the box); live key-validation endpoint `/v1/models`.

## No hardcoded model catalog (deliberate)
Sakana carries **no** hand-typed model list. Its `/model` picker is driven by the live `/v1/models` fetch (`OpenAIProvider::list_models`) — the same live-source pattern Hermes / OpenClaw / the desktop app use (models.dev). Nothing to drift out of date. (Matches flux-router/groq, which are also live-fetch-only.)

## Verification
- **Hetzner gate green:** `cargo fmt --check`, `cargo clippy --workspace -D warnings`, `cargo nextest --workspace` (9170 passed; only the known flake). New unit tests: `SakanaProvider` construct/register + `fish_` key detection.
- **Live API verified** (from an allowed IP): `GET /v1/models` → `fugu`, `fugu-ultra`, `fugu-ultra-20260615`; non-stream + streaming chat; the `fish_` test key.
- **Engine integration verified to the network boundary:** the engine builds the provider, resolves the `fish_` key, and issues a correct request to `api.sakana.ai`.

### Known caveat (infra, not code)
A full engine round-trip can't be confirmed from the Hetzner build box: Sakana's edge/WAF **403-blocks the datacenter IP** (a plain `curl` from the box gets the same HTML 403 that returns `200` from a residential IP). The final live engine turn should be confirmed from an allowed network (desktop app on a residential connection).