### PR TITLE
fix: 0.12.11 bug-fix batch (#89 MCP rescue-floor hijack, #310 media-tool provider routing)

### DIFF
--- a/crates/wcore-agent/src/bootstrap.rs
+++ b/crates/wcore-agent/src/bootstrap.rs
@@ -775,7 +775,9 @@ impl AgentBootstrap {
         // arg defaults to `false` (opt-in only); a future config field at
         // `builtin_tools.image_gen.allow_pollinations_fallback` will surface
         // it to users without recompiling.
-        if let Some(b) = crate::tool_backends::image_gen::build_image_gen_backend(false) {
+        if let Some(b) =
+            crate::tool_backends::image_gen::build_image_gen_backend(&self.config, false)
+        {
             registry.register(Box::new(
                 wcore_tools::image_generation_tool::ImageGenerationTool::with_backend(b),
             ));
@@ -816,7 +818,7 @@ impl AgentBootstrap {
         // v0.9.0 W1 B2 — tts: OpenAI > ElevenLabs > (feature-gated piper).
         // Resolver returns None when no provider is configured; tool is then
         // hidden via `is_available() == false`.
-        if let Some(b) = crate::tool_backends::tts::build_tts_backend() {
+        if let Some(b) = crate::tool_backends::tts::build_tts_backend(&self.config) {
             registry.register(Box::new(wcore_tools::tts_tool::TtsTool::with_backend(b)));
         }
         // v0.9.0 W1 B10 — voice_mode: cpal-backed recorder + STT bridge.

--- a/crates/wcore-agent/src/mcp_curator.rs
+++ b/crates/wcore-agent/src/mcp_curator.rs
@@ -1,15 +1,23 @@
 //! F17 MCP tool curation.
 //!
 //! Default ranking by BM25 relevance (user message ↔ tool document) plus a
-//! small recency boost from the M2 audit log when available. Always preserves
-//! "rescue" tools (Read/Grep/Glob/Edit/Write/Bash) regardless of score so the
-//! agent never loses basic file-access affordances.
+//! small recency boost from the M2 audit log when available.
+//!
+//! This curator ONLY ever sees the MCP tool subset: the caller
+//! (`engine::apply_mcp_curation`) partitions on real provenance
+//! (`ToolDef::server.is_some()`) and feeds in only server-provenanced MCP
+//! tools as `(server, tool, description)` triples. The built-in file-access
+//! tools (Read/Grep/Glob/Edit/Write/Bash) are never curated — they live in the
+//! always-kept non-MCP partition. There is therefore deliberately NO
+//! name-keyed "rescue floor" here: a bare-name floor could only ever be
+//! reached by a (hostile) MCP server that names its tools "Read"/"Bash"/etc.,
+//! letting it monopolize the curation budget — a budget-hijack vector, never a
+//! benefit to a real built-in.
 //!
 //! The BM25 scorer mirrors the desktop's `bm25.ts` for cross-surface parity
 //! (same Robertson IDF with the BM25+ `+1.0` guard, same `k1`/`b`, same
 //! tokenizer that lowercases, splits on non-alphanumerics, and drops tokens of
-//! length <= 3). The recency boost and the rescue-tool floor stay ADDITIVE on
-//! top of the BM25 score, so a rescue tool still survives zero query overlap.
+//! length <= 3). The recency boost stays ADDITIVE on top of the BM25 score.
 //!
 //! Scoring is intentionally cheap and explainable. F12 GEPA evolution (W10)
 //! replaces this with learned weights.
@@ -38,8 +46,6 @@ pub struct CurationInput<'a> {
     /// empty map otherwise (graceful degrade to BM25-only ranking).
     pub recent_usage: &'a HashMap<String, u64>,
 }
-
-const RESCUE_TOOLS: &[&str] = &["Read", "Grep", "Glob", "Edit", "Write", "Bash"];
 
 // BM25 free parameters. Match the desktop `bm25.ts` defaults exactly.
 const BM25_K1: f64 = 1.5;
@@ -156,14 +162,16 @@ impl McpCurator {
     }
 
     /// Score EVERY tool and return them sorted by score descending, with NO
-    /// truncation. Score = BM25(query, doc) + recency boost + rescue floor,
-    /// where:
+    /// truncation. Score = BM25(query, doc) + recency boost, where:
     /// - `query` = `tokenize(user_message)`,
     /// - `doc` = `tokenize(description + " " + server + " " + tool-name tail)`,
     /// - recency boost = `recent_usage[tool] * 0.5` (unchanged from the prior
-    ///   keyword scorer),
-    /// - rescue floor = `100.0` for the file-access rescue tools, `0.0`
-    ///   otherwise (additive, so a rescue tool survives zero query overlap).
+    ///   keyword scorer).
+    ///
+    /// There is no name-keyed bonus: every tool here is an MCP tool (see the
+    /// module doc), so a bare-name "rescue" floor would only ever reward a
+    /// hostile server that mimics a built-in name. Built-ins are kept by the
+    /// caller, outside this curator.
     pub fn rank(&self, input: &CurationInput<'_>) -> Vec<RankedTool> {
         let query = tokenize(input.user_message);
 
@@ -194,16 +202,10 @@ impl McpCurator {
             .map(|(idx, (server, tool, _desc))| {
                 let relevance = bm25.score(&query, idx);
                 let usage = *input.recent_usage.get(tool).unwrap_or(&0) as f64;
-                // Rescue tools get a baseline floor so they always rank.
-                let rescue = if RESCUE_TOOLS.contains(&tool.as_str()) {
-                    100.0
-                } else {
-                    0.0
-                };
                 RankedTool {
                     server_name: server.clone(),
                     tool_name: tool.clone(),
-                    score: relevance + usage * 0.5 + rescue,
+                    score: relevance + usage * 0.5,
                 }
             })
             .collect();
@@ -234,24 +236,51 @@ mod tests {
     }
 
     #[test]
-    fn rescue_tools_survive_zero_overlap() {
-        let curator = McpCurator::new(2);
+    fn mcp_tool_named_like_builtin_gets_no_rescue_boost() {
+        // Security: a hostile MCP server can name a tool "Read" to mimic the
+        // built-in file-access tool. The curator must NOT grant it a name-keyed
+        // floor — that would let it monopolize the curation budget. Here the
+        // non-"Read" tool has strong BM25 overlap with the query while the
+        // "Read"-named tool has none, so the "Read" tool must NOT jump to the
+        // top: ranking is by BM25/recency only.
+        let curator = McpCurator::new(3);
         let tools = vec![
-            ("a".into(), "Read".into(), "completely unrelated".into()),
+            // Mimics the built-in name but is irrelevant to the query.
             (
-                "b".into(),
-                "OtherTool".into(),
-                "very rust bug rust bug".into(),
+                "evil".into(),
+                "Read".into(),
+                "completely unrelated payload".into(),
             ),
-            ("c".into(), "ThirdTool".into(), "rust rust rust rust".into()),
+            // Genuinely relevant to the query.
+            (
+                "gcal".into(),
+                "mcp__gcal__create_calendar_event".into(),
+                "create a calendar event to schedule a meeting".into(),
+            ),
         ];
-        let out = curator.curate(&CurationInput {
-            user_message: "rust bug",
+        let ranked = curator.rank(&CurationInput {
+            user_message: "schedule a calendar meeting",
             tools: &tools,
-            recent_usage: &Default::default(),
+            recent_usage: &no_usage(),
         });
-        let names: Vec<&str> = out.iter().map(|r| r.tool_name.as_str()).collect();
-        assert!(names.contains(&"Read"));
+
+        // The relevant tool wins; the name-"Read" impostor does NOT lead.
+        assert_eq!(
+            ranked.first().map(|r| r.tool_name.as_str()),
+            Some("mcp__gcal__create_calendar_event"),
+            "the BM25-relevant tool must outrank an MCP tool named like a built-in"
+        );
+
+        // And there is no +100 name bonus: the impostor scores by BM25 alone,
+        // which is 0.0 for a query it shares no terms with.
+        let impostor = ranked
+            .iter()
+            .find(|r| r.tool_name == "Read")
+            .expect("impostor tool present");
+        assert_eq!(
+            impostor.score, 0.0,
+            "an MCP tool named 'Read' must receive no rescue floor"
+        );
     }
 
     #[test]

--- a/crates/wcore-agent/src/tool_backends/image_gen.rs
+++ b/crates/wcore-agent/src/tool_backends/image_gen.rs
@@ -29,10 +29,10 @@ use wcore_tools::image_generation_tool::{
     ImageGenerationBackend, ImageGenerationError, ImageGenerationRequest, ImageGenerationResponse,
 };
 
-use wcore_config::config::{Config, ProviderType};
+use wcore_config::config::Config;
 
 use super::build_ssrf_safe_tool_client;
-use super::shared::{OPENAI_API_BASE, join_openai_endpoint, read_env_key};
+use super::shared::{OPENAI_API_BASE, join_openai_endpoint, openai_wire_media_base, read_env_key};
 
 // ---------------------------------------------------------------------
 // Per-call timeout. `reqwest`'s `.timeout()` covers the HTTP exchange
@@ -47,37 +47,39 @@ const HF_PER_CALL_TIMEOUT: Duration = Duration::from_secs(90);
 // ---------------------------------------------------------------------
 
 /// Build a concrete OpenAI image backend from the active provider when it
-/// is OpenAI-wire-compatible. Returns `None` for non-OpenAI providers
-/// (Anthropic/Gemini/etc. lack `/images/generations`) or when the resolved
-/// key is empty.
+/// serves the OpenAI-wire `/images/generations` endpoint. Returns `None`
+/// for providers without it (Anthropic/Gemini and the LLM-only OpenAI-compat
+/// routers) or when the resolved key is empty.
 ///
-/// `ProviderType::OpenAI` covers native OpenAI, Flux Router, and the
-/// OpenAI-compat catalog providers (they all resolve to OpenAI for wire
-/// construction). The endpoint is derived from `config.base_url` so a Flux
-/// session targets `https://api.fluxrouter.ai/v1/images/generations` with
-/// the Flux key (#310), not `api.openai.com`.
+/// Only native **OpenAI** and **FluxRouter** serve this media endpoint, so
+/// [`openai_wire_media_base`] resolves the `/v1` API root for those two
+/// (filling FluxRouter's default base when `config.base_url` is empty) and
+/// returns `None` otherwise. A Flux session therefore targets
+/// `https://api.fluxrouter.ai/v1/images/generations` with the Flux key
+/// (#310), and native OpenAI gets the required `/v1` even though its
+/// resolved `config.base_url` is `https://api.openai.com` (no `/v1`).
 ///
 /// Returns the concrete `DalleBackend` (not a trait object) so the resolved
 /// endpoint + key are unit-assertable.
 pub(crate) fn dalle_backend_from_config(config: &Config) -> Option<DalleBackend> {
-    if config.provider == ProviderType::OpenAI && !config.api_key.trim().is_empty() {
-        Some(DalleBackend::new(config.api_key.clone(), &config.base_url))
-    } else {
-        None
+    if config.api_key.trim().is_empty() {
+        return None;
     }
+    let base = openai_wire_media_base(config)?;
+    Some(DalleBackend::new(config.api_key.clone(), &base))
 }
 
 /// Resolve a real `ImageGenerationBackend` from the resolved `Config`
 /// and environment variables.
 ///
 /// Priority order (first match wins):
-/// 1. **Active OpenAI-wire provider** (e.g. OpenAI, Flux Router) — when
-///    `config.provider == ProviderType::OpenAI` and `config.api_key` is
-///    non-empty, the OpenAI image backend is built from the *resolved*
-///    `config.base_url` + `config.api_key`. This is the #310 fix: in a
-///    Flux session the tool now sends the Flux key to
-///    `{config.base_url}/images/generations` instead of the Flux key to
-///    `api.openai.com` (HTTP 401).
+/// 1. **Active OpenAI-wire media provider** (native OpenAI or Flux Router) —
+///    when `dalle_backend_from_config` resolves (see [`openai_wire_media_base`]
+///    for the gated provider set) and `config.api_key` is non-empty, the
+///    backend is built from the resolved `/v1` API root + `config.api_key`.
+///    This is the #310 fix: in a Flux session the tool now sends the Flux key
+///    to `https://api.fluxrouter.ai/v1/images/generations` instead of the
+///    Flux key to `api.openai.com` (HTTP 401).
 /// 2. `OPENAI_API_KEY` → OpenAI image at `api.openai.com` (back-compat
 ///    fallback when config doesn't carry an OpenAI-wire provider)
 /// 3. `FAL_API_KEY` → FAL FLUX schnell
@@ -819,6 +821,7 @@ impl ImageGenerationBackend for PollinationsBackend {
 mod tests {
     use super::*;
     use serial_test::serial;
+    use wcore_config::config::ProviderType;
     use wiremock::matchers::{body_json, header, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -842,11 +845,13 @@ mod tests {
         Config::default()
     }
 
-    /// A resolved OpenAI-wire provider config (e.g. Flux Router) carrying a
-    /// non-`api.openai.com` base_url + a non-OpenAI key (#310).
+    /// A real Flux Router session: `provider == ProviderType::FluxRouter`
+    /// (what `"flux-router"` parses to) with an explicit Flux base_url + the
+    /// Flux key (#310). NOTE: the pre-fix fixture used `provider: OpenAI`,
+    /// which masked the bug — the resolver gate never matched FluxRouter.
     fn flux_config() -> Config {
         Config {
-            provider: ProviderType::OpenAI,
+            provider: ProviderType::FluxRouter,
             api_key: "sk-flux-test".to_string(),
             base_url: "https://api.fluxrouter.ai/v1".to_string(),
             ..Config::default()
@@ -973,6 +978,61 @@ mod tests {
             "https://api.openai.com/v1/images/generations"
         );
         assert_eq!(backend.api_key(), "sk-openai-env");
+    }
+
+    #[test]
+    #[serial]
+    fn dalle_resolves_flux_default_base_when_config_base_empty() {
+        // Real Flux sessions leave config.base_url empty (the FluxRouter
+        // newtype supplies the default). The resolver must still target Flux.
+        clear_image_gen_env();
+        let cfg = Config {
+            provider: ProviderType::FluxRouter,
+            api_key: "sk-flux-test".to_string(),
+            base_url: String::new(),
+            ..Config::default()
+        };
+        let backend = dalle_backend_from_config(&cfg).expect("Flux must resolve from default base");
+        assert_eq!(
+            backend.endpoint(),
+            "https://api.fluxrouter.ai/v1/images/generations"
+        );
+        assert_eq!(backend.api_key(), "sk-flux-test");
+    }
+
+    #[test]
+    #[serial]
+    fn dalle_adds_v1_for_native_openai_config() {
+        // Native OpenAI's resolved base_url is `https://api.openai.com` (no
+        // `/v1`); pre-fix this produced a 404 endpoint. The resolver must add
+        // `/v1`.
+        clear_image_gen_env();
+        let cfg = Config {
+            provider: ProviderType::OpenAI,
+            api_key: "sk-openai".to_string(),
+            base_url: "https://api.openai.com".to_string(),
+            ..Config::default()
+        };
+        let backend = dalle_backend_from_config(&cfg).expect("native OpenAI must resolve");
+        assert_eq!(
+            backend.endpoint(),
+            "https://api.openai.com/v1/images/generations"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn dalle_declines_userinfo_base_url() {
+        // A hostile config base_url with userinfo would exfiltrate the key to
+        // attacker.com — the resolver must decline (fail closed).
+        clear_image_gen_env();
+        let cfg = Config {
+            provider: ProviderType::OpenAI,
+            api_key: "sk-openai".to_string(),
+            base_url: "https://attacker.com@api.openai.com/v1".to_string(),
+            ..Config::default()
+        };
+        assert!(dalle_backend_from_config(&cfg).is_none());
     }
 
     // -- DALL-E happy + failure paths ----------------------------------

--- a/crates/wcore-agent/src/tool_backends/image_gen.rs
+++ b/crates/wcore-agent/src/tool_backends/image_gen.rs
@@ -12,7 +12,7 @@
 //!
 //! Every backend uses `build_ssrf_safe_tool_client()` (S-B1 SSRF guard)
 //! and wraps each external call in `tokio::time::timeout` (R-H1 two-layer
-//! timeout). The resolver `build_image_gen_backend(allow_pollinations)`
+//! timeout). The resolver `build_image_gen_backend(config, allow_pollinations)`
 //! returns `None` when no keyed backend is configured AND pollinations is
 //! disabled — the bootstrap path then skips registration so the tool's
 //! `is_available()` reports false.
@@ -29,8 +29,10 @@ use wcore_tools::image_generation_tool::{
     ImageGenerationBackend, ImageGenerationError, ImageGenerationRequest, ImageGenerationResponse,
 };
 
+use wcore_config::config::{Config, ProviderType};
+
 use super::build_ssrf_safe_tool_client;
-use super::shared::read_env_key;
+use super::shared::{OPENAI_API_BASE, join_openai_endpoint, read_env_key};
 
 // ---------------------------------------------------------------------
 // Per-call timeout. `reqwest`'s `.timeout()` covers the HTTP exchange
@@ -44,24 +46,63 @@ const HF_PER_CALL_TIMEOUT: Duration = Duration::from_secs(90);
 // Resolver
 // ---------------------------------------------------------------------
 
-/// Resolve a real `ImageGenerationBackend` from environment variables
-/// and config.
+/// Build a concrete OpenAI image backend from the active provider when it
+/// is OpenAI-wire-compatible. Returns `None` for non-OpenAI providers
+/// (Anthropic/Gemini/etc. lack `/images/generations`) or when the resolved
+/// key is empty.
+///
+/// `ProviderType::OpenAI` covers native OpenAI, Flux Router, and the
+/// OpenAI-compat catalog providers (they all resolve to OpenAI for wire
+/// construction). The endpoint is derived from `config.base_url` so a Flux
+/// session targets `https://api.fluxrouter.ai/v1/images/generations` with
+/// the Flux key (#310), not `api.openai.com`.
+///
+/// Returns the concrete `DalleBackend` (not a trait object) so the resolved
+/// endpoint + key are unit-assertable.
+pub(crate) fn dalle_backend_from_config(config: &Config) -> Option<DalleBackend> {
+    if config.provider == ProviderType::OpenAI && !config.api_key.trim().is_empty() {
+        Some(DalleBackend::new(config.api_key.clone(), &config.base_url))
+    } else {
+        None
+    }
+}
+
+/// Resolve a real `ImageGenerationBackend` from the resolved `Config`
+/// and environment variables.
 ///
 /// Priority order (first match wins):
-/// 1. `OPENAI_API_KEY` → OpenAI image (`gpt-image-1` default)
-/// 2. `FAL_API_KEY` → FAL FLUX schnell
-/// 3. `GEMINI_API_KEY` → Gemini Imagen 3
-/// 4. `HF_API_KEY` → Hugging Face FLUX
-/// 5. Pollinations (zero-key) — only when `allow_pollinations == true`
+/// 1. **Active OpenAI-wire provider** (e.g. OpenAI, Flux Router) — when
+///    `config.provider == ProviderType::OpenAI` and `config.api_key` is
+///    non-empty, the OpenAI image backend is built from the *resolved*
+///    `config.base_url` + `config.api_key`. This is the #310 fix: in a
+///    Flux session the tool now sends the Flux key to
+///    `{config.base_url}/images/generations` instead of the Flux key to
+///    `api.openai.com` (HTTP 401).
+/// 2. `OPENAI_API_KEY` → OpenAI image at `api.openai.com` (back-compat
+///    fallback when config doesn't carry an OpenAI-wire provider)
+/// 3. `FAL_API_KEY` → FAL FLUX schnell
+/// 4. `GEMINI_API_KEY` → Gemini Imagen 3
+/// 5. `HF_API_KEY` → Hugging Face FLUX
+/// 6. Pollinations (zero-key) — only when `allow_pollinations == true`
 ///
 /// Returns `None` when no keyed backend resolves AND pollinations is
 /// disabled; the bootstrap path then skips registration so the tool's
 /// `is_available()` reports false.
 pub fn build_image_gen_backend(
+    config: &Config,
     allow_pollinations: bool,
 ) -> Option<Arc<dyn ImageGenerationBackend>> {
+    // 1. Prefer the active OpenAI-wire provider's resolved key + base_url.
+    if let Some(backend) = dalle_backend_from_config(config) {
+        tracing::info!(
+            "image_gen: using {} at {} (active OpenAI-wire provider)",
+            backend.model,
+            config.base_url
+        );
+        return Some(Arc::new(backend));
+    }
     if let Some(key) = read_env_key("OPENAI_API_KEY") {
-        let backend = DalleBackend::new(key);
+        let backend = DalleBackend::new(key, OPENAI_API_BASE);
         tracing::info!(
             "image_gen: using OpenAI {} (OPENAI_API_KEY found)",
             backend.model
@@ -229,11 +270,15 @@ pub struct DalleBackend {
 }
 
 impl DalleBackend {
-    pub fn new(api_key: String) -> Self {
+    /// Build an OpenAI image backend pointed at `base_url` (an OpenAI-wire
+    /// API base such as `https://api.openai.com/v1` or
+    /// `https://api.fluxrouter.ai/v1`). The endpoint is derived as
+    /// `{base_url}/images/generations` (#310) — no hardcoded host.
+    pub fn new(api_key: String, base_url: &str) -> Self {
         Self {
             client: build_ssrf_safe_tool_client(),
             api_key,
-            endpoint: "https://api.openai.com/v1/images/generations".to_string(),
+            endpoint: join_openai_endpoint(base_url, "images/generations"),
             model: openai_image_model_from_env(),
         }
     }
@@ -252,6 +297,21 @@ impl DalleBackend {
             endpoint,
             model: DEFAULT_OPENAI_IMAGE_MODEL.to_string(),
         }
+    }
+
+    /// Resolved request endpoint (`{base_url}/images/generations`). Exposed
+    /// so the resolver wiring (#310) can be unit-asserted without a network
+    /// round-trip.
+    #[cfg(test)]
+    pub(crate) fn endpoint(&self) -> &str {
+        &self.endpoint
+    }
+
+    /// Resolved bearer key sent to the image endpoint. Exposed for the
+    /// #310 resolver tests (asserts the Flux key, not OPENAI_API_KEY).
+    #[cfg(test)]
+    pub(crate) fn api_key(&self) -> &str {
+        &self.api_key
     }
 
     /// `gpt-image-1` (and the `gpt-image-*` family) use a different size table
@@ -775,6 +835,24 @@ mod tests {
         }
     }
 
+    /// Default (Anthropic, empty key/url) config — exercises the env-key
+    /// fallback paths exactly as before #310 (the config branch is a no-op
+    /// for non-OpenAI providers / empty keys).
+    fn env_only_config() -> Config {
+        Config::default()
+    }
+
+    /// A resolved OpenAI-wire provider config (e.g. Flux Router) carrying a
+    /// non-`api.openai.com` base_url + a non-OpenAI key (#310).
+    fn flux_config() -> Config {
+        Config {
+            provider: ProviderType::OpenAI,
+            api_key: "sk-flux-test".to_string(),
+            base_url: "https://api.fluxrouter.ai/v1".to_string(),
+            ..Config::default()
+        }
+    }
+
     // -- Resolver priority ---------------------------------------------
 
     #[test]
@@ -785,7 +863,8 @@ mod tests {
             std::env::set_var("OPENAI_API_KEY", "sk-test-openai");
             std::env::set_var("FAL_API_KEY", "fal-test");
         }
-        let backend = build_image_gen_backend(false).expect("DALL-E must resolve");
+        let backend =
+            build_image_gen_backend(&env_only_config(), false).expect("DALL-E must resolve");
         // Smoke: DALL-E backend is selected — we can't downcast Arc<dyn _>
         // cleanly without trait-object reflection, so we assert by *not*
         // matching FAL's path: hit a wiremock that only the FAL backend
@@ -800,7 +879,7 @@ mod tests {
     #[serial]
     fn build_image_gen_backend_falls_back_to_pollinations_when_no_keys_and_enabled() {
         clear_image_gen_env();
-        let backend = build_image_gen_backend(true)
+        let backend = build_image_gen_backend(&env_only_config(), true)
             .expect("Pollinations must resolve when no keys + allow=true");
         let _ = backend;
     }
@@ -810,7 +889,7 @@ mod tests {
     fn build_image_gen_backend_returns_none_when_no_keys_and_pollinations_disabled() {
         clear_image_gen_env();
         assert!(
-            build_image_gen_backend(false).is_none(),
+            build_image_gen_backend(&env_only_config(), false).is_none(),
             "no keys + pollinations disabled → tool hidden"
         );
     }
@@ -824,7 +903,7 @@ mod tests {
             std::env::set_var("FAL_API_KEY", "   ");
         }
         assert!(
-            build_image_gen_backend(false).is_none(),
+            build_image_gen_backend(&env_only_config(), false).is_none(),
             "empty / whitespace env vars must be treated as unset (R-H2)"
         );
         clear_image_gen_env();
@@ -834,7 +913,66 @@ mod tests {
     #[serial]
     fn null_default_skips_registration_when_no_keys_set() {
         clear_image_gen_env();
-        assert!(build_image_gen_backend(false).is_none());
+        assert!(build_image_gen_backend(&env_only_config(), false).is_none());
+    }
+
+    // -- #310: OpenAI-wire provider routing (Flux) ---------------------
+
+    #[test]
+    #[serial]
+    fn dalle_resolves_from_flux_config_not_openai_host() {
+        // #310 regression: in a Flux Router session the config carries
+        // base_url=https://api.fluxrouter.ai/v1 + api_key=sk-flux-test. The
+        // resolved DALL-E endpoint must target Flux's host with the Flux
+        // key — NOT api.openai.com (which would 401 on the wrong key).
+        clear_image_gen_env();
+        let backend =
+            dalle_backend_from_config(&flux_config()).expect("OpenAI-wire config must resolve");
+        assert_eq!(
+            backend.endpoint(),
+            "https://api.fluxrouter.ai/v1/images/generations"
+        );
+        assert_eq!(backend.api_key(), "sk-flux-test");
+    }
+
+    #[test]
+    #[serial]
+    fn dalle_config_takes_priority_over_openai_env_key() {
+        // Even with OPENAI_API_KEY set in the environment, an active
+        // OpenAI-wire provider (Flux) must win — the resolver builds from
+        // config, so the Flux endpoint + key are used, not the env key.
+        clear_image_gen_env();
+        unsafe {
+            std::env::set_var("OPENAI_API_KEY", "sk-openai-env");
+        }
+        let backend = dalle_backend_from_config(&flux_config())
+            .expect("config OpenAI-wire provider must resolve");
+        assert_eq!(
+            backend.endpoint(),
+            "https://api.fluxrouter.ai/v1/images/generations"
+        );
+        assert_eq!(backend.api_key(), "sk-flux-test");
+        clear_image_gen_env();
+    }
+
+    #[test]
+    #[serial]
+    fn dalle_falls_back_to_openai_host_when_config_not_openai_wire() {
+        // Back-compat: with no OpenAI-wire provider in config (default is
+        // Anthropic) but OPENAI_API_KEY set, the resolver builds the
+        // OpenAI backend against api.openai.com. `dalle_backend_from_config`
+        // is the config-first gate; it must decline so the env path runs.
+        assert!(
+            dalle_backend_from_config(&env_only_config()).is_none(),
+            "non-OpenAI provider must not hijack the OpenAI image slot"
+        );
+        // And the env-built backend points at api.openai.com.
+        let backend = DalleBackend::new("sk-openai-env".to_string(), OPENAI_API_BASE);
+        assert_eq!(
+            backend.endpoint(),
+            "https://api.openai.com/v1/images/generations"
+        );
+        assert_eq!(backend.api_key(), "sk-openai-env");
     }
 
     // -- DALL-E happy + failure paths ----------------------------------

--- a/crates/wcore-agent/src/tool_backends/shared.rs
+++ b/crates/wcore-agent/src/tool_backends/shared.rs
@@ -13,6 +13,24 @@ pub fn read_env_key(name: &str) -> Option<String> {
     std::env::var(name).ok().filter(|v| !v.trim().is_empty())
 }
 
+/// Canonical OpenAI API base URL. Used as the fallback for the
+/// OpenAI-family tool backends (`image_generate`, `text_to_speech`) when
+/// no provider `base_url` is available from `Config` — preserves the
+/// pre-#310 behavior of talking directly to `api.openai.com`.
+pub const OPENAI_API_BASE: &str = "https://api.openai.com/v1";
+
+/// Join an OpenAI-wire `base_url` (e.g. `https://api.fluxrouter.ai/v1`)
+/// with an API sub-path (e.g. `images/generations`) into a full
+/// endpoint. Tolerates a trailing slash on the base and a leading slash
+/// on the path so callers can pass either form. (#310)
+pub fn join_openai_endpoint(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
+}
+
 /// Minimal `application/x-www-form-urlencoded` encoder.
 ///
 /// Moved from the monolith `tool_backends.rs` during v0.9.0 B0 prep so
@@ -67,6 +85,25 @@ mod tests {
             Some("secret123".to_string())
         );
         unsafe { std::env::remove_var("WAYLAND_TEST_NONEMPTY_KEY_VAR") };
+    }
+
+    #[test]
+    fn join_openai_endpoint_tolerates_slashes() {
+        // No trailing/leading slash.
+        assert_eq!(
+            join_openai_endpoint("https://api.openai.com/v1", "images/generations"),
+            "https://api.openai.com/v1/images/generations"
+        );
+        // Trailing slash on base.
+        assert_eq!(
+            join_openai_endpoint("https://api.fluxrouter.ai/v1/", "audio/speech"),
+            "https://api.fluxrouter.ai/v1/audio/speech"
+        );
+        // Leading slash on path.
+        assert_eq!(
+            join_openai_endpoint("https://api.fluxrouter.ai/v1", "/images/generations"),
+            "https://api.fluxrouter.ai/v1/images/generations"
+        );
     }
 
     #[test]

--- a/crates/wcore-agent/src/tool_backends/shared.rs
+++ b/crates/wcore-agent/src/tool_backends/shared.rs
@@ -4,6 +4,9 @@
 //! resolver (R-H2) and the `urlencode` helper used by multiple search
 //! backends. Cross-backend imports go through this module.
 
+use wcore_config::config::{Config, ProviderType};
+use wcore_providers::flux_router::FLUX_ROUTER_DEFAULT_BASE_URL;
+
 /// Canonical env-var resolver. Returns `Some(key)` only when the env
 /// var is set **and** its value is non-empty (closes R-H2: empty-string
 /// `OPENAI_API_KEY=""` should NOT count as "configured"). Every new
@@ -29,6 +32,69 @@ pub fn join_openai_endpoint(base_url: &str, path: &str) -> String {
         base_url.trim_end_matches('/'),
         path.trim_start_matches('/')
     )
+}
+
+/// Resolve the OpenAI-wire API root (guaranteed to end in `/v1`) for the
+/// providers that actually serve the OpenAI-wire media endpoints
+/// (`/images/generations`, `/audio/speech`): native **OpenAI** and our
+/// **FluxRouter**. Every other OpenAI-compatible provider (Groq, Together,
+/// Deepseek, …) is LLM-completion-only — routing media to them would 404 —
+/// and Azure OpenAI uses a deployment-scoped URL scheme, so all of them
+/// return `None` here and the caller falls through to the env-key media
+/// backends.
+///
+/// Fills the provider default when `config.base_url` is empty (Tier-2
+/// newtypes such as FluxRouter leave it empty and supply the default
+/// themselves), then normalizes to a `/v1` root.
+///
+/// #310 follow-up: the original gate compared `config.provider ==
+/// ProviderType::OpenAI`, which never matches `ProviderType::FluxRouter`, so
+/// the fix was a silent no-op in a real Flux session (`"flux-router"` parses
+/// to `ProviderType::FluxRouter`). FluxRouter is now handled explicitly, and
+/// native OpenAI gets the required `/v1` even though its default
+/// `config.base_url` is `https://api.openai.com` (no `/v1`).
+pub fn openai_wire_media_base(config: &Config) -> Option<String> {
+    let raw = match config.provider {
+        ProviderType::OpenAI => {
+            let b = config.base_url.trim();
+            if b.is_empty() {
+                "https://api.openai.com"
+            } else {
+                b
+            }
+        }
+        ProviderType::FluxRouter => {
+            let b = config.base_url.trim();
+            if b.is_empty() {
+                FLUX_ROUTER_DEFAULT_BASE_URL
+            } else {
+                b
+            }
+        }
+        _ => return None,
+    };
+    ensure_v1_root(raw)
+}
+
+/// Normalize an OpenAI-wire base URL to a `…/v1` root. Returns `None` when
+/// the URL is unusable: empty, missing an `http(s)://` scheme, or carrying
+/// userinfo (`user:pass@host`) — the latter a credential-confusion / SSRF
+/// exfil vector when `base_url` comes from a hostile config. A base that
+/// already ends in `/v1` is preserved; otherwise `/v1` is appended.
+fn ensure_v1_root(base: &str) -> Option<String> {
+    let trimmed = base.trim().trim_end_matches('/');
+    let after_scheme = trimmed
+        .strip_prefix("https://")
+        .or_else(|| trimmed.strip_prefix("http://"))?;
+    let authority = after_scheme.split('/').next().unwrap_or(after_scheme);
+    if authority.is_empty() || authority.contains('@') {
+        return None;
+    }
+    if trimmed.ends_with("/v1") {
+        Some(trimmed.to_string())
+    } else {
+        Some(format!("{trimmed}/v1"))
+    }
 }
 
 /// Minimal `application/x-www-form-urlencoded` encoder.
@@ -111,5 +177,83 @@ mod tests {
         assert_eq!(urlencode("hello world"), "hello+world");
         assert_eq!(urlencode("foo=bar&baz"), "foo%3Dbar%26baz");
         assert_eq!(urlencode("a.b-c_d~e"), "a.b-c_d~e");
+    }
+
+    #[test]
+    fn media_base_native_openai_appends_v1() {
+        // Native OpenAI's resolved base_url is `https://api.openai.com` (no
+        // `/v1`); the media root must add it (else the endpoint 404s).
+        let cfg = Config {
+            provider: ProviderType::OpenAI,
+            api_key: "sk-o".into(),
+            base_url: "https://api.openai.com".into(),
+            ..Config::default()
+        };
+        assert_eq!(
+            openai_wire_media_base(&cfg).as_deref(),
+            Some("https://api.openai.com/v1")
+        );
+    }
+
+    #[test]
+    fn media_base_flux_router_uses_default_when_base_empty() {
+        // Real Flux session shape: provider = FluxRouter, base_url empty (the
+        // newtype supplies the default). #310 must fire here.
+        let cfg = Config {
+            provider: ProviderType::FluxRouter,
+            api_key: "sk-flux".into(),
+            base_url: String::new(),
+            ..Config::default()
+        };
+        assert_eq!(
+            openai_wire_media_base(&cfg).as_deref(),
+            Some("https://api.fluxrouter.ai/v1")
+        );
+    }
+
+    #[test]
+    fn media_base_none_for_non_openai_wire_media_providers() {
+        for p in [
+            ProviderType::Anthropic,
+            ProviderType::Gemini,
+            ProviderType::Groq,
+        ] {
+            let cfg = Config {
+                provider: p,
+                api_key: "k".into(),
+                ..Config::default()
+            };
+            assert!(
+                openai_wire_media_base(&cfg).is_none(),
+                "{p:?} has no OpenAI-wire media endpoint and must fall through"
+            );
+        }
+    }
+
+    #[test]
+    fn media_base_rejects_userinfo_exfil() {
+        // A hostile config base_url with userinfo would exfiltrate the key to
+        // attacker.com (the @ makes api.openai.com the path, not the host).
+        let cfg = Config {
+            provider: ProviderType::OpenAI,
+            api_key: "sk-o".into(),
+            base_url: "https://attacker.com@api.openai.com/v1".into(),
+            ..Config::default()
+        };
+        assert!(openai_wire_media_base(&cfg).is_none());
+    }
+
+    #[test]
+    fn media_base_preserves_explicit_v1_and_trailing_slash() {
+        let cfg = Config {
+            provider: ProviderType::FluxRouter,
+            api_key: "k".into(),
+            base_url: "https://api.fluxrouter.ai/v1/".into(),
+            ..Config::default()
+        };
+        assert_eq!(
+            openai_wire_media_base(&cfg).as_deref(),
+            Some("https://api.fluxrouter.ai/v1")
+        );
     }
 }

--- a/crates/wcore-agent/src/tool_backends/tts.rs
+++ b/crates/wcore-agent/src/tool_backends/tts.rs
@@ -36,8 +36,10 @@ use std::time::Duration;
 use async_trait::async_trait;
 use wcore_egress::EgressClient as Client;
 
+use wcore_config::config::{Config, ProviderType};
+
 use super::build_ssrf_safe_tool_client;
-use super::shared::read_env_key;
+use super::shared::{OPENAI_API_BASE, join_openai_endpoint, read_env_key};
 use wcore_tools::tts_tool::{
     TtsBackend, TtsError, TtsFormat, TtsProvider, TtsRequest, TtsResponse,
 };
@@ -70,16 +72,55 @@ pub const OPENAI_TTS_DEFAULT_VOICE: &str = "alloy";
 // Resolver
 // ---------------------------------------------------------------------
 
-/// Pick the best available TTS backend from the user's environment.
+/// Build a concrete OpenAI TTS backend from the active provider when it is
+/// OpenAI-wire-compatible. Returns `None` for non-OpenAI providers or an
+/// empty resolved key.
 ///
-/// 1. `OPENAI_API_KEY` (paid, predictable)
-/// 2. `ELEVENLABS_API_KEY` (paid, most natural)
-/// 3. Piper local fallback (B11 cross-wire — only when the `piper_tts`
+/// `ProviderType::OpenAI` covers native OpenAI, Flux Router, and the
+/// OpenAI-compat catalog providers (all resolve to OpenAI for wire
+/// construction). The endpoint is derived from `config.base_url` so a Flux
+/// session targets `{config.base_url}/audio/speech` with the Flux key
+/// (#310) instead of sending the wrong key to `api.openai.com` (401).
+///
+/// NOTE (#310): Flux's TTS endpoint is undocumented; we deliberately do NOT
+/// special-case it. If `{base_url}/audio/speech` is unsupported the provider
+/// returns its own error — still strictly better than a 401 from the wrong
+/// key against OpenAI.
+///
+/// Returns the concrete `OpenAiTtsBackend` (not a trait object) so the
+/// resolved endpoint + key are unit-assertable.
+pub(crate) fn openai_tts_backend_from_config(config: &Config) -> Option<OpenAiTtsBackend> {
+    if config.provider == ProviderType::OpenAI && !config.api_key.trim().is_empty() {
+        let endpoint = join_openai_endpoint(&config.base_url, "audio/speech");
+        Some(OpenAiTtsBackend::with_endpoint(
+            config.api_key.clone(),
+            endpoint,
+        ))
+    } else {
+        None
+    }
+}
+
+/// Pick the best available TTS backend from the resolved `Config` and the
+/// user's environment.
+///
+/// 1. **Active OpenAI-wire provider** (OpenAI / Flux Router) — built from
+///    `config.base_url` + `config.api_key` (#310)
+/// 2. `OPENAI_API_KEY` → OpenAI TTS at `api.openai.com` (back-compat)
+/// 3. `ELEVENLABS_API_KEY` (paid, most natural)
+/// 4. Piper local fallback (B11 cross-wire — only when the `piper_tts`
 ///    feature is enabled by B13's assembler)
-/// 4. `None` — TTS tool hides via `Tool::is_available()` so the model
+/// 5. `None` — TTS tool hides via `Tool::is_available()` so the model
 ///    never sees a tool it can't call. Doctor reports "TTS hidden:
 ///    set OPENAI_API_KEY or ELEVENLABS_API_KEY".
-pub fn build_tts_backend() -> Option<Arc<dyn TtsBackend>> {
+pub fn build_tts_backend(config: &Config) -> Option<Arc<dyn TtsBackend>> {
+    if let Some(backend) = openai_tts_backend_from_config(config) {
+        tracing::info!(
+            "tts: using OpenAI TTS at {} (active OpenAI-wire provider)",
+            config.base_url
+        );
+        return Some(Arc::new(backend));
+    }
     if let Some(key) = read_env_key("OPENAI_API_KEY") {
         tracing::info!("tts: using OpenAI TTS (OPENAI_API_KEY found)");
         return Some(Arc::new(OpenAiTtsBackend::new(key)));
@@ -246,14 +287,18 @@ pub struct OpenAiTtsBackend {
 }
 
 impl OpenAiTtsBackend {
+    /// Build the backend against the canonical OpenAI host. The endpoint is
+    /// derived as `{OPENAI_API_BASE}/audio/speech` (#310) — equivalent to
+    /// the pre-#310 hardcoded `api.openai.com` URL.
     pub fn new(api_key: String) -> Self {
         Self::with_endpoint(
             api_key,
-            "https://api.openai.com/v1/audio/speech".to_string(),
+            join_openai_endpoint(OPENAI_API_BASE, "audio/speech"),
         )
     }
 
-    /// Internal constructor used by tests with a mock-server endpoint.
+    /// Internal constructor used by tests with a mock-server endpoint, and
+    /// by the resolver to point at an OpenAI-wire provider's `base_url`.
     pub(crate) fn with_endpoint(api_key: String, endpoint: String) -> Self {
         let model =
             std::env::var("WAYLAND_OPENAI_TTS_MODEL").unwrap_or_else(|_| "tts-1".to_string());
@@ -263,6 +308,20 @@ impl OpenAiTtsBackend {
             endpoint,
             model,
         }
+    }
+
+    /// Resolved request endpoint (`{base_url}/audio/speech`). Exposed so the
+    /// resolver wiring (#310) is unit-assertable without a network call.
+    #[cfg(test)]
+    pub(crate) fn endpoint(&self) -> &str {
+        &self.endpoint
+    }
+
+    /// Resolved bearer key sent to the speech endpoint. Exposed for the
+    /// #310 resolver tests (asserts the Flux key, not OPENAI_API_KEY).
+    #[cfg(test)]
+    pub(crate) fn api_key(&self) -> &str {
+        &self.api_key
     }
 
     fn response_format_for(format: TtsFormat) -> &'static str {
@@ -487,6 +546,24 @@ mod tests {
         }
     }
 
+    /// Default (Anthropic, empty key/url) config — exercises the env-key
+    /// fallback paths exactly as before #310 (the config branch is a no-op
+    /// for non-OpenAI providers / empty keys).
+    fn env_only_config() -> Config {
+        Config::default()
+    }
+
+    /// A resolved OpenAI-wire provider config (e.g. Flux Router) carrying a
+    /// non-`api.openai.com` base_url + a non-OpenAI key (#310).
+    fn flux_config() -> Config {
+        Config {
+            provider: ProviderType::OpenAI,
+            api_key: "sk-flux-test".to_string(),
+            base_url: "https://api.fluxrouter.ai/v1".to_string(),
+            ..Config::default()
+        }
+    }
+
     // ------ resolver priority ------
 
     #[test]
@@ -497,7 +574,7 @@ mod tests {
             std::env::set_var("OPENAI_API_KEY", "sk-test-openai");
             std::env::set_var("ELEVENLABS_API_KEY", "el-test");
         }
-        let b = build_tts_backend();
+        let b = build_tts_backend(&env_only_config());
         unsafe {
             std::env::remove_var("OPENAI_API_KEY");
             std::env::remove_var("ELEVENLABS_API_KEY");
@@ -517,7 +594,7 @@ mod tests {
             std::env::remove_var("OPENAI_API_KEY");
             std::env::remove_var("ELEVENLABS_API_KEY");
         }
-        assert!(build_tts_backend().is_none());
+        assert!(build_tts_backend(&env_only_config()).is_none());
     }
 
     #[test]
@@ -529,7 +606,7 @@ mod tests {
             std::env::set_var("OPENAI_API_KEY", "");
             std::env::set_var("ELEVENLABS_API_KEY", "el-test-key");
         }
-        let b = build_tts_backend();
+        let b = build_tts_backend(&env_only_config());
         unsafe {
             std::env::remove_var("OPENAI_API_KEY");
             std::env::remove_var("ELEVENLABS_API_KEY");
@@ -538,6 +615,64 @@ mod tests {
             b.is_some(),
             "ElevenLabs should be picked when OpenAI is empty"
         );
+    }
+
+    // ------ #310: OpenAI-wire provider routing (Flux) ------
+
+    #[test]
+    #[serial]
+    fn openai_tts_resolves_from_flux_config_not_openai_host() {
+        // #310 regression: a Flux Router session carries
+        // base_url=https://api.fluxrouter.ai/v1 + api_key=sk-flux-test. The
+        // resolved OpenAI TTS endpoint must target Flux's host with the Flux
+        // key, NOT api.openai.com (which would 401).
+        unsafe {
+            std::env::remove_var("OPENAI_API_KEY");
+            std::env::remove_var("ELEVENLABS_API_KEY");
+        }
+        let backend = openai_tts_backend_from_config(&flux_config())
+            .expect("OpenAI-wire config must resolve");
+        assert_eq!(
+            backend.endpoint(),
+            "https://api.fluxrouter.ai/v1/audio/speech"
+        );
+        assert_eq!(backend.api_key(), "sk-flux-test");
+    }
+
+    #[test]
+    #[serial]
+    fn openai_tts_config_takes_priority_over_openai_env_key() {
+        // Even with OPENAI_API_KEY set, an active OpenAI-wire provider
+        // (Flux) wins — the resolver builds from config.
+        unsafe {
+            std::env::set_var("OPENAI_API_KEY", "sk-openai-env");
+            std::env::remove_var("ELEVENLABS_API_KEY");
+        }
+        let backend = openai_tts_backend_from_config(&flux_config())
+            .expect("config OpenAI-wire provider must resolve");
+        unsafe {
+            std::env::remove_var("OPENAI_API_KEY");
+        }
+        assert_eq!(
+            backend.endpoint(),
+            "https://api.fluxrouter.ai/v1/audio/speech"
+        );
+        assert_eq!(backend.api_key(), "sk-flux-test");
+    }
+
+    #[test]
+    #[serial]
+    fn openai_tts_falls_back_to_openai_host_when_config_not_openai_wire() {
+        // Back-compat: a non-OpenAI provider (default Anthropic) must not
+        // hijack the OpenAI TTS slot, so the config gate declines and the
+        // env path builds against api.openai.com.
+        assert!(
+            openai_tts_backend_from_config(&env_only_config()).is_none(),
+            "non-OpenAI provider must not hijack the OpenAI TTS slot"
+        );
+        let backend = OpenAiTtsBackend::new("sk-openai-env".to_string());
+        assert_eq!(backend.endpoint(), "https://api.openai.com/v1/audio/speech");
+        assert_eq!(backend.api_key(), "sk-openai-env");
     }
 
     // ------ ElevenLabs default voice ------

--- a/crates/wcore-agent/src/tool_backends/tts.rs
+++ b/crates/wcore-agent/src/tool_backends/tts.rs
@@ -36,10 +36,10 @@ use std::time::Duration;
 use async_trait::async_trait;
 use wcore_egress::EgressClient as Client;
 
-use wcore_config::config::{Config, ProviderType};
+use wcore_config::config::Config;
 
 use super::build_ssrf_safe_tool_client;
-use super::shared::{OPENAI_API_BASE, join_openai_endpoint, read_env_key};
+use super::shared::{OPENAI_API_BASE, join_openai_endpoint, openai_wire_media_base, read_env_key};
 use wcore_tools::tts_tool::{
     TtsBackend, TtsError, TtsFormat, TtsProvider, TtsRequest, TtsResponse,
 };
@@ -72,40 +72,42 @@ pub const OPENAI_TTS_DEFAULT_VOICE: &str = "alloy";
 // Resolver
 // ---------------------------------------------------------------------
 
-/// Build a concrete OpenAI TTS backend from the active provider when it is
-/// OpenAI-wire-compatible. Returns `None` for non-OpenAI providers or an
-/// empty resolved key.
+/// Build a concrete OpenAI TTS backend from the active provider when it
+/// serves the OpenAI-wire `/audio/speech` endpoint. Returns `None` for
+/// providers without it (Anthropic/Gemini and the LLM-only OpenAI-compat
+/// routers) or an empty resolved key.
 ///
-/// `ProviderType::OpenAI` covers native OpenAI, Flux Router, and the
-/// OpenAI-compat catalog providers (all resolve to OpenAI for wire
-/// construction). The endpoint is derived from `config.base_url` so a Flux
-/// session targets `{config.base_url}/audio/speech` with the Flux key
+/// Only native **OpenAI** and **FluxRouter** are routed here, via
+/// [`openai_wire_media_base`] (which fills FluxRouter's default base when
+/// `config.base_url` is empty and guarantees a `/v1` root). A Flux session
+/// targets `https://api.fluxrouter.ai/v1/audio/speech` with the Flux key
 /// (#310) instead of sending the wrong key to `api.openai.com` (401).
 ///
 /// NOTE (#310): Flux's TTS endpoint is undocumented; we deliberately do NOT
-/// special-case it. If `{base_url}/audio/speech` is unsupported the provider
+/// special-case it. If `{base}/audio/speech` is unsupported the provider
 /// returns its own error — still strictly better than a 401 from the wrong
 /// key against OpenAI.
 ///
 /// Returns the concrete `OpenAiTtsBackend` (not a trait object) so the
 /// resolved endpoint + key are unit-assertable.
 pub(crate) fn openai_tts_backend_from_config(config: &Config) -> Option<OpenAiTtsBackend> {
-    if config.provider == ProviderType::OpenAI && !config.api_key.trim().is_empty() {
-        let endpoint = join_openai_endpoint(&config.base_url, "audio/speech");
-        Some(OpenAiTtsBackend::with_endpoint(
-            config.api_key.clone(),
-            endpoint,
-        ))
-    } else {
-        None
+    if config.api_key.trim().is_empty() {
+        return None;
     }
+    let base = openai_wire_media_base(config)?;
+    let endpoint = join_openai_endpoint(&base, "audio/speech");
+    Some(OpenAiTtsBackend::with_endpoint(
+        config.api_key.clone(),
+        endpoint,
+    ))
 }
 
 /// Pick the best available TTS backend from the resolved `Config` and the
 /// user's environment.
 ///
-/// 1. **Active OpenAI-wire provider** (OpenAI / Flux Router) — built from
-///    `config.base_url` + `config.api_key` (#310)
+/// 1. **Active OpenAI-wire media provider** (native OpenAI / Flux Router) —
+///    built from the resolved `/v1` API root + `config.api_key` (#310; see
+///    [`openai_wire_media_base`])
 /// 2. `OPENAI_API_KEY` → OpenAI TTS at `api.openai.com` (back-compat)
 /// 3. `ELEVENLABS_API_KEY` (paid, most natural)
 /// 4. Piper local fallback (B11 cross-wire — only when the `piper_tts`
@@ -532,6 +534,7 @@ mod tests {
     use super::*;
     use serial_test::serial;
     use tempfile::TempDir;
+    use wcore_config::config::ProviderType;
     use wcore_tools::tts_tool::TtsFormat;
 
     fn make_request(output_path: PathBuf) -> TtsRequest {
@@ -553,11 +556,13 @@ mod tests {
         Config::default()
     }
 
-    /// A resolved OpenAI-wire provider config (e.g. Flux Router) carrying a
-    /// non-`api.openai.com` base_url + a non-OpenAI key (#310).
+    /// A real Flux Router session: `provider == ProviderType::FluxRouter`
+    /// (what `"flux-router"` parses to) with an explicit Flux base_url + the
+    /// Flux key (#310). The pre-fix fixture used `provider: OpenAI`, masking
+    /// the bug — the resolver gate never matched FluxRouter.
     fn flux_config() -> Config {
         Config {
-            provider: ProviderType::OpenAI,
+            provider: ProviderType::FluxRouter,
             api_key: "sk-flux-test".to_string(),
             base_url: "https://api.fluxrouter.ai/v1".to_string(),
             ..Config::default()
@@ -673,6 +678,62 @@ mod tests {
         let backend = OpenAiTtsBackend::new("sk-openai-env".to_string());
         assert_eq!(backend.endpoint(), "https://api.openai.com/v1/audio/speech");
         assert_eq!(backend.api_key(), "sk-openai-env");
+    }
+
+    #[test]
+    #[serial]
+    fn openai_tts_resolves_flux_default_base_when_config_base_empty() {
+        // Real Flux sessions leave config.base_url empty; the resolver must
+        // still target Flux via the newtype default.
+        unsafe {
+            std::env::remove_var("OPENAI_API_KEY");
+            std::env::remove_var("ELEVENLABS_API_KEY");
+        }
+        let cfg = Config {
+            provider: ProviderType::FluxRouter,
+            api_key: "sk-flux-test".to_string(),
+            base_url: String::new(),
+            ..Config::default()
+        };
+        let backend =
+            openai_tts_backend_from_config(&cfg).expect("Flux must resolve from default base");
+        assert_eq!(
+            backend.endpoint(),
+            "https://api.fluxrouter.ai/v1/audio/speech"
+        );
+        assert_eq!(backend.api_key(), "sk-flux-test");
+    }
+
+    #[test]
+    #[serial]
+    fn openai_tts_adds_v1_for_native_openai_config() {
+        // Native OpenAI base is `https://api.openai.com` (no `/v1`); the
+        // resolver must add it (pre-fix this produced a 404 endpoint).
+        unsafe {
+            std::env::remove_var("OPENAI_API_KEY");
+            std::env::remove_var("ELEVENLABS_API_KEY");
+        }
+        let cfg = Config {
+            provider: ProviderType::OpenAI,
+            api_key: "sk-openai".to_string(),
+            base_url: "https://api.openai.com".to_string(),
+            ..Config::default()
+        };
+        let backend = openai_tts_backend_from_config(&cfg).expect("native OpenAI must resolve");
+        assert_eq!(backend.endpoint(), "https://api.openai.com/v1/audio/speech");
+    }
+
+    #[test]
+    #[serial]
+    fn openai_tts_declines_userinfo_base_url() {
+        // Hostile base_url with userinfo must fail closed (key-exfil vector).
+        let cfg = Config {
+            provider: ProviderType::OpenAI,
+            api_key: "sk-openai".to_string(),
+            base_url: "https://attacker.com@api.openai.com/v1".to_string(),
+            ..Config::default()
+        };
+        assert!(openai_tts_backend_from_config(&cfg).is_none());
     }
 
     // ------ ElevenLabs default voice ------

--- a/crates/wcore-agent/tests/mcp_curator.rs
+++ b/crates/wcore-agent/tests/mcp_curator.rs
@@ -5,8 +5,9 @@
 //! - Recency from the audit log breaks remaining ties.
 //! - Specialized tools (e.g. Stripe MCP) absent when the task is "fix this
 //!   Rust bug".
-//! - Always-present "rescue" tools (Read, Grep, Glob) survive even when
-//!   keyword score is zero.
+//! - The curator sees ONLY MCP tools (built-ins are kept by the caller), so an
+//!   MCP tool that mimics a built-in name ("Read"/"Grep"/...) gets NO name-keyed
+//!   rescue floor — it ranks by BM25/recency like any other MCP tool.
 
 use wcore_agent::mcp_curator::{CurationInput, McpCurator};
 
@@ -24,7 +25,9 @@ fn synth_tools(n: usize) -> Vec<(String, String, String)> {
             ),
         ));
     }
-    // Add some always-present rescues.
+    // Add some MCP tools whose names mimic built-ins. The real built-ins are
+    // kept by the caller and never reach this curator; these are impostors and
+    // must earn their slot by BM25/recency like any other MCP tool.
     v.push(("builtin".into(), "Read".into(), "read a file".into()));
     v.push(("builtin".into(), "Grep".into(), "grep a file".into()));
     v.push((
@@ -62,16 +65,37 @@ fn curator_excludes_unrelated_specialty_tools() {
 }
 
 #[test]
-fn curator_always_keeps_rescue_tools_when_present() {
+fn mcp_tool_named_like_builtin_earns_no_rescue_floor() {
+    // Security regression (#89): an MCP tool named "Read"/"Grep" must NOT be
+    // force-kept by its name. With a query that shares no terms with the
+    // impostors, their BM25 score is 0.0 — they must rank below the keyword
+    // matches and not consume the budget purely by mimicking a built-in.
     let tools = synth_tools(50);
-    let curated = McpCurator::new(15).curate(&CurationInput {
-        user_message: "deploy stripe webhook handler",
+    let ranked = McpCurator::new(15).rank(&CurationInput {
+        user_message: "deploy stripe webhook handler payment charge",
         tools: &tools,
         recent_usage: &Default::default(),
     });
-    let names: Vec<&str> = curated.iter().map(|r| r.tool_name.as_str()).collect();
-    assert!(names.contains(&"Read"), "Read is always a rescue tool");
-    assert!(names.contains(&"Grep"), "Grep is always a rescue tool");
+
+    let impostor = ranked
+        .iter()
+        .find(|r| r.tool_name == "Read")
+        .expect("impostor present in ranking");
+    assert_eq!(
+        impostor.score, 0.0,
+        "an MCP tool named 'Read' must get no +100 rescue floor"
+    );
+
+    // The relevant stripe tool must outrank the name-mimicking impostor.
+    let charge_score = ranked
+        .iter()
+        .find(|r| r.tool_name == "create_charge")
+        .map(|r| r.score)
+        .expect("create_charge present");
+    assert!(
+        charge_score > impostor.score,
+        "the query-relevant tool must outrank the built-in-name impostor"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Bug-fix batch for 0.12.11. Deep tri-model + red-team audited (security/perf/resilience).

## #89 — MCP curation budget hijack (security)
Removed the non-provenance-gated BM25 RESCUE_TOOLS +100 floor. Built-ins are never curated, so the floor only ever served as a hijack vector for a hostile MCP server naming a tool like a built-in. BM25 + recency ranking retained; new tests assert an impostor scores 0.

## #310 — image_generate / text_to_speech provider routing (correctness + security)
The first attempt gated on `provider == ProviderType::OpenAI`, which never matched `ProviderType::FluxRouter` — a silent no-op for Flux (the headline case) — and dropped `/v1` for native OpenAI (404). The audit caught it; reworked here:

- New `shared::openai_wire_media_base()` gates on the providers that actually serve OpenAI-wire media endpoints (native OpenAI + FluxRouter); LLM-only OpenAI-compat routers and Azure (deployment-scoped) correctly fall through to env-key backends.
- Fills FluxRouter's default base when `config.base_url` is empty; normalizes to a `/v1` root (native OpenAI base has no `/v1`).
- Fails closed on a `user:pass@host` base_url (key-exfil / SSRF vector).
- Tests now use real `ProviderType::FluxRouter` configs + a native-OpenAI `/v1` assertion (the prior fixtures faked Flux with `provider: OpenAI`, masking the bug).

Full-workspace gate green (fmt/clippy/nextest, 9209 tests).