### PR TITLE
release: wayland-core 0.12.13 — Windows sandbox #321-324, billing #329, Ollama #389, config #325-327, Flux reasoning #318

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.12.13](https://github.com/FerroxLabs/wayland-core/compare/v0.12.12...v0.12.13) (2026-06-27)
+
+### Reliability & hygiene
+
+A focused round of audited fixes across the sandbox, provider runtime, and configuration surface.
+
+- **Windows sandbox runs real subprocesses again.** The AppContainer backend no longer caps active processes too aggressively (`ActiveProcessLimit` raised to 512), resolves the launch shell correctly, and emits clearer diagnostics when a shell can't be found. ([#321](https://github.com/FerroxLabs/wayland-core/issues/321), [#322](https://github.com/FerroxLabs/wayland-core/issues/322), [#323](https://github.com/FerroxLabs/wayland-core/issues/323), [#324](https://github.com/FerroxLabs/wayland-core/issues/324))
+- **Anthropic errors are classified correctly.** Non-credit Anthropic API errors are no longer misread as out-of-credit / billing failures, so genuine transient errors surface instead of a misleading "purchase credits" signal. ([#329](https://github.com/FerroxLabs/wayland-core/issues/329))
+- **Graceful retry for Ollama models without tool support.** When an Ollama model returns a 400 because it doesn't support tools, the request now retries cleanly without tools instead of failing the turn. ([#389](https://github.com/FerroxLabs/wayland-core/issues/389))
+- **Config hygiene.** `env_passthrough` is now wired through, unknown configuration keys produce a warning (via `serde_ignored`) instead of being silently dropped, and the sandbox configuration surface is exposed as a toggle. ([#325](https://github.com/FerroxLabs/wayland-core/issues/325), [#326](https://github.com/FerroxLabs/wayland-core/issues/326), [#327](https://github.com/FerroxLabs/wayland-core/issues/327))
+- **Flux reasoning summaries render as thinking.** A FluxRouter `reasoning_summary` is now decoded into a per-turn thinking subject, so reasoning summaries appear as proper thinking content. ([#318](https://github.com/FerroxLabs/wayland-core/issues/318))
+
 ## [0.12.12](https://github.com/FerroxLabs/wayland-core/compare/v0.12.11...v0.12.12) (2026-06-27)
 
 ### Crucible reliability & cost accuracy

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8928,7 +8928,7 @@ dependencies = [
 
 [[package]]
 name = "wayland-browser"
-version = "0.12.11"
+version = "0.12.13"
 dependencies = [
  "async-trait",
  "inventory",
@@ -8945,7 +8945,7 @@ dependencies = [
 
 [[package]]
 name = "wayland-cua"
-version = "0.12.11"
+version = "0.12.13"
 dependencies = [
  "async-trait",
  "inventory",
@@ -8962,7 +8962,7 @@ dependencies = [
 
 [[package]]
 name = "wayland-honcho"
-version = "0.12.11"
+version = "0.12.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8983,7 +8983,7 @@ dependencies = [
 
 [[package]]
 name = "wayland-ijfw"
-version = "0.12.11"
+version = "0.12.13"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9002,7 +9002,7 @@ dependencies = [
 
 [[package]]
 name = "wayland-ollama"
-version = "0.12.11"
+version = "0.12.13"
 dependencies = [
  "async-trait",
  "futures",
@@ -9023,7 +9023,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-acp"
-version = "0.12.11"
+version = "0.12.13"
 dependencies = [
  "async-trait",
  "axum",
@@ -9046,7 +9046,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-agent"
-version = "0.12.11"
+version = "0.12.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9136,7 +9136,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-agents-pack"
-version = "0.12.11"
+version = "0.12.13"
 dependencies = [
  "dirs",
  "serde",
@@ -9149,7 +9149,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-browser"
-version = "0.12.11"
+version = "0.12.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9179,7 +9179,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-budget"
-version = "0.12.11"
+version = "0.12.13"
 dependencies = [
  "chrono",
  "parking_lot",
@@ -9192,7 +9192,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-discord"
-version = "0.12.11"
+version = "0.12.13"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9213,7 +9213,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-email"
-version = "0.12.11"
+version = "0.12.13"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9232,7 +9232,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-imessage"
-version = "0.12.11"
+version = "0.12.13"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9249,7 +9249,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-matrix"
-version = "0.12.11"
+version = "0.12.13"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9268,7 +9268,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-msteams"
-version = "0.12.11"
+version = "0.12.13"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -9289,7 +9289,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-signal"
-version = "0.12.11"
+version = "0.12.13"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9304,7 +9304,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-slack"
-version = "0.12.11"
+version = "0.12.13"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9327,7 +9327,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-sms"
-version = "0.12.11"
+version = "0.12.13"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -9350,7 +9350,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-telegram"
-version = "0.12.11"
+version = "0.12.13"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9369,7 +9369,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-whatsapp"
-version = "0.12.11"
+version = "0.12.13"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9392,7 +9392,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channels"
-version = "0.12.11"
+version = "0.12.13"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9408,7 +9408,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channels-registry"
-version = "0.12.11"
+version = "0.12.13"
 dependencies = [
  "dirs",
  "serde",
@@ -9433,7 +9433,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-cli"
-version = "0.12.11"
+version = "0.12.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9516,7 +9516,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-compact"
-version = "0.12.11"
+version = "0.12.13"
 dependencies = [
  "regex",
  "serde",
@@ -9525,7 +9525,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-config"
-version = "0.12.11"
+version = "0.12.13"
 dependencies = [
  "anyhow",
  "argon2",
@@ -9563,7 +9563,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-cron"
-version = "0.12.11"
+version = "0.12.13"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9580,7 +9580,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-cua"
-version = "0.12.11"
+version = "0.12.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9616,7 +9616,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-dispatch"
-version = "0.12.11"
+version = "0.12.13"
 dependencies = [
  "rand 0.9.4",
  "rand_distr",
@@ -9629,7 +9629,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-egress"
-version = "0.12.11"
+version = "0.12.13"
 dependencies = [
  "async-trait",
  "http 1.4.1",
@@ -9642,7 +9642,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-eval"
-version = "0.12.11"
+version = "0.12.13"
 dependencies = [
  "rstest",
  "serde",
@@ -9659,7 +9659,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-eval-scenarios"
-version = "0.12.11"
+version = "0.12.13"
 dependencies = [
  "anyhow",
  "clap",
@@ -9679,7 +9679,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-evolve"
-version = "0.12.11"
+version = "0.12.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9719,7 +9719,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-honcho-adapter"
-version = "0.12.11"
+version = "0.12.13"
 dependencies = [
  "async-trait",
  "serde",
@@ -9734,7 +9734,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-mcp"
-version = "0.12.11"
+version = "0.12.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9761,7 +9761,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-memory"
-version = "0.12.11"
+version = "0.12.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9802,7 +9802,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-observability"
-version = "0.12.11"
+version = "0.12.13"
 dependencies = [
  "chrono",
  "opentelemetry",
@@ -9826,7 +9826,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-permissions"
-version = "0.12.11"
+version = "0.12.13"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9843,7 +9843,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-plugin-api"
-version = "0.12.11"
+version = "0.12.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9870,7 +9870,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-plugin-subprocess"
-version = "0.12.11"
+version = "0.12.13"
 dependencies = [
  "anyhow",
  "serde",
@@ -9889,7 +9889,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-plugin-wasm"
-version = "0.12.11"
+version = "0.12.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9911,7 +9911,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-pluginsrc"
-version = "0.12.11"
+version = "0.12.13"
 dependencies = [
  "serde",
  "serde_json",
@@ -9926,7 +9926,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-pricing"
-version = "0.12.11"
+version = "0.12.13"
 dependencies = [
  "chrono",
  "dirs",
@@ -9945,7 +9945,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-protocol"
-version = "0.12.11"
+version = "0.12.13"
 dependencies = [
  "rstest",
  "serde",
@@ -9957,7 +9957,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-providers"
-version = "0.12.11"
+version = "0.12.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9992,7 +9992,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-replay"
-version = "0.12.11"
+version = "0.12.13"
 dependencies = [
  "serde",
  "serde_json",
@@ -10003,7 +10003,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-repomap"
-version = "0.12.11"
+version = "0.12.13"
 dependencies = [
  "ignore",
  "regex",
@@ -10016,7 +10016,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-safety"
-version = "0.12.11"
+version = "0.12.13"
 dependencies = [
  "async-trait",
  "regex",
@@ -10029,7 +10029,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-sandbox"
-version = "0.12.11"
+version = "0.12.13"
 dependencies = [
  "async-trait",
  "bollard",
@@ -10049,7 +10049,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-skills"
-version = "0.12.11"
+version = "0.12.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10086,7 +10086,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-swarm"
-version = "0.12.11"
+version = "0.12.13"
 dependencies = [
  "futures",
  "humantime-serde",
@@ -10105,7 +10105,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-tools"
-version = "0.12.11"
+version = "0.12.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10152,7 +10152,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-types"
-version = "0.12.11"
+version = "0.12.13"
 dependencies = [
  "async-trait",
  "chrono",
@@ -10162,7 +10162,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-user-model"
-version = "0.12.11"
+version = "0.12.13"
 dependencies = [
  "async-trait",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8918,7 +8918,7 @@ dependencies = [
 
 [[package]]
 name = "wayland-browser"
-version = "0.12.9"
+version = "0.12.11"
 dependencies = [
  "async-trait",
  "inventory",
@@ -8935,7 +8935,7 @@ dependencies = [
 
 [[package]]
 name = "wayland-cua"
-version = "0.12.9"
+version = "0.12.11"
 dependencies = [
  "async-trait",
  "inventory",
@@ -8952,7 +8952,7 @@ dependencies = [
 
 [[package]]
 name = "wayland-honcho"
-version = "0.12.9"
+version = "0.12.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8973,7 +8973,7 @@ dependencies = [
 
 [[package]]
 name = "wayland-ijfw"
-version = "0.12.9"
+version = "0.12.11"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8992,7 +8992,7 @@ dependencies = [
 
 [[package]]
 name = "wayland-ollama"
-version = "0.12.9"
+version = "0.12.11"
 dependencies = [
  "async-trait",
  "futures",
@@ -9013,7 +9013,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-acp"
-version = "0.12.9"
+version = "0.12.11"
 dependencies = [
  "async-trait",
  "axum",
@@ -9036,7 +9036,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-agent"
-version = "0.12.9"
+version = "0.12.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9125,7 +9125,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-agents-pack"
-version = "0.12.9"
+version = "0.12.11"
 dependencies = [
  "dirs",
  "serde",
@@ -9138,7 +9138,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-browser"
-version = "0.12.9"
+version = "0.12.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9168,7 +9168,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-budget"
-version = "0.12.9"
+version = "0.12.11"
 dependencies = [
  "chrono",
  "parking_lot",
@@ -9181,7 +9181,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-discord"
-version = "0.12.9"
+version = "0.12.11"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9202,7 +9202,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-email"
-version = "0.12.9"
+version = "0.12.11"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9221,7 +9221,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-imessage"
-version = "0.12.9"
+version = "0.12.11"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9238,7 +9238,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-matrix"
-version = "0.12.9"
+version = "0.12.11"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9257,7 +9257,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-msteams"
-version = "0.12.9"
+version = "0.12.11"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -9278,7 +9278,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-signal"
-version = "0.12.9"
+version = "0.12.11"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9293,7 +9293,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-slack"
-version = "0.12.9"
+version = "0.12.11"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9316,7 +9316,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-sms"
-version = "0.12.9"
+version = "0.12.11"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -9339,7 +9339,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-telegram"
-version = "0.12.9"
+version = "0.12.11"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9358,7 +9358,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-whatsapp"
-version = "0.12.9"
+version = "0.12.11"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9381,7 +9381,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channels"
-version = "0.12.9"
+version = "0.12.11"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9397,7 +9397,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channels-registry"
-version = "0.12.9"
+version = "0.12.11"
 dependencies = [
  "dirs",
  "serde",
@@ -9422,7 +9422,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-cli"
-version = "0.12.9"
+version = "0.12.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9440,6 +9440,7 @@ dependencies = [
  "mockito",
  "nucleo",
  "open",
+ "parking_lot",
  "portable-pty",
  "pulldown-cmark",
  "rand 0.8.6",
@@ -9475,6 +9476,7 @@ dependencies = [
  "wcore-acp",
  "wcore-agent",
  "wcore-agents-pack",
+ "wcore-budget",
  "wcore-channels-registry",
  "wcore-compact",
  "wcore-config",
@@ -9503,7 +9505,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-compact"
-version = "0.12.9"
+version = "0.12.11"
 dependencies = [
  "regex",
  "serde",
@@ -9512,7 +9514,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-config"
-version = "0.12.9"
+version = "0.12.11"
 dependencies = [
  "anyhow",
  "argon2",
@@ -9549,7 +9551,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-cron"
-version = "0.12.9"
+version = "0.12.11"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9566,7 +9568,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-cua"
-version = "0.12.9"
+version = "0.12.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9602,7 +9604,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-dispatch"
-version = "0.12.9"
+version = "0.12.11"
 dependencies = [
  "rand 0.9.4",
  "rand_distr",
@@ -9615,7 +9617,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-egress"
-version = "0.12.9"
+version = "0.12.11"
 dependencies = [
  "async-trait",
  "http 1.4.1",
@@ -9628,7 +9630,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-eval"
-version = "0.12.9"
+version = "0.12.11"
 dependencies = [
  "rstest",
  "serde",
@@ -9645,7 +9647,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-eval-scenarios"
-version = "0.12.9"
+version = "0.12.11"
 dependencies = [
  "anyhow",
  "clap",
@@ -9665,7 +9667,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-evolve"
-version = "0.12.9"
+version = "0.12.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9705,7 +9707,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-honcho-adapter"
-version = "0.12.9"
+version = "0.12.11"
 dependencies = [
  "async-trait",
  "serde",
@@ -9720,7 +9722,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-mcp"
-version = "0.12.9"
+version = "0.12.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9747,7 +9749,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-memory"
-version = "0.12.9"
+version = "0.12.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9788,7 +9790,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-observability"
-version = "0.12.9"
+version = "0.12.11"
 dependencies = [
  "chrono",
  "opentelemetry",
@@ -9812,7 +9814,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-permissions"
-version = "0.12.9"
+version = "0.12.11"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9829,7 +9831,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-plugin-api"
-version = "0.12.9"
+version = "0.12.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9856,7 +9858,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-plugin-subprocess"
-version = "0.12.9"
+version = "0.12.11"
 dependencies = [
  "anyhow",
  "serde",
@@ -9875,7 +9877,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-plugin-wasm"
-version = "0.12.9"
+version = "0.12.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9897,7 +9899,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-pluginsrc"
-version = "0.12.9"
+version = "0.12.11"
 dependencies = [
  "serde",
  "serde_json",
@@ -9912,7 +9914,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-pricing"
-version = "0.12.9"
+version = "0.12.11"
 dependencies = [
  "chrono",
  "dirs",
@@ -9931,7 +9933,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-protocol"
-version = "0.12.9"
+version = "0.12.11"
 dependencies = [
  "rstest",
  "serde",
@@ -9943,7 +9945,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-providers"
-version = "0.12.9"
+version = "0.12.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9978,7 +9980,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-replay"
-version = "0.12.9"
+version = "0.12.11"
 dependencies = [
  "serde",
  "serde_json",
@@ -9989,7 +9991,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-repomap"
-version = "0.12.9"
+version = "0.12.11"
 dependencies = [
  "ignore",
  "regex",
@@ -10002,7 +10004,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-safety"
-version = "0.12.9"
+version = "0.12.11"
 dependencies = [
  "async-trait",
  "regex",
@@ -10015,7 +10017,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-sandbox"
-version = "0.12.9"
+version = "0.12.11"
 dependencies = [
  "async-trait",
  "bollard",
@@ -10035,7 +10037,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-skills"
-version = "0.12.9"
+version = "0.12.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10072,7 +10074,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-swarm"
-version = "0.12.9"
+version = "0.12.11"
 dependencies = [
  "futures",
  "humantime-serde",
@@ -10091,7 +10093,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-tools"
-version = "0.12.9"
+version = "0.12.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10138,7 +10140,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-types"
-version = "0.12.9"
+version = "0.12.11"
 dependencies = [
  "async-trait",
  "chrono",
@@ -10148,7 +10150,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-user-model"
-version = "0.12.9"
+version = "0.12.11"
 dependencies = [
  "async-trait",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6857,6 +6857,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_ignored"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115dffd5f3853e06e746965a20dcbae6ee747ae30b543d91b0e089668bb07798"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9113,6 +9123,7 @@ dependencies = [
  "wcore-pricing",
  "wcore-protocol",
  "wcore-providers",
+ "wcore-sandbox",
  "wcore-skills",
  "wcore-swarm",
  "wcore-tools",
@@ -9530,6 +9541,7 @@ dependencies = [
  "reqwest",
  "rpassword",
  "serde",
+ "serde_ignored",
  "serde_json",
  "serde_yaml",
  "serial_test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,7 +143,7 @@ members = [
 exclude = ["templates/**", "examples/**"]
 
 [workspace.package]
-version = "0.12.12"
+version = "0.12.13"
 edition = "2024"
 rust-version = "1.95"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -219,6 +219,10 @@ reqwest = { version = "0.12", features = ["json", "stream", "multipart", "rustls
 # Serialization
 serde      = { version = "1", features = ["derive"] }
 serde_json = "1"
+# #326: surface unknown / mis-sectioned config keys as warnings (rather
+# than silently dropping them) without the breaking-change risk of
+# `deny_unknown_fields`.
+serde_ignored = "0.1"
 
 # OpenAPI 3.0.3 document generation for the REST transport (wcore-acp).
 # Pinned to 4.x for axum 0.7 compatibility; utoipa 5 requires axum 0.8

--- a/crates/wcore-agent/Cargo.toml
+++ b/crates/wcore-agent/Cargo.toml
@@ -14,6 +14,9 @@ wcore-config.workspace    = true
 wcore-providers.workspace = true
 wcore-egress.workspace = true
 wcore-tools.workspace     = true
+# #327: bootstrap installs the config-sourced sandbox toggle
+# (`[tools] sandbox` / `allow_no_sandbox`) via `set_config_sandbox`.
+wcore-sandbox.workspace   = true
 wcore-mcp.workspace       = true
 wcore-skills.workspace    = true
 # v0.8.0 Task K — wire `TemplateRouter` as primary orchestration-template

--- a/crates/wcore-agent/src/agents/channel_sink.rs
+++ b/crates/wcore-agent/src/agents/channel_sink.rs
@@ -156,6 +156,14 @@ impl OutputSink for ChannelSink {
         self.relay(ProtocolEvent::Thinking {
             text: text.to_string(),
             msg_id: msg_id.to_string(),
+            subject: None,
+        });
+    }
+    fn emit_thinking_subject(&self, subject: &str, msg_id: &str) {
+        self.relay(ProtocolEvent::Thinking {
+            text: String::new(),
+            msg_id: msg_id.to_string(),
+            subject: Some(subject.to_string()),
         });
     }
     fn emit_tool_call(&self, _name: &str, _input: &str) {

--- a/crates/wcore-agent/src/bootstrap.rs
+++ b/crates/wcore-agent/src/bootstrap.rs
@@ -582,6 +582,23 @@ impl AgentBootstrap {
         // Windows (set once at boot; WAYLAND_BASH_SHELL env still overrides).
         wcore_config::shell::set_bash_shell_config(self.config.tools.windows_shell.clone());
 
+        // #325: install the config-sourced env passthrough allowlist so
+        // `[tools] env_passthrough` actually forwards the named vars into
+        // sandboxed tool children (the sandbox secret filter still drops
+        // secret-shaped names). Skill-declared passthroughs are additive.
+        wcore_tools::env_passthrough::set_config_passthrough(
+            self.config.tools.env_passthrough.iter(),
+        );
+
+        // #327: install the config-sourced sandbox toggle so `[tools]
+        // sandbox` / `[tools] allow_no_sandbox` are honored by
+        // `wcore_sandbox::default_for_platform`. The `WAYLAND_SANDBOX` /
+        // `WAYLAND_ALLOW_NO_SANDBOX` env vars still take precedence.
+        wcore_sandbox::set_config_sandbox(
+            self.config.tools.sandbox.clone(),
+            self.config.tools.allow_no_sandbox,
+        );
+
         registry.register(Box::new(wcore_tools::read::ReadTool::new(
             file_cache.clone(),
         )));

--- a/crates/wcore-agent/src/engine.rs
+++ b/crates/wcore-agent/src/engine.rs
@@ -4479,6 +4479,15 @@ impl AgentEngine {
                             self.output.emit_thinking(&text, &self.current_msg_id);
                             thinking_text.push_str(&text);
                         }
+                        LlmEvent::ThinkingSubject(subject) => {
+                            // #318 — per-turn thinking SUBJECT. Display-only:
+                            // emit on the same msg_id as the reasoning text
+                            // that follows so the host attaches it to the
+                            // in-flight thinking block. Do NOT fold it into
+                            // `thinking_text` (it's a heading, not content).
+                            self.output
+                                .emit_thinking_subject(&subject, &self.current_msg_id);
+                        }
                         LlmEvent::Done {
                             stop_reason: sr,
                             finish_reason: fr,

--- a/crates/wcore-agent/src/oauth/xai.rs
+++ b/crates/wcore-agent/src/oauth/xai.rs
@@ -454,6 +454,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn get_returns_a_fresh_stored_token_without_refreshing() {
         // Isolate from any real ~/.grok/auth.json so the test is deterministic.
         unsafe { std::env::set_var("GROK_HOME", "/nonexistent-grok-home-for-test") };
@@ -468,6 +469,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn reads_real_grok_auth_json_shape() {
         // The host-prefixed wrapper with a `key` is extracted; a JWT `key`
         // yields an expiry from its `exp` claim.

--- a/crates/wcore-agent/src/output/mod.rs
+++ b/crates/wcore-agent/src/output/mod.rs
@@ -15,6 +15,13 @@ pub trait OutputSink: Send + Sync {
     fn emit_text_delta(&self, text: &str, msg_id: &str);
     /// Stream thinking content from LLM
     fn emit_thinking(&self, text: &str, msg_id: &str);
+    /// #318 — emit a per-turn thinking SUBJECT: a short opaque display label
+    /// for the in-flight reasoning block (e.g. Flux `reasoning_summary`).
+    /// Default no-op so terminal/null/test sinks need no change; only
+    /// `ProtocolSink` overrides to emit a `Thinking` event carrying
+    /// `subject: Some(..)` on the same `msg_id`/turn as the reasoning text
+    /// that follows.
+    fn emit_thinking_subject(&self, _subject: &str, _msg_id: &str) {}
     /// Announce a tool call
     fn emit_tool_call(&self, name: &str, input: &str);
     /// Display tool result

--- a/crates/wcore-agent/src/output/protocol_sink.rs
+++ b/crates/wcore-agent/src/output/protocol_sink.rs
@@ -503,6 +503,18 @@ impl OutputSink for ProtocolSink {
         let _ = self.writer.emit(&ProtocolEvent::Thinking {
             text: text.to_string(),
             msg_id: msg_id.to_string(),
+            subject: None,
+        });
+    }
+
+    fn emit_thinking_subject(&self, subject: &str, msg_id: &str) {
+        // #318 — subject-only chunk: empty `text`, `subject: Some(..)`. Lands
+        // on the same msg_id as the reasoning text that follows, so the host
+        // attaches it as the heading of the same in-flight thinking block.
+        let _ = self.writer.emit(&ProtocolEvent::Thinking {
+            text: String::new(),
+            msg_id: msg_id.to_string(),
+            subject: Some(subject.to_string()),
         });
     }
 

--- a/crates/wcore-agent/src/spawner.rs
+++ b/crates/wcore-agent/src/spawner.rs
@@ -1122,6 +1122,9 @@ mod posture_inheritance_tests {
                 skills: wcore_config::config::SkillsPermissionConfig::default(),
                 verify_edits: false,
                 windows_shell: None,
+                env_passthrough: Vec::new(),
+                sandbox: None,
+                allow_no_sandbox: None,
             },
             ..Default::default()
         }

--- a/crates/wcore-agent/src/test_utils/mod.rs
+++ b/crates/wcore-agent/src/test_utils/mod.rs
@@ -156,6 +156,14 @@ impl OutputSink for TestSink {
         self.record(&ProtocolEvent::Thinking {
             text: text.to_string(),
             msg_id: msg_id.to_string(),
+            subject: None,
+        });
+    }
+    fn emit_thinking_subject(&self, subject: &str, msg_id: &str) {
+        self.record(&ProtocolEvent::Thinking {
+            text: String::new(),
+            msg_id: msg_id.to_string(),
+            subject: Some(subject.to_string()),
         });
     }
     fn emit_tool_call(&self, name: &str, _input: &str) {

--- a/crates/wcore-agent/tests/acceptance/helpers.rs
+++ b/crates/wcore-agent/tests/acceptance/helpers.rs
@@ -97,6 +97,9 @@ pub fn openai_config(api_key: &str) -> Config {
             skills: wcore_config::config::SkillsPermissionConfig::default(),
             verify_edits: false,
             windows_shell: None,
+            env_passthrough: Vec::new(),
+            sandbox: None,
+            allow_no_sandbox: None,
         },
         session: SessionConfig {
             enabled: false,
@@ -134,6 +137,9 @@ pub fn bedrock_config() -> Config {
             skills: wcore_config::config::SkillsPermissionConfig::default(),
             verify_edits: false,
             windows_shell: None,
+            env_passthrough: Vec::new(),
+            sandbox: None,
+            allow_no_sandbox: None,
         },
         session: SessionConfig {
             enabled: false,

--- a/crates/wcore-agent/tests/common/mod.rs
+++ b/crates/wcore-agent/tests/common/mod.rs
@@ -262,6 +262,9 @@ pub fn test_config() -> Config {
             skills: wcore_config::config::SkillsPermissionConfig::default(),
             verify_edits: false,
             windows_shell: None,
+            env_passthrough: Vec::new(),
+            sandbox: None,
+            allow_no_sandbox: None,
         },
         session: SessionConfig {
             enabled: false,

--- a/crates/wcore-agent/tests/e2e/anthropic.rs
+++ b/crates/wcore-agent/tests/e2e/anthropic.rs
@@ -41,6 +41,9 @@ fn anthropic_config(api_key: &str) -> Config {
             skills: wcore_config::config::SkillsPermissionConfig::default(),
             verify_edits: false,
             windows_shell: None,
+            env_passthrough: Vec::new(),
+            sandbox: None,
+            allow_no_sandbox: None,
         },
         session: SessionConfig {
             enabled: false,

--- a/crates/wcore-agent/tests/e2e/compaction.rs
+++ b/crates/wcore-agent/tests/e2e/compaction.rs
@@ -51,6 +51,9 @@ fn openai_config(api_key: &str) -> Config {
             skills: wcore_config::config::SkillsPermissionConfig::default(),
             verify_edits: false,
             windows_shell: None,
+            env_passthrough: Vec::new(),
+            sandbox: None,
+            allow_no_sandbox: None,
         },
         session: SessionConfig {
             enabled: false,

--- a/crates/wcore-agent/tests/e2e/openai.rs
+++ b/crates/wcore-agent/tests/e2e/openai.rs
@@ -40,6 +40,9 @@ fn openai_config(api_key: &str) -> Config {
             skills: wcore_config::config::SkillsPermissionConfig::default(),
             verify_edits: false,
             windows_shell: None,
+            env_passthrough: Vec::new(),
+            sandbox: None,
+            allow_no_sandbox: None,
         },
         session: SessionConfig {
             enabled: false,

--- a/crates/wcore-cli/src/tui/engine_bridge.rs
+++ b/crates/wcore-cli/src/tui/engine_bridge.rs
@@ -230,6 +230,15 @@ impl OutputSink for ChannelSink {
         self.send(ProtocolEvent::Thinking {
             text: text.to_string(),
             msg_id: msg_id.to_string(),
+            subject: None,
+        });
+    }
+
+    fn emit_thinking_subject(&self, subject: &str, msg_id: &str) {
+        self.send(ProtocolEvent::Thinking {
+            text: String::new(),
+            msg_id: msg_id.to_string(),
+            subject: Some(subject.to_string()),
         });
     }
 

--- a/crates/wcore-cli/src/tui/fixtures.rs
+++ b/crates/wcore-cli/src/tui/fixtures.rs
@@ -29,6 +29,7 @@ pub fn full_conversation() -> Vec<ProtocolEvent> {
         ProtocolEvent::Thinking {
             text: "The user wants a greeting.".into(),
             msg_id: "m1".into(),
+            subject: None,
         },
         ProtocolEvent::TextDelta {
             text: "Hello! ".into(),

--- a/crates/wcore-cli/src/tui/protocol_bridge.rs
+++ b/crates/wcore-cli/src/tui/protocol_bridge.rs
@@ -2074,6 +2074,7 @@ mod tests {
             ProtocolEvent::Thinking {
                 text: "reasoning...".into(),
                 msg_id: "m1".into(),
+                subject: None,
             },
         );
         assert_eq!(app.session.thinking, "reasoning...");

--- a/crates/wcore-config/Cargo.toml
+++ b/crates/wcore-config/Cargo.toml
@@ -18,6 +18,7 @@ parking_lot.workspace = true
 
 serde.workspace      = true
 serde_json.workspace = true
+serde_ignored.workspace = true
 toml.workspace       = true
 anyhow.workspace     = true
 thiserror.workspace  = true

--- a/crates/wcore-config/src/config.rs
+++ b/crates/wcore-config/src/config.rs
@@ -682,6 +682,28 @@ pub struct ToolsConfig {
     /// runtime. The host (desktop app) writes this key from its shell toggle.
     #[serde(default)]
     pub windows_shell: Option<String>,
+    /// #325 — environment-variable names passed through to sandboxed tool
+    /// children (`bash` / `script`). By default the sandbox strips
+    /// everything but a curated base allowlist (locale / `PATH` / etc.);
+    /// names listed here are additionally forwarded. Secret-shaped names
+    /// (`*_API_KEY`, `*_TOKEN`, `WAYLAND_VAULT_*`, …) are still dropped by
+    /// the sandbox's secret filter even if listed here. Wired at bootstrap
+    /// into `wcore_tools::env_passthrough::set_config_passthrough`.
+    #[serde(default)]
+    pub env_passthrough: Vec<String>,
+    /// #327 — sandbox backend selection, mirroring the `WAYLAND_SANDBOX`
+    /// env var (`"none"` / `"docker"`; unset = platform default backend).
+    /// The env var, when set, takes precedence for back-compat. `"none"`
+    /// additionally requires `allow_no_sandbox = true` (or the
+    /// `WAYLAND_ALLOW_NO_SANDBOX` env var) or the sandbox fails closed.
+    #[serde(default)]
+    pub sandbox: Option<String>,
+    /// #327 — operator opt-in to run with NO isolation when the platform
+    /// sandbox is unavailable (or `sandbox = "none"`), mirroring the
+    /// `WAYLAND_ALLOW_NO_SANDBOX` env var. The env var, when set, takes
+    /// precedence for back-compat. Defaults to off (fail closed).
+    #[serde(default)]
+    pub allow_no_sandbox: Option<bool>,
 }
 
 impl Default for ToolsConfig {
@@ -692,6 +714,9 @@ impl Default for ToolsConfig {
             skills: SkillsPermissionConfig::default(),
             verify_edits: true,
             windows_shell: None,
+            env_passthrough: Vec::new(),
+            sandbox: None,
+            allow_no_sandbox: None,
         }
     }
 }
@@ -2637,6 +2662,12 @@ fn try_load_config_file(path: &Path) -> Result<ConfigFile, ConfigLoadError> {
             // non-fatal (the warning is the load-bearing signal).
             crate::credentials::warn_if_world_readable(path);
             let _ = crate::credentials::secure_credential_file(path);
+            // #326: warn (don't fail) on unknown / mis-sectioned keys so a
+            // typo'd or wrong-section setting is discoverable instead of
+            // being silently dropped. Runs before the real parse; a clean
+            // `deny_unknown_fields` would reject existing configs on a
+            // release, so we surface rather than reject.
+            warn_unknown_config_keys(&content, path);
             toml::from_str(&content).map_err(|source| ConfigLoadError::ParseFailed {
                 path: path.display().to_string(),
                 source,
@@ -2645,6 +2676,51 @@ fn try_load_config_file(path: &Path) -> Result<ConfigFile, ConfigLoadError> {
         // No file (or unreadable) → fresh-install defaults are correct.
         Err(_) => Ok(ConfigFile::default()),
     }
+}
+
+/// #326: emit a `warn`-level log for every config key that is unknown to
+/// `ConfigFile` (a typo) or mis-sectioned (a real key under the wrong
+/// table — e.g. `env_passthrough` under `[security]` instead of `[tools]`).
+///
+/// Uses `serde_ignored` to collect the ignored key paths during a throwaway
+/// deserialize. This is deliberately a WARNING, not `#[serde(deny_unknown_fields)]`:
+/// a hard deny would turn a previously-accepted config (e.g. one carrying a
+/// future-version key, or a harmlessly-misplaced one) into a hard startup
+/// failure on upgrade. Warning keeps the config loading while making the
+/// misconfiguration visible. A genuinely malformed TOML still errors on the
+/// real parse downstream.
+fn warn_unknown_config_keys(raw: &str, path: &Path) {
+    for key in collect_unknown_config_keys(raw) {
+        tracing::warn!(
+            target: "wcore_config",
+            key = %key,
+            path = %path.display(),
+            "ignoring unknown or mis-sectioned config key `{key}` in {} — \
+             it has no effect; check for a typo or wrong [section]",
+            path.display(),
+        );
+    }
+}
+
+/// Collect the dotted paths of every config key that `ConfigFile` ignores
+/// during deserialize — the testable core of [`warn_unknown_config_keys`].
+///
+/// Returns an empty vec when the TOML is malformed (the authoritative parse
+/// surfaces that error separately) or when every key is recognized.
+fn collect_unknown_config_keys(raw: &str) -> Vec<String> {
+    // toml 1.x returns a `Result` from the parse-time deserializer
+    // constructor; a malformed document is reported by the real parse.
+    let de = match toml::Deserializer::parse(raw) {
+        Ok(de) => de,
+        Err(_) => return Vec::new(),
+    };
+    let unknown = std::cell::RefCell::new(Vec::new());
+    // The deserialized value is discarded; we only want the ignored paths.
+    let _ = serde_ignored::deserialize(de, |key_path| {
+        unknown.borrow_mut().push(key_path.to_string());
+    })
+    .map(|_cfg: ConfigFile| ());
+    unknown.into_inner()
 }
 
 /// Infallible config-file loader, used only by the read-only `/profile` and
@@ -3078,6 +3154,15 @@ fn merge_config_files(global: ConfigFile, project: ConfigFile) -> ConfigFile {
             verify_edits: project.tools.verify_edits || global.tools.verify_edits,
             // #182 — project overrides global for the Windows shell selector.
             windows_shell: project.tools.windows_shell.or(global.tools.windows_shell),
+            // #325 — concatenate passthrough allowlists (global first), like
+            // the skills deny/allow merge above; both layers' vars apply.
+            env_passthrough: [global.tools.env_passthrough, project.tools.env_passthrough].concat(),
+            // #327 — project overrides global for the sandbox toggle.
+            sandbox: project.tools.sandbox.or(global.tools.sandbox),
+            allow_no_sandbox: project
+                .tools
+                .allow_no_sandbox
+                .or(global.tools.allow_no_sandbox),
         }
     } else {
         ToolsConfig {
@@ -3089,6 +3174,12 @@ fn merge_config_files(global: ConfigFile, project: ConfigFile) -> ConfigFile {
             },
             verify_edits: project.tools.verify_edits || global.tools.verify_edits,
             windows_shell: project.tools.windows_shell.or(global.tools.windows_shell),
+            env_passthrough: [global.tools.env_passthrough, project.tools.env_passthrough].concat(),
+            sandbox: project.tools.sandbox.or(global.tools.sandbox),
+            allow_no_sandbox: project
+                .tools
+                .allow_no_sandbox
+                .or(global.tools.allow_no_sandbox),
         }
     };
 
@@ -6015,5 +6106,93 @@ skills_lifecycle = true
                 }
             }
         }
+    }
+
+    // -------------------------------------------------------------------------
+    // #325 — `[tools] env_passthrough` parses onto ToolsConfig.
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn tools_env_passthrough_parses_from_toml() {
+        let cfg: ConfigFile =
+            toml::from_str("[tools]\nenv_passthrough = [\"KUBECONFIG\", \"AWS_PROFILE\"]\n")
+                .expect("parse");
+        assert_eq!(
+            cfg.tools.env_passthrough,
+            vec!["KUBECONFIG".to_string(), "AWS_PROFILE".to_string()]
+        );
+    }
+
+    #[test]
+    fn tools_env_passthrough_defaults_empty() {
+        let cfg: ConfigFile = toml::from_str("[tools]\n").expect("parse");
+        assert!(cfg.tools.env_passthrough.is_empty());
+    }
+
+    // -------------------------------------------------------------------------
+    // #327 — `[tools] sandbox` / `allow_no_sandbox` parse onto ToolsConfig.
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn tools_sandbox_toggle_parses_from_toml() {
+        let cfg: ConfigFile =
+            toml::from_str("[tools]\nsandbox = \"none\"\nallow_no_sandbox = true\n")
+                .expect("parse");
+        assert_eq!(cfg.tools.sandbox.as_deref(), Some("none"));
+        assert_eq!(cfg.tools.allow_no_sandbox, Some(true));
+    }
+
+    #[test]
+    fn tools_sandbox_toggle_defaults_none() {
+        let cfg: ConfigFile = toml::from_str("[tools]\n").expect("parse");
+        assert!(cfg.tools.sandbox.is_none());
+        assert!(cfg.tools.allow_no_sandbox.is_none());
+    }
+
+    // -------------------------------------------------------------------------
+    // #326 — unknown / mis-sectioned config keys are surfaced (not denied).
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn unknown_top_level_key_is_collected() {
+        let keys = collect_unknown_config_keys("definitely_not_a_key = 1\n");
+        assert!(
+            keys.iter().any(|k| k == "definitely_not_a_key"),
+            "a typo'd top-level key must be surfaced, got {keys:?}"
+        );
+    }
+
+    #[test]
+    fn mis_sectioned_key_is_collected() {
+        // The issue's exact repro: env_passthrough under [security] (where it
+        // does not belong) instead of [tools].
+        let keys = collect_unknown_config_keys("[security]\nenv_passthrough = [\"Path\"]\n");
+        assert!(
+            keys.iter().any(|k| k == "security.env_passthrough"),
+            "a mis-sectioned key must be surfaced with its section path, got {keys:?}"
+        );
+    }
+
+    #[test]
+    fn known_keys_are_not_flagged() {
+        // A fully-valid config must produce zero unknown-key warnings — proving
+        // the warn pass doesn't false-positive on legitimate settings (and so
+        // won't spam existing users on upgrade).
+        let raw = "[default]\nprovider = \"anthropic\"\n\
+                   [tools]\nauto_approve = true\nenv_passthrough = [\"KUBECONFIG\"]\n\
+                   sandbox = \"docker\"\n\
+                   [security]\nenabled = true\negress_allow = [\"example.com\"]\n";
+        let keys = collect_unknown_config_keys(raw);
+        assert!(
+            keys.is_empty(),
+            "valid keys must not be flagged, got {keys:?}"
+        );
+    }
+
+    #[test]
+    fn malformed_toml_collects_nothing() {
+        // Malformed TOML is reported by the authoritative parse, not here.
+        let keys = collect_unknown_config_keys("this is = = not toml");
+        assert!(keys.is_empty());
     }
 }

--- a/crates/wcore-evolve/src/mutator/llm_paraphrase_provider.rs
+++ b/crates/wcore-evolve/src/mutator/llm_paraphrase_provider.rs
@@ -215,6 +215,7 @@ async fn collect_text(
             // tool-use blocks (every provider, on prompt non-compliance), or
             // Flux web-search citations/results — none belong in a paraphrase.
             LlmEvent::ThinkingDelta(_)
+            | LlmEvent::ThinkingSubject(_)
             | LlmEvent::ToolUse { .. }
             | LlmEvent::Citations(_)
             | LlmEvent::SearchResults(_)

--- a/crates/wcore-protocol/src/events.rs
+++ b/crates/wcore-protocol/src/events.rs
@@ -39,6 +39,13 @@ pub enum ProtocolEvent {
     Thinking {
         text: String,
         msg_id: String,
+        /// #318 — optional per-turn thinking SUBJECT: a short opaque display
+        /// label for the reasoning block (Flux `reasoning_summary`). Present
+        /// only on the subject-carrying chunk (where `text` is typically
+        /// empty); omitted from the JSON on ordinary thinking-text chunks so
+        /// the v0 wire shape is preserved for hosts that don't read it.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        subject: Option<String>,
     },
     ToolRequest {
         msg_id: String,
@@ -713,6 +720,42 @@ mod tests {
         assert_eq!(json["type"], "text_delta");
         assert_eq!(json["text"], "hello");
         assert_eq!(json["msg_id"], "m1");
+    }
+
+    /// #318: a plain thinking-text event (no subject) must serialize WITHOUT
+    /// the `subject` key — preserving the v0 wire shape for hosts that don't
+    /// read it (skip_serializing_if = Option::is_none).
+    #[test]
+    fn test_thinking_event_without_subject_omits_key() {
+        let event = ProtocolEvent::Thinking {
+            text: "step 1".to_string(),
+            msg_id: "m1".to_string(),
+            subject: None,
+        };
+        let json = serde_json::to_value(&event).unwrap();
+        assert_eq!(json["type"], "thinking");
+        assert_eq!(json["text"], "step 1");
+        assert_eq!(json["msg_id"], "m1");
+        assert!(
+            json.get("subject").is_none(),
+            "subject must be omitted when None, got {json}"
+        );
+    }
+
+    /// #318: a subject-carrying thinking event serializes the field as exactly
+    /// `subject` (the name the desktop matches on), with an empty `text`.
+    #[test]
+    fn test_thinking_event_with_subject_serializes_subject() {
+        let event = ProtocolEvent::Thinking {
+            text: String::new(),
+            msg_id: "m1".to_string(),
+            subject: Some("Reasoning through the problem".to_string()),
+        };
+        let json = serde_json::to_value(&event).unwrap();
+        assert_eq!(json["type"], "thinking");
+        assert_eq!(json["text"], "");
+        assert_eq!(json["msg_id"], "m1");
+        assert_eq!(json["subject"], "Reasoning through the problem");
     }
 
     #[test]

--- a/crates/wcore-protocol/tests/golden_v0_1_21.rs
+++ b/crates/wcore-protocol/tests/golden_v0_1_21.rs
@@ -85,6 +85,9 @@ fn golden_thinking_v0_1_21() {
     let got = serialize(&ProtocolEvent::Thinking {
         text: "considering options".into(),
         msg_id: "m-1".into(),
+        // #318 additive field; None omits `subject` from the wire so the v0
+        // shape below is byte-identical for hosts that don't read it.
+        subject: None,
     });
     assert_eq!(
         got,

--- a/crates/wcore-providers/src/classify.rs
+++ b/crates/wcore-providers/src/classify.rs
@@ -70,18 +70,21 @@ fn classify_by_body(body: &str) -> Option<FailoverReason> {
         return Some(FailoverReason::SessionExpired);
     }
     // Billing must key on GENUINE credit/quota/payment signals, never on the
-    // bare word "billing". Anthropic appends a "Please go to Plans & Billing
-    // to upgrade or purchase credits." remediation link to a wide range of
-    // error bodies — including non-billing ones — so a bare `contains("billing")`
-    // mis-classifies an unrelated failure as out-of-credit and surfaces a false
-    // "balance is too low" to a user whose balance is fine (issue #329). Match
-    // the real signals instead: insufficient quota, an explicit credit-balance
-    // exhaustion, a request to purchase credits, payment-required, or the
-    // "billing plan" entitlement phrasing.
+    // bare word "billing" — and never on "purchase credits". Anthropic appends a
+    // "Please go to Plans & Billing to upgrade or purchase credits." remediation
+    // tail to a wide range of error bodies — including non-billing ones — so any
+    // match on a substring of that tail (`contains("billing")`, but ALSO
+    // `contains("purchase credits")`) mis-classifies an unrelated failure as
+    // out-of-credit and surfaces a false "balance is too low" to a user whose
+    // balance is fine, pinning the key into a permanent cooldown (issue #329).
+    // Match only the unambiguous signals: insufficient quota, an explicit
+    // credit-balance exhaustion, payment-required, or the "billing plan"
+    // entitlement phrasing. A genuine Anthropic credit error always carries
+    // "credit balance is too low", so dropping "purchase credits" loses no
+    // real-credit coverage.
     if b.contains("insufficient_quota")
         || b.contains("insufficient quota")
         || b.contains("credit balance is too low")
-        || b.contains("purchase credits")
         || b.contains("billing plan")
         || b.contains("payment required")
     {
@@ -392,20 +395,24 @@ mod tests {
     }
 
     /// Issue #329 regression: an Anthropic error that is NOT about credits but
-    /// whose remediation text mentions "Plans & Billing" must NOT be classified
-    /// as Billing (which would surface a false "balance is too low" and pin the
-    /// key into a permanent cooldown). Before the fix the bare `contains("billing")`
-    /// match swallowed this; now it falls through to its real reason.
+    /// carries the standard remediation tail ("Please go to Plans & Billing to
+    /// upgrade or purchase credits.") must NOT be classified as Billing (which
+    /// would surface a false "balance is too low" and pin the key into a
+    /// permanent cooldown). The tail contains the substring "purchase credits",
+    /// so keying Billing on "purchase credits" would re-introduce the exact #329
+    /// bug; this test pins that "purchase credits" is NOT a Billing signal. The
+    /// body deliberately omits "credit balance is too low" — the only genuine
+    /// credit signal — so a correct classifier falls through to its real reason.
     #[test]
     fn body_non_billing_error_with_billing_link_is_not_billing() {
         let body = "{\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",\
             \"message\":\"This model requires a specific feature. \
-            Visit Plans & Billing for details.\"}}";
+            Please go to Plans & Billing to upgrade or purchase credits.\"}}";
         assert_ne!(
             classify_failover(&dummy_err(), None, Some(body), None),
             FailoverReason::Billing,
-            "a non-credit error that merely links to Plans & Billing must not \
-             be classified as out-of-credit"
+            "a non-credit error that merely carries the standard 'purchase \
+             credits' remediation tail must not be classified as out-of-credit"
         );
     }
 

--- a/crates/wcore-providers/src/classify.rs
+++ b/crates/wcore-providers/src/classify.rs
@@ -69,9 +69,20 @@ fn classify_by_body(body: &str) -> Option<FailoverReason> {
     if b.contains("session expired") || b.contains("session has expired") {
         return Some(FailoverReason::SessionExpired);
     }
+    // Billing must key on GENUINE credit/quota/payment signals, never on the
+    // bare word "billing". Anthropic appends a "Please go to Plans & Billing
+    // to upgrade or purchase credits." remediation link to a wide range of
+    // error bodies — including non-billing ones — so a bare `contains("billing")`
+    // mis-classifies an unrelated failure as out-of-credit and surfaces a false
+    // "balance is too low" to a user whose balance is fine (issue #329). Match
+    // the real signals instead: insufficient quota, an explicit credit-balance
+    // exhaustion, a request to purchase credits, payment-required, or the
+    // "billing plan" entitlement phrasing.
     if b.contains("insufficient_quota")
         || b.contains("insufficient quota")
-        || b.contains("billing")
+        || b.contains("credit balance is too low")
+        || b.contains("purchase credits")
+        || b.contains("billing plan")
         || b.contains("payment required")
     {
         return Some(FailoverReason::Billing);
@@ -363,6 +374,38 @@ mod tests {
         assert_eq!(
             classify_failover(&dummy_err(), None, Some("payment required"), None),
             FailoverReason::Billing
+        );
+    }
+
+    /// Issue #329: a genuine Anthropic low-credit 400 body must still classify
+    /// as Billing. The signal is the credit-balance phrasing, NOT the trailing
+    /// "Plans & Billing" link.
+    #[test]
+    fn body_billing_anthropic_credit_balance_too_low() {
+        let anthropic_body = "{\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",\
+            \"message\":\"Your credit balance is too low to access the Anthropic API. \
+            Please go to Plans & Billing to upgrade or purchase credits.\"}}";
+        assert_eq!(
+            classify_failover(&dummy_err(), None, Some(anthropic_body), None),
+            FailoverReason::Billing
+        );
+    }
+
+    /// Issue #329 regression: an Anthropic error that is NOT about credits but
+    /// whose remediation text mentions "Plans & Billing" must NOT be classified
+    /// as Billing (which would surface a false "balance is too low" and pin the
+    /// key into a permanent cooldown). Before the fix the bare `contains("billing")`
+    /// match swallowed this; now it falls through to its real reason.
+    #[test]
+    fn body_non_billing_error_with_billing_link_is_not_billing() {
+        let body = "{\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",\
+            \"message\":\"This model requires a specific feature. \
+            Visit Plans & Billing for details.\"}}";
+        assert_ne!(
+            classify_failover(&dummy_err(), None, Some(body), None),
+            FailoverReason::Billing,
+            "a non-credit error that merely links to Plans & Billing must not \
+             be classified as out-of-credit"
         );
     }
 

--- a/crates/wcore-providers/src/openai.rs
+++ b/crates/wcore-providers/src/openai.rs
@@ -1563,6 +1563,21 @@ fn parse_sse_chunk(data: &str, state: &mut StreamState) -> Vec<LlmEvent> {
 
     let delta = &choice["delta"];
 
+    // Per-turn thinking SUBJECT (#318). Flux's Chat Completions stream emits
+    // `delta.reasoning_summary` — a short opaque display string (a gerund
+    // phrase like "Reasoning through the problem") exactly once per turn,
+    // immediately BEFORE the first `delta.reasoning_content` chunk, only on
+    // turns that produce reasoning. Surface it as a distinct subject event
+    // that the host attaches as the heading of the in-flight thinking block.
+    // Opaque — never switch on the value. Absent ⇒ no subject (never
+    // synthesized). This mirrors the Responses-API `reasoning_summary` path
+    // in `openai_responses.rs`, unified on the same thinking channel.
+    if let Some(summary) = delta["reasoning_summary"].as_str()
+        && !summary.is_empty()
+    {
+        events.push(LlmEvent::ThinkingSubject(summary.to_string()));
+    }
+
     // Reasoning content (OpenAI reasoning models). OpenAI o-series and
     // most reasoning-capable openai-compat providers (incl. Gemini Pro
     // on the v1beta openai-compat surface) put thoughts under
@@ -4085,6 +4100,60 @@ mod tests {
         match &events[0] {
             LlmEvent::ThinkingDelta(t) => assert_eq!(t, "weighing options"),
             other => panic!("expected ThinkingDelta, got {other:?}"),
+        }
+    }
+
+    // --- #318 Flux reasoning_summary → thinking SUBJECT ------------------
+
+    /// #318: a chunk carrying only `delta.reasoning_summary` (Flux's per-turn
+    /// opaque subject label, emitted just before the first reasoning_content)
+    /// must yield exactly one `LlmEvent::ThinkingSubject`, NOT a ThinkingDelta
+    /// or TextDelta. Mirrors `parse_reasoning_summary_delta_is_thinking` on
+    /// the Responses-API path.
+    #[test]
+    fn parse_reasoning_summary_delta_is_thinking_subject() {
+        let mut state = StreamState::new();
+        let chunk = r#"{"choices":[{"delta":{"reasoning_summary":"Reasoning through the problem"},"index":0}]}"#;
+        let events = parse_sse_chunk(chunk, &mut state);
+        assert_eq!(events.len(), 1, "expected exactly one ThinkingSubject");
+        match &events[0] {
+            LlmEvent::ThinkingSubject(s) => assert_eq!(s, "Reasoning through the problem"),
+            other => panic!("expected ThinkingSubject, got {other:?}"),
+        }
+    }
+
+    /// #318: a normal `delta.reasoning_content` chunk (no reasoning_summary)
+    /// still yields `ThinkingDelta` — the subject path is additive and must
+    /// not disturb the established reasoning-text routing.
+    #[test]
+    fn reasoning_content_without_summary_still_thinking_delta() {
+        let mut state = StreamState::new();
+        let chunk = r#"{"choices":[{"delta":{"reasoning_content":"step 1: parse"},"index":0}]}"#;
+        let events = parse_sse_chunk(chunk, &mut state);
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            LlmEvent::ThinkingDelta(t) => assert_eq!(t, "step 1: parse"),
+            other => panic!("expected ThinkingDelta, got {other:?}"),
+        }
+    }
+
+    /// #318: an absent `reasoning_summary` field is a clean no-op — a plain
+    /// text chunk produces only its `TextDelta`, never a stray subject.
+    #[test]
+    fn absent_reasoning_summary_is_noop() {
+        let mut state = StreamState::new();
+        let chunk = r#"{"choices":[{"delta":{"content":"hello"},"index":0}]}"#;
+        let events = parse_sse_chunk(chunk, &mut state);
+        assert_eq!(events.len(), 1);
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, LlmEvent::ThinkingSubject(_))),
+            "absent reasoning_summary must not synthesize a subject, got {events:?}"
+        );
+        match &events[0] {
+            LlmEvent::TextDelta(t) => assert_eq!(t, "hello"),
+            other => panic!("expected TextDelta, got {other:?}"),
         }
     }
 

--- a/crates/wcore-providers/src/openai.rs
+++ b/crates/wcore-providers/src/openai.rs
@@ -676,6 +676,25 @@ impl OpenAIProvider {
     }
 }
 
+/// True when a provider HTTP error means "this model does not support tool
+/// calling" — the request was otherwise valid and would succeed if the `tools`
+/// array were dropped.
+///
+/// Ollama models without tool support (e.g. `smollm2:135m`) reject the OpenAI-
+/// compatible chat request with a 400 `... does not support tools`
+/// (`type: invalid_request_error`). Unlike Groq's Compound family — a small,
+/// known set we can name-gate in [`openai_compat::model_supports_tool_calling`]
+/// — local Ollama no-tool models are open-ended (any small model the user has
+/// pulled), so we cannot enumerate them. Detect the error and retry once
+/// without tools so the turn still completes. See FerroxLabs/wayland#389.
+///
+/// Matched conservatively: a 400 whose body mentions "does not support tools"
+/// (case-insensitive). The phrasing is Ollama's; the substring is specific
+/// enough not to collide with unrelated 400s.
+fn is_tools_unsupported_error(status: u16, body: &str) -> bool {
+    status == 400 && body.to_ascii_lowercase().contains("does not support tools")
+}
+
 /// Strip configured patterns from text content
 fn strip_patterns_from_text(text: &str, compat: &ProviderCompat) -> String {
     match &compat.strip_patterns {
@@ -1081,12 +1100,49 @@ impl LlmProvider for OpenAIProvider {
             None => self.select_key()?,
         };
 
+        // Whether the body we are about to send actually carries a `tools`
+        // array. Used to gate the tools-unsupported retry below: dropping tools
+        // only helps if tools were attached in the first place.
+        let body_has_tools = body.get("tools").is_some();
+
         let primary = self.effective_base_url();
         let response = match self
             .try_send(&primary, use_responses, &body, &key, using_bearer, request)
             .await
         {
             Ok(resp) => resp,
+            // Tools-unsupported retry (#389): an Ollama model without tool
+            // support rejects the request with a 400 `... does not support
+            // tools`. The request is otherwise valid, so rebuild the body
+            // without the `tools` array and retry once on the same host so the
+            // turn completes instead of surfacing a raw provider 400. Only fires
+            // when tools were actually attached.
+            Err(ProviderError::Api {
+                status,
+                ref message,
+            }) if body_has_tools && is_tools_unsupported_error(status, message) => {
+                tracing::warn!(
+                    model = %request.model,
+                    "model does not support tools; retrying request without tools (#389)"
+                );
+                let mut no_tools_request = request.clone();
+                no_tools_request.tools.clear();
+                no_tools_request.web_search = false;
+                let no_tools_body = if use_responses {
+                    openai_responses::build_responses_body(&no_tools_request, &self.compat)
+                } else {
+                    self.build_request_body(&no_tools_request)
+                };
+                self.try_send(
+                    &primary,
+                    use_responses,
+                    &no_tools_body,
+                    &key,
+                    using_bearer,
+                    &no_tools_request,
+                )
+                .await?
+            }
             // Region-locked-key failover: a credential rejected here (401/403)
             // may belong to the provider's alternate platform (e.g. Moonshot's
             // `api.moonshot.cn` vs `.ai`). When a fallback host is configured
@@ -1946,6 +2002,41 @@ mod tests {
 
     fn no_compat() -> ProviderCompat {
         ProviderCompat::default()
+    }
+
+    // --- is_tools_unsupported_error (#389) --------------------------------
+
+    #[test]
+    fn tools_unsupported_matches_ollama_400() {
+        // The exact provider error from #389.
+        let body = r#"{"error":{"message":"registry.ollama.ai/library/smollm2:135m does not support tools","type":"invalid_request_error"}}"#;
+        assert!(is_tools_unsupported_error(400, body));
+    }
+
+    #[test]
+    fn tools_unsupported_is_case_insensitive() {
+        assert!(is_tools_unsupported_error(
+            400,
+            "Model Does Not Support Tools"
+        ));
+    }
+
+    #[test]
+    fn tools_unsupported_ignores_other_400s() {
+        // A 400 unrelated to tool support must NOT trigger the retry.
+        assert!(!is_tools_unsupported_error(
+            400,
+            r#"{"error":{"message":"invalid api key"}}"#
+        ));
+    }
+
+    #[test]
+    fn tools_unsupported_ignores_non_400_status() {
+        // Same wording on a non-400 status is not the case we retry.
+        assert!(!is_tools_unsupported_error(
+            500,
+            "model does not support tools"
+        ));
     }
 
     // --- FluxRouter typed 402 / entitlement error parsing -----------------

--- a/crates/wcore-providers/tests/provider_openai_test.rs
+++ b/crates/wcore-providers/tests/provider_openai_test.rs
@@ -576,6 +576,101 @@ async fn test_openai_400_bad_request_surfaces_as_api_error() {
     }
 }
 
+/// #389: an Ollama no-tool model returns a 400 `... does not support tools` on
+/// the first (tools-bearing) request. The provider must transparently retry the
+/// same request without the `tools` array so the turn completes, instead of
+/// surfacing a raw provider 400.
+#[tokio::test]
+async fn test_openai_retries_without_tools_on_unsupported_400() {
+    use wcore_types::tool::ToolDef;
+
+    let server = MockServer::start().await;
+
+    // Higher-priority mock: serves ONLY the first request (the one carrying
+    // `tools`) and rejects it exactly the way Ollama does for a no-tool model.
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(ResponseTemplate::new(400).set_body_string(
+            r#"{"error":{"message":"registry.ollama.ai/library/smollm2:135m does not support tools","type":"invalid_request_error"}}"#,
+        ))
+        .up_to_n_times(1)
+        .with_priority(1)
+        .mount(&server)
+        .await;
+
+    // Lower-priority fallback: serves the retry (no `tools`) with a normal
+    // text response so the turn completes.
+    let chunk = json!({
+        "id": "chatcmpl-389",
+        "object": "chat.completion.chunk",
+        "choices": [{
+            "index": 0,
+            "delta": {"content": "hi"},
+            "finish_reason": "stop"
+        }],
+        "usage": {"prompt_tokens": 5, "completion_tokens": 1}
+    })
+    .to_string();
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_raw(build_sse_body(&[&chunk]), "text/event-stream"),
+        )
+        .with_priority(2)
+        .mount(&server)
+        .await;
+
+    let provider = OpenAIProvider::new(
+        "test-key",
+        &server.uri(),
+        ProviderCompat::openai_defaults(),
+        DebugConfig::default(),
+    );
+
+    // A request that carries a tool — without it the retry path is not exercised.
+    let mut request = make_request();
+    request.tools = vec![ToolDef {
+        name: "Read".into(),
+        description: "Read a file".into(),
+        input_schema: json!({
+            "type": "object",
+            "properties": {"path": {"type": "string"}},
+            "required": ["path"]
+        }),
+        deferred: false,
+        server: None,
+    }];
+
+    let rx = provider
+        .stream(&request)
+        .await
+        .expect("turn must complete via the no-tools retry, not a raw 400");
+    let events = collect_events(rx).await;
+
+    // The retry produced a usable text response.
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, LlmEvent::TextDelta(t) if t == "hi")),
+        "expected the retried (no-tools) response text, got: {events:?}"
+    );
+
+    // Exactly two requests hit the server: the original (with tools) and the
+    // retry (without tools).
+    let received = server.received_requests().await.expect("recorded requests");
+    assert_eq!(received.len(), 2, "expected original + one retry");
+    let first: serde_json::Value = serde_json::from_slice(&received[0].body).unwrap();
+    let second: serde_json::Value = serde_json::from_slice(&received[1].body).unwrap();
+    assert!(
+        first.get("tools").is_some(),
+        "first request must carry tools"
+    );
+    assert!(
+        second.get("tools").is_none(),
+        "retry must omit the tools array"
+    );
+}
+
 /// 403 Forbidden → ProviderError::Api{status:403}, not Ok.
 #[tokio::test]
 async fn test_openai_403_forbidden_surfaces_as_api_error() {

--- a/crates/wcore-sandbox/src/backends/appcontainer.rs
+++ b/crates/wcore-sandbox/src/backends/appcontainer.rs
@@ -23,7 +23,7 @@
 //!      SidsToDisable=[Administrators, Users, Authenticated Users]).
 //!   3. SetTokenInformation(TokenIntegrityLevel, S-1-16-4096 Low).
 //!   4. CreateJobObjectW + SetInformationJobObject:
-//!        - Extended limits: KILL_ON_JOB_CLOSE, ACTIVE_PROCESS=1,
+//!        - Extended limits: KILL_ON_JOB_CLOSE, ACTIVE_PROCESS=512,
 //!          DIE_ON_UNHANDLED_EXCEPTION, PRIORITY_CLASS=BELOW_NORMAL,
 //!          (BREAKAWAY_OK=0 / SILENT_BREAKAWAY_OK=0 default), plus
 //!          PROCESS_MEMORY / PROCESS_TIME from manifest if set.
@@ -68,7 +68,7 @@ mod windows_impl {
     use std::collections::BTreeMap;
     use std::ffi::OsStr;
     use std::mem;
-    use std::os::windows::ffi::OsStrExt;
+    use std::os::windows::ffi::{OsStrExt, OsStringExt};
     use std::ptr;
     use std::sync::{Mutex, OnceLock};
     use std::time::Duration;
@@ -203,30 +203,46 @@ mod windows_impl {
         out
     }
 
-    /// Allowlist of bare executable names the sandbox is permitted to spawn
-    /// without an absolute path. Restricted to canonical Windows shells so a
-    /// caller never accidentally pulls something from `PATH` whose resolution
-    /// is operator- or LLM-influenceable. Resolution goes through
-    /// `GetSystemDirectoryW` instead of `SearchPathW`, which always returns
-    /// `C:\Windows\System32` and excludes CWD/PATH from search.
+    /// Classification of a bare (non-absolute) `argv[0]`. Only `cmd` is
+    /// runnable under the Low-integrity restricted-token AppContainer; every
+    /// other shell is recognized solely so the resolver can return a clear,
+    /// actionable error instead of a cryptic `CreateProcessAsUserW 0x2`
+    /// (file-not-found, #323) or `0xC0000135` (DLL-not-found, #324) at spawn
+    /// time.
+    #[derive(PartialEq, Eq, Debug)]
+    enum BareShell {
+        /// `cmd` / `cmd.exe` — lives in `System32`, imports only the minimal
+        /// `System32` DLL set, and is the one shell that loads under this
+        /// sandbox token.
+        Cmd,
+        /// `powershell` / `pwsh` — NOT in `System32` (Windows PowerShell is in
+        /// `System32\WindowsPowerShell\v1.0\`, pwsh in `Program Files`), and
+        /// requires .NET / GAC assemblies that do not load under the Low-IL
+        /// restricted token (#324).
+        PowerShell,
+        /// `bash` / `sh` — git-bash needs `msys-2.0.dll` from `Program Files`,
+        /// and even static busybox-w32 links network/auth/UI DLLs the Low-IL
+        /// token cannot load (#324). Not resolvable from `System32` either.
+        Unsupported,
+    }
+
+    /// Classify a bare executable name against the canonical Windows shells.
+    /// Returns `None` for anything not recognized as a shell at all (those are
+    /// rejected with the generic "pass an absolute path" message). Resolution
+    /// of `cmd` goes through `GetSystemDirectoryW` (always `C:\Windows\System32`,
+    /// excluding CWD/PATH) — never `SearchPathW` — so a caller can never pull
+    /// something from `PATH` whose resolution is operator- or LLM-influenceable.
     ///
-    /// Both `cmd` and `cmd.exe` are accepted because Windows callers
-    /// conventionally omit `.exe` and rely on `PATHEXT` to resolve it; the
-    /// resolver appends `.exe` when it concatenates against `System32\`.
-    fn allowlisted_shell(name: &str) -> bool {
-        matches!(
-            name.to_ascii_lowercase().as_str(),
-            "cmd"
-                | "cmd.exe"
-                | "powershell"
-                | "powershell.exe"
-                | "pwsh"
-                | "pwsh.exe"
-                | "bash"
-                | "bash.exe"
-                | "sh"
-                | "sh.exe"
-        )
+    /// Both `cmd` and `cmd.exe` map to `Cmd` because Windows callers
+    /// conventionally omit `.exe`; the resolver appends it when concatenating
+    /// against `System32\`.
+    fn classify_bare_shell(name: &str) -> Option<BareShell> {
+        match name.to_ascii_lowercase().as_str() {
+            "cmd" | "cmd.exe" => Some(BareShell::Cmd),
+            "powershell" | "powershell.exe" | "pwsh" | "pwsh.exe" => Some(BareShell::PowerShell),
+            "bash" | "bash.exe" | "sh" | "sh.exe" => Some(BareShell::Unsupported),
+            _ => None,
+        }
     }
 
     /// Returns true for any UNC / device path: `\\server\share\…`, `\\?\…`,
@@ -271,7 +287,20 @@ mod windows_impl {
     /// Resolution rules:
     ///   * Absolute file → validated via `try_exists()` + `metadata()`,
     ///     returned widened.
-    ///   * Allowlisted bare shell → pinned to `C:\Windows\System32\<name>.exe`.
+    ///   * Bare `cmd` / `cmd.exe` → pinned to `C:\Windows\System32\cmd.exe`,
+    ///     whose existence is then validated (the bare-shell branch used to
+    ///     skip the existence check the absolute branch performs, so an
+    ///     unresolvable shell surfaced only as a cryptic spawn-time `0x2` —
+    ///     #323).
+    ///   * Bare `powershell` / `pwsh` → rejected with a clear message: these
+    ///     do NOT live in `System32` (the old code pinned them there, yielding
+    ///     `0x2`/file-not-found, #323) and cannot load their .NET/GAC
+    ///     dependencies under the Low-IL restricted-token AppContainer
+    ///     (`0xC0000135`, #324). The message names the real install locations
+    ///     and the supported alternative.
+    ///   * Bare `bash` / `sh` → rejected with a clear message: git-bash and
+    ///     busybox link DLLs the Low-IL token cannot load (#324), and they are
+    ///     not in `System32` to begin with.
     fn resolve_program(program: &str) -> Result<Vec<u16>> {
         if program.is_empty() {
             return Err(SandboxError::ExecFailed("argv[0] is empty".into()));
@@ -310,13 +339,43 @@ mod windows_impl {
                 }
             }
         }
-        if !allowlisted_shell(program) {
-            return Err(SandboxError::ExecFailed(format!(
-                "argv[0] {program:?} is not an absolute path and not in the AppContainer \
-                 shell allowlist (cmd.exe, powershell.exe, pwsh.exe, bash.exe, sh.exe). \
-                 Pass the absolute path to the executable."
-            )));
+        match classify_bare_shell(program) {
+            Some(BareShell::Cmd) => {}
+            Some(BareShell::PowerShell) => {
+                return Err(SandboxError::ExecFailed(format!(
+                    "argv[0] {program:?}: PowerShell is not supported under the Windows \
+                     AppContainer sandbox. powershell.exe lives in \
+                     C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\ and pwsh.exe in \
+                     C:\\Program Files\\PowerShell\\7\\ (neither is in System32), and both \
+                     require .NET / GAC assemblies that cannot load under the sandbox's \
+                     Low-integrity restricted token (they fail with STATUS_DLL_NOT_FOUND \
+                     0xC0000135). Use cmd as the sandbox shell, or pass an absolute path to \
+                     a sandbox-compatible executable."
+                )));
+            }
+            Some(BareShell::Unsupported) => {
+                return Err(SandboxError::ExecFailed(format!(
+                    "argv[0] {program:?}: this shell is not supported under the Windows \
+                     AppContainer sandbox. git-bash requires msys-2.0.dll from \
+                     C:\\Program Files\\Git, and even static busybox-w32 links \
+                     network/auth/UI DLLs (Secur32, WS2_32, bcrypt, USER32) that cannot \
+                     load under the sandbox's Low-integrity restricted token \
+                     (STATUS_DLL_NOT_FOUND 0xC0000135). Use cmd as the sandbox shell, or \
+                     pass an absolute path to a sandbox-compatible executable."
+                )));
+            }
+            None => {
+                return Err(SandboxError::ExecFailed(format!(
+                    "argv[0] {program:?} is not an absolute path and is not a recognized \
+                     sandbox shell. The only bare shell the AppContainer sandbox can run is \
+                     cmd (cmd.exe). Pass the absolute path to the executable."
+                )));
+            }
         }
+        // Bare `cmd` / `cmd.exe`: pin to System32\cmd.exe and validate it
+        // exists, mirroring the absolute-path branch's existence check so an
+        // unresolvable shell yields a descriptive error naming the path rather
+        // than a cryptic CreateProcessAsUserW 0x2 at spawn time (#323).
         let sysdir = system_directory()?;
         let mut buf = sysdir;
         if !buf.ends_with(&[b'\\' as u16]) {
@@ -328,6 +387,23 @@ mod windows_impl {
         if !program.to_ascii_lowercase().ends_with(".exe") {
             for u in OsStr::new(".exe").encode_wide() {
                 buf.push(u);
+            }
+        }
+        // Validate existence on the widened (NUL-free) path before returning.
+        let resolved = std::path::PathBuf::from(std::ffi::OsString::from_wide(&buf));
+        match resolved.try_exists() {
+            Ok(true) => {}
+            Ok(false) => {
+                return Err(SandboxError::ExecFailed(format!(
+                    "argv[0] {program:?} resolved to {} which does not exist",
+                    resolved.display()
+                )));
+            }
+            Err(e) => {
+                return Err(SandboxError::ExecFailed(format!(
+                    "argv[0] {program:?} resolved to {} which is unreadable: {e}",
+                    resolved.display()
+                )));
             }
         }
         buf.push(0);
@@ -408,6 +484,26 @@ mod windows_impl {
     /// `SECURITY_MANDATORY_LOW_RID` from the SDK — the SubAuthority of
     /// the Low Integrity Level SID (`S-1-16-4096`).
     const SECURITY_MANDATORY_LOW_RID: u32 = 0x1000;
+
+    /// Job Object `ActiveProcessLimit` — the maximum number of concurrently
+    /// active processes in the sandbox job (#321, #322). High enough for a
+    /// shell plus a parallel build's worker processes, low enough to bound a
+    /// runaway fork. This is NOT the primary fork-bomb guard: `KILL_ON_JOB_CLOSE`
+    /// plus the optional per-process memory cap are. It is a defense-in-depth
+    /// ceiling.
+    ///
+    /// The previous value of 1 was the root cause of BOTH #322 (the cap itself)
+    /// AND #321 (reported as "AppContainer cannot spawn child processes — Bash
+    /// runs only cmd builtins"). cmd.exe is process #1 in the job and is
+    /// assigned to the job before `ResumeThread`; with a cap of 1 every child
+    /// it tries to launch is process #2, which the kernel denies before the
+    /// child's image runs. cmd builtins (`echo`, `dir`) work because they
+    /// execute IN cmd's process; external programs (`git`, `node`, even
+    /// `cmd /c <abs cmd.exe> /c exit 42`) fail at the fork. #321's restricted-
+    /// token/CSRSS theory does not hold: the spawn is rejected by the job cap
+    /// before the child token is ever used, and the restricted token is left
+    /// untouched here so the `live_integrity.rs` boundary assertions still hold.
+    const SANDBOX_ACTIVE_PROCESS_LIMIT: u32 = 512;
 
     fn system_directory() -> Result<Vec<u16>> {
         let needed = unsafe { GetSystemDirectoryW(ptr::null_mut(), 0) };
@@ -976,7 +1072,7 @@ mod windows_impl {
             let mut limits: JOBOBJECT_EXTENDED_LIMIT_INFORMATION = mem::zeroed();
             // Always-on hardening flags:
             //   KILL_ON_JOB_CLOSE        — child dies if engine drops job
-            //   ACTIVE_PROCESS=1         — fork-bomb prevention
+            //   ACTIVE_PROCESS=N         — runaway-fork cap (see below)
             //   DIE_ON_UNHANDLED_EXC.    — no WerFault popup
             //   PRIORITY_CLASS=BELOW_N.  — child can't starve the engine
             //   BREAKAWAY_OK=0           — CREATE_BREAKAWAY_FROM_JOB rejected
@@ -993,7 +1089,16 @@ mod windows_impl {
             // future Windows / driver toggles the default.
             limits.BasicLimitInformation.LimitFlags &=
                 !(JOB_OBJECT_LIMIT_BREAKAWAY_OK | JOB_OBJECT_LIMIT_SILENT_BREAKAWAY_OK);
-            limits.BasicLimitInformation.ActiveProcessLimit = 1;
+            // #322: an ActiveProcessLimit of 1 permits only the shell process
+            // and structurally blocks EVERY subprocess (git, node, npm, a
+            // parallel build), making the sandboxed Bash tool unusable for the
+            // build/run workflows it exists to serve. Raise the cap to a value
+            // high enough for normal command execution and parallel builds
+            // while still bounding a runaway fork. KILL_ON_JOB_CLOSE plus the
+            // optional PROCESS_MEMORY cap remain the meaningful fork-bomb
+            // guards (a fork bomb exhausts memory long before 512 PIDs), so the
+            // active-process cap can safely be raised off 1.
+            limits.BasicLimitInformation.ActiveProcessLimit = SANDBOX_ACTIVE_PROCESS_LIMIT;
             limits.BasicLimitInformation.PriorityClass = BELOW_NORMAL_PRIORITY_CLASS;
             if let Some(mem_bytes) = manifest.max_memory_bytes {
                 limits.BasicLimitInformation.LimitFlags |= JOB_OBJECT_LIMIT_PROCESS_MEMORY;
@@ -1366,7 +1471,39 @@ mod windows_impl {
                 )));
             }
             let stdout = drain_pipe(stdout_r.as_raw());
-            let stderr = drain_pipe(stderr_r.as_raw());
+            let mut stderr = drain_pipe(stderr_r.as_raw());
+
+            // #324: a child that loads a DLL the Low-IL restricted-token
+            // AppContainer cannot map (PowerShell's .NET/GAC, git-bash's
+            // msys-2.0.dll, busybox-w32's Secur32/WS2_32/bcrypt/USER32) dies at
+            // image initialization with NTSTATUS STATUS_DLL_NOT_FOUND and empty
+            // output — which surfaces to the user as "the command did nothing."
+            // Bare shells are rejected in `resolve_program`, but a caller can
+            // still reach here by passing such a shell as an ABSOLUTE path, so
+            // annotate the empty failure with an actionable diagnostic instead
+            // of leaving it silent. Annotate stderr (not an Err) so the exit
+            // code and any partial output are preserved for the caller.
+            const STATUS_DLL_NOT_FOUND: i32 = 0xC000_0135u32 as i32;
+            const STATUS_DLL_INIT_FAILED: i32 = 0xC000_0142u32 as i32;
+            if matches!(
+                exit_code as i32,
+                STATUS_DLL_NOT_FOUND | STATUS_DLL_INIT_FAILED
+            ) && stdout.is_empty()
+                && stderr.is_empty()
+            {
+                let hint = format!(
+                    "wcore-sandbox: the program exited at image initialization with \
+                     {ec:#010x} (STATUS_DLL_NOT_FOUND / STATUS_DLL_INIT_FAILED) and no \
+                     output. Under the Windows AppContainer sandbox's Low-integrity \
+                     restricted token, executables that depend on DLLs outside the minimal \
+                     System32 set (e.g. PowerShell's .NET/GAC assemblies, git-bash's \
+                     msys-2.0.dll, or even static busybox-w32's network/auth/UI imports) \
+                     cannot load. Use cmd as the sandbox shell, or run a sandbox-compatible \
+                     executable.\n",
+                    ec = exit_code,
+                );
+                stderr.extend_from_slice(hint.as_bytes());
+            }
 
             tracing::debug!(
                 target: "wcore_sandbox",
@@ -1933,9 +2070,53 @@ mod windows_impl {
             let err = resolve_program("notepad.exe").unwrap_err();
             let msg = format!("{err:?}");
             assert!(
-                msg.contains("not in the AppContainer shell allowlist"),
-                "expected allowlist rejection, got {msg}"
+                msg.contains("not a recognized") && msg.contains("Pass the absolute path"),
+                "expected unrecognized-shell rejection, got {msg}"
             );
+        }
+
+        #[test]
+        fn classify_bare_shell_buckets() {
+            assert_eq!(classify_bare_shell("cmd"), Some(BareShell::Cmd));
+            assert_eq!(classify_bare_shell("CMD.EXE"), Some(BareShell::Cmd));
+            assert_eq!(
+                classify_bare_shell("powershell"),
+                Some(BareShell::PowerShell)
+            );
+            assert_eq!(classify_bare_shell("pwsh.exe"), Some(BareShell::PowerShell));
+            assert_eq!(classify_bare_shell("bash"), Some(BareShell::Unsupported));
+            assert_eq!(classify_bare_shell("sh.exe"), Some(BareShell::Unsupported));
+            assert_eq!(classify_bare_shell("notepad.exe"), None);
+        }
+
+        #[test]
+        fn resolve_program_bare_powershell_rejected_with_actionable_message() {
+            // #323/#324: bare powershell/pwsh used to be pinned to System32
+            // (wrong path → cryptic 0x2) and would fail to load under the
+            // Low-IL token anyway (0xC0000135). Now rejected up front with a
+            // message that names the real locations and the cause.
+            for shell in ["powershell", "powershell.exe", "pwsh", "pwsh.exe"] {
+                let err = resolve_program(shell).unwrap_err();
+                let msg = format!("{err:?}");
+                assert!(
+                    msg.contains("PowerShell is not supported") && msg.contains("0xC0000135"),
+                    "expected actionable PowerShell rejection for {shell}, got {msg}"
+                );
+            }
+        }
+
+        #[test]
+        fn resolve_program_bare_bash_rejected_with_actionable_message() {
+            // #324: git-bash/busybox cannot load under the sandbox token.
+            for shell in ["bash", "bash.exe", "sh", "sh.exe"] {
+                let err = resolve_program(shell).unwrap_err();
+                let msg = format!("{err:?}");
+                assert!(
+                    msg.contains("not supported under the Windows AppContainer sandbox")
+                        && msg.contains("0xC0000135"),
+                    "expected actionable bash rejection for {shell}, got {msg}"
+                );
+            }
         }
 
         #[test]

--- a/crates/wcore-sandbox/src/lib.rs
+++ b/crates/wcore-sandbox/src/lib.rs
@@ -26,6 +26,8 @@ pub use manifest::{NetworkPolicy, SandboxManifest, SyscallPolicy};
 use async_trait::async_trait;
 use std::sync::Arc;
 use std::sync::Mutex;
+use std::sync::OnceLock;
+use std::sync::RwLock;
 use std::time::{Duration, Instant};
 
 /// Operator opt-in that permits running model-driven commands with NO
@@ -34,11 +36,82 @@ use std::time::{Duration, Instant};
 /// degrading to host-permission execution (audit M-2 / rel-concurrency-70).
 const ALLOW_NO_SANDBOX_ENV: &str = "WAYLAND_ALLOW_NO_SANDBOX";
 
-/// True iff the operator has explicitly opted in to unsandboxed execution
-/// via `WAYLAND_ALLOW_NO_SANDBOX=1` (or `=true`).
+/// Env-var name selecting the sandbox backend (`none` / `docker`).
+const SANDBOX_ENV: &str = "WAYLAND_SANDBOX";
+
+/// #327: config-sourced sandbox toggle, installed once at bootstrap from
+/// `[tools] sandbox` / `[tools] allow_no_sandbox`.
+///
+/// This is a process-global fallback consulted only when the corresponding
+/// env var is unset — the `WAYLAND_SANDBOX` / `WAYLAND_ALLOW_NO_SANDBOX`
+/// env vars keep precedence for back-compat. Mirrors the process-global
+/// pattern used by `wcore_tools::env_passthrough::set_config_passthrough`.
+#[derive(Clone, Default)]
+struct SandboxConfigOverride {
+    /// Backend selection (`Some("none")` / `Some("docker")`), or `None` to
+    /// leave the platform default.
+    backend: Option<String>,
+    /// Operator opt-in to unsandboxed execution; `None` = unset.
+    allow_no_sandbox: Option<bool>,
+}
+
+fn sandbox_config_override() -> &'static RwLock<SandboxConfigOverride> {
+    static CFG: OnceLock<RwLock<SandboxConfigOverride>> = OnceLock::new();
+    CFG.get_or_init(|| RwLock::new(SandboxConfigOverride::default()))
+}
+
+/// Install the config-sourced sandbox toggle (#327).
+///
+/// Called once at host bootstrap with the resolved `[tools] sandbox` /
+/// `[tools] allow_no_sandbox` values. The `WAYLAND_SANDBOX` /
+/// `WAYLAND_ALLOW_NO_SANDBOX` env vars still take precedence — config is
+/// only the fallback when the env var is absent. Subsequent calls replace
+/// the previous config (the host owns the source of truth).
+pub fn set_config_sandbox(backend: Option<String>, allow_no_sandbox: Option<bool>) {
+    let normalized = backend.and_then(|b| {
+        let t = b.trim();
+        if t.is_empty() {
+            None
+        } else {
+            Some(t.to_string())
+        }
+    });
+    let mut guard = match sandbox_config_override().write() {
+        Ok(g) => g,
+        Err(p) => p.into_inner(),
+    };
+    *guard = SandboxConfigOverride {
+        backend: normalized,
+        allow_no_sandbox,
+    };
+}
+
+/// Resolve the effective sandbox backend selection: the `WAYLAND_SANDBOX`
+/// env var wins; otherwise the config-installed value (#327); otherwise
+/// `None` (platform default).
+fn resolved_sandbox_choice() -> Option<String> {
+    if let Ok(v) = std::env::var(SANDBOX_ENV) {
+        return Some(v);
+    }
+    sandbox_config_override()
+        .read()
+        .ok()
+        .and_then(|g| g.backend.clone())
+}
+
+/// True iff the operator has explicitly opted in to unsandboxed execution.
+///
+/// The `WAYLAND_ALLOW_NO_SANDBOX=1` (or `=true`) env var wins; otherwise
+/// the config-installed `[tools] allow_no_sandbox` value is consulted
+/// (#327).
 pub fn no_sandbox_opt_in() -> bool {
-    std::env::var(ALLOW_NO_SANDBOX_ENV)
-        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+    if let Ok(v) = std::env::var(ALLOW_NO_SANDBOX_ENV) {
+        return v == "1" || v.eq_ignore_ascii_case("true");
+    }
+    sandbox_config_override()
+        .read()
+        .ok()
+        .and_then(|g| g.allow_no_sandbox)
         .unwrap_or(false)
 }
 
@@ -264,7 +337,8 @@ impl SandboxRegistry {
 /// returns [`backends::no_sandbox::NoSandboxBackend`] with a rate-limited
 /// warning on every selection.
 pub fn default_for_platform() -> Box<dyn backends::SandboxBackend> {
-    if let Ok(choice) = std::env::var("WAYLAND_SANDBOX") {
+    // #327: env var wins; otherwise the config-installed `[tools] sandbox`.
+    if let Some(choice) = resolved_sandbox_choice() {
         match choice.as_str() {
             "none" => {
                 // Explicit operator request for no sandbox. Honor it only
@@ -332,26 +406,49 @@ pub fn default_for_platform() -> Box<dyn backends::SandboxBackend> {
     unsandboxed_fallback()
 }
 
+/// Crate-wide serialization lock for tests that mutate the process-global
+/// sandbox state (`WAYLAND_SANDBOX` / `WAYLAND_ALLOW_NO_SANDBOX` env vars and
+/// the `#327` config override). Both `fail_closed_tests` and
+/// `config_toggle_tests` touch the SAME globals, so they must share one lock —
+/// per-module locks would let env mutations from one module race the reads of
+/// the other.
+#[cfg(test)]
+static SANDBOX_TEST_LOCK: Mutex<()> = Mutex::new(());
+
 #[cfg(test)]
 mod fail_closed_tests {
     use super::*;
     use backends::SandboxBackend as _;
 
     /// Serialize the env-mutating tests in this module — `WAYLAND_SANDBOX`
-    /// and `WAYLAND_ALLOW_NO_SANDBOX` are process-global.
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
+    /// and `WAYLAND_ALLOW_NO_SANDBOX` are process-global. Shared with
+    /// `config_toggle_tests` (same globals).
+    use super::SANDBOX_TEST_LOCK as ENV_LOCK;
 
     /// RAII guard that snapshots and restores both sandbox env vars so a
     /// test never leaks state into a sibling.
+    ///
+    /// These tests assert pure-env behavior, so `capture()` also clears the
+    /// `#327` config override (snapshotting it for restore) — otherwise a
+    /// config value left by a sibling `config_toggle_tests` case would bleed
+    /// into `no_sandbox_opt_in` / `default_for_platform`.
     struct EnvGuard {
         sandbox: Option<String>,
         allow: Option<String>,
+        cfg: SandboxConfigOverride,
     }
     impl EnvGuard {
         fn capture() -> Self {
+            let cfg = sandbox_config_override()
+                .read()
+                .map(|g| g.clone())
+                .unwrap_or_default();
+            // Clear config so these tests observe env-only behavior.
+            set_config_sandbox(None, None);
             Self {
                 sandbox: std::env::var("WAYLAND_SANDBOX").ok(),
                 allow: std::env::var(ALLOW_NO_SANDBOX_ENV).ok(),
+                cfg,
             }
         }
         fn set_sandbox(v: Option<&str>) {
@@ -377,6 +474,7 @@ mod fail_closed_tests {
         fn drop(&mut self) {
             Self::set_sandbox(self.sandbox.as_deref());
             Self::set_allow(self.allow.as_deref());
+            set_config_sandbox(self.cfg.backend.clone(), self.cfg.allow_no_sandbox);
         }
     }
 
@@ -409,7 +507,7 @@ mod fail_closed_tests {
 
     #[test]
     fn unsandboxed_fallback_fails_closed_without_opt_in() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         let _g = EnvGuard::capture();
         EnvGuard::set_allow(None);
         let backend = unsandboxed_fallback();
@@ -422,7 +520,7 @@ mod fail_closed_tests {
 
     #[test]
     fn unsandboxed_fallback_runs_no_sandbox_with_opt_in() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         let _g = EnvGuard::capture();
         EnvGuard::set_allow(Some("1"));
         let backend = unsandboxed_fallback();
@@ -435,7 +533,7 @@ mod fail_closed_tests {
 
     #[test]
     fn sandbox_none_fails_closed_without_opt_in() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         let _g = EnvGuard::capture();
         EnvGuard::set_sandbox(Some("none"));
         EnvGuard::set_allow(None);
@@ -450,7 +548,7 @@ mod fail_closed_tests {
 
     #[test]
     fn sandbox_none_honored_with_opt_in() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         let _g = EnvGuard::capture();
         EnvGuard::set_sandbox(Some("none"));
         EnvGuard::set_allow(Some("1"));
@@ -476,7 +574,7 @@ mod fail_closed_tests {
 
     #[test]
     fn opt_in_parsing_accepts_1_and_true() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         let _g = EnvGuard::capture();
         EnvGuard::set_allow(Some("1"));
         assert!(no_sandbox_opt_in());
@@ -490,5 +588,158 @@ mod fail_closed_tests {
         assert!(!no_sandbox_opt_in());
         EnvGuard::set_allow(None);
         assert!(!no_sandbox_opt_in());
+    }
+}
+
+#[cfg(test)]
+mod config_toggle_tests {
+    //! #327: `[tools] sandbox` / `[tools] allow_no_sandbox` config toggle.
+    //!
+    //! The config-installed values are a fallback consulted only when the
+    //! corresponding env var is unset; the env var keeps precedence. Both
+    //! the env vars and the config override are process-global, so these
+    //! tests serialize on a private lock and restore all state on drop.
+    use super::*;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    /// Snapshot + restore both sandbox env vars AND the config override so a
+    /// test never leaks state into a sibling (config override is process-global).
+    struct StateGuard {
+        sandbox: Option<String>,
+        allow: Option<String>,
+        cfg: SandboxConfigOverride,
+    }
+    impl StateGuard {
+        fn capture() -> Self {
+            let cfg = sandbox_config_override()
+                .read()
+                .map(|g| g.clone())
+                .unwrap_or_default();
+            Self {
+                sandbox: std::env::var(SANDBOX_ENV).ok(),
+                allow: std::env::var(ALLOW_NO_SANDBOX_ENV).ok(),
+                cfg,
+            }
+        }
+        fn clear_env() {
+            // SAFETY: serialized via ENV_LOCK.
+            unsafe {
+                std::env::remove_var(SANDBOX_ENV);
+                std::env::remove_var(ALLOW_NO_SANDBOX_ENV);
+            }
+        }
+    }
+    impl Drop for StateGuard {
+        fn drop(&mut self) {
+            // SAFETY: serialized via ENV_LOCK.
+            unsafe {
+                match &self.sandbox {
+                    Some(v) => std::env::set_var(SANDBOX_ENV, v),
+                    None => std::env::remove_var(SANDBOX_ENV),
+                }
+                match &self.allow {
+                    Some(v) => std::env::set_var(ALLOW_NO_SANDBOX_ENV, v),
+                    None => std::env::remove_var(ALLOW_NO_SANDBOX_ENV),
+                }
+            }
+            set_config_sandbox(self.cfg.backend.clone(), self.cfg.allow_no_sandbox);
+        }
+    }
+
+    #[test]
+    fn config_allow_no_sandbox_opt_in_honored_when_env_unset() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let _g = StateGuard::capture();
+        StateGuard::clear_env();
+        set_config_sandbox(None, None);
+        assert!(!no_sandbox_opt_in(), "default must be off");
+        set_config_sandbox(None, Some(true));
+        assert!(
+            no_sandbox_opt_in(),
+            "[tools] allow_no_sandbox = true must opt in when env is unset"
+        );
+    }
+
+    #[test]
+    fn env_allow_no_sandbox_wins_over_config() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let _g = StateGuard::capture();
+        StateGuard::clear_env();
+        // Config says opt-in, env explicitly says off → env wins (back-compat).
+        set_config_sandbox(None, Some(true));
+        // SAFETY: serialized via ENV_LOCK.
+        unsafe { std::env::set_var(ALLOW_NO_SANDBOX_ENV, "0") };
+        assert!(
+            !no_sandbox_opt_in(),
+            "WAYLAND_ALLOW_NO_SANDBOX must take precedence over config"
+        );
+    }
+
+    #[test]
+    fn config_sandbox_none_honored_with_config_opt_in() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let _g = StateGuard::capture();
+        StateGuard::clear_env();
+        // Pure-config path: sandbox=none + allow_no_sandbox=true, no env vars.
+        set_config_sandbox(Some("none".into()), Some(true));
+        let backend = default_for_platform();
+        assert_eq!(
+            backend.name(),
+            "no_sandbox",
+            "[tools] sandbox=\"none\" + allow_no_sandbox=true must select NoSandbox"
+        );
+    }
+
+    #[test]
+    fn config_sandbox_none_fails_closed_without_opt_in() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let _g = StateGuard::capture();
+        StateGuard::clear_env();
+        // sandbox=none from config but no opt-in → must fail closed, exactly
+        // like the env-var path (audit M-2 invariant preserved).
+        set_config_sandbox(Some("none".into()), Some(false));
+        let backend = default_for_platform();
+        assert_eq!(
+            backend.name(),
+            "fail_closed",
+            "config sandbox=none without the opt-in must fail closed"
+        );
+    }
+
+    #[test]
+    fn env_sandbox_backend_wins_over_config_backend() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let _g = StateGuard::capture();
+        StateGuard::clear_env();
+        // Config selects docker; env forces none. The env WAYLAND_SANDBOX
+        // backend selection wins. With the env opt-in set, none resolves to
+        // NoSandbox (proving env's `none` overrode config's `docker`).
+        set_config_sandbox(Some("docker".into()), Some(false));
+        // SAFETY: serialized via ENV_LOCK.
+        unsafe {
+            std::env::set_var(SANDBOX_ENV, "none");
+            std::env::set_var(ALLOW_NO_SANDBOX_ENV, "1");
+        }
+        let backend = default_for_platform();
+        assert_eq!(
+            backend.name(),
+            "no_sandbox",
+            "env WAYLAND_SANDBOX must take precedence over config sandbox backend"
+        );
+    }
+
+    #[test]
+    fn empty_config_backend_is_treated_as_unset() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let _g = StateGuard::capture();
+        StateGuard::clear_env();
+        // A whitespace-only [tools] sandbox must normalize to None (platform
+        // default), not a bogus backend name.
+        set_config_sandbox(Some("   ".into()), None);
+        assert!(
+            resolved_sandbox_choice().is_none(),
+            "blank config sandbox must resolve to None"
+        );
     }
 }

--- a/crates/wcore-sandbox/src/lib.rs
+++ b/crates/wcore-sandbox/src/lib.rs
@@ -598,10 +598,11 @@ mod config_toggle_tests {
     //! The config-installed values are a fallback consulted only when the
     //! corresponding env var is unset; the env var keeps precedence. Both
     //! the env vars and the config override are process-global, so these
-    //! tests serialize on a private lock and restore all state on drop.
+    //! tests serialize on the shared SANDBOX_TEST_LOCK (the same lock
+    //! fail_closed_tests uses) and restore all state on drop.
     use super::*;
 
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
+    use super::SANDBOX_TEST_LOCK as ENV_LOCK;
 
     /// Snapshot + restore both sandbox env vars AND the config override so a
     /// test never leaks state into a sibling (config override is process-global).

--- a/crates/wcore-tools/src/env_passthrough.rs
+++ b/crates/wcore-tools/src/env_passthrough.rs
@@ -590,6 +590,56 @@ mod tests {
 
     #[test]
     #[serial]
+    fn config_passthrough_var_is_applied_to_sandboxed_env() {
+        // #325: a var named in `[tools] env_passthrough` (installed via
+        // set_config_passthrough at bootstrap) must actually appear in the
+        // curated sandbox env — proving the config is no longer inert.
+        let _g = guard();
+        unsafe {
+            std::env::set_var("TEST_CFG_PASSTHROUGH_VAR", "from-config");
+        }
+        // Without the config allowlist the var is stripped.
+        assert!(
+            !build_sandboxed_env(&[])
+                .iter()
+                .any(|(k, _)| k == "TEST_CFG_PASSTHROUGH_VAR"),
+            "var must be stripped before config passthrough installs it"
+        );
+        // Install it the way the host does at bootstrap.
+        set_config_passthrough(["TEST_CFG_PASSTHROUGH_VAR"]);
+        let env = build_sandboxed_env(&[]);
+        assert!(
+            env.iter()
+                .any(|(k, v)| k == "TEST_CFG_PASSTHROUGH_VAR" && v == "from-config"),
+            "a config-passthrough var must be forwarded into the sandboxed env"
+        );
+        unsafe {
+            std::env::remove_var("TEST_CFG_PASSTHROUGH_VAR");
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn config_passthrough_cannot_leak_a_secret_shaped_var() {
+        // #325 safety: even if a user lists a secret-shaped name in
+        // [tools] env_passthrough, the sandbox secret filter still drops it.
+        let _g = guard();
+        unsafe {
+            std::env::set_var("TEST_CFG_SECRET_TOKEN", "nope");
+        }
+        set_config_passthrough(["TEST_CFG_SECRET_TOKEN"]);
+        let env = build_sandboxed_env(&[]);
+        assert!(
+            !env.iter().any(|(k, _)| k == "TEST_CFG_SECRET_TOKEN"),
+            "a secret-shaped config passthrough var must still be dropped"
+        );
+        unsafe {
+            std::env::remove_var("TEST_CFG_SECRET_TOKEN");
+        }
+    }
+
+    #[test]
+    #[serial]
     fn build_sandboxed_env_with_prefixes_keeps_discovery_drops_secrets() {
         let _g = guard();
         unsafe {

--- a/crates/wcore-types/src/llm.rs
+++ b/crates/wcore-types/src/llm.rs
@@ -117,6 +117,14 @@ pub enum LlmEvent {
     },
     /// Thinking content (Anthropic only)
     ThinkingDelta(String),
+    /// Per-turn thinking SUBJECT: a short opaque display label for the
+    /// reasoning block (e.g. Flux's `delta.reasoning_summary`, a gerund
+    /// phrase like "Reasoning through the problem"). Distinct from
+    /// `ThinkingDelta` (the raw thinking text). Emitted once per turn,
+    /// immediately before the first `ThinkingDelta`, only on turns that
+    /// actually produce reasoning. The host renders it as the heading for
+    /// the in-flight thinking block. Opaque — never switch on the value.
+    ThinkingSubject(String),
     /// Response complete
     Done {
         stop_reason: StopReason,


### PR DESCRIPTION
wayland-core 0.12.13 — five audited fixes on top of 0.12.12.

- Windows sandbox (#321-324): AppContainer Job Object ActiveProcessLimit 1→512 so Bash/tools can spawn child processes; shell resolution existence-checked with actionable pwsh/bash rejects; 0xC0000135 diagnostics. (#321 and #322 were the same root cause.)
- Anthropic billing misclassification (#329): classify_by_body no longer flags non-credit errors that merely carry the "Plans & Billing" link as out-of-credit; genuine credit errors still classify as Billing.
- Ollama no-tool graceful retry (#389): a model that returns "does not support tools" (400) is retried once without tools so the turn completes.
- Config hygiene (#325-327): tools.env_passthrough is applied (secret filter still wins); warn-on-unknown/mis-sectioned config keys (serde_ignored, non-breaking); Bash sandbox togglable from config (env still wins; fail-closed preserved).
- Flux reasoning_summary decode (#318): choices[0].delta.reasoning_summary -> ThinkingSubject (per-turn heading), latest-wins; additive, back-compat (golden test green).

Each fix was cross-audited in isolation; the integrated branch is being cross-audited as a whole. Cherry-picked onto v0.12.12 with zero hard conflicts; version 0.12.13; full local gate green (fmt/clippy clean, cargo test 1475 pass; the 1 failing oauth::xai test is a pre-existing GROK_HOME env-race flake, byte-identical to main, passes in isolation).

CI GATE: the Windows runner must confirm the sandbox subprocess behavior at runtime — the live_integrity sandbox test was previously masked by the ActiveProcessLimit=1 bug and is now load-bearing for the first time. Do not tag until that is green.
