### PR TITLE
fix: OpenAI tool-name sanitization (#297) + WSL canonicalize off-reactor (#287)

### DIFF
--- a/crates/wcore-providers/src/lib.rs
+++ b/crates/wcore-providers/src/lib.rs
@@ -35,6 +35,7 @@ pub mod openai_chatgpt;
 pub mod openai_compat;
 pub mod openai_compatible;
 pub mod openai_responses;
+pub mod openai_tool_name;
 pub mod openrouter;
 pub mod paste_detect;
 pub mod perplexity;

--- a/crates/wcore-providers/src/openai.rs
+++ b/crates/wcore-providers/src/openai.rs
@@ -14,6 +14,7 @@ use wcore_types::tool::{ToolDef, truncate_deferred_description};
 use crate::key_rotation::{KeyPool, split_keys};
 use crate::openai_compat;
 use crate::openai_responses;
+use crate::openai_tool_name::{decode_tool_name, encode_tool_name};
 use crate::retry::builder_send_with_retry;
 use crate::{
     LlmProvider, ModelInfo, ProviderError, alias_models, dump_request_body, dump_response_chunk,
@@ -304,7 +305,7 @@ impl OpenAIProvider {
                                     "id": id,
                                     "type": "function",
                                     "function": {
-                                        "name": name,
+                                        "name": encode_tool_name(name),
                                         "arguments": serde_json::to_string(input).unwrap_or_default()
                                     }
                                 });
@@ -393,7 +394,7 @@ impl OpenAIProvider {
                     json!({
                         "type": "function",
                         "function": {
-                            "name": t.name,
+                            "name": encode_tool_name(&t.name),
                             "description": format!(
                                 "(Deferred) {short_desc} — Use ToolSearch to load full schema before calling."
                             ),
@@ -407,7 +408,7 @@ impl OpenAIProvider {
                     json!({
                         "type": "function",
                         "function": {
-                            "name": t.name,
+                            "name": encode_tool_name(&t.name),
                             "description": t.description,
                             "parameters": normalize_tool_parameters(&t.input_schema)
                         }
@@ -1612,7 +1613,7 @@ fn parse_sse_chunk(data: &str, state: &mut StreamState) -> Vec<LlmEvent> {
                     };
                     events.push(LlmEvent::ToolUse {
                         id: tc.id,
-                        name: tc.name,
+                        name: decode_tool_name(&tc.name),
                         input,
                         extra: tc.extra,
                     });
@@ -3616,6 +3617,56 @@ mod tests {
         assert!(spawn_params["properties"].as_object().unwrap().is_empty());
         let spawn_desc = result[1]["function"]["description"].as_str().unwrap();
         assert!(spawn_desc.contains("ToolSearch"));
+    }
+
+    /// #297: WCore tool ids contain `:` / `::` / `.`, which OpenAI rejects with
+    /// `400 invalid_value` on `tools[N].function.name`. build_tools must emit
+    /// names matching `^[a-zA-Z0-9_-]+$`, and a clean snake_case name must be
+    /// left untouched (no blast radius for normal tools).
+    #[test]
+    fn build_tools_sanitizes_invalid_names_issue_297() {
+        let tools = vec![
+            ToolDef {
+                name: "Browser::execute".into(),
+                description: "b".into(),
+                input_schema: json!({"type": "object", "properties": {}}),
+                deferred: false,
+            },
+            ToolDef {
+                name: "ai.perplexity-perplexity-mcp".into(),
+                description: "p".into(),
+                input_schema: json!({"type": "object", "properties": {}}),
+                deferred: false,
+            },
+            ToolDef {
+                name: "get_weather".into(),
+                description: "w".into(),
+                input_schema: json!({"type": "object", "properties": {}}),
+                deferred: false,
+            },
+        ];
+        let result = OpenAIProvider::build_tools(&tools);
+        let wire_legal = |s: &str| {
+            !s.is_empty()
+                && s.bytes()
+                    .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_')
+        };
+        for entry in &result {
+            let name = entry["function"]["name"].as_str().unwrap();
+            assert!(wire_legal(name), "emitted illegal wire name: {name}");
+        }
+        // Invalid names are wrapped; the clean snake_case one is verbatim.
+        assert_ne!(result[0]["function"]["name"], json!("Browser::execute"));
+        assert_eq!(result[2]["function"]["name"], json!("get_weather"));
+        // And they decode back to the canonical ids the engine dispatches on.
+        assert_eq!(
+            decode_tool_name(result[0]["function"]["name"].as_str().unwrap()),
+            "Browser::execute"
+        );
+        assert_eq!(
+            decode_tool_name(result[1]["function"]["name"].as_str().unwrap()),
+            "ai.perplexity-perplexity-mcp"
+        );
     }
 
     #[test]

--- a/crates/wcore-providers/src/openai_responses.rs
+++ b/crates/wcore-providers/src/openai_responses.rs
@@ -75,6 +75,7 @@
 
 use serde_json::{Value, json};
 
+use crate::openai_tool_name::{decode_tool_name, encode_tool_name};
 use wcore_config::compat::ProviderCompat;
 use wcore_types::llm::{LlmEvent, LlmRequest};
 use wcore_types::message::{ContentBlock, FinishReason, Message, Role, StopReason, TokenUsage};
@@ -233,7 +234,7 @@ fn push_assistant_items(input: &mut Vec<Value>, msg: &Message) {
             input.push(json!({
                 "type": "function_call",
                 "call_id": id,
-                "name": name,
+                "name": encode_tool_name(name),
                 "arguments": serde_json::to_string(args).unwrap_or_else(|_| "{}".to_string()),
             }));
         }
@@ -284,7 +285,7 @@ fn build_responses_tools(tools: &[ToolDef]) -> Vec<Value> {
                 let short_desc = truncate_deferred_description(&t.description);
                 json!({
                     "type": "function",
-                    "name": t.name,
+                    "name": encode_tool_name(&t.name),
                     "description": format!(
                         "(Deferred) {short_desc} — Use ToolSearch to load full schema before calling."
                     ),
@@ -293,7 +294,7 @@ fn build_responses_tools(tools: &[ToolDef]) -> Vec<Value> {
             } else {
                 json!({
                     "type": "function",
-                    "name": t.name,
+                    "name": encode_tool_name(&t.name),
                     "description": t.description,
                     "parameters": t.input_schema,
                 })
@@ -606,7 +607,7 @@ fn finalize_tool_call(item: &Value, state: &mut ResponsesStreamState) -> Option<
     state.saw_tool_call = true;
     Some(LlmEvent::ToolUse {
         id: call_id,
-        name,
+        name: decode_tool_name(&name),
         input,
         extra: None,
     })

--- a/crates/wcore-providers/src/openai_tool_name.rs
+++ b/crates/wcore-providers/src/openai_tool_name.rs
@@ -1,0 +1,191 @@
+//! Reversible tool-name codec for the OpenAI wire format.
+//!
+//! OpenAI (and every OpenAI-compatible endpoint: ChatGPT subscription, Groq,
+//! DeepSeek, Together, Sakana, …) constrains tool/function names to
+//! `^[a-zA-Z0-9_-]+$` and returns `400 invalid_value` on
+//! `tools[N].function.name` otherwise. WCore tool ids routinely contain `:`,
+//! `::`, and `.` — e.g. `Browser::execute`, `tool:brave`,
+//! `ai.perplexity-perplexity-mcp`, `com.microsoft-markitdown` — so the raw name
+//! is rejected (FerroxLabs/wayland#297).
+//!
+//! Sanitizing outbound alone is not enough: the model then calls back with the
+//! sanitized spelling and the engine has no tool by that name. The fix must
+//! round-trip — encode every name we serialize OUTBOUND (tool definitions AND
+//! assistant-history `tool_calls`) and decode every name we parse INBOUND
+//! (streamed `tool_call`/`function_call`) back to the canonical id before the
+//! provider emits [`LlmEvent::ToolUse`](wcore_types::llm::LlmEvent). The engine
+//! and everything downstream keep seeing canonical ids unchanged.
+//!
+//! The codec is **stateless and reversible** — no per-request registry, so it
+//! is trivially correct across the shared `Arc<OpenAIProvider>` serving
+//! concurrent streams and across both the chat and Responses SSE paths.
+//!
+//! Encoding is conditional on a [`SENTINEL`] prefix so the common case is a
+//! no-op:
+//! * A name that already matches `^[a-zA-Z0-9_-]+$` **and** does not start with
+//!   the sentinel is emitted unchanged. Normal snake_case OpenAI tools
+//!   (`get_weather`, `Read`, `Bash`) are never touched.
+//! * Any other name is emitted as `SENTINEL + hex`, where every byte that is
+//!   not `[A-Za-z0-9-]` (this includes `_`, so the escape marker is
+//!   unambiguous, and any multi-byte UTF-8) is written as `_HH` (uppercase
+//!   hex). The encoder also wraps the rare real name that itself starts with
+//!   the sentinel, so a leading sentinel on the wire ALWAYS denotes an encoded
+//!   name — decode never misfires on a genuine tool id.
+
+/// Marker prefix identifying an encoded name on the wire. Valid under the
+/// OpenAI name charset. Chosen to be an improbable real tool-name prefix; the
+/// encoder self-guards any name that nonetheless starts with it, so collision
+/// probability affects only how often a name is wrapped, never correctness.
+const SENTINEL: &str = "wct_";
+
+/// True when `name` is safe to put on the wire verbatim: non-empty, every byte
+/// in `[A-Za-z0-9_-]`, and not masquerading as an encoded name.
+fn is_plain(name: &str) -> bool {
+    !name.is_empty()
+        && !name.starts_with(SENTINEL)
+        && name
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_')
+}
+
+/// Encode a canonical WCore tool name into an OpenAI-wire-legal function name.
+/// A no-op for names that are already legal and unambiguous (see module docs).
+pub(crate) fn encode_tool_name(name: &str) -> String {
+    if is_plain(name) {
+        return name.to_string();
+    }
+    let mut out = String::with_capacity(SENTINEL.len() + name.len() * 3);
+    out.push_str(SENTINEL);
+    for &b in name.as_bytes() {
+        if b.is_ascii_alphanumeric() || b == b'-' {
+            out.push(b as char);
+        } else {
+            // Escape '_' and every other non-charset byte (incl. ':', '.', and
+            // multi-byte UTF-8) so '_' unambiguously introduces an escape.
+            out.push('_');
+            out.push_str(&format!("{b:02X}"));
+        }
+    }
+    out
+}
+
+/// Decode a wire function name back to the canonical WCore tool id. A no-op for
+/// any name without the sentinel prefix (i.e. names emitted verbatim, or a
+/// model-hallucinated name we never sent — which then surfaces as a normal
+/// unknown-tool error downstream).
+pub(crate) fn decode_tool_name(name: &str) -> String {
+    let Some(body) = name.strip_prefix(SENTINEL) else {
+        return name.to_string();
+    };
+    let bytes = body.as_bytes();
+    let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'_' {
+            // Expect exactly two hex digits. If malformed (truncated stream or
+            // a hallucinated name), keep the byte literally — best effort.
+            if i + 2 < bytes.len()
+                && let (Some(hi), Some(lo)) = (hex_val(bytes[i + 1]), hex_val(bytes[i + 2]))
+            {
+                out.push(hi * 16 + lo);
+                i += 3;
+                continue;
+            }
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+fn hex_val(b: u8) -> Option<u8> {
+    match b {
+        b'0'..=b'9' => Some(b - b'0'),
+        b'A'..=b'F' => Some(b - b'A' + 10),
+        b'a'..=b'f' => Some(b - b'a' + 10),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Names already legal under `^[a-zA-Z0-9_-]+$` must pass through untouched
+    /// — zero blast radius for normal OpenAI snake_case / CamelCase tools.
+    #[test]
+    fn plain_names_are_unchanged() {
+        for n in ["Read", "Bash", "get_weather", "web-search", "Tool123", "a"] {
+            assert_eq!(encode_tool_name(n), n, "encode changed plain name {n}");
+            assert_eq!(decode_tool_name(n), n, "decode changed plain name {n}");
+        }
+    }
+
+    /// The exact offenders from the bug report round-trip to canonical ids and
+    /// the encoded form is OpenAI-wire-legal.
+    #[test]
+    fn reporter_bad_names_round_trip() {
+        let bad = [
+            "Browser::execute",
+            "tool:brave",
+            "tool:tavily",
+            "ai.perplexity-perplexity-mcp",
+            "com.microsoft-markitdown",
+            "org.wikipedia-wikipedia-mcp",
+        ];
+        for n in bad {
+            let enc = encode_tool_name(n);
+            assert!(
+                enc != n && enc.starts_with(SENTINEL),
+                "{n} should be wrapped, got {enc}"
+            );
+            assert!(is_wire_legal(&enc), "encoded {enc} is not wire-legal");
+            assert_eq!(decode_tool_name(&enc), n, "round-trip failed for {n}");
+        }
+    }
+
+    /// A real name that itself starts with the sentinel is wrapped (not emitted
+    /// verbatim) so a leading sentinel on the wire always denotes an encoded
+    /// name — decode is never ambiguous.
+    #[test]
+    fn names_starting_with_sentinel_are_guarded() {
+        for n in ["wct_foo", "wct_", "wct_a_b"] {
+            let enc = encode_tool_name(n);
+            assert!(is_wire_legal(&enc));
+            assert_eq!(decode_tool_name(&enc), n, "guard round-trip failed for {n}");
+        }
+    }
+
+    /// Underscores in the original survive the escape (encoded only inside a
+    /// wrapped name; a plain underscore name is untouched).
+    #[test]
+    fn underscores_round_trip_inside_wrapped_names() {
+        // Plain underscore name: untouched.
+        assert_eq!(encode_tool_name("a_b"), "a_b");
+        // Wrapped because of the dot; the underscore must still survive.
+        let n = "a.b_c";
+        assert_eq!(decode_tool_name(&encode_tool_name(n)), n);
+    }
+
+    /// Arbitrary unicode round-trips byte-exact.
+    #[test]
+    fn unicode_round_trips() {
+        let n = "tool:café→x";
+        let enc = encode_tool_name(n);
+        assert!(is_wire_legal(&enc));
+        assert_eq!(decode_tool_name(&enc), n);
+    }
+
+    /// A non-sentinel name the model "invents" is left alone (becomes a normal
+    /// unknown-tool error upstream, not corrupted by decode).
+    #[test]
+    fn decode_passes_through_unknown_plain_names() {
+        assert_eq!(decode_tool_name("Hallucinated_Tool"), "Hallucinated_Tool");
+    }
+
+    fn is_wire_legal(s: &str) -> bool {
+        !s.is_empty()
+            && s.bytes()
+                .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_')
+    }
+}

--- a/crates/wcore-tools/src/vfs.rs
+++ b/crates/wcore-tools/src/vfs.rs
@@ -223,7 +223,7 @@ impl<F: VirtualFs> SandboxedFs<F> {
     ///      step 2's canonical prefix already starts with `self.root`,
     ///      so the suffix is allowed because no symlink can escape
     ///      through a not-yet-created node.
-    fn contain(&self, path: &Path) -> Result<PathBuf, VfsError> {
+    async fn contain(&self, path: &Path) -> Result<PathBuf, VfsError> {
         let normalized = lex_normalize(path, &self.root);
 
         // Walk up the path to the longest existing prefix, canonicalize
@@ -231,7 +231,7 @@ impl<F: VirtualFs> SandboxedFs<F> {
         // sits inside `self.root`. If the prefix canonicalizes to
         // somewhere outside the root, refuse — even if the trailing
         // not-yet-existing suffix is benign.
-        let (canon_prefix, suffix) = match canonicalize_existing_prefix(&normalized) {
+        let (canon_prefix, suffix) = match canonicalize_existing_prefix(&normalized).await {
             Some((prefix, suffix)) => (prefix, suffix),
             None => {
                 return Err(VfsError::OutsideSandbox {
@@ -266,10 +266,18 @@ impl<F: VirtualFs> SandboxedFs<F> {
 /// suffix. Returns `None` only when even `path.ancestors()` can't yield
 /// a real prefix (e.g. relative path with no anchor) — the caller
 /// should refuse such inputs.
-fn canonicalize_existing_prefix(path: &Path) -> Option<(PathBuf, PathBuf)> {
+async fn canonicalize_existing_prefix(path: &Path) -> Option<(PathBuf, PathBuf)> {
     let mut p: &Path = path;
     loop {
-        if let Ok(canon) = fs::canonicalize(p) {
+        // `tokio::fs::canonicalize` offloads the blocking `std::fs::canonicalize`
+        // syscall to the blocking pool. On a stalled network mount — e.g. a
+        // Windows `\\wsl$\` 9P share (FerroxLabs/wayland#287) — that syscall can
+        // hang indefinitely; keeping it OFF the runtime thread means the
+        // per-tool dispatch timeout still fires (an error result) instead of the
+        // worker wedging mid-poll and the tool hanging silently forever. A
+        // blocking syscall on the reactor cannot be preempted by
+        // `tokio::time::timeout`.
+        if let Ok(canon) = tokio::fs::canonicalize(p).await {
             // Suffix is the part of `path` that lives beyond `p`. When
             // `p == path` (the whole path exists and canonicalized
             // cleanly), the suffix is empty and the read target IS the
@@ -307,27 +315,27 @@ fn lex_normalize(path: &Path, base: &Path) -> PathBuf {
 #[async_trait]
 impl<F: VirtualFs + 'static> VirtualFs for SandboxedFs<F> {
     async fn read(&self, path: &Path) -> Result<Vec<u8>, VfsError> {
-        let p = self.contain(path)?;
+        let p = self.contain(path).await?;
         self.inner.read(&p).await
     }
     async fn write(&self, path: &Path, contents: &[u8]) -> Result<(), VfsError> {
-        let p = self.contain(path)?;
+        let p = self.contain(path).await?;
         self.inner.write(&p, contents).await
     }
     async fn exists(&self, path: &Path) -> Result<bool, VfsError> {
-        let p = self.contain(path)?;
+        let p = self.contain(path).await?;
         self.inner.exists(&p).await
     }
     async fn list(&self, dir: &Path) -> Result<Vec<PathBuf>, VfsError> {
-        let p = self.contain(dir)?;
+        let p = self.contain(dir).await?;
         self.inner.list(&p).await
     }
     async fn remove_file(&self, path: &Path) -> Result<(), VfsError> {
-        let p = self.contain(path)?;
+        let p = self.contain(path).await?;
         self.inner.remove_file(&p).await
     }
     async fn metadata(&self, path: &Path) -> Result<VfsMetadata, VfsError> {
-        let p = self.contain(path)?;
+        let p = self.contain(path).await?;
         self.inner.metadata(&p).await
     }
     fn root(&self) -> Option<&Path> {


### PR DESCRIPTION
Batched core-lane fixes for the 0.12.9 cut. Both gate-green on Hetzner (fmt + clippy `--workspace -D warnings` + nextest 9177 passed) and **live-verified**.

## #297 — ChatGPT Subscription tool calls 400
OpenAI-wire endpoints require `^[a-zA-Z0-9_-]+$` on `tools[N].name`; WCore ids contain `:` `::` `.` (`Browser::execute`, `tool:brave`, `ai.perplexity-perplexity-mcp`) → `400 invalid_value`, blocking all tool use on the ChatGPT-sub path.

Fix: stateless reversible tool-name codec (`openai_tool_name.rs`). Legal names pass through untouched; offenders are wrapped `wct_<hexescaped>` outbound and decoded back to the canonical id inbound, so the engine keeps dispatching on canonical ids. Wired at all 6 boundaries (tool-defs + assistant-history × chat + Responses paths). Fixes every OpenAI-wire provider at once.

Live: replayed against the real ChatGPT-sub backend (`gpt-5.5`) — raw name → 400, encoded name → 200 SSE.

## #287 — Tools hang silently on WSL mounts
`SandboxedFs::contain()` ran `std::fs::canonicalize` (blocking, sync) inline on the tokio runtime on every file op. On a stalled `\\wsl$\` 9P mount that syscall wedges the worker mid-poll, and a task stuck mid-poll cannot be preempted by `tokio::time::timeout` — so the 30s dispatch deadline never fired (silent ~60min hang).

Fix: move the containment canonicalize off the reactor via `tokio::fs::canonicalize` (identical symlink semantics → SECURITY MAJOR #13 + per-op TOCTOU preserved). A stalled mount now degrades to a clean 30s timeout error.

Live (real Win11 + Ubuntu WSL2): sync canonicalize under a 3s timeout = 21s hang (timeout defeated); async = timeout fires at 3.02s; real `\\wsl$\Ubuntu` path = <16ms (no regression).

Issues (tracked on the coordination repo, closed via the release / `wl released` flow — not by this merge): FerroxLabs/wayland#297, FerroxLabs/wayland#287. Both already marked `fixed-pending-release` in wayland-core@0.12.9.