### PR TITLE
fix(sandbox): reap AppContainer job tree before draining pipes (#100)

### DIFF
--- a/crates/wcore-sandbox/src/backends/appcontainer.rs
+++ b/crates/wcore-sandbox/src/backends/appcontainer.rs
@@ -114,7 +114,7 @@ mod windows_impl {
         JOB_OBJECT_UILIMIT_READCLIPBOARD, JOB_OBJECT_UILIMIT_SYSTEMPARAMETERS,
         JOB_OBJECT_UILIMIT_WRITECLIPBOARD, JOBOBJECT_BASIC_UI_RESTRICTIONS,
         JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JobObjectBasicUIRestrictions,
-        JobObjectExtendedLimitInformation, SetInformationJobObject,
+        JobObjectExtendedLimitInformation, SetInformationJobObject, TerminateJobObject,
     };
     use windows_sys::Win32::System::Pipes::CreatePipe;
     use windows_sys::Win32::System::SystemInformation::GetSystemDirectoryW;
@@ -1369,6 +1369,12 @@ mod windows_impl {
 
             // ---- 9. CreateProcessAsUserW (suspended) ----
             let mut pi: PROCESS_INFORMATION = mem::zeroed();
+            // NOTE: do NOT add CREATE_NO_WINDOW here. Under the AppContainer
+            // Low-IL restricted token, forcing `cmd.exe` window-less makes its
+            // console-host init fail with 0xC0000142 (STATUS_DLL_INIT_FAILED) —
+            // breaking every command. cmd needs its console host; the #100 hang
+            // is instead handled at drain time by reaping the whole job tree, so
+            // a lingering conhost can't keep the inherited pipe write-end open.
             let creation_flags =
                 EXTENDED_STARTUPINFO_PRESENT | CREATE_SUSPENDED | 0x0400 /* CREATE_UNICODE_ENVIRONMENT */;
             let cp_ok = CreateProcessAsUserW(
@@ -1451,8 +1457,6 @@ mod windows_impl {
             let wait_res = WaitForSingleObject(process.as_raw(), timeout_ms);
             let mut timed_out = false;
             if wait_res == WAIT_TIMEOUT {
-                TerminateProcess(process.as_raw(), 1);
-                WaitForSingleObject(process.as_raw(), 1_000);
                 timed_out = true;
             } else if wait_res != WAIT_OBJECT_0 {
                 return Err(SandboxError::ExecFailed(format!(
@@ -1463,13 +1467,30 @@ mod windows_impl {
             }
 
             // ---- 12. Exit code + drain ----
+            // Capture the child's exit code BEFORE reaping the tree (only
+            // meaningful on a clean exit; on timeout it is replaced by the
+            // `Timeout` error below).
             let mut exit_code: u32 = 0;
-            if GetExitCodeProcess(process.as_raw(), &mut exit_code) == 0 {
+            if !timed_out && GetExitCodeProcess(process.as_raw(), &mut exit_code) == 0 {
                 return Err(SandboxError::ExecFailed(format!(
                     "GetExitCodeProcess: {:#x}",
                     GetLastError()
                 )));
             }
+
+            // Reap the ENTIRE job tree before draining (#100). The direct child
+            // can spawn helpers — most notably a console host (`conhost.exe`) —
+            // that outlive it and keep the inherited stdout/stderr write-ends
+            // open. A plain `TerminateProcess(child)` leaves them running, so the
+            // blocking `drain_pipe` below would never reach EOF and the call
+            // would hang far past the timeout (observed as a 120s "command timed
+            // out" with no output on disconnected RDP sessions). Terminating the
+            // job closes every member's handles so the pipes EOF; bytes already
+            // written to the pipe buffers stay readable. The short wait lets the
+            // kernel finish closing the handles before we read.
+            TerminateJobObject(job.as_raw(), if timed_out { 1 } else { exit_code });
+            WaitForSingleObject(process.as_raw(), 2_000);
+
             let stdout = drain_pipe(stdout_r.as_raw());
             let mut stderr = drain_pipe(stderr_r.as_raw());
 

--- a/crates/wcore-sandbox/tests/live_integrity.rs
+++ b/crates/wcore-sandbox/tests/live_integrity.rs
@@ -174,3 +174,45 @@ async fn live_cmd_runs_when_allowlist_has_missing_path() {
         String::from_utf8_lossy(&out.stdout)
     );
 }
+
+/// #100 regression: a runaway command must be bounded by the manifest timeout.
+/// On timeout the backend terminates the whole job tree and reaps it before
+/// draining, so the blocking `drain_pipe` can reach EOF even when the child (or
+/// a helper it spawned, e.g. a console host) is still alive — otherwise the call
+/// hangs far past the timeout (the 120s "command timed out, no output" symptom).
+#[tokio::test(flavor = "current_thread")]
+async fn live_runaway_command_is_bounded_by_timeout() {
+    if std::env::var("WAYLAND_SANDBOX_LIVE_WINDOWS").is_err() {
+        return;
+    }
+
+    let b = AppContainerBackend::new();
+    let m = SandboxManifest {
+        timeout: Some(Duration::from_secs(3)),
+        ..Default::default()
+    };
+    let start = std::time::Instant::now();
+    // `for /l %i in (0,0,1)` never reaches its end value -> infinite cmd loop.
+    let r = b
+        .execute(
+            &m,
+            SandboxCommand {
+                argv: vec![
+                    "cmd.exe".into(),
+                    "/c".into(),
+                    "for /l %i in (0,0,1) do @rem".into(),
+                ],
+                cwd: None,
+            },
+        )
+        .await;
+    let secs = start.elapsed().as_secs();
+    assert!(
+        secs <= 8,
+        "runaway command must be bounded by the 3s timeout; took {secs}s (drain hung past timeout)"
+    );
+    assert!(
+        matches!(r, Err(wcore_sandbox::SandboxError::Timeout)),
+        "expected SandboxError::Timeout, got {r:?}"
+    );
+}


### PR DESCRIPTION
Fixes the second Windows-sandbox blocker for v0.12.14 / desktop 0.11.4 (issue #100): a sandboxed Bash child hangs to the 120s timeout with no output on Windows (reproduced live on disconnected RDP sessions).

### Root cause
On completion/timeout the AppContainer backend terminated only the **direct child** (`TerminateProcess(cmd)`). But `cmd.exe` spawns a console host (`conhost.exe`) that can outlive it and keep the **inherited stdout/stderr pipe write-ends open**. The drain step then did a **blocking `ReadFile` until EOF** — which never came — so `execute_blocking` hung far past the timeout. The Bash tool's outer 120s timeout then fired with 0 output: exactly the #100 symptom.

### Fix
Capture the child's exit code, then **`TerminateJobObject` the whole tree** before draining. Job breakaway is already disabled, so every descendant (including conhost) is a job member and gets reaped → all pipe write-ends close → drain reaches EOF → bounded result/timeout. Bytes already buffered stay readable.

Also evaluated `CREATE_NO_WINDOW` (to avoid the console host entirely) — **rejected**: under the AppContainer Low-IL restricted token it makes cmd's console init fail with `0xC0000142` (STATUS_DLL_INIT_FAILED), breaking every command. So cmd keeps its console and the hang is handled at drain time.

### Verification (native Windows, x86_64-pc-windows-msvc)
- **No regression**: `echo`/`ver`/`whoami` behave identically before/after.
- **Bounded timeout**: a runaway command now returns `SandboxError::Timeout` in ~3s instead of hanging (new live test `live_runaway_command_is_bounded_by_timeout`).
- The 2 pre-existing `live_fs_acl` failures on the box are unrelated (they fail on pre-fix code too).

**Honest note on the live hang:** the actual disconnected-RDP desktop hang could not be reproduced in any standalone harness (raw `execute()`, the real `BashTool::execute_streaming` path, with/without console, in session 0 and in session 1 connected *and* disconnected) — it requires the live Electron parent context. This fix removes the only mechanism that can turn a lingering descendant into an unbounded drain hang, and guarantees the sandbox path can no longer hang past the timeout. **Overwatch's live desktop re-verify is the final gate** before 0.11.4 (per the stated plan: re-bundle 0.12.14 → re-verify Windows shells live).