### PR TITLE
feat(mcp): provider tool-count cap + real MCP provenance + web-fetch de-flake (0.12.10)

### DIFF
--- a/.github/osv-scanner.toml
+++ b/.github/osv-scanner.toml
@@ -94,3 +94,26 @@ reason = "proc-macro-error: build-time proc-macro, no runtime surface; transitiv
 # not ignored — ratatui upgraded 0.29 -> 0.30, which moved lru to 0.16.x. The
 # vulnerable lru 0.12.5 is gone from the tree. (The migration was a single
 # `where B::Error: ...` bound; all wcore-cli tests stayed green.)
+
+# ── opentelemetry_sdk 0.27.1 (CVE-2026-48504, Medium 5.3) ─────────────────
+# Unbounded memory allocation in W3C Baggage propagation:
+# `BaggagePropagator::extract_with_context` parsed an attacker-controlled
+# inbound `baggage` HTTP header before enforcing the W3C size limits. The
+# attack surface is the RECEIVING side of context propagation — a server
+# extracting baggage from untrusted inbound requests.
+#
+# NOT REACHABLE in wayland-core: it is a CLI agent and an OTLP trace EXPORTER,
+# not a server that extracts baggage from untrusted inbound headers. The
+# `otlp` feature is optional and DEFAULT-OFF (crates/wcore-observability), the
+# opentelemetry crates enable only `features = ["trace"]` (no baggage
+# propagator), and the codebase never references `BaggagePropagator`,
+# `extract_with_context`, or `set_text_map_propagator` (`grep` -> 0 hits).
+# Newly published; surfaced on main's 2026-06-26 scan (pre-existing ambient
+# advisory, not a code change in this PR). The fix requires opentelemetry
+# 0.32.1 — a 5-crate (opentelemetry / -otlp / -proto / -http / _sdk) lockstep
+# major jump with breaking exporter-builder API churn; tracked as a fast-follow
+# bump rather than risked into a release. Revisit on the opentelemetry 0.32 bump.
+[[IgnoredVulns]]
+id = "GHSA-w9wp-h8wv-79jx"
+ignoreUntil = "2026-09-02T00:00:00Z"
+reason = "opentelemetry_sdk baggage-extract DoS: receiving-side only; wayland-core is an OTLP exporter, otlp feature default-off, only trace feature enabled, no BaggagePropagator usage (0 grep hits). Not reachable. Tracked; revisit on opentelemetry 0.32 bump."

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1007,12 +1007,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bytecount"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
-
-[[package]]
 name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1249,9 +1243,9 @@ dependencies = [
 
 [[package]]
 name = "cff-parser"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f5b6e9141c036f3ff4ce7b2f7e432b0f00dee416ddcd4f17741d189ddc2e9d"
+checksum = "c5810ca1a2b5870df2aab1c03e11c40c361ba51d6e3e361e56310f1cb3b4e087"
 
 [[package]]
 name = "cfg-if"
@@ -3133,11 +3127,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3571,7 +3567,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.57.0",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -4320,9 +4316,9 @@ checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "lopdf"
-version = "0.38.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7184fdea2bc3cd272a1acec4030c321a8f9875e877b3f92a53f2f6033fdc289"
+checksum = "25aab26d99567469098e64a02f42679f8965c6401263eefa31d8f2dcc37a221c"
 dependencies = [
  "aes",
  "bitflags 2.11.1",
@@ -4330,14 +4326,13 @@ dependencies = [
  "ecb",
  "encoding_rs",
  "flate2",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "indexmap 2.14.0",
  "itoa",
  "log",
  "md-5 0.10.6",
  "nom 8.0.0",
- "nom_locate",
- "rand 0.9.4",
+ "rand 0.10.1",
  "rangemap",
  "sha2 0.10.9",
  "stringprep",
@@ -4727,17 +4722,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "nom_locate"
-version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b577e2d69827c4740cba2b52efaad1c4cc7c73042860b199710b3575c68438d"
-dependencies = [
- "bytecount",
- "memchr",
- "nom 8.0.0",
 ]
 
 [[package]]
@@ -5390,9 +5374,9 @@ checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "pdf-extract"
-version = "0.10.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28ba1758a3d3f361459645780e09570b573fc3c82637449e9963174c813a98"
+checksum = "417e8fdc940f1d5bc62c5f89864c3a2255f74f69aa353c98509213d67df61e73"
 dependencies = [
  "adobe-cmap-parser",
  "cff-parser",
@@ -5864,7 +5848,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -8934,7 +8918,7 @@ dependencies = [
 
 [[package]]
 name = "wayland-browser"
-version = "0.12.6"
+version = "0.12.9"
 dependencies = [
  "async-trait",
  "inventory",
@@ -8951,7 +8935,7 @@ dependencies = [
 
 [[package]]
 name = "wayland-cua"
-version = "0.12.6"
+version = "0.12.9"
 dependencies = [
  "async-trait",
  "inventory",
@@ -8968,7 +8952,7 @@ dependencies = [
 
 [[package]]
 name = "wayland-honcho"
-version = "0.12.6"
+version = "0.12.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8989,7 +8973,7 @@ dependencies = [
 
 [[package]]
 name = "wayland-ijfw"
-version = "0.12.6"
+version = "0.12.9"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9008,7 +8992,7 @@ dependencies = [
 
 [[package]]
 name = "wayland-ollama"
-version = "0.12.6"
+version = "0.12.9"
 dependencies = [
  "async-trait",
  "futures",
@@ -9029,7 +9013,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-acp"
-version = "0.12.6"
+version = "0.12.9"
 dependencies = [
  "async-trait",
  "axum",
@@ -9052,7 +9036,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-agent"
-version = "0.12.6"
+version = "0.12.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9141,7 +9125,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-agents-pack"
-version = "0.12.6"
+version = "0.12.9"
 dependencies = [
  "dirs",
  "serde",
@@ -9154,7 +9138,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-browser"
-version = "0.12.6"
+version = "0.12.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9184,7 +9168,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-budget"
-version = "0.12.6"
+version = "0.12.9"
 dependencies = [
  "chrono",
  "parking_lot",
@@ -9197,7 +9181,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-discord"
-version = "0.12.6"
+version = "0.12.9"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9218,7 +9202,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-email"
-version = "0.12.6"
+version = "0.12.9"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9237,7 +9221,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-imessage"
-version = "0.12.6"
+version = "0.12.9"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9254,7 +9238,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-matrix"
-version = "0.12.6"
+version = "0.12.9"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9273,7 +9257,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-msteams"
-version = "0.12.6"
+version = "0.12.9"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -9294,7 +9278,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-signal"
-version = "0.12.6"
+version = "0.12.9"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9309,7 +9293,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-slack"
-version = "0.12.6"
+version = "0.12.9"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9332,7 +9316,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-sms"
-version = "0.12.6"
+version = "0.12.9"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -9355,7 +9339,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-telegram"
-version = "0.12.6"
+version = "0.12.9"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9374,7 +9358,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-whatsapp"
-version = "0.12.6"
+version = "0.12.9"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9397,7 +9381,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channels"
-version = "0.12.6"
+version = "0.12.9"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9413,7 +9397,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channels-registry"
-version = "0.12.6"
+version = "0.12.9"
 dependencies = [
  "dirs",
  "serde",
@@ -9438,7 +9422,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-cli"
-version = "0.12.6"
+version = "0.12.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9519,7 +9503,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-compact"
-version = "0.12.6"
+version = "0.12.9"
 dependencies = [
  "regex",
  "serde",
@@ -9528,7 +9512,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-config"
-version = "0.12.6"
+version = "0.12.9"
 dependencies = [
  "anyhow",
  "argon2",
@@ -9565,7 +9549,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-cron"
-version = "0.12.6"
+version = "0.12.9"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9582,7 +9566,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-cua"
-version = "0.12.6"
+version = "0.12.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9618,7 +9602,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-dispatch"
-version = "0.12.6"
+version = "0.12.9"
 dependencies = [
  "rand 0.9.4",
  "rand_distr",
@@ -9631,7 +9615,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-egress"
-version = "0.12.6"
+version = "0.12.9"
 dependencies = [
  "async-trait",
  "http 1.4.1",
@@ -9644,7 +9628,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-eval"
-version = "0.12.6"
+version = "0.12.9"
 dependencies = [
  "rstest",
  "serde",
@@ -9661,7 +9645,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-eval-scenarios"
-version = "0.12.6"
+version = "0.12.9"
 dependencies = [
  "anyhow",
  "clap",
@@ -9681,7 +9665,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-evolve"
-version = "0.12.6"
+version = "0.12.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9721,7 +9705,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-honcho-adapter"
-version = "0.12.6"
+version = "0.12.9"
 dependencies = [
  "async-trait",
  "serde",
@@ -9736,7 +9720,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-mcp"
-version = "0.12.6"
+version = "0.12.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9763,7 +9747,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-memory"
-version = "0.12.6"
+version = "0.12.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9804,7 +9788,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-observability"
-version = "0.12.6"
+version = "0.12.9"
 dependencies = [
  "chrono",
  "opentelemetry",
@@ -9828,7 +9812,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-permissions"
-version = "0.12.6"
+version = "0.12.9"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9845,7 +9829,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-plugin-api"
-version = "0.12.6"
+version = "0.12.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9857,6 +9841,7 @@ dependencies = [
  "schemars 0.8.22",
  "serde",
  "serde_json",
+ "serial_test",
  "sha2 0.10.9",
  "tempfile",
  "thiserror 2.0.18",
@@ -9871,7 +9856,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-plugin-subprocess"
-version = "0.12.6"
+version = "0.12.9"
 dependencies = [
  "anyhow",
  "serde",
@@ -9890,7 +9875,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-plugin-wasm"
-version = "0.12.6"
+version = "0.12.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9912,7 +9897,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-pluginsrc"
-version = "0.12.6"
+version = "0.12.9"
 dependencies = [
  "serde",
  "serde_json",
@@ -9927,7 +9912,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-pricing"
-version = "0.12.6"
+version = "0.12.9"
 dependencies = [
  "chrono",
  "dirs",
@@ -9946,7 +9931,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-protocol"
-version = "0.12.6"
+version = "0.12.9"
 dependencies = [
  "rstest",
  "serde",
@@ -9958,7 +9943,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-providers"
-version = "0.12.6"
+version = "0.12.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9993,7 +9978,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-replay"
-version = "0.12.6"
+version = "0.12.9"
 dependencies = [
  "serde",
  "serde_json",
@@ -10004,7 +9989,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-repomap"
-version = "0.12.6"
+version = "0.12.9"
 dependencies = [
  "ignore",
  "regex",
@@ -10017,7 +10002,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-safety"
-version = "0.12.6"
+version = "0.12.9"
 dependencies = [
  "async-trait",
  "regex",
@@ -10030,7 +10015,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-sandbox"
-version = "0.12.6"
+version = "0.12.9"
 dependencies = [
  "async-trait",
  "bollard",
@@ -10050,7 +10035,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-skills"
-version = "0.12.6"
+version = "0.12.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10087,7 +10072,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-swarm"
-version = "0.12.6"
+version = "0.12.9"
 dependencies = [
  "futures",
  "humantime-serde",
@@ -10106,7 +10091,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-tools"
-version = "0.12.6"
+version = "0.12.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10153,7 +10138,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-types"
-version = "0.12.6"
+version = "0.12.9"
 dependencies = [
  "async-trait",
  "chrono",
@@ -10163,7 +10148,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-user-model"
-version = "0.12.6"
+version = "0.12.9"
 dependencies = [
  "async-trait",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -358,7 +358,9 @@ psl = "2"
 
 # T15: pure-Rust PDF text extraction (no native deps). Optional —
 # wcore-tools gates it behind the default-on `pdf` cargo feature.
-pdf-extract = "0.10"
+# Pinned >=0.12 so the transitive lopdf is >=0.42, clearing
+# RUSTSEC-2026-0187 (stack overflow via deeply nested PDF objects).
+pdf-extract = "0.12"
 
 # T8: read-only image metadata inspection. `image` reads only the header
 # for dimensions — the full pixel buffer is never decoded; `kamadak-exif`

--- a/crates/wcore-agent/src/cache_diagnostics.rs
+++ b/crates/wcore-agent/src/cache_diagnostics.rs
@@ -177,6 +177,7 @@ mod tests {
             description: "Read a file".into(),
             input_schema: json!({"type": "object"}),
             deferred: false,
+            server: None,
         }]
     }
 
@@ -292,6 +293,7 @@ mod tests {
             description: "Write a file".into(),
             input_schema: json!({"type": "object"}),
             deferred: false,
+            server: None,
         }];
         detector.record_request("prompt", &new_tools);
         let diag = detector

--- a/crates/wcore-agent/src/compact/estimate.rs
+++ b/crates/wcore-agent/src/compact/estimate.rs
@@ -268,6 +268,7 @@ mod tests {
             description: "reads".into(),
             input_schema: json!({"type": "object"}),
             deferred: false,
+            server: None,
         }];
 
         let messages_only = estimate_tokens_from_messages(&messages);

--- a/crates/wcore-agent/src/engine.rs
+++ b/crates/wcore-agent/src/engine.rs
@@ -1032,6 +1032,15 @@ pub struct AgentEngine {
     /// tools — keeping the emitted tool-zone prefix byte-stable (a cache-safe
     /// append) on every union-growth turn instead of a mid-array insert.
     mcp_curation_cache: Option<(u64, Vec<String>)>,
+    /// Cache-stability (token-opt) for the provider tool-CAP path, mirroring
+    /// `mcp_curation_cache` but keyed on the cap's own (inventory, budget). When
+    /// the cap must trim the MCP tail (chiefly in curation-OFF mode, where the
+    /// full MCP inventory reaches the cap), BM25 decides WHICH MCP tools are
+    /// most relevant, but the emitted order is an inventory-keyed APPEND-ONLY
+    /// union so the serialized tool-zone prefix stays byte-stable turn-to-turn
+    /// (a cache READ, not a per-turn prefix rewrite). Reset when the MCP
+    /// inventory or the MCP budget changes.
+    mcp_cap_cache: Option<(u64, Vec<String>)>,
     /// Token-opt (diff-resend): handle to the shared file-state cache (the same
     /// `Arc` the Read/Edit/Write tools hold). Used only to bump the cache's
     /// compaction generation after a compaction pass, so stale read bases stop
@@ -1534,6 +1543,7 @@ impl AgentEngine {
             per_turn_costs: Vec::new(),
             mcp_curation: config.mcp.curation.clone(),
             mcp_curation_cache: None,
+            mcp_cap_cache: None,
             file_cache: None,
             session_state: None,
             audit_log: None,
@@ -1709,6 +1719,7 @@ impl AgentEngine {
             per_turn_costs: Vec::new(),
             mcp_curation: config.mcp.curation.clone(),
             mcp_curation_cache: None,
+            mcp_cap_cache: None,
             file_cache: None,
             session_state: None,
             audit_log: None,
@@ -7119,12 +7130,20 @@ impl AgentEngine {
     /// MCP servers can push the array past it (222 > 128 -> API 400). Separate
     /// from `apply_mcp_curation` (a relevance/token optimization): this is the
     /// correctness guarantee. Keeps ALL non-MCP tools (built-ins, ToolSearch,
-    /// skills, plan) and fills the remaining budget with MCP tools in order,
-    /// truncating the MCP tail. Dropped MCP tools stay DISCOVERABLE via the
-    /// `ToolSearch` meta-tool (its registry is a full bootstrap snapshot).
-    /// `None` cap = no-op.
+    /// skills, plan) and fills the remaining budget with the most RELEVANT MCP
+    /// tools (BM25 over the current user message), truncating the rest. Dropped
+    /// MCP tools stay DISCOVERABLE via the `ToolSearch` meta-tool (its registry
+    /// is a full bootstrap snapshot). `None` cap = no-op.
+    ///
+    /// Cache-stability (token-opt): when the cap must trim, the kept MCP set is
+    /// emitted in an inventory-keyed APPEND-ONLY UNION order (mirroring
+    /// `apply_mcp_curation`), NOT re-sorted by relevance every turn. BM25 only
+    /// decides which NEW tools to admit when budget allows; a tool, once
+    /// admitted, holds its slot. This keeps the serialized tool-zone prefix
+    /// byte-stable across same-context turns (a cache READ, not a per-turn
+    /// prefix rewrite that would thrash the Anthropic prompt cache).
     fn apply_provider_tool_cap(
-        &self,
+        &mut self,
         tools: Vec<wcore_types::tool::ToolDef>,
     ) -> Vec<wcore_types::tool::ToolDef> {
         let limit = match self.compat.max_tools() {
@@ -7138,24 +7157,112 @@ impl AgentEngine {
         // prefix: a non-colliding MCP tool keeps its bare name, so the prefix
         // would count it as a built-in and ALWAYS keep it — letting a swarm of
         // bare-named MCP tools blow past the provider limit (#359).
-        let non_mcp_count = tools.iter().filter(|t| t.server.is_none()).count();
+        let (mcp_tools, non_mcp): (Vec<_>, Vec<_>) =
+            tools.into_iter().partition(|t| t.server.is_some());
+        let non_mcp_count = non_mcp.len();
         let mcp_budget = limit.saturating_sub(non_mcp_count);
-        let mut kept = Vec::with_capacity(tools.len().min(limit.max(non_mcp_count)));
-        let mut mcp_taken = 0usize;
-        let mut mcp_total = 0usize;
-        for t in tools {
-            if t.server.is_some() {
-                mcp_total += 1;
-                if mcp_taken < mcp_budget {
-                    kept.push(t);
-                    mcp_taken += 1;
+        let mcp_total = mcp_tools.len();
+
+        // Under budget after partition — keep every MCP tool, no trim, no churn.
+        if mcp_total <= mcp_budget {
+            let mut kept = non_mcp;
+            kept.extend(mcp_tools);
+            return kept;
+        }
+
+        // No MCP budget at all (built-ins alone meet/exceed the cap): drop the
+        // entire MCP block. Correctness > strict limit for built-ins, matching
+        // the prior behavior. No BM25/union work needed.
+        if mcp_budget == 0 {
+            tracing::info!(
+                target: "wcore_agent::engine",
+                "provider tool cap: {} tools exceeded the provider limit of {}; kept {} \
+                 (incl. all {} non-MCP), {} MCP tools hidden but reachable via ToolSearch",
+                non_mcp_count + mcp_total,
+                limit,
+                non_mcp_count,
+                non_mcp_count,
+                mcp_total
+            );
+            return non_mcp;
+        }
+
+        // Over budget. Rank the MCP tools by BM25 relevance (same scorer the
+        // curator uses), then take this turn's top `mcp_budget` names. The
+        // emitted order, however, is the inventory-keyed append-only union —
+        // not the per-turn relevance order — so the prefix stays byte-stable.
+        let inventory_hash = {
+            use std::hash::{Hash, Hasher};
+            let mut names: Vec<&str> = mcp_tools.iter().map(|t| t.name.as_str()).collect();
+            names.sort_unstable();
+            let mut h = std::collections::hash_map::DefaultHasher::new();
+            names.hash(&mut h);
+            // The budget is part of the cache key: a budget change (e.g. a new
+            // built-in shrinking the MCP slots) legitimately resets the union.
+            mcp_budget.hash(&mut h);
+            h.finish()
+        };
+
+        let user_msg = self.most_recent_user_text();
+        let usage = self.recent_mcp_usage();
+        let triples: Vec<(String, String, String)> = mcp_tools
+            .iter()
+            .map(|t| {
+                let server = t
+                    .server
+                    .clone()
+                    .unwrap_or_else(|| t.name.split("__").nth(1).unwrap_or("mcp").to_string());
+                (server, t.name.clone(), t.description.clone())
+            })
+            .collect();
+        // `curate` truncates to the cap's MCP budget = this turn's admit set.
+        let ranked = crate::mcp_curator::McpCurator::new(mcp_budget).curate(
+            &crate::mcp_curator::CurationInput {
+                user_message: &user_msg,
+                tools: &triples,
+                recent_usage: &usage,
+            },
+        );
+        let this_turn: Vec<String> = ranked.into_iter().map(|r| r.tool_name).collect();
+
+        // Union into the (inventory, budget)-keyed cache, APPEND-ONLY: an
+        // already-kept name holds its slot; a newly-admitted name is pushed at
+        // the END (a cache-safe append, not a mid-array insert). Cap the union
+        // length at `mcp_budget` so the kept set never exceeds the provider
+        // limit even as the union grows across turns — once full, no new tool
+        // displaces an admitted one for the life of this inventory/budget.
+        let keep_order: Vec<String> = match self.mcp_cap_cache.as_mut() {
+            Some((hash, order)) if *hash == inventory_hash => {
+                for name in this_turn {
+                    if order.len() >= mcp_budget {
+                        break;
+                    }
+                    if !order.contains(&name) {
+                        order.push(name);
+                    }
                 }
-            } else {
-                // Built-ins/ToolSearch/skills/plan are essential and few — always kept.
-                kept.push(t);
+                order.clone()
+            }
+            _ => {
+                let mut order = this_turn;
+                order.truncate(mcp_budget);
+                self.mcp_cap_cache = Some((inventory_hash, order.clone()));
+                order
+            }
+        };
+
+        // Emit non-MCP tools first (preserving their relative order), then the
+        // kept MCP block in FIRST-ADD union order.
+        let by_name: std::collections::HashMap<&str, &wcore_types::tool::ToolDef> =
+            mcp_tools.iter().map(|t| (t.name.as_str(), t)).collect();
+        let mut kept = non_mcp;
+        for name in &keep_order {
+            if let Some(t) = by_name.get(name.as_str()) {
+                kept.push((*t).clone());
             }
         }
-        let hidden = mcp_total - mcp_taken;
+
+        let hidden = mcp_total - keep_order.len();
         if hidden > 0 {
             tracing::info!(
                 target: "wcore_agent::engine",
@@ -7913,6 +8020,7 @@ mod set_config_tests {
             per_turn_costs: Vec::new(),
             mcp_curation: wcore_config::config::McpCurationPolicy::default(),
             mcp_curation_cache: None,
+            mcp_cap_cache: None,
             file_cache: None,
             session_state: None,
             audit_log: None,
@@ -8254,6 +8362,63 @@ mod set_config_tests {
             capped.len(),
             5,
             "all server:None tools kept (correctness > strict limit for built-ins)"
+        );
+    }
+
+    /// Cap-path relevance + cache-stability: when the provider cap must trim a
+    /// large MCP inventory, BM25 keeps the calendar-relevant tool for a calendar
+    /// request (not array-order tail-truncation), AND the emitted set is
+    /// byte-identical across two same-context turns (no prompt-cache prefix
+    /// churn — the inventory-keyed append-only union holds slots).
+    #[test]
+    fn provider_tool_cap_keeps_relevant_and_is_cache_stable() {
+        use wcore_types::message::{ContentBlock, Message, Role};
+
+        let mut engine = make_engine("m");
+        // Tiny cap so the 200 generic MCP tools must be trimmed hard.
+        engine.compat.max_tools = Some(5);
+        engine.audit_log = None; // BM25-only ranking → deterministic
+        engine.messages = vec![Message::new(
+            Role::User,
+            vec![ContentBlock::Text {
+                text: "schedule a calendar meeting".to_string(),
+            }],
+        )];
+
+        let mut tools = vec![builtin_tool("Read"), builtin_tool("ToolSearch")];
+        // The one relevant tool, placed in the MIDDLE of the array so array-order
+        // truncation would drop it — only BM25 can rescue it.
+        for i in 0..100 {
+            tools.push(cap_mcp_tool(&format!("mcp__srv__generic{i:03}")));
+        }
+        tools.push(wcore_types::tool::ToolDef {
+            name: "mcp__gcal__create_calendar_event".to_string(),
+            description: "Create a calendar event to schedule a meeting".to_string(),
+            input_schema: serde_json::json!({"type": "object"}),
+            deferred: false,
+            server: Some("gcal".to_string()),
+        });
+        for i in 100..200 {
+            tools.push(cap_mcp_tool(&format!("mcp__srv__generic{i:03}")));
+        }
+
+        let turn1 = engine.apply_provider_tool_cap(tools.clone());
+        let names1: Vec<&str> = turn1.iter().map(|t| t.name.as_str()).collect();
+        assert_eq!(turn1.len(), 5, "total capped to the provider limit");
+        assert!(
+            names1.contains(&"mcp__gcal__create_calendar_event"),
+            "BM25 must retain the calendar tool for a calendar request, \
+             not array-order tail-truncate it"
+        );
+        assert!(names1.contains(&"Read") && names1.contains(&"ToolSearch"));
+
+        // Turn 2, same context: the emitted set must be byte-identical (the
+        // append-only union holds every slot — no prefix churn).
+        let turn2 = engine.apply_provider_tool_cap(tools);
+        let names2: Vec<&str> = turn2.iter().map(|t| t.name.as_str()).collect();
+        assert_eq!(
+            names1, names2,
+            "cap emission must be byte-stable across same-context turns"
         );
     }
 
@@ -8989,6 +9154,7 @@ mod phase6_tests {
             per_turn_costs: Vec::new(),
             mcp_curation: wcore_config::config::McpCurationPolicy::default(),
             mcp_curation_cache: None,
+            mcp_cap_cache: None,
             file_cache: None,
             session_state: None,
             audit_log: None,
@@ -9281,6 +9447,7 @@ mod compact_tests {
             per_turn_costs: Vec::new(),
             mcp_curation: wcore_config::config::McpCurationPolicy::default(),
             mcp_curation_cache: None,
+            mcp_cap_cache: None,
             file_cache: None,
             session_state: None,
             audit_log: None,
@@ -10603,6 +10770,7 @@ mod plan_mode_tests {
             per_turn_costs: Vec::new(),
             mcp_curation: wcore_config::config::McpCurationPolicy::default(),
             mcp_curation_cache: None,
+            mcp_cap_cache: None,
             file_cache: None,
             session_state: None,
             audit_log: None,
@@ -11028,6 +11196,7 @@ mod hook_integration_tests {
             per_turn_costs: Vec::new(),
             mcp_curation: wcore_config::config::McpCurationPolicy::default(),
             mcp_curation_cache: None,
+            mcp_cap_cache: None,
             file_cache: None,
             session_state: None,
             audit_log: None,
@@ -11751,6 +11920,7 @@ mod approval_bridge_engine_tests {
             per_turn_costs: Vec::new(),
             mcp_curation: wcore_config::config::McpCurationPolicy::default(),
             mcp_curation_cache: None,
+            mcp_cap_cache: None,
             file_cache: None,
             session_state: None,
             audit_log: None,
@@ -12571,6 +12741,7 @@ mod user_model_writeback_tests {
             per_turn_costs: Vec::new(),
             mcp_curation: wcore_config::config::McpCurationPolicy::default(),
             mcp_curation_cache: None,
+            mcp_cap_cache: None,
             file_cache: None,
             session_state: None,
             audit_log: None,

--- a/crates/wcore-agent/src/engine.rs
+++ b/crates/wcore-agent/src/engine.rs
@@ -3965,6 +3965,12 @@ impl AgentEngine {
             // empty/keyword-only when self.audit_log is None.
             let tools = self.apply_mcp_curation(tools);
 
+            // #344/#359: enforce the provider's HARD tool-array cap (OpenAI =
+            // 128). MCP servers can push the total past the limit even after
+            // curation; this is the correctness guarantee, separate from the
+            // relevance trim above.
+            let tools = self.apply_provider_tool_cap(tools);
+
             // Build system prompt: append plan mode instructions when active
             let system = if self.plan_state.is_active {
                 format!(
@@ -7099,6 +7105,62 @@ impl AgentEngine {
         keep
     }
 
+    /// #344/#359 — provider-aware HARD cap on the total tool count. A provider
+    /// request's tool array must not exceed the provider's limit (OpenAI = 128);
+    /// MCP servers can push the array past it (222 > 128 -> API 400). Separate
+    /// from `apply_mcp_curation` (a relevance/token optimization): this is the
+    /// correctness guarantee. Keeps ALL non-MCP tools (built-ins, ToolSearch,
+    /// skills, plan) and fills the remaining budget with MCP tools in order,
+    /// truncating the MCP tail. Dropped MCP tools stay DISCOVERABLE via the
+    /// `ToolSearch` meta-tool (its registry is a full bootstrap snapshot).
+    /// `None` cap = no-op.
+    fn apply_provider_tool_cap(
+        &self,
+        tools: Vec<wcore_types::tool::ToolDef>,
+    ) -> Vec<wcore_types::tool::ToolDef> {
+        let limit = match self.compat.max_tools() {
+            Some(l) => l,
+            None => return tools,
+        };
+        if tools.len() <= limit {
+            return tools;
+        }
+        let non_mcp_count = tools
+            .iter()
+            .filter(|t| !t.name.starts_with("mcp__"))
+            .count();
+        let mcp_budget = limit.saturating_sub(non_mcp_count);
+        let mut kept = Vec::with_capacity(tools.len().min(limit.max(non_mcp_count)));
+        let mut mcp_taken = 0usize;
+        let mut mcp_total = 0usize;
+        for t in tools {
+            if t.name.starts_with("mcp__") {
+                mcp_total += 1;
+                if mcp_taken < mcp_budget {
+                    kept.push(t);
+                    mcp_taken += 1;
+                }
+            } else {
+                // Built-ins/ToolSearch/skills/plan are essential and few — always kept.
+                kept.push(t);
+            }
+        }
+        let hidden = mcp_total - mcp_taken;
+        if hidden > 0 {
+            tracing::info!(
+                target: "wcore_agent::engine",
+                "provider tool cap: {} tools exceeded the provider limit of {}; kept {} \
+                 (incl. all {} non-MCP), {} MCP tools hidden but reachable via ToolSearch",
+                non_mcp_count + mcp_total,
+                limit,
+                kept.len(),
+                non_mcp_count,
+                hidden
+            );
+        }
+        kept
+    }
+
     /// W6 F17 recency input for `McpCurator`. Reads the M2 audit log via the
     /// `recent_tool_uses` API. When `audit_log` is `None` the curator
     /// gracefully degrades to keyword-only ranking.
@@ -7986,6 +8048,114 @@ mod set_config_tests {
         engine.messages = user("echo fresh tool");
         let after_change = names(engine.apply_mcp_curation(tools2));
         assert!(after_change.contains(&"mcp__srv__echo".to_string()));
+    }
+
+    // --- #344/#359: provider-aware hard cap on the total tool count ---
+
+    /// Build a non-MCP/built-in `ToolDef` (name must NOT start with `mcp__`).
+    fn builtin_tool(name: &str) -> wcore_types::tool::ToolDef {
+        wcore_types::tool::ToolDef {
+            name: name.to_string(),
+            description: format!("{name} built-in tool"),
+            input_schema: serde_json::json!({"type": "object"}),
+            deferred: false,
+        }
+    }
+
+    /// Build an MCP `ToolDef` (`mcp__{server}__{tool}`).
+    fn cap_mcp_tool(name: &str) -> wcore_types::tool::ToolDef {
+        wcore_types::tool::ToolDef {
+            name: name.to_string(),
+            description: format!("{name} mcp tool"),
+            input_schema: serde_json::json!({"type": "object"}),
+            deferred: false,
+        }
+    }
+
+    #[test]
+    fn provider_tool_cap_truncates_total_to_limit() {
+        let mut engine = make_engine("m");
+        engine.compat.max_tools = Some(10);
+
+        let mut tools = vec![
+            builtin_tool("Read"),
+            builtin_tool("Write"),
+            builtin_tool("Bash"),
+            builtin_tool("ToolSearch"),
+        ];
+        for i in 0..20 {
+            tools.push(cap_mcp_tool(&format!("mcp__srv__tool{i:02}")));
+        }
+
+        let capped = engine.apply_provider_tool_cap(tools);
+        assert_eq!(capped.len(), 10, "total must be truncated to the limit");
+
+        let names: Vec<&str> = capped.iter().map(|t| t.name.as_str()).collect();
+        for b in ["Read", "Write", "Bash", "ToolSearch"] {
+            assert!(names.contains(&b), "built-in {b} must be kept");
+        }
+        let mcp_kept = capped
+            .iter()
+            .filter(|t| t.name.starts_with("mcp__"))
+            .count();
+        assert_eq!(mcp_kept, 6, "exactly (limit - non_mcp) MCP tools kept");
+    }
+
+    #[test]
+    fn provider_tool_cap_noop_when_unset() {
+        let mut engine = make_engine("m");
+        engine.compat.max_tools = None;
+
+        let tools: Vec<_> = (0..50)
+            .map(|i| cap_mcp_tool(&format!("mcp__srv__tool{i:02}")))
+            .collect();
+        let capped = engine.apply_provider_tool_cap(tools);
+        assert_eq!(capped.len(), 50, "no cap configured → unchanged");
+    }
+
+    #[test]
+    fn provider_tool_cap_noop_under_limit() {
+        let mut engine = make_engine("m");
+        engine.compat.max_tools = Some(128);
+
+        let tools: Vec<_> = (0..30)
+            .map(|i| cap_mcp_tool(&format!("mcp__srv__tool{i:02}")))
+            .collect();
+        let capped = engine.apply_provider_tool_cap(tools);
+        assert_eq!(capped.len(), 30, "under the limit → unchanged");
+    }
+
+    #[test]
+    fn provider_tool_cap_keeps_all_builtins_even_when_budget_tiny() {
+        let mut engine = make_engine("m");
+        engine.compat.max_tools = Some(3);
+
+        let mut tools = vec![
+            builtin_tool("Read"),
+            builtin_tool("Write"),
+            builtin_tool("Edit"),
+            builtin_tool("Bash"),
+            builtin_tool("Grep"),
+            builtin_tool("ToolSearch"),
+        ];
+        for i in 0..10 {
+            tools.push(cap_mcp_tool(&format!("mcp__srv__tool{i:02}")));
+        }
+
+        let capped = engine.apply_provider_tool_cap(tools);
+        let names: Vec<&str> = capped.iter().map(|t| t.name.as_str()).collect();
+        for b in ["Read", "Write", "Edit", "Bash", "Grep", "ToolSearch"] {
+            assert!(
+                names.contains(&b),
+                "built-in {b} must be kept even when built-ins alone exceed the cap"
+            );
+        }
+        let mcp_kept = capped
+            .iter()
+            .filter(|t| t.name.starts_with("mcp__"))
+            .count();
+        assert_eq!(mcp_kept, 0, "no MCP budget left → 0 MCP tools kept");
+        assert_eq!(capped.len(), 6, "correctness > strict limit for built-ins");
     }
 
     /// Cache-stability regression (token-opt, finding #174): when turn 2

--- a/crates/wcore-agent/src/engine.rs
+++ b/crates/wcore-agent/src/engine.rs
@@ -3958,11 +3958,13 @@ impl AgentEngine {
                     .to_tool_defs_filtered(|t| t.name() != "ExitPlanMode")
             };
 
-            // W6 F17: trim MCP tools to a curated top-K. MCP tools are named
-            // `mcp__{server}__{tool}` (verified at wcore-mcp/src/tool_proxy.rs:14);
-            // non-MCP tools (builtins, skills, spawn, plan tools) are always
-            // kept. Off-policy is a no-op. Audit-log recency degrades to
-            // empty/keyword-only when self.audit_log is None.
+            // W6 F17: trim MCP tools to a curated top-K. MCP tools are
+            // identified by real provenance (`ToolDef::server.is_some()`), not
+            // the `mcp__` name prefix — a non-colliding MCP tool keeps its bare
+            // name (wcore-mcp/src/tool_proxy.rs). Non-MCP tools (builtins,
+            // skills, spawn, plan tools) are always kept. Off-policy is a no-op.
+            // Audit-log recency degrades to empty/keyword-only when
+            // self.audit_log is None.
             let tools = self.apply_mcp_curation(tools);
 
             // #344/#359: enforce the provider's HARD tool-array cap (OpenAI =
@@ -7014,9 +7016,12 @@ impl AgentEngine {
 
     /// W6 F17: trim MCP tools in the per-turn `ToolDef` list to a curated
     /// top-K. Non-MCP tools (builtins, skills, spawn, plan) are always kept.
-    /// MCP tools are identified by the `mcp__` name prefix (verified at
-    /// `wcore-mcp/src/tool_proxy.rs:14`). Curation source: the most recent
-    /// user message in `self.messages`. `Off` policy is a no-op.
+    /// MCP tools are identified by their REAL provenance (`ToolDef::server`
+    /// is `Some`), NOT the `mcp__` name prefix: a non-colliding MCP tool keeps
+    /// its bare original name (see `wcore-mcp/src/tool_proxy.rs`), so the prefix
+    /// would misclassify it as a built-in and never curate it (#359). Curation
+    /// source: the most recent user message in `self.messages`. `Off` policy is
+    /// a no-op.
     fn apply_mcp_curation(
         &mut self,
         tools: Vec<wcore_types::tool::ToolDef>,
@@ -7025,9 +7030,9 @@ impl AgentEngine {
             wcore_config::config::McpCurationPolicy::Off => return tools,
             wcore_config::config::McpCurationPolicy::TopK { k } => *k,
         };
-        // Partition into MCP and non-MCP slices.
+        // Partition into MCP and non-MCP slices by real provenance.
         let (mcp_tools, mut keep): (Vec<_>, Vec<_>) =
-            tools.into_iter().partition(|t| t.name.starts_with("mcp__"));
+            tools.into_iter().partition(|t| t.server.is_some());
         if mcp_tools.len() <= top_k {
             keep.extend(mcp_tools);
             return keep;
@@ -7057,9 +7062,13 @@ impl AgentEngine {
         let triples: Vec<(String, String, String)> = mcp_tools
             .iter()
             .map(|t| {
-                // Synthesize a server name from the prefix; description from
-                // the ToolDef's description field.
-                let server = t.name.split("__").nth(1).unwrap_or("mcp").to_string();
+                // Real provenance from `ToolDef::server`; this slice is the MCP
+                // partition so `server` is always `Some` here. Fall back to the
+                // prefix-derived name only defensively.
+                let server = t
+                    .server
+                    .clone()
+                    .unwrap_or_else(|| t.name.split("__").nth(1).unwrap_or("mcp").to_string());
                 (server, t.name.clone(), t.description.clone())
             })
             .collect();
@@ -7125,16 +7134,17 @@ impl AgentEngine {
         if tools.len() <= limit {
             return tools;
         }
-        let non_mcp_count = tools
-            .iter()
-            .filter(|t| !t.name.starts_with("mcp__"))
-            .count();
+        // Classify by REAL provenance (`ToolDef::server`), not the `mcp__` name
+        // prefix: a non-colliding MCP tool keeps its bare name, so the prefix
+        // would count it as a built-in and ALWAYS keep it — letting a swarm of
+        // bare-named MCP tools blow past the provider limit (#359).
+        let non_mcp_count = tools.iter().filter(|t| t.server.is_none()).count();
         let mcp_budget = limit.saturating_sub(non_mcp_count);
         let mut kept = Vec::with_capacity(tools.len().min(limit.max(non_mcp_count)));
         let mut mcp_taken = 0usize;
         let mut mcp_total = 0usize;
         for t in tools {
-            if t.name.starts_with("mcp__") {
+            if t.server.is_some() {
                 mcp_total += 1;
                 if mcp_taken < mcp_budget {
                     kept.push(t);
@@ -7994,6 +8004,9 @@ mod set_config_tests {
                 description: desc.to_string(),
                 input_schema: serde_json::json!({"type": "object"}),
                 deferred: false,
+                // #174 tools are mcp__-prefixed AND carry real provenance —
+                // both signals classify them as MCP.
+                server: Some("srv".to_string()),
             }
         }
         let tools = vec![
@@ -8052,23 +8065,25 @@ mod set_config_tests {
 
     // --- #344/#359: provider-aware hard cap on the total tool count ---
 
-    /// Build a non-MCP/built-in `ToolDef` (name must NOT start with `mcp__`).
+    /// Build a non-MCP/built-in `ToolDef` (`server: None`).
     fn builtin_tool(name: &str) -> wcore_types::tool::ToolDef {
         wcore_types::tool::ToolDef {
             name: name.to_string(),
             description: format!("{name} built-in tool"),
             input_schema: serde_json::json!({"type": "object"}),
             deferred: false,
+            server: None,
         }
     }
 
-    /// Build an MCP `ToolDef` (`mcp__{server}__{tool}`).
+    /// Build an MCP `ToolDef` (`mcp__{server}__{tool}`, real provenance set).
     fn cap_mcp_tool(name: &str) -> wcore_types::tool::ToolDef {
         wcore_types::tool::ToolDef {
             name: name.to_string(),
             description: format!("{name} mcp tool"),
             input_schema: serde_json::json!({"type": "object"}),
             deferred: false,
+            server: Some("srv".to_string()),
         }
     }
 
@@ -8158,6 +8173,143 @@ mod set_config_tests {
         assert_eq!(capped.len(), 6, "correctness > strict limit for built-ins");
     }
 
+    // --- #359: provenance-based MCP classification (NOT the `mcp__` prefix) ---
+
+    /// Build a BARE-named MCP `ToolDef`: real provenance (`server: Some`) but a
+    /// name with NO `mcp__` prefix — exactly what `tool_proxy.rs` registers for
+    /// a non-colliding MCP tool (e.g. `execute_sql`, `list_calendar_events`).
+    fn bare_mcp_tool(name: &str) -> wcore_types::tool::ToolDef {
+        wcore_types::tool::ToolDef {
+            name: name.to_string(),
+            description: format!("{name} bare-named mcp tool"),
+            input_schema: serde_json::json!({"type": "object"}),
+            deferred: false,
+            server: Some("db".to_string()),
+        }
+    }
+
+    /// #359 regression — a BARE-named MCP tool (no `mcp__` prefix) must count
+    /// against the provider cap and be DROPPED when over budget. Pre-fix it was
+    /// classified as a pseudo-built-in (name-prefix check) and ALWAYS kept,
+    /// letting a swarm of bare-named MCP tools blow past the provider limit.
+    #[test]
+    fn provider_tool_cap_drops_bare_named_mcp_over_budget() {
+        let mut engine = make_engine("m");
+        engine.compat.max_tools = Some(4);
+
+        // 2 real built-ins (server: None) + 10 bare-named MCP tools (server:
+        // Some, NO `mcp__` prefix). Budget = 4 - 2 = 2 MCP slots.
+        let mut tools = vec![builtin_tool("Read"), builtin_tool("ToolSearch")];
+        for i in 0..10 {
+            tools.push(bare_mcp_tool(&format!("execute_sql_{i:02}")));
+        }
+
+        let capped = engine.apply_provider_tool_cap(tools);
+
+        // Both built-ins kept; exactly (limit - non_mcp) = 2 bare MCP tools kept.
+        let names: Vec<&str> = capped.iter().map(|t| t.name.as_str()).collect();
+        assert!(names.contains(&"Read"));
+        assert!(names.contains(&"ToolSearch"));
+        let mcp_kept = capped.iter().filter(|t| t.server.is_some()).count();
+        assert_eq!(
+            mcp_kept, 2,
+            "bare-named MCP tools must be budgeted/truncated like prefixed ones"
+        );
+        assert_eq!(
+            capped.len(),
+            4,
+            "total must be capped at the provider limit"
+        );
+        // The dropped bare MCP tools are NOT silently kept as pseudo-builtins.
+        assert!(
+            capped.iter().filter(|t| t.server.is_none()).count() == 2,
+            "only the two real built-ins are server:None"
+        );
+    }
+
+    /// #359 regression — a real built-in (`server: None`) is NEVER classified as
+    /// MCP, so it is always kept by the cap even when it shares a non-prefixed
+    /// snake_case name shape with MCP tools.
+    #[test]
+    fn provider_tool_cap_never_drops_real_builtin() {
+        let mut engine = make_engine("m");
+        engine.compat.max_tools = Some(3);
+
+        // 5 built-ins (server: None) exceed the cap of 3 — but built-ins are
+        // always kept; only MCP tools are ever truncated.
+        let tools = vec![
+            builtin_tool("Read"),
+            builtin_tool("Write"),
+            builtin_tool("execute"), // bare snake_case name, but server: None
+            builtin_tool("Bash"),
+            builtin_tool("ToolSearch"),
+        ];
+
+        let capped = engine.apply_provider_tool_cap(tools);
+        let names: Vec<&str> = capped.iter().map(|t| t.name.as_str()).collect();
+        for b in ["Read", "Write", "execute", "Bash", "ToolSearch"] {
+            assert!(names.contains(&b), "built-in {b} must never be dropped");
+        }
+        assert_eq!(
+            capped.len(),
+            5,
+            "all server:None tools kept (correctness > strict limit for built-ins)"
+        );
+    }
+
+    /// #359 regression — a BARE-named MCP tool is subject to curation. The
+    /// curator must rank/trim it like a prefixed MCP tool; a built-in with the
+    /// same snake_case shape (server: None) must never be curated away.
+    #[test]
+    fn mcp_curation_curates_bare_named_mcp_and_spares_builtin() {
+        use wcore_types::message::{ContentBlock, Message, Role};
+
+        let names = |v: Vec<wcore_types::tool::ToolDef>| -> Vec<String> {
+            v.into_iter().map(|t| t.name).collect()
+        };
+
+        // 1 built-in (server: None) + 4 BARE-named MCP tools (server: Some, no
+        // `mcp__` prefix). With k=2 and 4 MCP tools > k, curation must engage.
+        let tools = vec![
+            builtin_tool("Read"), // server: None → always kept, never curated
+            bare_mcp_tool("query_alpha_database"),
+            bare_mcp_tool("send_bravo_email"),
+            bare_mcp_tool("compile_charlie_report"),
+            bare_mcp_tool("remove_delta_entry"),
+        ];
+
+        let mut engine = make_engine("m");
+        engine.mcp_curation = wcore_config::config::McpCurationPolicy::TopK { k: 2 };
+        engine.audit_log = None; // keyword-only ranking → deterministic
+        engine.messages = vec![Message::new(
+            Role::User,
+            vec![ContentBlock::Text {
+                text: "query alpha database".to_string(),
+            }],
+        )];
+
+        let kept = names(engine.apply_mcp_curation(tools));
+
+        // The built-in survives unconditionally (it is NOT an MCP tool).
+        assert!(
+            kept.contains(&"Read".to_string()),
+            "real built-in must never be curated away"
+        );
+        // The keyword-matching bare MCP tool is surfaced...
+        assert!(
+            kept.contains(&"query_alpha_database".to_string()),
+            "keyword-matched bare MCP tool must be curated in"
+        );
+        // ...and curation actually trimmed the bare MCP set (4 MCP > k=2), i.e.
+        // bare-named MCP tools ARE subject to TopK (pre-fix they were treated as
+        // built-ins and ALL kept).
+        let mcp_kept = kept.iter().filter(|n| n.as_str() != "Read").count();
+        assert_eq!(
+            mcp_kept, 2,
+            "bare-named MCP tools must be curated to TopK (k=2), not all kept"
+        );
+    }
+
     /// Cache-stability regression (token-opt, finding #174): when turn 2
     /// unions in a tool that sorts EARLIER in registry-iteration order than an
     /// already-kept tool, the kept set must stay APPEND-ONLY — the new tool
@@ -8179,6 +8331,8 @@ mod set_config_tests {
                 description: desc.to_string(),
                 input_schema: serde_json::json!({"type": "object"}),
                 deferred: false,
+                // #174 tools are mcp__-prefixed AND carry real provenance.
+                server: Some("srv".to_string()),
             }
         }
         // Registry order: alpha sits at index 0, ahead of zulu/yankee. Turn 1

--- a/crates/wcore-agent/src/mcp_curator.rs
+++ b/crates/wcore-agent/src/mcp_curator.rs
@@ -1,9 +1,15 @@
 //! F17 MCP tool curation.
 //!
-//! Default top-K ranking by keyword overlap (user message ↔ tool description)
-//! plus a small recency boost from the M2 audit log when available. Always
-//! preserves "rescue" tools (Read/Grep/Glob/Edit/Write/Bash) regardless of
-//! score so the agent never loses basic file-access affordances.
+//! Default ranking by BM25 relevance (user message ↔ tool document) plus a
+//! small recency boost from the M2 audit log when available. Always preserves
+//! "rescue" tools (Read/Grep/Glob/Edit/Write/Bash) regardless of score so the
+//! agent never loses basic file-access affordances.
+//!
+//! The BM25 scorer mirrors the desktop's `bm25.ts` for cross-surface parity
+//! (same Robertson IDF with the BM25+ `+1.0` guard, same `k1`/`b`, same
+//! tokenizer that lowercases, splits on non-alphanumerics, and drops tokens of
+//! length <= 3). The recency boost and the rescue-tool floor stay ADDITIVE on
+//! top of the BM25 score, so a rescue tool still survives zero query overlap.
 //!
 //! Scoring is intentionally cheap and explainable. F12 GEPA evolution (W10)
 //! replaces this with learned weights.
@@ -19,18 +25,126 @@ pub struct RankedTool {
 
 #[derive(Debug, Clone)]
 pub struct CurationInput<'a> {
-    /// Most recent user message in the turn — the keyword overlap source.
+    /// Most recent user message in the turn — the BM25 query source.
     pub user_message: &'a str,
     /// (server, tool, description) triples — verbatim from
-    /// `McpManager::all_tools()` (mapped at the call site).
+    /// `McpManager::all_tools()` (mapped at the call site). The `server` is the
+    /// REAL provenance (`ToolDef::server`), threaded through by the caller; it
+    /// is folded into the BM25 document alongside the description and the
+    /// tool-name tail.
     pub tools: &'a [(String, String, String)],
     /// `tool_name -> uses-in-last-N-seconds`. From
     /// `wcore_memory::audit::AuditLog::recent_tool_uses` when available;
-    /// empty map otherwise (graceful degrade to keyword-only ranking).
+    /// empty map otherwise (graceful degrade to BM25-only ranking).
     pub recent_usage: &'a HashMap<String, u64>,
 }
 
 const RESCUE_TOOLS: &[&str] = &["Read", "Grep", "Glob", "Edit", "Write", "Bash"];
+
+// BM25 free parameters. Match the desktop `bm25.ts` defaults exactly.
+const BM25_K1: f64 = 1.5;
+const BM25_B: f64 = 0.75;
+
+/// Lowercase, split on non-alphanumerics, drop tokens of length <= 3.
+///
+/// Applied to BOTH the query and every document so an MCP tool name like
+/// `mcp__gcal__list_calendar_events` becomes
+/// `["gcal", "list", "calendar", "events"]` (the `mcp`/`__` noise and any
+/// <=3-char fragment fall away). Matches the desktop tokenizer.
+fn tokenize(s: &str) -> Vec<String> {
+    s.split(|c: char| !c.is_alphanumeric())
+        .filter(|t| t.len() > 3)
+        .map(|t| t.to_lowercase())
+        .collect()
+}
+
+/// A precomputed BM25 index over a fixed document set.
+///
+/// `score(query, doc_idx)` returns the standard Okapi BM25 sum over the query
+/// terms with Robertson IDF guarded by the BM25+ `+1.0` term (which keeps the
+/// IDF non-negative even for a term present in every document). The guard is
+/// REQUIRED for parity with the desktop scorer and to avoid a term that is
+/// common across tools pushing a relevant document's score below an unrelated
+/// one.
+struct Bm25 {
+    /// Per-document term frequencies.
+    doc_terms: Vec<HashMap<String, usize>>,
+    /// Per-document length (token count).
+    doc_len: Vec<usize>,
+    /// Document frequency per term (#docs containing the term).
+    df: HashMap<String, usize>,
+    /// Number of documents.
+    n: usize,
+    /// Average document length.
+    avgdl: f64,
+}
+
+impl Bm25 {
+    fn new(docs: &[Vec<String>]) -> Self {
+        let n = docs.len();
+        let mut df: HashMap<String, usize> = HashMap::new();
+        let mut doc_terms: Vec<HashMap<String, usize>> = Vec::with_capacity(n);
+        let mut doc_len: Vec<usize> = Vec::with_capacity(n);
+        let mut total_len: usize = 0;
+
+        for doc in docs {
+            let mut tf: HashMap<String, usize> = HashMap::new();
+            for term in doc {
+                *tf.entry(term.clone()).or_insert(0) += 1;
+            }
+            // Document frequency counts each distinct term once per document.
+            for term in tf.keys() {
+                *df.entry(term.clone()).or_insert(0) += 1;
+            }
+            total_len += doc.len();
+            doc_len.push(doc.len());
+            doc_terms.push(tf);
+        }
+
+        let avgdl = if n == 0 {
+            0.0
+        } else {
+            total_len as f64 / n as f64
+        };
+
+        Self {
+            doc_terms,
+            doc_len,
+            df,
+            n,
+            avgdl,
+        }
+    }
+
+    /// Robertson IDF with the BM25+ `+1.0` guard:
+    /// `ln(((N - df + 0.5) / (df + 0.5)) + 1.0)`. The `+1.0` keeps the result
+    /// non-negative for every term (including one present in all documents).
+    fn idf(&self, term: &str) -> f64 {
+        let df = *self.df.get(term).unwrap_or(&0) as f64;
+        let n = self.n as f64;
+        (((n - df + 0.5) / (df + 0.5)) + 1.0).ln()
+    }
+
+    fn score(&self, query: &[String], doc_idx: usize) -> f64 {
+        if doc_idx >= self.doc_terms.len() || self.avgdl <= 0.0 {
+            return 0.0;
+        }
+        let tf_map = &self.doc_terms[doc_idx];
+        let dl = self.doc_len[doc_idx] as f64;
+        let mut score = 0.0;
+        for term in query {
+            let tf = *tf_map.get(term).unwrap_or(&0) as f64;
+            if tf <= 0.0 {
+                continue;
+            }
+            let idf = self.idf(term);
+            let numerator = tf * (BM25_K1 + 1.0);
+            let denominator = tf + BM25_K1 * (1.0 - BM25_B + BM25_B * dl / self.avgdl);
+            score += idf * numerator / denominator;
+        }
+        score
+    }
+}
 
 pub struct McpCurator {
     top_k: usize,
@@ -41,19 +155,44 @@ impl McpCurator {
         Self { top_k }
     }
 
-    pub fn curate(&self, input: &CurationInput<'_>) -> Vec<RankedTool> {
-        let msg_lower = input.user_message.to_lowercase();
-        let msg_terms: Vec<&str> = msg_lower
-            .split_whitespace()
-            .filter(|t| t.len() > 3)
+    /// Score EVERY tool and return them sorted by score descending, with NO
+    /// truncation. Score = BM25(query, doc) + recency boost + rescue floor,
+    /// where:
+    /// - `query` = `tokenize(user_message)`,
+    /// - `doc` = `tokenize(description + " " + server + " " + tool-name tail)`,
+    /// - recency boost = `recent_usage[tool] * 0.5` (unchanged from the prior
+    ///   keyword scorer),
+    /// - rescue floor = `100.0` for the file-access rescue tools, `0.0`
+    ///   otherwise (additive, so a rescue tool survives zero query overlap).
+    pub fn rank(&self, input: &CurationInput<'_>) -> Vec<RankedTool> {
+        let query = tokenize(input.user_message);
+
+        // Build the document corpus from REAL provenance: the description, the
+        // real server name, and the tool-name tail (last `__`-segment, or the
+        // bare name when the MCP tool keeps its un-prefixed original name).
+        let docs: Vec<Vec<String>> = input
+            .tools
+            .iter()
+            .map(|(server, tool, desc)| {
+                let tail = tool.rsplit("__").next().unwrap_or(tool.as_str());
+                let mut doc_src = String::with_capacity(desc.len() + server.len() + tail.len() + 2);
+                doc_src.push_str(desc);
+                doc_src.push(' ');
+                doc_src.push_str(server);
+                doc_src.push(' ');
+                doc_src.push_str(tail);
+                tokenize(&doc_src)
+            })
             .collect();
+
+        let bm25 = Bm25::new(&docs);
 
         let mut ranked: Vec<RankedTool> = input
             .tools
             .iter()
-            .map(|(server, tool, desc)| {
-                let desc_lower = desc.to_lowercase();
-                let overlap = msg_terms.iter().filter(|t| desc_lower.contains(*t)).count() as f64;
+            .enumerate()
+            .map(|(idx, (server, tool, _desc))| {
+                let relevance = bm25.score(&query, idx);
                 let usage = *input.recent_usage.get(tool).unwrap_or(&0) as f64;
                 // Rescue tools get a baseline floor so they always rank.
                 let rescue = if RESCUE_TOOLS.contains(&tool.as_str()) {
@@ -64,16 +203,23 @@ impl McpCurator {
                 RankedTool {
                     server_name: server.clone(),
                     tool_name: tool.clone(),
-                    score: overlap * 10.0 + usage * 0.5 + rescue,
+                    score: relevance + usage * 0.5 + rescue,
                 }
             })
             .collect();
 
+        // Stable sort: equal-score tools retain their input (registry) order,
+        // which the #174 append-only/cache-stability invariants depend on.
         ranked.sort_by(|a, b| {
             b.score
                 .partial_cmp(&a.score)
                 .unwrap_or(std::cmp::Ordering::Equal)
         });
+        ranked
+    }
+
+    pub fn curate(&self, input: &CurationInput<'_>) -> Vec<RankedTool> {
+        let mut ranked = self.rank(input);
         ranked.truncate(self.top_k);
         ranked
     }
@@ -82,6 +228,10 @@ impl McpCurator {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn no_usage() -> HashMap<String, u64> {
+        HashMap::new()
+    }
 
     #[test]
     fn rescue_tools_survive_zero_overlap() {
@@ -102,5 +252,103 @@ mod tests {
         });
         let names: Vec<&str> = out.iter().map(|r| r.tool_name.as_str()).collect();
         assert!(names.contains(&"Read"));
+    }
+
+    #[test]
+    fn tokenize_splits_on_underscores_and_drops_short_tokens() {
+        let toks = tokenize("mcp__gcal__list_calendar_events");
+        assert_eq!(toks, vec!["gcal", "list", "calendar", "events"]);
+        // <=3-char fragments and the `mcp`/`__` noise drop out.
+        assert!(!toks.contains(&"mcp".to_string()));
+    }
+
+    #[test]
+    fn bm25_ranks_query_term_match_above_unrelated() {
+        // doc 0 shares "calendar" with the query; doc 1 shares nothing.
+        let docs = vec![
+            tokenize("create a calendar event for the meeting"),
+            tokenize("compile zulu reports into a summary"),
+        ];
+        let bm25 = Bm25::new(&docs);
+        let query = tokenize("calendar meeting");
+        let s0 = bm25.score(&query, 0);
+        let s1 = bm25.score(&query, 1);
+        assert!(s0 > 0.0, "matching doc must score positive");
+        assert!(s1 <= 0.0, "unrelated doc scores zero");
+        assert!(s0 > s1, "matching doc must outrank the unrelated one");
+    }
+
+    #[test]
+    fn robertson_idf_is_non_negative_for_ubiquitous_term() {
+        // "report" appears in every document — without the BM25+ `+1.0` guard
+        // its IDF would go negative. The guard keeps it >= 0.
+        let docs = vec![
+            tokenize("alpha report data"),
+            tokenize("bravo report data"),
+            tokenize("charlie report data"),
+        ];
+        let bm25 = Bm25::new(&docs);
+        assert!(
+            bm25.idf("report") >= 0.0,
+            "ubiquitous-term IDF must stay non-negative (BM25+ guard)"
+        );
+        // A rare term still scores higher than the ubiquitous one.
+        assert!(bm25.idf("alpha") > bm25.idf("report"));
+    }
+
+    #[test]
+    fn calendar_relevant_tool_outranks_generic_tools() {
+        let curator = McpCurator::new(3);
+        let tools = vec![
+            (
+                "gcal".into(),
+                "mcp__gcal__create_calendar_event".into(),
+                "Create a calendar event to schedule a meeting".into(),
+            ),
+            (
+                "db".into(),
+                "mcp__db__execute_sql".into(),
+                "Run a SQL query against the database".into(),
+            ),
+            (
+                "email".into(),
+                "mcp__email__send_message".into(),
+                "Send an email message to a recipient".into(),
+            ),
+        ];
+        let out = curator.curate(&CurationInput {
+            user_message: "schedule a calendar meeting",
+            tools: &tools,
+            recent_usage: &no_usage(),
+        });
+        assert_eq!(
+            out.first().map(|r| r.tool_name.as_str()),
+            Some("mcp__gcal__create_calendar_event"),
+            "the calendar tool must rank first for a calendar request"
+        );
+    }
+
+    #[test]
+    fn rank_scores_every_tool_without_truncation() {
+        let curator = McpCurator::new(1);
+        let tools = vec![
+            ("a".into(), "ToolA".into(), "alpha database records".into()),
+            ("b".into(), "ToolB".into(), "bravo email messages".into()),
+            ("c".into(), "ToolC".into(), "charlie compile reports".into()),
+        ];
+        let ranked = curator.rank(&CurationInput {
+            user_message: "alpha database",
+            tools: &tools,
+            recent_usage: &no_usage(),
+        });
+        // rank() returns ALL tools (no truncation); curate() truncates to top_k.
+        assert_eq!(ranked.len(), 3);
+        let curated = curator.curate(&CurationInput {
+            user_message: "alpha database",
+            tools: &tools,
+            recent_usage: &no_usage(),
+        });
+        assert_eq!(curated.len(), 1);
+        assert_eq!(curated[0].tool_name, "ToolA");
     }
 }

--- a/crates/wcore-agent/src/tool_backends/http_fetch.rs
+++ b/crates/wcore-agent/src/tool_backends/http_fetch.rs
@@ -71,8 +71,8 @@ impl FetchBackend for HttpFetchBackend {
             Ok(outcome) => outcome,
             Err(_) => FetchOutcome::Err {
                 message: format!(
-                    "fetch exceeded wall-clock deadline of {}ms (HTTP, body decode, and \
-                     readability extraction combined)",
+                    "fetch timed out: exceeded wall-clock deadline of {}ms (HTTP, body \
+                     decode, and readability extraction combined)",
                     req.timeout_ms
                 ),
             },

--- a/crates/wcore-config/src/compat.rs
+++ b/crates/wcore-config/src/compat.rs
@@ -266,6 +266,12 @@ pub struct ProviderCompat {
     /// `[compat.tier_models] cheap = "claude-haiku-4" balanced = "..."`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tier_models: Option<TierModels>,
+
+    /// #344/#359 — the provider's hard cap on the number of tools per request
+    /// (OpenAI's tool-array limit is 128). `None` = no cap. Enforced engine-side
+    /// after MCP curation, since MCP servers can push the array past the limit.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_tools: Option<usize>,
 }
 
 impl ProviderCompat {
@@ -417,6 +423,9 @@ impl ProviderCompat {
             // the pricing.toml catalog so they resolve correctly before reaching this fallback.
             cost_per_input_token: Some(0.0),
             cost_per_output_token: Some(0.0),
+            // #344/#359: OpenAI's hard tool-array limit is 128. Enforced
+            // engine-side after MCP curation so MCP servers can't push past it.
+            max_tools: Some(128),
             ..Default::default()
         }
     }
@@ -471,6 +480,9 @@ impl ProviderCompat {
             cost_per_output_token: Some(0.0),
             cost_per_cache_read_token: Some(0.0),
             cost_per_cache_write_token: Some(0.0),
+            // #344/#359: OpenAI-wire routers/providers (ChatGPT, Azure,
+            // flux-router, …) inherit the 128 tool-array hard cap.
+            max_tools: Some(128),
             ..Self::openai_defaults()
         }
     }
@@ -728,6 +740,7 @@ impl ProviderCompat {
                 .replays_thinking_in_history
                 .or(defaults.replays_thinking_in_history),
             tier_models: user.tier_models.or(defaults.tier_models),
+            max_tools: user.max_tools.or(defaults.max_tools),
         }
     }
 
@@ -848,6 +861,12 @@ impl ProviderCompat {
     /// (`wcore_providers::openai_compat::wants_max_completion_tokens`).
     pub fn uses_max_completion_tokens(&self) -> Option<bool> {
         self.uses_max_completion_tokens
+    }
+
+    /// #344/#359: the provider's hard cap on the number of tools per request.
+    /// `None` (the default for non-OpenAI wire protocols) means no cap.
+    pub fn max_tools(&self) -> Option<usize> {
+        self.max_tools
     }
 }
 

--- a/crates/wcore-mcp/src/tool_proxy.rs
+++ b/crates/wcore-mcp/src/tool_proxy.rs
@@ -125,6 +125,15 @@ impl Tool for McpToolProxy {
         ToolCategory::Mcp
     }
 
+    /// Provenance for curation / provider-cap classification. Returns the
+    /// originating MCP server name regardless of whether the display name was
+    /// prefixed (`mcp__{server}__{tool}` on collision) or kept bare. This is
+    /// what lets the engine classify a non-colliding (bare-named) MCP tool as
+    /// MCP instead of mistaking it for a built-in.
+    fn mcp_server(&self) -> Option<&str> {
+        Some(&self.server_name)
+    }
+
     fn describe(&self, input: &Value) -> String {
         format!(
             "MCP {}/{}: {}",

--- a/crates/wcore-providers/src/anthropic_shared.rs
+++ b/crates/wcore-providers/src/anthropic_shared.rs
@@ -848,6 +848,7 @@ mod tests {
             description: "Run a shell command".to_string(),
             input_schema: schema.clone(),
             deferred: false,
+            server: None,
         }];
         // act
         let result = build_tools(&tools);
@@ -878,12 +879,14 @@ mod tests {
                 description: "Read a file".into(),
                 input_schema: json!({"type": "object", "properties": {"path": {"type": "string"}}}),
                 deferred: false,
+                server: None,
             },
             ToolDef {
                 name: "SpawnTool".into(),
                 description: "Spawn sub-agents".into(),
                 input_schema: json!({"type": "object", "properties": {"agents": {"type": "array"}}}),
                 deferred: true,
+                server: None,
             },
         ];
         let result = build_tools(&tools);
@@ -1059,6 +1062,7 @@ mod tests {
         let tool = ToolDef {
             name: "transcribe_audio".into(),
             description: "test".into(),
+            server: None,
             deferred: false,
             input_schema: json!({
                 "type": "object",
@@ -1091,6 +1095,7 @@ mod tests {
         let tool = ToolDef {
             name: "spotify".into(),
             description: "test".into(),
+            server: None,
             deferred: false,
             input_schema: json!({
                 "type": "object",

--- a/crates/wcore-providers/src/gemini.rs
+++ b/crates/wcore-providers/src/gemini.rs
@@ -1197,6 +1197,7 @@ mod tests {
             description: "read a file".into(),
             input_schema: json!({"type": "object", "properties": {"path": {"type": "string"}}}),
             deferred: false,
+            server: None,
         }];
         let body = provider.build_request_body(&request);
         let decls = &body["tools"][0]["functionDeclarations"];
@@ -1554,6 +1555,7 @@ mod tests {
                 "additionalProperties": false
             }),
             deferred: false,
+            server: None,
         }];
         let decls = build_function_declarations(&tools);
         assert_eq!(decls.len(), 1);

--- a/crates/wcore-providers/src/openai.rs
+++ b/crates/wcore-providers/src/openai.rs
@@ -2799,6 +2799,7 @@ mod tests {
             description: "read a file".into(),
             input_schema: json!({"type": "object"}),
             deferred: false,
+            server: None,
         }];
         let body = provider.build_request_body(&req);
         let tools = body["tools"].as_array().expect("tools array present");
@@ -2824,6 +2825,7 @@ mod tests {
             description: "read a file".into(),
             input_schema: json!({"type": "object"}),
             deferred: false,
+            server: None,
         }];
         let body = provider.build_request_body(&req);
         let tools = body["tools"].as_array().expect("tools array present");
@@ -2923,6 +2925,7 @@ mod tests {
             description: "Read a file".into(),
             input_schema: json!({"type": "object", "properties": {"path": {"type": "string"}}}),
             deferred: false,
+            server: None,
         }]
     }
 
@@ -3598,12 +3601,14 @@ mod tests {
                 description: "Read a file".into(),
                 input_schema: json!({"type": "object", "properties": {"path": {"type": "string"}}}),
                 deferred: false,
+                server: None,
             },
             ToolDef {
                 name: "SpawnTool".into(),
                 description: "Spawn sub-agents".into(),
                 input_schema: json!({"type": "object", "properties": {"agents": {"type": "array"}}}),
                 deferred: true,
+                server: None,
             },
         ];
         let result = OpenAIProvider::build_tools(&tools);
@@ -3631,18 +3636,21 @@ mod tests {
                 description: "b".into(),
                 input_schema: json!({"type": "object", "properties": {}}),
                 deferred: false,
+                server: None,
             },
             ToolDef {
                 name: "ai.perplexity-perplexity-mcp".into(),
                 description: "p".into(),
                 input_schema: json!({"type": "object", "properties": {}}),
                 deferred: false,
+                server: None,
             },
             ToolDef {
                 name: "get_weather".into(),
                 description: "w".into(),
                 input_schema: json!({"type": "object", "properties": {}}),
                 deferred: false,
+                server: None,
             },
         ];
         let result = OpenAIProvider::build_tools(&tools);
@@ -3680,6 +3688,7 @@ mod tests {
                 description: "run a command".into(),
                 input_schema: json!({"type": "object"}),
                 deferred: false,
+                server: None,
             },
             ToolDef {
                 name: "ijfw_run".into(),
@@ -3687,12 +3696,14 @@ mod tests {
                 // arbitrary-object tool, still missing properties
                 input_schema: json!({"type": "object", "additionalProperties": true}),
                 deferred: false,
+                server: None,
             },
             ToolDef {
                 name: "Read".into(),
                 description: "read".into(),
                 input_schema: json!({"type": "object", "properties": {"path": {"type": "string"}}, "required": ["path"]}),
                 deferred: false,
+                server: None,
             },
         ];
         let result = OpenAIProvider::build_tools(&tools);

--- a/crates/wcore-providers/src/openai_chatgpt.rs
+++ b/crates/wcore-providers/src/openai_chatgpt.rs
@@ -501,6 +501,7 @@ mod tests {
             description: "Read a file".into(),
             input_schema: json!({ "type": "object", "properties": {} }),
             deferred: false,
+            server: None,
         }]));
         assert_eq!(with_tools["tool_choice"], json!("auto"));
         assert_eq!(with_tools["parallel_tool_calls"], json!(true));

--- a/crates/wcore-providers/src/openai_responses.rs
+++ b/crates/wcore-providers/src/openai_responses.rs
@@ -729,6 +729,7 @@ mod tests {
                 description: "Read a file".into(),
                 input_schema: json!({ "type": "object", "properties": {} }),
                 deferred: false,
+                server: None,
             }],
             ..Default::default()
         };

--- a/crates/wcore-providers/tests/gemini_test.rs
+++ b/crates/wcore-providers/tests/gemini_test.rs
@@ -517,6 +517,7 @@ async fn gemini_request_body_carries_tools_and_safety_settings() {
             "required": ["path"]
         }),
         deferred: false,
+        server: None,
     }];
     request.system = "Be terse.".into();
     request.messages.insert(

--- a/crates/wcore-tools/src/lib.rs
+++ b/crates/wcore-tools/src/lib.rs
@@ -397,6 +397,19 @@ pub trait Tool: Send + Sync {
     /// Tool category for protocol classification
     fn category(&self) -> ToolCategory;
 
+    /// Provenance: the MCP server this tool is sourced from, or `None` for a
+    /// built-in / skill / spawn / plan tool.
+    ///
+    /// This is the REAL MCP-classification signal. A non-colliding MCP tool
+    /// keeps its bare original name (no `mcp__{server}__` prefix — see
+    /// `wcore-mcp/src/tool_proxy.rs`), so the name alone cannot tell it apart
+    /// from a built-in. `McpToolProxy` overrides this to return `Some(server)`;
+    /// every built-in falls through to `None`. Surfaced onto `ToolDef::server`
+    /// by the registry so curation and the provider tool cap classify correctly.
+    fn mcp_server(&self) -> Option<&str> {
+        None
+    }
+
     /// AUDIT B-1 follow-up — per-input category override.
     ///
     /// The dispatch-timeout (see `orchestration::tool_dispatch_timeout`)
@@ -483,6 +496,9 @@ impl<T: Tool + ?Sized> Tool for std::sync::Arc<T> {
     }
     fn category(&self) -> ToolCategory {
         (**self).category()
+    }
+    fn mcp_server(&self) -> Option<&str> {
+        (**self).mcp_server()
     }
     fn category_for(&self, input: &Value) -> ToolCategory {
         (**self).category_for(input)

--- a/crates/wcore-tools/src/registry.rs
+++ b/crates/wcore-tools/src/registry.rs
@@ -197,6 +197,7 @@ impl ToolRegistry {
                 description: t.description().to_string(),
                 input_schema: t.input_schema(),
                 deferred: t.is_deferred(),
+                server: t.mcp_server().map(str::to_string),
             })
             .collect()
     }
@@ -216,6 +217,7 @@ impl ToolRegistry {
                 description: t.description().to_string(),
                 input_schema: t.input_schema(),
                 deferred: t.is_deferred(),
+                server: t.mcp_server().map(str::to_string),
             })
             .collect()
     }

--- a/crates/wcore-tools/src/tool_search.rs
+++ b/crates/wcore-tools/src/tool_search.rs
@@ -136,18 +136,21 @@ mod tests {
                 description: "Read a file".into(),
                 input_schema: json!({"type": "object", "properties": {"path": {"type": "string"}}}),
                 deferred: false,
+                server: None,
             },
             ToolDef {
                 name: "SpawnTool".into(),
                 description: "Spawn sub-agents".into(),
                 input_schema: json!({"type": "object", "properties": {"agents": {"type": "array"}}}),
                 deferred: true,
+                server: None,
             },
             ToolDef {
                 name: "EnterPlanMode".into(),
                 description: "Enter plan mode".into(),
                 input_schema: json!({"type": "object", "properties": {}}),
                 deferred: true,
+                server: None,
             },
         ]
     }

--- a/crates/wcore-tools/tests/tool_search_cancel_test.rs
+++ b/crates/wcore-tools/tests/tool_search_cancel_test.rs
@@ -32,6 +32,7 @@ fn build_large_registry(n: usize) -> Vec<ToolDef> {
             ),
             input_schema: json!({"type": "object"}),
             deferred: true,
+            server: None,
         })
         .collect()
 }
@@ -153,6 +154,7 @@ async fn tool_search_still_works_without_cancel() {
         description: "Findable by query".into(),
         input_schema: json!({"type": "object"}),
         deferred: true,
+        server: None,
     });
     let tool = ToolSearchTool::new(defs);
 

--- a/crates/wcore-types/src/tool.rs
+++ b/crates/wcore-types/src/tool.rs
@@ -31,13 +31,21 @@ pub fn truncate_deferred_description(desc: &str) -> String {
 }
 
 /// Definition of a tool for the API
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct ToolDef {
     pub name: String,
     pub description: String,
     pub input_schema: JsonSchema,
     /// Whether this tool's full schema is deferred (only name + stub sent to LLM).
     pub deferred: bool,
+    /// Provenance: `Some(server_name)` for a tool sourced from an MCP server,
+    /// `None` for a built-in / skill / spawn / plan tool. This is the REAL
+    /// classification signal — an MCP tool whose original name does NOT collide
+    /// with a built-in keeps its bare name (no `mcp__` prefix), so the name
+    /// alone cannot distinguish it from a built-in. Curation
+    /// (`apply_mcp_curation`) and the provider hard cap (`apply_provider_tool_cap`)
+    /// MUST classify on this field, not on the `mcp__` name prefix.
+    pub server: Option<String>,
 }
 
 /// Result from executing a tool
@@ -70,6 +78,7 @@ mod tests {
             description: "Run a shell command".to_string(),
             input_schema: schema.clone(),
             deferred: false,
+            server: None,
         };
         // assert
         assert_eq!(tool.name, "bash");
@@ -85,6 +94,7 @@ mod tests {
             description: "Does nothing".to_string(),
             input_schema: json!({}),
             deferred: false,
+            server: None,
         };
         // assert
         assert_eq!(tool.input_schema, json!({}));
@@ -137,6 +147,7 @@ mod tests {
             description: "desc".to_string(),
             input_schema: json!({}),
             deferred: false,
+            server: None,
         };
         assert!(!tool.deferred);
     }
@@ -148,6 +159,7 @@ mod tests {
             description: "desc".to_string(),
             input_schema: json!({}),
             deferred: true,
+            server: None,
         };
         assert!(tool.deferred);
     }


### PR DESCRIPTION
## Why
The desktop's Lane-3 `ToolSelector` (BM25 rank → cap → `allow_list`) only protects the **desktop** host. Driving **wayland-core directly (CLI / json-stream) with connected MCPs and routing to Flux Auto → gpt-5** bypasses it entirely — the engine assembles the array itself and sends the full MCP union (Google Workspace alone = 122; +others = 222 > 128 → API 400). That's the `needs:core` half of #344.

## What
Engine-side provider-aware hard cap — the correctness backstop for **every** host:
- `ProviderCompat.max_tools: Option<usize>` (+ merge + accessor). OpenAI / ChatGPT / Azure / OpenAI-wire routers (incl. **Flux** — the #344 path) = `Some(128)`; others `None`.
- `apply_provider_tool_cap`, enforced right after `apply_mcp_curation`: keeps **all** non-MCP tools (built-ins, ToolSearch, skills, plan) and truncates the MCP tail to fit. Dropped MCP tools stay discoverable via the `ToolSearch` meta-tool (full bootstrap snapshot). `None` = no-op; logs the trim.

Complementary to, not a duplicate of, desktop Lane 3: for the desktop host `allow_list` pre-caps so this never fires; for the CLI it's the only protection.

## Relationship to the existing layers
- **Separate from `apply_mcp_curation`** (a relevance/token optimization via `TopK`). This is the hard correctness guarantee.
- Closes #359 the right way — a provider-aware cap, **not** the naive `take(top_k)` clamp, which broke the #174 cache-stability tests and dropped current-turn-relevant tools. #174 tests stay green (the cap sits at ~128, far above the `k` they use).

## Tests
`provider_tool_cap_truncates_total_to_limit`, `_noop_when_unset`, `_noop_under_limit`, `_keeps_all_builtins_even_when_budget_tiny`. Hetzner gate green (fmt/clippy/nextest 0; 2286 wcore-agent/config tests pass).

Refs #344 #359