### PR TITLE
fix: Crucible pricing-catalog loading, Gemini slug resolution, Opus temperature gate

### DIFF
--- a/crates/wcore-pricing/src/lib.rs
+++ b/crates/wcore-pricing/src/lib.rs
@@ -47,11 +47,23 @@ pub struct PricingCatalog {
 
 impl PricingCatalog {
     pub fn load_default() -> Result<Self, PricingError> {
-        if let Ok(path) = std::env::var("WAYLAND_PRICING_PATH") {
-            let raw = std::fs::read_to_string(&path)?;
-            return Ok(toml::from_str(&raw)?);
-        }
-        Ok(toml::from_str(BUNDLED_PRICING_TOML)?)
+        let raw = if let Ok(path) = std::env::var("WAYLAND_PRICING_PATH") {
+            std::fs::read_to_string(&path)?
+        } else {
+            BUNDLED_PRICING_TOML.to_string()
+        };
+        Self::from_toml_str(&raw)
+    }
+
+    /// Parse a catalog from a TOML string. Deserializes directly into the
+    /// provider→model map instead of going through `PricingCatalog`'s
+    /// `#[serde(flatten)]`, which the `toml` crate mishandles for
+    /// externally-supplied catalogs: a perfectly valid `WAYLAND_PRICING_PATH`
+    /// file whose first line is a bare `[provider.model]` table otherwise
+    /// fails to load with a spurious "TOML parse error at line 1, column 1".
+    pub fn from_toml_str(raw: &str) -> Result<Self, PricingError> {
+        let providers: HashMap<String, HashMap<String, ModelPrice>> = toml::from_str(raw)?;
+        Ok(Self { providers })
     }
 
     pub fn get(&self, provider: &str, model: &str) -> Result<&ModelPrice, PricingError> {
@@ -59,7 +71,21 @@ impl PricingCatalog {
             .providers
             .get(provider)
             .ok_or_else(|| PricingError::UnknownProvider(provider.into()))?;
-        prov.get(model).ok_or_else(|| PricingError::UnknownModel {
+        if let Some(p) = prov.get(model) {
+            return Ok(p);
+        }
+        // Live API model slugs use dots in the version segment
+        // (`gemini-2.5-flash`) while catalog keys use dashes
+        // (`gemini-2-5-flash`). Retry with dots→dashes so a dotted slug still
+        // resolves. Exact match is tried first, so dotted catalog keys
+        // (e.g. `gpt-4.1-mini`) are unaffected.
+        let normalized = model.replace('.', "-");
+        if normalized != model
+            && let Some(p) = prov.get(&normalized)
+        {
+            return Ok(p);
+        }
+        Err(PricingError::UnknownModel {
             provider: provider.into(),
             model: model.into(),
         })
@@ -203,6 +229,36 @@ pub static DEFAULT_CATALOG: Lazy<PricingCatalog> = Lazy::new(|| {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // Regression (#4): a custom catalog whose FIRST line is a bare
+    // `[provider.model]` table (no leading comment) must parse. The old
+    // `#[serde(flatten)]` load path failed here with "parse error line 1".
+    #[test]
+    fn from_toml_str_parses_leading_bare_table() {
+        let raw = "[anthropic.claude-opus-4-7]\ninput_per_mtok_usd = 5.0\noutput_per_mtok_usd = 25.0\n\n[openai.gpt-4o]\ninput_per_mtok_usd = 2.5\noutput_per_mtok_usd = 10.0\n";
+        let cat = PricingCatalog::from_toml_str(raw).expect("leading-table catalog parses");
+        assert_eq!(cat.providers.len(), 2);
+        assert!(cat.get("anthropic", "claude-opus-4-7").is_ok());
+    }
+
+    // Regression (#1): a dotted live API slug must resolve to the dashed
+    // catalog key. Exact match still wins for genuinely-dotted keys.
+    #[test]
+    fn dotted_api_slug_resolves_to_dashed_key() {
+        let raw = "[gemini.gemini-2-5-flash]\ninput_per_mtok_usd = 0.30\noutput_per_mtok_usd = 2.50\n\n[openai.\"gpt-4.1-mini\"]\ninput_per_mtok_usd = 0.40\noutput_per_mtok_usd = 1.60\n";
+        let cat = PricingCatalog::from_toml_str(raw).unwrap();
+        // dotted lookup resolves to the dashed key
+        assert!(cat.get("gemini", "gemini-2.5-flash").is_ok());
+        // exact (dashed) still works
+        assert!(cat.get("gemini", "gemini-2-5-flash").is_ok());
+        // a genuinely-dotted catalog key is matched exactly (not mangled)
+        assert!(cat.get("openai", "gpt-4.1-mini").is_ok());
+        // a real miss still errors
+        assert!(matches!(
+            cat.get("gemini", "ghost-9"),
+            Err(PricingError::UnknownModel { .. })
+        ));
+    }
 
     fn fixture_catalog() -> PricingCatalog {
         let raw = r#"

--- a/crates/wcore-providers/src/openai_compat.rs
+++ b/crates/wcore-providers/src/openai_compat.rs
@@ -106,11 +106,19 @@ pub fn responses_api_override(model: &str, override_flag: Option<bool>) -> bool 
 }
 
 /// True when the model accepts an explicit `temperature`. False for the
-/// `o1*` / `o3*` reasoning families (which fix `temperature` at `1.0`),
+/// `o1*` / `o3*` reasoning families (which fix `temperature` at `1.0`) and
+/// Anthropic's Opus 4.x reasoning models (which reject an explicit value),
 /// true everywhere else — including `gpt-5*`, which still honors it.
 pub fn accepts_temperature(model: &str) -> bool {
     let m = lower(model);
-    !is_o_series(&m)
+    !is_o_series(&m) && !is_temperature_locked(&m)
+}
+
+/// Models that reject an explicit `temperature` outside the OpenAI o-series.
+/// Anthropic's Opus 4.x family returns HTTP 400 "temperature is deprecated
+/// for this model" when a value is sent, so it must be omitted for them.
+fn is_temperature_locked(lower_model: &str) -> bool {
+    lower_model.contains("opus-4")
 }
 
 /// Crucible #3: emit `body["temperature"]` for the request, but only when ALL
@@ -396,6 +404,22 @@ mod tests {
     #[test]
     fn accepts_temperature_o1_is_false() {
         assert!(!accepts_temperature("o1"));
+    }
+
+    // Anthropic Opus 4.x rejects an explicit temperature (HTTP 400).
+    #[test]
+    fn accepts_temperature_opus_4x_is_false() {
+        assert!(!accepts_temperature("claude-opus-4-7"));
+        assert!(!accepts_temperature("claude-opus-4-6"));
+        assert!(!accepts_temperature("claude-opus-4-8"));
+        assert!(!accepts_temperature("anthropic/claude-opus-4-7"));
+    }
+
+    // Sonnet/Haiku still honor temperature — only Opus 4.x is locked.
+    #[test]
+    fn accepts_temperature_non_opus_claude_is_true() {
+        assert!(accepts_temperature("claude-sonnet-4-6"));
+        assert!(accepts_temperature("claude-haiku-4-5"));
     }
 
     #[test]


### PR DESCRIPTION
Three real bugs surfaced while validating Crucible live in the TUI (a 0.12.11 proof run). Each would silently bite real users with a Gemini or Opus roster; the Crucible auto-assembler refused to convene councils as a downstream effect.

## Fixes

1. **Custom `WAYLAND_PRICING_PATH` catalogs failed to load.** `PricingCatalog` deserialized via `#[serde(flatten)]`, which the `toml` crate mishandles for externally-supplied files — a perfectly valid catalog whose first line is a bare `[provider.model]` table failed with a spurious `TOML parse error at line 1, column 1`, leaving every model "unpriced". Now parsed by deserializing the provider map directly (`PricingCatalog::from_toml_str`).

2. **Gemini always read as "unpriced".** Catalog keys use dashes (`gemini-2-5-flash`) but the live API slug uses dots (`gemini-2.5-flash`), so `get()` missed every time — mis-reporting cost and (via the assembler's "≥3 priced families" rule) preventing Gemini councils from convening. `get()` now falls back from a dotted slug to the dashed key; exact match wins first, so genuinely-dotted keys (`gpt-4.1-mini`) are unaffected.

3. **Opus 4.x rejected an explicit `temperature`.** Crucible's per-tier temperature was sent to `claude-opus-4-7`, which returns HTTP 400 "temperature is deprecated for this model" — killing the proposer and the Opus aggregator. `accepts_temperature` now excludes the `opus-4` family alongside the OpenAI o-series.

## Tests
Regression tests for all three (leading-bare-table parse, dotted→dashed resolution + exact-match precedence, Opus-4.x exclusion with Sonnet/Haiku still accepting). Gate-green on Hetzner: `wcore-pricing` + `wcore-providers`, 811 tests pass, clippy + fmt clean.

## Known follow-up (not in this PR)
The engine turn-cost *log* can attribute a sub-agent's cost to the session-default provider (cosmetic; the authoritative council spend in `spend.rs` is correct). Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)