### PR TITLE
fix(sandbox): skip non-existent paths in AppContainer DACL grant/deny (#321-324 follow-up)

### DIFF
--- a/crates/wcore-agent/tests/bootstrap_test.rs
+++ b/crates/wcore-agent/tests/bootstrap_test.rs
@@ -56,8 +56,26 @@ fn null_output() -> Arc<dyn wcore_agent::output::OutputSink> {
     Arc::new(NullSink)
 }
 
+/// Pin `WAYLAND_PLUGINS_DIR` to a fresh empty directory so on-disk plugin
+/// discovery cannot pick up plugins installed on the host or CI runner (e.g. an
+/// `ijfw` plugin that registers an `ijfw-memory` MCP server). Without this, the
+/// no-MCP assertions below fail on any machine that has a plugin installed.
+/// Returns BOTH the guard and the `TempDir`; the caller must bind both for the
+/// duration of the test (the guard restores the env on drop; the dir must
+/// outlive `build()`). Requires `#[serial]` since it mutates process-global env.
+fn isolated_plugins() -> (tempfile::TempDir, EnvGuard) {
+    let dir = tempfile::TempDir::new().expect("plugins dir");
+    let guard = EnvGuard::set(&[(
+        "WAYLAND_PLUGINS_DIR",
+        dir.path().to_str().expect("utf8 plugins dir"),
+    )]);
+    (dir, guard)
+}
+
 #[tokio::test]
+#[serial]
 async fn bootstrap_builds_engine_with_model_in_prompt() {
+    let (_plugins, _env) = isolated_plugins();
     let config = minimal_config();
     let workdir = tempfile::TempDir::new().expect("workdir");
     let result = AgentBootstrap::new(config, workdir.path().to_str().unwrap(), null_output())
@@ -242,7 +260,9 @@ async fn bootstrap_no_plan_tools_when_disabled() {
 }
 
 #[tokio::test]
+#[serial]
 async fn bootstrap_no_mcp_when_no_servers() {
+    let (_plugins, _env) = isolated_plugins();
     let config = minimal_config();
     let workdir = tempfile::TempDir::new().expect("workdir");
     let result = AgentBootstrap::new(config, workdir.path().to_str().unwrap(), null_output())

--- a/crates/wcore-sandbox/src/backends/appcontainer.rs
+++ b/crates/wcore-sandbox/src/backends/appcontainer.rs
@@ -1723,6 +1723,20 @@ mod windows_impl {
     ) -> Result<Vec<std::path::PathBuf>> {
         let mut granted: Vec<std::path::PathBuf> = Vec::new();
         for path in paths {
+            // A grant target that doesn't exist can't be ACL'd: GetNamedSecurityInfoW
+            // returns ERROR_FILE_NOT_FOUND (0x2), which would abort the entire spawn.
+            // The local allowlist intentionally includes optional dev caches
+            // (~/.cache, ~/.cargo, ~/.npm, ~/.rustup) that are simply absent on
+            // non-developer machines, so skip any path that isn't present rather than
+            // failing every sandboxed command. (#321-324)
+            if !path.exists() {
+                tracing::debug!(
+                    target: "wcore_sandbox",
+                    path = %path.display(),
+                    "skipping AppContainer DACL grant for non-existent path"
+                );
+                continue;
+            }
             if !acl_path_is_safe(path) {
                 unsafe { revoke_appcontainer_dacl(&granted, sid) };
                 return Err(SandboxError::ExecFailed(format!(
@@ -1756,6 +1770,16 @@ mod windows_impl {
     ) -> Result<Vec<std::path::PathBuf>> {
         let mut denied: Vec<std::path::PathBuf> = Vec::new();
         for path in paths {
+            // A deny target that doesn't exist needs no ACE (nothing there to read),
+            // and GetNamedSecurityInfoW would otherwise fail (0x2) and abort the spawn.
+            if !path.exists() {
+                tracing::debug!(
+                    target: "wcore_sandbox",
+                    path = %path.display(),
+                    "skipping AppContainer DACL deny for non-existent path"
+                );
+                continue;
+            }
             if !acl_path_is_safe(path) {
                 unsafe { revoke_appcontainer_dacl(&denied, sid) };
                 return Err(SandboxError::ExecFailed(format!(

--- a/crates/wcore-sandbox/src/backends/appcontainer.rs
+++ b/crates/wcore-sandbox/src/backends/appcontainer.rs
@@ -1871,6 +1871,49 @@ mod windows_impl {
             assert_eq!(quote_arg("hello"), "hello");
         }
 
+        // ---------- DACL grant/deny skip absent paths (#321-324 field fix) ----------
+
+        // A path that does not exist must be skipped, not treated as a hard
+        // failure: the local allowlist intentionally includes optional dev
+        // caches (~/.cache, ~/.cargo, ~/.npm, ~/.rustup) that are absent on
+        // non-developer machines. Before the fix, `GetNamedSecurityInfoW`
+        // returned ERROR_FILE_NOT_FOUND (0x2) for these, aborting every
+        // sandboxed command. The skip happens before the SID is ever used, so a
+        // null SID is safe here and proves we never reach the Win32 ACL calls.
+        #[test]
+        fn grant_skips_nonexistent_path_instead_of_failing() {
+            let missing =
+                std::path::PathBuf::from(r"C:\__wcore_nonexistent_grant_target__\nope.txt");
+            assert!(!missing.exists(), "test precondition: path must not exist");
+            let granted =
+                unsafe { grant_appcontainer_dacl(&[missing], std::ptr::null_mut(), ACL_READ_MASK) };
+            assert!(
+                granted.is_ok(),
+                "missing grant target must be skipped, got error: {:?}",
+                granted.as_ref().err()
+            );
+            assert!(
+                granted.unwrap().is_empty(),
+                "an absent path must not be reported as granted"
+            );
+        }
+
+        #[test]
+        fn deny_skips_nonexistent_path_instead_of_failing() {
+            let missing = std::path::PathBuf::from(r"C:\__wcore_nonexistent_deny_target__\secret");
+            assert!(!missing.exists(), "test precondition: path must not exist");
+            let denied = unsafe { deny_appcontainer_dacl(&[missing], std::ptr::null_mut()) };
+            assert!(
+                denied.is_ok(),
+                "missing deny target must be skipped, got error: {:?}",
+                denied.as_ref().err()
+            );
+            assert!(
+                denied.unwrap().is_empty(),
+                "an absent path must not be reported as denied"
+            );
+        }
+
         // ---------- acl_path_is_safe (R61 filesystem grants) ----------
 
         #[test]

--- a/crates/wcore-sandbox/tests/live_integrity.rs
+++ b/crates/wcore-sandbox/tests/live_integrity.rs
@@ -120,3 +120,57 @@ async fn live_cmd_builtin_runs_under_hardened_sandbox() {
         String::from_utf8_lossy(&out.stdout)
     );
 }
+
+/// Field regression (#321-324 follow-up, PR #99). The local fs allowlist
+/// routinely includes optional dev caches (`~/.cache`, `~/.cargo`, `~/.npm`,
+/// `~/.rustup`) that are ABSENT on non-developer machines. Before the
+/// grant/deny skip-missing fix, `GetNamedSecurityInfoW` returned
+/// `ERROR_FILE_NOT_FOUND` (0x2) on the absent path and aborted the whole spawn,
+/// so EVERY sandboxed shell command hard-failed in the field. This proves a real
+/// sandboxed `cmd` still runs end-to-end when the allowlist contains a
+/// non-existent path alongside a real one.
+#[tokio::test(flavor = "current_thread")]
+async fn live_cmd_runs_when_allowlist_has_missing_path() {
+    if std::env::var("WAYLAND_SANDBOX_LIVE_WINDOWS").is_err() {
+        return;
+    }
+
+    let real = std::env::temp_dir();
+    let missing = std::path::PathBuf::from(r"C:\__wcore_absent_cache__\.npm");
+    assert!(
+        !missing.exists(),
+        "precondition: the allowlist path must be absent"
+    );
+
+    let b = AppContainerBackend::new();
+    let m = SandboxManifest {
+        fs_read_allow: vec![real, missing],
+        timeout: Some(Duration::from_secs(10)),
+        ..Default::default()
+    };
+    let out = b
+        .execute(
+            &m,
+            SandboxCommand {
+                argv: vec![
+                    "cmd.exe".into(),
+                    "/c".into(),
+                    "echo allowlist-skip-ok".into(),
+                ],
+                cwd: None,
+            },
+        )
+        .await
+        .expect("AppContainer spawn must succeed despite a non-existent allowlist path");
+    assert_eq!(
+        out.exit_code,
+        0,
+        "cmd must run when the allowlist has a missing path; stderr={:?}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stdout).contains("allowlist-skip-ok"),
+        "expected 'allowlist-skip-ok' in stdout: {:?}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+}


### PR DESCRIPTION
## What
Skip non-existent paths in the AppContainer DACL grant and deny loops instead of aborting the whole sandboxed command.

## Why (found by live testing 0.12.13 on Windows)
`WorkspacePolicy::trusted_local` adds optional dev caches to the fs allowlist:
`for sub in [".cache", ".cargo", ".npm", ".rustup"] { writable_extra.push(home.join(sub)); }`
without checking existence. On a machine missing any of them, `grant_appcontainer_dacl` calls `GetNamedSecurityInfoW` on the absent path, gets `ERROR_FILE_NOT_FOUND (0x2)`, and returns `SandboxError::ExecFailed` — aborting the ENTIRE command before the child runs.

Observed live driving the Bash tool on a Windows box without `~/.npm`:
`[Bash error] Failed to execute command: sandbox child execution failed: GetNamedSecurityInfoW for C:\Users\seand\.npm: 0x2`

A non-developer Windows machine has none of `.cargo`/`.rustup`/`.npm`, so EVERY sandboxed shell tool fails for them. This is why #321-324 ("AppContainer can spawn subprocesses") did not translate into working shell tools in practice.

## Fix
In `grant_appcontainer_dacl` and `deny_appcontainer_dacl`, `continue` past any path that doesn't exist (you can't ACL a path that isn't there; a missing deny-target needs no ACE). Defensive and minimal — no change to the grant logic for paths that do exist.

## Not covered here
A separate symptom — with the path present, `cmd.exe /c whoami` then hung to the 120s timeout — is still under investigation (possible AppContainer/`CreateProcessAsUserW` interaction vs a disconnected-session test artifact). Tracked separately; this PR fixes the unambiguous hard-fail.

## Test
Live retest on Windows after build. Unit coverage to follow once the live fix is confirmed.
