### PR TITLE
docs: Crucible, isolated profiles & cost governance + 0.12.x feature coverage

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,11 +1,51 @@
 # Documentation
 
-## Table of Contents
+## Getting started
 
 - **[Getting Started](getting-started.md)** — Installation, CLI parameters, configuration files, usage examples, session management, REPL mode
+- **[Advanced Features](advanced.md)** — Sub-agent spawning, hook system, prompt caching, VCR recording/replay, AGENTS.md hierarchical loading, plan mode, context compression, file state cache, output compaction
+- **[Troubleshooting](troubleshooting.md)** — Common errors, diagnostics, and solutions
+
+## Providers & routing
+
+- **[Providers & Auth](providers.md)** — Multi-provider configuration, profile inheritance, AWS Bedrock, Google Vertex AI, OAuth login
+
+## Tools & MCP
+
 - **[Built-in Tools](tools.md)** — Read, Write, Edit, Bash, Grep, Glob, Spawn — detailed reference and concurrency notes
 - **[MCP Integration](mcp.md)** — Model Context Protocol client: stdio, SSE, and streamable-http transports
-- **[Providers & Auth](providers.md)** — Multi-provider configuration, profile inheritance, AWS Bedrock, Google Vertex AI, OAuth login
-- **[Advanced Features](advanced.md)** — Sub-agent spawning, hook system, prompt caching, VCR recording/replay, AGENTS.md hierarchical loading, memory system, plan mode, context compression, file state cache, output compaction
+
+## Orchestration
+
+- **[ForgeFlows (Dynamic Workflows)](workflows.md)** — Declarative multi-stage workflow engine: RON definitions, graph lowering, the WorkflowRunner execution path
+- **[Crucible](crucible.md)** — Cross-provider Mixture-of-Providers council: fan-out, fusion, and per-tier model selection
+
+## Profiles & cost
+
+- **[Isolated Profiles](profiles.md)** — Independent `WAYLAND_HOME`-rooted environments with separate config, credentials, memory, and skills, managed by the `wayland-core profile` command family
+- **[Cost & Token-Spend Governance](cost-governance.md)** — Three independent cost-control mechanisms: spend caps, token budgets, and per-tier accounting
+
+## Memory
+
+- **[Memory Model](memory.md)** — The 5-partition × 3-tier SQLite-backed long-term memory layer
+
+## Security
+
+- **[Channels](channels.md)** — Inbound security model for chat-platform messages (Telegram, Discord, and others)
+
+## Extensibility
+
+- **[Skills](skills.md)** — Named prompt snippets the agent can invoke on demand: front matter, shell expansion, conditional activation
+- **[Plugin Authors Guide](plugin-authors.md)** — Stable plugin API for contributing tools, hooks, providers, skills, rules, MCP servers, and user-model backends without forking
+- **[Marketplace Allowlist Format](marketplace-format.md)** — v1.0 index format backing `wayland-core plugin install`
+- **[wcore-evolve](wcore-evolve.md)** — The W10B GEPA skill-evolution loop: child generation, scoring, and retention
+
+## Embedding
+
 - **[JSON Stream Protocol](json-stream-protocol.md)** — Host integration protocol specification (`--json-stream` mode)
-- **[Troubleshooting](troubleshooting.md)** — Common errors, diagnostics, and solutions
+
+## Architecture
+
+- **[Architecture](architecture.md)** — Cargo workspace crate map and dependency-graph layering
+- **[Endurance & Resilience Trial](resilience.md)** — Ongoing experiment in long-horizon, unattended autonomous operation
+- **[E2E Infrastructure](e2e.md)** — End-to-end test runner on DigitalOcean ephemeral droplets

--- a/docs/cost-governance.md
+++ b/docs/cost-governance.md
@@ -1,0 +1,252 @@
+# Cost & token-spend governance
+
+Wayland Core ships three **independent** cost-control mechanisms. Each is
+configured separately, each tracks something different, and each fails its own
+way when a limit is hit. All are opt-in except the Crucible daily envelope,
+which defaults on.
+
+| Mechanism | Config block | Tracks | When a cap trips |
+|-----------|--------------|--------|------------------|
+| Execution-tree budget | `[budget]` | wall time, tool runtime, process count, agent depth, tokens, USD — across the whole session tree | Emits a single `BudgetExceeded` protocol event on the first cap to trip |
+| Per-session spend tracker | `[session_cap]` | input + output tokens, USD cost per session | Warns at 80%, then blocks the **next** turn and terminates the run cleanly |
+| Crucible council caps | `[crucible]` | per-run worst-case council cost, per-day aggregate, per-stakes-tier auto cost | Refuses to spawn the council (per-run / daily) or trims the roster (stakes tiers) |
+
+These caps are **post-hoc** for the engine path: the provider has already billed
+a turn by the time it is charged, so a cap blocks the turn *after* the one that
+crossed it. It never un-spends the crossing turn.
+
+> **Note on "#65 token-spend governance".** The 0.12.6 `#65` change is a
+> *performance improvement* — routing-tier wiring, cheap-but-accurate
+> compaction, bounded retries, and prompt-cache hygiene. It **reduces** spend; it
+> is not a configurable cap. The configurable caps are the three blocks above.
+
+---
+
+## 1. Execution-tree budget (`[budget]`)
+
+Use this to bound a whole run — including every sub-agent it spawns — across
+multiple dimensions at once (not just money). Counters are **tree-shaped**:
+when a child records tokens or cost, the counter rolls up to all of its
+ancestors, so a stricter child cap never relaxes the parent.
+
+When any cap is exceeded the engine emits a single `BudgetExceeded` protocol
+event carrying the `reason`, the `observed` value, and the `limit`. Caps are
+checked in a **fixed, deterministic order**, so the first one to trip is always
+reported the same way:
+
+```
+max_wall_time → max_tool_runtime → max_processes → max_agent_depth
+            → max_tokens_in → max_tokens_out → max_cost_usd
+```
+
+```toml
+[budget]
+max_wall_time_secs    = 600      # 10 minutes of wall clock
+max_tool_runtime_secs = 300      # cumulative tool runtime
+max_processes         = 8        # concurrent Bash/Script children
+max_agent_depth       = 3        # sub-agent delegation depth
+max_tokens_in         = 2_000_000
+max_tokens_out        = 400_000
+max_cost_usd          = 5.00
+```
+
+### Config reference
+
+| Field | Type | Default | Meaning |
+|-------|------|---------|---------|
+| `[budget].max_wall_time_secs` | `Option<u64>` | `None` | Wall-clock cap for the tree, in seconds |
+| `[budget].max_tool_runtime_secs` | `Option<u64>` | `None` | Cumulative tool-runtime cap, in seconds |
+| `[budget].max_processes` | `Option<usize>` | `None` | Max concurrent child processes (Bash/Script) |
+| `[budget].max_agent_depth` | `Option<usize>` | `None` | Max sub-agent delegation depth |
+| `[budget].max_tokens_in` | `Option<u64>` | `None` | Input-token cap for the tree |
+| `[budget].max_tokens_out` | `Option<u64>` | `None` | Output-token cap for the tree |
+| `[budget].max_cost_usd` | `Option<f64>` | `None` | USD cost cap for the tree (checked last) |
+
+Every field is optional; leave one unset to leave that dimension uncapped.
+
+---
+
+## 2. Per-session spend tracker (`[session_cap]`)
+
+Use this when you only want a **money / token spend** ceiling per session, with
+an early warning. It is configured with the same shape as `[budget]`, but the
+tracker only consumes the **token and cost** fields — see the gotcha below.
+
+After every accepted LLM turn the engine charges the tracker:
+`charge(session_id, tokens, cost)`. Cost is read from the `wcore-pricing`
+catalog for the model **actually dispatched** (so a tier-swapped cheap turn is
+billed cheap), falling back to a `ProviderCompat` heuristic on a catalog miss.
+
+What happens as the total climbs:
+
+- **At ≥ 80%** of the strictest configured cap, the tracker emits one `CapWarn`
+  alongside the normal `Charge` event.
+- **On the charge that would cross a cap**, the charge is **rejected and does not
+  stick** — running totals are not incremented. The engine then repairs any
+  orphaned `tool_use` blocks, emits a `BudgetExceeded` protocol event plus a
+  user-visible `Run stopped: budget cap … exceeded` error, and finishes the run
+  cleanly rather than starting another paid turn.
+
+Each session has its own bucket; separate sessions never share a cap.
+
+```toml
+[session_cap]
+max_tokens_in  = 1_000_000
+max_tokens_out = 200_000
+max_cost_usd   = 1.50
+```
+
+### Config reference
+
+| Field | Type | Default | Meaning |
+|-------|------|---------|---------|
+| `[session_cap]` (whole block) | `Option<BudgetConfig>` | `None` | Opt-in per-session tracker. Same 7-field shape as `[budget]`, but only the token + cost fields below are wired in |
+| `[session_cap].max_tokens_in` + `max_tokens_out` | `Option<u64>` (each) | `None` | **Summed** (saturating) into one per-session token cap. Either or both may be set |
+| `[session_cap].max_cost_usd` | `Option<f64>` | `None` | Per-session USD cap charged against each turn |
+
+> **Gotcha — these are not interchangeable with `[budget]`.** Only the token and
+> USD fields of `[session_cap]` are enforced. `max_wall_time_secs`,
+> `max_tool_runtime_secs`, `max_processes`, and `max_agent_depth` are **ignored**
+> inside `[session_cap]`. Put time / process / depth caps in `[budget]`, and
+> token / USD spend caps in `[session_cap]` (or in `[budget]` if you also want
+> them tree-rolled-up).
+
+> **Not yet available — a generic per-user/day cap.** The tracker has an internal
+> per-user daily USD bucket (keyed by user and UTC day), but it has **no TOML
+> field** and the engine's per-turn path does not call it. The only
+> config-wired daily cap that ships today is the Crucible `daily_cap_usd` below.
+
+---
+
+## 3. Crucible council caps (`[crucible]`)
+
+The [Crucible](../README.md#crucible--a-mixture-of-providers-council) council fans a task out across multiple
+providers, so it is the most expensive thing the engine can do — and it has the
+most cost machinery. Before spawning anything, the council certifies a
+**judge-inclusive worst-case estimate** (the aggregator/judge is the dominant
+cost and scales with proposer count) and refuses to run if that estimate
+violates a hard cap or cannot be priced.
+
+Pricing is catalog-driven (`wcore-pricing` `DEFAULT_CATALOG`), accounted in
+integer **microcents** (no float drift). A catalog miss contributes `0` cost but
+flags the roster `priced = false`, so the council can tell *free* from
+*unpriced* and never silently passes a cap on an undercount.
+
+There are three distinct caps:
+
+- **`max_cost_usd` — strict per-run ceiling.** If set and the certified
+  worst-case estimate exceeds it, the council refuses with `OverBudget`. An
+  unpriceable roster is refused with `UnpriceableRoster` rather than run against
+  a `$0` undercount. Unset by default.
+- **`daily_cap_usd` — soft per-day envelope.** Defaults to **`$20`**. Binds
+  *only* when the roster is fully priceable: if prior daily spend plus this
+  council's certified ceiling exceeds the cap, the council refuses before spawn
+  with `DailyBudgetExhausted`. An unpriced roster is never hard-refused here.
+- **`cap_low_usd` / `cap_med_usd` / `cap_high_usd` — auto-path stakes caps.** In
+  auto mode (`--auto`) a difficulty classifier picks a stakes tier and the
+  assembler trims the roster to fit that tier's cap. Defaults: `$0.02` / `$0.05`
+  / `$0.15`. `--deep` forces the High tier.
+
+### Config reference
+
+| Field | Type | Default | Meaning |
+|-------|------|---------|---------|
+| `[crucible].enabled` | `bool` | `false` | Council kill-switch; no fan-out unless `true` |
+| `[crucible].max_cost_usd` | `Option<f64>` | `None` | **Strict** per-run hard ceiling; refuses `OverBudget` / `UnpriceableRoster` |
+| `[crucible].daily_cap_usd` | `Option<f64>` | `Some(20.0)` | **Soft** per-user/day envelope; binds only on a fully-priceable roster |
+| `[crucible].cap_low_usd` | `f64` | `0.02` | Auto-path spend cap for a Low-stakes council |
+| `[crucible].cap_med_usd` | `f64` | `0.05` | Auto-path spend cap for a Med-stakes council |
+| `[crucible].cap_high_usd` | `f64` | `0.15` | Auto-path spend cap for a High-stakes council (used by `--deep`) |
+| `[crucible].max_proposers` | `usize` | `5` | Upper bound on roster size — a blast-radius cap at roster validation |
+| `[crucible].proposer_max_turns` | `usize` | `4` | Per-proposer turn budget; feeds the worst-case estimate |
+| `[crucible].flux_markup` | `f64` | `1.0` | Multiplier on the native-SKU price when pricing a `flux-pinned-*` model (stopgap until Flux emits authoritative cost) |
+| `[crucible].crucible_auto_spend` | `bool` | `false` | In a non-TTY invocation, auto-approve the plan instead of failing closed. Default `false` = headless/piped runs never spend without explicit human approval |
+
+The certified worst-case also uses an internal per-proposer output budget
+constant (`DEFAULT_PROPOSER_MAX_TOKENS = 4096`) as the single source of truth, so
+the estimate cannot drift from actual spend.
+
+### Minimal council config
+
+```toml
+[crucible]
+enabled    = true
+proposers  = ["anthropic:claude-…", "openai:gpt-…"]
+aggregator = "anthropic:claude-…"
+# defaults apply: daily_cap_usd = $20, no per-run cap,
+# max_proposers = 5, tiers $0.02 / $0.05 / $0.15
+```
+
+### Raising caps interactively
+
+In an interactive (TTY) crucible run the approval loop can raise caps in place:
+
+- `ApprovePremium { ceiling_usd }` and `Edit { budget_usd }` raise all three
+  stakes-tier caps and re-assemble a stronger roster.
+- A `--judge` override re-prices the roster against the **actual** pinned judge
+  and re-checks the (possibly-raised) cap. If it still exceeds, the council
+  appends a `WARNING: pinned judge est … exceeds the … cap` note and proceeds —
+  it never silently overspends or mis-reports.
+
+### Crucible CLI flags
+
+```bash
+wayland-core crucible "<task>"      # run the council, subject to [crucible] caps
+```
+
+| Flag | Effect |
+|------|--------|
+| `--auto` | Gate a manual roster behind a cheap difficulty classifier (trivial → single direct call; high-stakes → full council) |
+| `--deep` | Treat the task as **High** stakes — widest roster + strongest judge, governed by `cap_high_usd` |
+| `--council <specs>` | Pin the auto candidate pool to exactly these `provider:model` specs (forces auto mode) |
+| `--judge <spec>` | Pin the aggregator; re-prices the roster and re-checks the stakes cap |
+| `--direct` | Force a single direct answer instead of convening a council |
+| `--force-council` | Convene regardless of the gate |
+| `--deny <families>` | Exclude provider families from an auto roster |
+| `--advisor` / `--terminal` | Choose the synthesis sink — inject into the trusted loop vs print-and-stop (mutually exclusive) |
+
+> **Gotcha — the daily envelope is in-process only.** The Crucible `daily_cap_usd`
+> aggregates spend **within a single CLI process**, not across separate
+> invocations. Cross-process daily persistence is not yet shipped. The CLI
+> council identity is the `WAYLAND_USER_ID` env var (default `default`).
+
+---
+
+## Worked examples
+
+**Per-session USD cap blocks the next turn.** With `[session_cap] max_cost_usd =
+1.50`, once cumulative turn cost crosses `$1.50` the engine emits
+`BudgetExceeded` and stops. The crossing turn is still billed — caps are
+post-hoc.
+
+**A token cap does not stick on overrun.** With a per-session token cap of
+`1500`: a `1000`-token charge is accepted; a following `600`-token charge is
+rejected (`CapExceeded`); the session total stays at `1000`, not `1600`.
+
+**Separate sessions, separate buckets.** With `max_cost_usd = 0.10`: session
+`s1` charges `$0.09` (ok) and session `s2` charges `$0.09` (ok — a fresh
+bucket); then `s1 + $0.05` is rejected.
+
+**The 80% warning fires once.** With `max_cost_usd = 0.10`, a single `$0.09`
+charge (90%) emits exactly one `CapWarn` alongside its `Charge`.
+
+**Crucible refuses an unpriceable roster.** With `[crucible] max_cost_usd = 5.0`
+and a member the catalog can't price → `UnpriceableRoster`; the council never
+runs.
+
+**Crucible refuses before spawn when the day is exhausted.** A small
+`daily_cap_usd` where prior spend plus the certified ceiling exceeds the cap →
+`DailyBudgetExhausted` before any provider call.
+
+**An auto-path stakes cap trims the roster.** A small `cap_med_usd` makes the
+assembler trim to a council that fits; set it below the cost of any viable
+council (e.g. `0.0001`) and there is no viable roster.
+
+---
+
+## See also
+
+- [Crucible](../README.md#crucible--a-mixture-of-providers-council) — the council itself, roster selection, and
+  synthesis modes.
+- [Providers & Authentication](providers.md) — provider pricing and model
+  selection that feed the cost catalog.

--- a/docs/crucible.md
+++ b/docs/crucible.md
@@ -1,0 +1,325 @@
+# Crucible (Mixture-of-Providers council)
+
+Crucible is wayland-core's **cross-provider council**. It fans a single task out
+to *N* proposer sub-agents — each pinned to a **different** LLM provider, each
+using that provider's own API key — then a separate **aggregator** (the "judge")
+fuses the proposals into one answer. It is a Mixture-of-Providers (MoP) design:
+instead of trusting one model, you put several vendors' best models in a room,
+let them answer independently, and have a cooler-running judge reconcile them.
+
+Crucible is **opt-in and OFF by default**. It is **BYO-keys**: every council
+member is resolved to a keyed provider from your own `[providers]` config, so you
+only ever run the models you've already connected. The whole council is
+**read-only by construction** — proposers and the judge get no `Bash`/`Write`/`Edit` —
+and because it costs roughly *N×* a single call, it ships with first-class cost
+controls.
+
+![Crucible run](img/crucible-run.png)
+
+## When to use it
+
+Use Crucible for high-stakes, single-shot questions where a second (and third)
+opinion is worth the spend: security audits, architecture reviews, cross-checking
+a plan, comparing designs. For routine work, leave it off — a normal single-model
+session is cheaper and faster.
+
+It is deliberately a *deliberation* tool, not an everyday driver. The default
+caps (a soft $20/day envelope, per-stakes ceilings on the auto path) and the
+pre-flight approval card exist precisely because a council is more expensive than
+one call.
+
+## Enabling it
+
+Crucible does nothing until you turn it on. With it disabled, `wayland-core crucible`
+exits with an error telling you to set `enabled = true` and list `proposers`.
+
+Minimal config in your `[crucible]` block:
+
+```toml
+[crucible]
+enabled = true
+proposers = ["openai", "anthropic:claude-opus-4-8"]
+```
+
+A partial table backfills every omitted bound from its default
+(`min_proposers = 1`, `max_proposers = 5`, `proposer_deadline_s = 90`,
+temperatures `0.6`/`0.4`, `mode = "terminal"`, `daily_cap_usd = 20`), so you only
+write the fields you want to change.
+
+Each proposer spec resolves to its own keyed provider from your on-disk
+`[providers]` map. A member whose credential can't be resolved is **skipped, not
+fatal** — the council runs with whoever has a working key — while an unknown
+provider id is reported as an error. (The exact provider/auth field names live in
+the `[providers]` config; see [providers.md](providers.md).)
+
+### Provider spec format
+
+A proposer/aggregator spec is either:
+
+- `"provider"` — the provider's default model, or
+- `"provider:model"` — a specific model.
+
+Exactly one `:` is allowed; an empty provider, a trailing `:`, or `a:b:c` are
+malformed. Flux routes use the form `flux-router:flux-pinned-<model>`. Crucible
+canonicalizes families so the *same* model never counts as two diverse picks: a
+`flux-pinned-*` model maps back to its underlying vendor, and
+`openrouter:<vendor>/<model>` is canonicalized to the upstream vendor.
+
+## Running it
+
+The command is `wayland-core crucible "<task>"`. The task is a single quoted
+positional argument.
+
+```bash
+wayland-core crucible "cross-audit this security plan"
+```
+
+By default this runs **manual mode**: the roster is taken verbatim from your
+`[crucible].proposers`/`aggregator`, and the council always convenes.
+
+### Flags
+
+| Flag | Effect |
+|------|--------|
+| `--auto` | Manual roster, but **gate first**: a cheap classifier decides convene-vs-direct (a trivial ask answers with one direct call). Without `--auto` the manual council always convenes. |
+| `--council <spec,spec,...>` | Pin the **auto** candidate pool to exactly these comma-separated specs (forces auto mode). |
+| `--judge <provider:model>` | Pin the auto aggregator/judge; the roster is re-priced and the tier cap re-checked (warns if it now exceeds the cap). |
+| `--direct` | Force a single direct answer (auto mode). |
+| `--force-council` | Force convening a council regardless of the gate (auto mode); Med stakes, or High with `--deep`. |
+| `--deep` | Treat the task as High stakes — widest roster + strongest judge (auto mode). |
+| `--deny <family,family,...>` | Exclude these provider families from an auto roster (forces auto mode). |
+| `--advisor` | Inject the fused synthesis into the normal **trusted** agent loop as fenced private guidance, instead of print-and-stop. Overrides `[crucible].mode`. |
+| `--terminal` | Force terminal (print-and-stop) mode, overriding `[crucible].mode`. Mutually exclusive with `--advisor` (usage error if both). |
+
+Any of `--council`, `--judge`, `--direct`, `--force-council`, `--deep`, or
+`--deny` switches Crucible into **auto** assembly (below), as does
+`assembly = "auto"` in config.
+
+## Manual vs auto assembly
+
+**Manual** (default, `assembly = "manual"`): the roster is your `proposers` list
+plus `aggregator`, used exactly as written. This is the predictable, shipped path —
+you decide who's on the council.
+
+**Auto** (`assembly = "auto"`, or any auto-triggering flag): a **pure
+deterministic** assembler picks a cost-effective, provider-diverse roster from
+your keyed candidate pool, prints a pre-flight plan card, and waits for approval
+before spending. The assembler:
+
+- classifies stakes and sizes the roster accordingly (see the gate below),
+- reserves the **strongest** provider family as a *decoupled* judge — it is never
+  also a proposer,
+- requires **≥ 3 priced families** for a real council; with fewer it falls back
+  to a single strong Direct answer,
+- excludes deny-listed families and unpriceable specs,
+- applies an intra-family price floor (a flash/mini SKU can't take a slot a
+  flagship should hold),
+- fits the roster under the stakes-tier cost cap with a **downshift ladder**:
+  downshift the judge → drop the priciest proposer → fall to a single Direct.
+
+### The gate (Low / Med / High stakes)
+
+The gate (`classify_task`) is a **cheap, deterministic keyword + length
+heuristic** — no LLM call, no token spend. A high-signal keyword in the leading
+instruction span marks the task **High**; any other signal, or a task of ≥ 40
+words, marks it **Med**; otherwise it's **Direct** (Low). Stakes map to proposer
+count:
+
+| Stakes | Proposers |
+|--------|-----------|
+| Low | 0 (a single direct answer) |
+| Med | 3 |
+| High | 5 |
+
+The count is clamped to `max_proposers` and to the number of available candidate
+families. For example, "What day is today?" routes Direct, while "Do a detailed
+security audit of this deployment plan" (or any 40+-word task) convenes a council.
+
+On the manual path the gate only runs when you pass `--auto`; otherwise the
+manual council always convenes.
+
+## Proposers, aggregator, and fusion
+
+Proposers run **hotter** for diversity (`proposer_temperature`, default `0.6`);
+the aggregator runs **cooler** for convergence (`aggregator_temperature`, default
+`0.4`). Both are clamped to `0.0..=2.0` (NaN/inf → `0.0`) before reaching the
+wire.
+
+An `LlmSynthesisAggregator` pinned to your configured `aggregator` provider fuses
+the usable proposals. If no aggregator is set or resolvable, or it errors, the
+council falls back to the **first usable proposal verbatim** — you always get an
+answer. The aggregator spec is validated against known built-in providers/aliases
+at config load.
+
+**Quorum and tail-latency.** At least `min_proposers` usable (non-error,
+non-blank) proposals are required — always ≥ 1 — or the run fails with an
+insufficient-proposals error. Each proposer has a hard `proposer_deadline_s` (90s)
+backstop. Once quorum is met, the soft `global_deadline_s` (25s) cancels
+stragglers. `proposer_concurrency` (4) caps concurrent spawns that share one
+credential prefix, so a `flux:*` roster doesn't thundering-herd a single key.
+
+## Security: prompt-injection fencing
+
+Crucible treats every proposal as untrusted input to the judge. Each proposal is
+wrapped in `[UNTRUSTED DATA]` markers with a security preamble, and any
+boundary-marker tokens inside a proposal's text are neutralized with a zero-width
+space — a proposal can't forge a closing delimiter to break out of its fence.
+
+The aggregator runs **read-only** (no `Bash`/`Write`/`Edit`), so even a
+successful injection inside a proposal can't reach a side-effecting tool. In
+advisor mode (below) the synthesis is re-fenced as `[UNTRUSTED DATA]` before it
+ever reaches the trusted loop.
+
+## Advisor vs terminal mode
+
+How the fused answer is consumed:
+
+- **Terminal** (default): print the fused synthesis and stop. Fully read-only.
+- **Advisor** (`--advisor` or `mode = "advisor"`): re-fence the synthesis as
+  `[UNTRUSTED DATA]` at the tail of the user turn, then run the **normal trusted,
+  full-tool** main agent loop over it. The agent reasons and acts on the council's
+  guidance instead of just echoing it.
+
+Precedence: `--advisor` wins, then `--terminal`, else `[crucible].mode`. Passing
+both `--advisor` and `--terminal` is a usage error.
+
+## Cost and budget gating
+
+Because a council is *N×* a single call, spend is governed at three levels.
+
+- **Per-run hard cap** — `max_cost_usd` (default `None`) is **strict**: an
+  unpriceable roster under it is refused, and an over-estimate is rejected as
+  over-budget. `None` means no per-run cap.
+- **Daily cap** — `daily_cap_usd` (default `$20`) is **soft**: it binds only on a
+  priceable roster, pre-checking `spent + certified > cap`. *Note: in the current
+  build this accumulates per-process within a single CLI invocation; cross-process
+  daily persistence is a later stage, so the envelope does not yet bind across
+  separate `wayland-core crucible` calls.*
+- **Stakes-tier auto caps** — `cap_low_usd` / `cap_med_usd` / `cap_high_usd`
+  (`$0.02` / `$0.05` / `$0.15`) bound the auto assembler. When a roster doesn't
+  fit, the downshift ladder kicks in (downshift judge → drop priciest proposer →
+  single Direct). Raise `cap_high_usd` (or use `--deep`) to widen a High plan.
+
+**No surprise spend.** The auto path prints a typed proposal card and requires
+approval. In a non-TTY (headless/CI) session it **fails closed** unless
+`crucible_auto_spend = true` (default `false`). The card always renders
+`price unknown` (never `$0`) for an unpriceable ceiling.
+
+After a run, a provenance line is printed to stderr, e.g.:
+
+```
+crucible: skipped proposer 'vertex' (provider 'vertex' has no usable api key)
+crucible: fused 2 proposal(s) from [anthropic, openai]
+crucible: spend = 180 in + 90 out tokens, ~$0.0020 across 2 member(s)
+```
+
+## The council card (TUI)
+
+In the TUI, the same typed plan renders on the approval rail: a scale glyph,
+per-member proposer/judge rows (the judge accented), a `You're approving up to
+$X.XXXX` ceiling, a `One model alone ≈ $X.XXXX` baseline, a judge-independence
+line, a `today: $spent / $cap` daily line, and the reason/trims trace. Keys are
+`[Enter] run` and `[Esc] cancel — no charge`.
+
+![Crucible TUI council](img/crucible-tui.png)
+
+## Empty-state bootstrap
+
+When both `proposers` and `candidate_pool` are empty, the auto path falls back to
+a default Flux pool (flux-pinned `gpt-5` / `claude-opus-4-7` / `deepseek-v4-pro` /
+`gemini-2-5-pro`) so `/crucible` works as soon as you've connected a Flux key.
+
+## Privacy-safe learning log
+
+With `log_assembly = true` (default `false`), each auto council appends one JSON
+line to `crucible-assembly.jsonl` under your user config directory, recording
+**only** the stakes class, provider-family mix, aggregator family, and
+estimated-vs-actual cost. It never logs task text, trims, model specs, or keys.
+
+## Configuration reference
+
+All fields live under `[crucible]`.
+
+| Field | Type | Default | Meaning |
+|-------|------|---------|---------|
+| `enabled` | bool | `false` | Kill-switch. OFF keeps the council inert; the CLI errors unless this is true. |
+| `proposers` | list of string | `[]` | Provider specs (`"provider"` / `"provider:model"`), one per proposer. |
+| `candidate_pool` | list of string | `[]` | Extra `provider:model` specs the **auto** assembler may draw from; ignored on the manual path. |
+| `aggregator` | string (optional) | none | Spec for the judge that fuses proposals; none → first usable proposal. Validated at load. |
+| `min_proposers` | int | `1` | Minimum non-error proposals for a valid result (quorum). |
+| `max_proposers` | int | `5` | Upper bound on roster size (cost / blast-radius cap). |
+| `proposer_max_turns` | int | `4` | Per-proposer turn budget. |
+| `proposer_concurrency` | int | `4` | Max concurrent proposer spawns per resolved route/credential prefix; `0` = unbounded. |
+| `proposer_deadline_s` | int | `90` | Per-proposer wall-clock hard deadline (seconds). |
+| `max_cost_usd` | float (optional) | none | **Strict** per-run hard spend ceiling (USD). none = no per-run cap. |
+| `daily_cap_usd` | float (optional) | `20.0` | **Soft** per-user/day spend ceiling (USD); binds only on a priceable roster. |
+| `assembly` | `"manual"` \| `"auto"` | `manual` | Roster selection mode. |
+| `flux_markup` | float | `1.0` | Multiplier on the native-SKU price when pricing a `flux-pinned-*` model. |
+| `global_deadline_s` | int | `25` | Global soft deadline (seconds); once quorum is met, stragglers are cancelled. Kept below `proposer_deadline_s`. |
+| `cap_low_usd` | float | `0.02` | Auto-path spend cap (USD) for a Low-stakes council. |
+| `cap_med_usd` | float | `0.05` | Auto-path spend cap (USD) for a Med-stakes council. |
+| `cap_high_usd` | float | `0.15` | Auto-path spend cap (USD) for a High-stakes council. |
+| `log_assembly` | bool | `false` | Opt-in privacy-safe per-auto-council logging to `crucible-assembly.jsonl`. |
+| `proposer_temperature` | float | `0.6` | Proposer sampling temperature (diversity); clamped `0.0..=2.0`. |
+| `aggregator_temperature` | float | `0.4` | Aggregator sampling temperature (convergence); clamped `0.0..=2.0`. |
+| `mode` | `"terminal"` \| `"advisor"` | `terminal` | How the synthesis is consumed (print-and-stop vs injected guidance). |
+| `crucible_auto_spend` | bool | `false` | In a non-TTY invocation, auto-approve the plan instead of failing closed. |
+
+## Examples
+
+**Full manual council**, fan out to three providers and fuse with an Opus judge:
+
+```toml
+[crucible]
+enabled = true
+proposers = ["openai:gpt-5", "anthropic:claude-opus-4-8", "deepseek:deepseek-v4-pro"]
+aggregator = "anthropic:claude-opus-4-8"
+min_proposers = 2
+max_cost_usd = 0.50
+```
+
+```bash
+wayland-core crucible "cross-audit this security plan"
+```
+
+**Auto-assembled, deep (High stakes)** — widest provider-diverse roster +
+strongest decoupled judge, with a proposal card before any spend:
+
+```toml
+[crucible]
+enabled = true
+assembly = "auto"
+proposers = ["openai:gpt-5"]
+candidate_pool = ["anthropic:claude-opus-4-8", "deepseek:deepseek-v4-pro", "google:gemini-2-5-pro"]
+```
+
+```bash
+wayland-core crucible --deep "audit this auth flow"
+```
+
+**Advisor mode** — fuse the council answer, then run the normal full-tool trusted
+loop with the synthesis fenced as advice:
+
+```bash
+wayland-core crucible --advisor "design the new dashboard layout"
+```
+
+**Headless / CI** — fails closed (no spend) unless `crucible_auto_spend = true`
+is set under `[crucible]`:
+
+```bash
+wayland-core crucible --council openai:gpt-5,anthropic:claude-opus-4-8,deepseek:deepseek-v4-pro \
+  "compare these designs"
+```
+
+## Gotchas
+
+- Crucible is OFF by default and errors out until `enabled = true` plus a
+  `proposers` roster (or a candidate pool / Flux key for auto).
+- It is BYO-keys: a member with no resolvable credential is silently skipped, not
+  fatal — check the stderr provenance line to see who actually ran.
+- A council costs roughly *N×* one call. Mind `max_cost_usd`, the daily envelope,
+  and the stakes-tier caps.
+- In non-interactive runs, auto mode fails closed unless you explicitly set
+  `crucible_auto_spend = true`.
+- `--advisor` and `--terminal` are mutually exclusive.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -103,22 +103,133 @@ Authorization = "Bearer ${cred:mcp:agent-vault:token}"
 
 ## Deferred Loading
 
-MCP tools can be registered as "deferred" — their full schema is not loaded into the system prompt at startup, reducing initial token usage. The LLM discovers deferred tools via the `ToolSearch` tool when needed.
+MCP tools are registered as "deferred" **by default** — their full schema is not loaded into the system prompt at startup, reducing initial token usage. The LLM discovers deferred tools via the `ToolSearch` tool when needed. Set `deferred = false` on a server to send its full tool schemas eagerly instead.
 
 ```toml
-[mcp.servers.large-toolset]
+[mcp.servers.small-toolset]
 transport = "stdio"
 command = "npx"
 args = ["-y", "my-mcp-server"]
-deferred = true    # Don't load tool schemas at startup
+deferred = false    # Send full tool schemas at startup (opt out of deferral)
 ```
 
 | `deferred` | Behavior |
 |------------|----------|
-| `false` (default for config servers) | Tool schemas included in system prompt at startup |
-| `true` | Tools registered but schemas loaded on-demand via ToolSearch |
+| `true` (default when omitted) | Tools registered but schemas loaded on-demand via ToolSearch |
+| `false` | Tool schemas included in system prompt at startup |
 
-Use `deferred = true` for MCP servers with many tools to keep the initial system prompt small.
+Leave `deferred` at its default (`true`) for MCP servers with many tools to keep the initial system prompt small; set `deferred = false` only for a small, always-needed toolset.
+
+## Smart Tool Curation
+
+A single large MCP server (e.g. Google Workspace) can advertise dozens or
+hundreds of tools. Sending all of them on every turn wastes context tokens and,
+on some providers, overflows the provider's tool-array limit (an OpenAI request
+with more than 128 tools fails with an API 400). Wayland Core handles this with
+two independent passes applied to the outbound tool list each turn, in this
+order:
+
+1. **Relevance curation** (`[mcp].curation`) — a token/relevance optimization
+   that trims the MCP tools to the most relevant `k` for the turn.
+2. **Provider hard cap** (`max_tools` compat field) — a correctness guarantee
+   that caps the *total* tool array at the provider's limit.
+
+Both passes only ever touch **MCP** tools. The built-in tools (Read, Write,
+Edit, Bash, Grep, Glob, Spawn, ToolSearch, plan tools, skills) are always kept.
+
+### How tools are classified (real provenance)
+
+An MCP tool is identified by its **real provenance** — `ToolDef.server` is
+`Some(server_name)` for any tool sourced from an MCP server, and `None` for a
+built-in/skill/spawn/plan tool. Classification is **not** done on the `mcp__`
+name prefix: a non-colliding MCP tool keeps its bare, un-prefixed original name
+(see [Tool Naming](#tool-naming)), so the prefix alone cannot distinguish it
+from a built-in. Using the prefix would misclassify a uniquely-named MCP tool as
+a built-in and never curate or cap it.
+
+### Relevance ranking (BM25 + recency)
+
+Within the MCP partition, tools are ranked by:
+
+```
+score = BM25(user_message, tool_document) + recent_usage[tool] * 0.5
+```
+
+- **BM25 relevance** — the query is the most recent user message in the turn.
+  Each tool's "document" is its `description` + the real server name + the
+  tool-name tail (the last `__`-segment, or the bare name). The tokenizer
+  lowercases, splits on non-alphanumerics, and drops tokens of length ≤ 3, so
+  `mcp__gcal__list_calendar_events` tokenizes to `["gcal", "list", "calendar",
+  "events"]`. BM25 parameters are `k1 = 1.5`, `b = 0.75`, with Robertson IDF
+  guarded by the BM25+ `+1.0` term (keeps IDF non-negative for a term present in
+  every tool). This mirrors the desktop app's `bm25.ts` for cross-surface
+  parity.
+- **Recency boost** — an additive `0.5` per recent use, read from the long-term
+  audit log. When no audit log is available the curator gracefully degrades to
+  BM25-only ranking.
+
+There is deliberately **no** name-keyed "rescue" bonus. Because only MCP tools
+are ranked here, a bare-name floor (e.g. matching the name `Read`) could only
+ever reward a hostile MCP server that names a tool like a built-in to monopolize
+the curation budget — a budget-hijack vector closed in 0.12.11. Built-ins are
+kept by the caller, outside the curator.
+
+### Configuring relevance curation — `[mcp].curation`
+
+```toml
+# Default: keep the 15 most relevant MCP tools per turn.
+[mcp.curation]
+kind = "top_k"
+k = 15
+
+# Or disable curation entirely (expose every connected MCP tool).
+[mcp.curation]
+kind = "off"
+```
+
+| `[mcp].curation` `kind` | Behavior |
+|-------------------------|----------|
+| `top_k` (default, `k = 15`) | Trim the per-turn MCP tool list to the `k` highest-ranked tools |
+| `off` | Expose every connected MCP tool (no relevance trim) |
+
+When the connected MCP tool count is already ≤ `k`, curation is a no-op.
+
+### Provider hard cap — `max_tools`
+
+After relevance curation, the engine enforces the provider's hard tool-array
+limit. This is a `ProviderCompat` field, set per-provider:
+
+| Provider | `max_tools` default |
+|----------|---------------------|
+| OpenAI / OpenAI-wire (Azure, ChatGPT, flux-router, routers, …) | `128` |
+| Anthropic (and providers that don't set it) | none (uncapped) |
+
+The cap keeps **all** non-MCP tools, then fills the remaining budget with the
+most BM25-relevant MCP tools and truncates the rest. If the built-ins alone
+meet or exceed the limit, the entire MCP block is dropped for that request. You
+can override the cap per provider in `wcore.toml`:
+
+```toml
+[providers.openai.compat]
+max_tools = 64
+```
+
+### Dropped tools stay reachable
+
+MCP tools trimmed by either pass are not lost — they remain **discoverable via
+the `ToolSearch` meta-tool**, whose registry is a full bootstrap snapshot. The
+model can search for and surface a curated-out tool when a turn actually needs
+it.
+
+### Cache stability
+
+Both passes emit the kept MCP set in an **append-only union order** keyed on the
+MCP tool inventory (the hard cap additionally keys on its budget). A tool, once
+admitted, holds its slot; newly-surfaced tools are appended at the end. This
+keeps the serialized tool-zone prefix byte-stable across same-context turns so
+the provider prompt cache is read, not rewritten, every turn. The union resets
+only when the inventory itself changes (server connect/disconnect or plugin
+reload).
 
 ## Local (loopback) MCP servers — `allow_local`
 

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -1,0 +1,335 @@
+# Isolated Profiles
+
+An **isolated profile** is a self-contained `WAYLAND_HOME`-rooted home with its
+own `config.toml`, credentials, OAuth tokens, long-term memory, and skills.
+Switching profiles switches *everything* — different API keys, different memory,
+different session history — with no cross-contamination between them.
+
+This is a different feature from the `--profile <name>` **config selector**
+(named `[profiles.*]` sections inside one config file). See
+[Isolated profiles vs. the config selector](#isolated-profiles-vs-the-config-selector)
+below — the two share the `--profile` flag and are easy to confuse.
+
+## What an isolated profile is
+
+Wayland Core normally writes all of its state into a single home directory (the
+"default home"). An isolated profile is an **independent home directory** that
+Wayland Core uses *instead of* the default home for the duration of a launch.
+Because the home root is the only thing the engine consults at runtime, swapping
+the home swaps the entire environment:
+
+| Store | On-disk entry | Holds |
+|-------|---------------|-------|
+| config | `config.toml` | Provider, model, MCP servers, all settings |
+| credentials | `credentials.toml` / `credentials.enc` / `credentials.kdf.json` | Provider API keys (plaintext or encrypted vault) |
+| oauth | `oauth/` | OAuth tokens (e.g. ChatGPT-subscription auth) |
+| memory | `memory/` | Long-term cross-session memory |
+| skills | `skills/` | Installed and drafted skills |
+
+Everything else the engine writes (`.env`, `logs/`, sessions, `cron/`,
+`evolved/`) also lives under the profile home, so it is isolated too. The
+profiles control plane reports the five stores above via `profile show`.
+
+## When to use one
+
+- **Multiple accounts / clients.** Keep each client's keys, memory, and session
+  history fully separate — there is no shared credential or memory store to leak
+  across.
+- **Work vs. personal.** Different providers, different defaults, different
+  history, one binary.
+- **Throwaway / experimental setups.** Create a profile, try a configuration,
+  delete the whole home when done.
+
+If you only want to switch *provider/model settings* and are happy sharing one
+credential and memory store, you want the config selector instead — see below.
+
+## How a profile is selected at launch
+
+Wayland Core resolves the active home **once**, at process entry, and
+materializes it into the `WAYLAND_HOME` environment variable. After that,
+`WAYLAND_HOME` is the single source of truth for the rest of the run.
+
+Resolution order (first match wins):
+
+1. **`WAYLAND_HOME` already set** in the environment — an explicit override
+   always wins and is never overridden.
+2. **`--profile <name>` on the command line** — if a profile directory of that
+   name exists, its home becomes `WAYLAND_HOME`.
+3. **The active pointer** — the profile recorded by `profile use` (see below).
+4. **Otherwise the default home** — the pre-profiles single home.
+
+If a selected name is invalid or its directory does not exist, Wayland Core
+prints a warning to stderr and **falls through to the default home** — it never
+aborts the launch (so `--help` and the like always run). The one exception is
+host mode; see [Host / JSON-stream mode](#host--json-stream-mode).
+
+There are three ways to activate a profile, in order of how "sticky" they are:
+
+```bash
+# 1. Per-launch, environment override (most explicit, never second-guessed)
+WAYLAND_HOME=/path/to/profiles/work wayland-core "..."
+
+# 2. Per-launch, by name
+wayland-core --profile work "..."     # see the caveat in the disambiguation section
+
+# 3. Persistent — set the active pointer once, then launch bare
+wayland-core profile use work
+wayland-core "..."                    # uses 'work' until you change the pointer
+```
+
+## The `wayland-core profile` command family
+
+```
+wayland-core profile <SUBCOMMAND>
+```
+
+| Subcommand | Purpose |
+|------------|---------|
+| `create <name>` | Create a new, empty isolated profile |
+| `use <name>` | Set the active profile for future launches |
+| `list` | List all profiles (active marked with `*`) |
+| `show [name]` | Show a profile's home path and which stores it contains (defaults to the active profile) |
+| `rename <old> <new>` | Rename a profile (re-points the active pointer if it named `old`) |
+| `delete <name>` | Delete a profile and its entire home directory |
+| `export <name>` | Copy a profile's home tree to a directory (secrets excluded by default) |
+| `import <path>` | Adopt a directory tree as a new profile |
+
+### `create`
+
+```
+wayland-core profile create <name> [--base <name>] [--use]
+```
+
+Creates a new, empty profile (its own config / credentials / memory).
+
+| Flag | Behavior |
+|------|----------|
+| `--base <name>` | Record an inheritance marker naming an existing profile. **No state is copied** — and never any secrets. A `profile.toml` with `base = "<name>"` is written; inheritance is resolved at launch in a later release. A missing base is a hard error and leaves no half-made profile behind. |
+| `--use` | Also set the new profile active (writes the active pointer). |
+
+```bash
+wayland-core profile create work
+wayland-core profile create client.acme --use
+wayland-core profile create staging --base work      # marker only, no secrets copied
+```
+
+### `use`
+
+```
+wayland-core profile use <name>
+```
+
+Writes the **active pointer** so future launches that pass neither `--profile`
+nor `WAYLAND_HOME` use this profile. The profile must already exist (`use` does
+not create). The name is case-folded.
+
+```bash
+wayland-core profile use work
+```
+
+### `list`
+
+```
+wayland-core profile list
+```
+
+Lists all profiles, sorted, with the active one marked `*`. Reports an empty
+state cleanly, and warns if the active pointer names a profile that no longer
+has a directory (a dangling pointer you can repair).
+
+### `show`
+
+```
+wayland-core profile show [name]
+```
+
+Prints the profile's home path and which stores are present (config,
+credentials, oauth, memory, skills). Defaults to the active profile when `name`
+is omitted. **Never prints secret values** — only whether each store exists.
+
+```bash
+wayland-core profile show          # the active profile
+wayland-core profile show work
+```
+
+### `rename`
+
+```
+wayland-core profile rename <old> <new>
+```
+
+Renames the profile directory. `new` must not already exist. If the active
+pointer currently names `old`, it is re-pointed to `new` so the active selection
+follows the rename. A case-only rename (`work` → `Work`) maps to the same
+on-disk directory and is a no-op success.
+
+### `delete`
+
+```
+wayland-core profile delete <name> [--yes] [--force]
+```
+
+Deletes the profile **and its entire home directory**.
+
+| Flag | Behavior |
+|------|----------|
+| `--yes` | Skip the interactive confirmation prompt. On a non-interactive stdin (no TTY) deletion is **refused** without this flag rather than blocking. |
+| `--force` | Allow deleting the **currently-active** profile. Without it, deleting the active profile is refused. When the active profile is deleted, the active pointer is cleared so the next launch falls through to the default home. |
+
+```bash
+wayland-core profile delete staging --yes
+wayland-core profile delete work --yes --force      # also allowed when 'work' is active
+```
+
+### `export`
+
+```
+wayland-core profile export <name> [--out <path>] [--include-secrets]
+```
+
+Copies the profile's home tree into a plain directory.
+
+| Flag | Behavior |
+|------|----------|
+| `--out <path>` | Destination directory (created if absent). Defaults to a directory named after the profile (lowercased) in the current working directory. |
+| `--include-secrets` | Include secrets in the export. **By default secrets are excluded** — `credentials*` files and the `oauth/` directory are skipped. Passing this prints a stderr warning, because the export then contains live keys. |
+
+Symlinks in the tree are never followed (path-escape defense).
+
+```bash
+wayland-core profile export work --out ./work-backup
+wayland-core profile export work --out ./work-full --include-secrets   # WARNS — contains keys
+```
+
+### `import`
+
+```
+wayland-core profile import <path> [--as <name>]
+```
+
+Adopts an existing directory tree (for example, a `profile export` tree) as a
+**new** profile. The new profile must not already exist.
+
+| Flag | Behavior |
+|------|----------|
+| `--as <name>` | Name for the imported profile. Defaults to the source directory's name (any trailing `.ext` removed). |
+
+The source must be an existing directory. Symlinks are never followed
+(zip-slip / path-escape defense). Secrets in the source are **not** filtered on
+import — you are adopting a tree you supplied, so whether it carries keys depends
+on how it was exported.
+
+```bash
+wayland-core profile import ./work-backup
+wayland-core profile import ./some-tree --as work
+```
+
+## Profile names
+
+Names become filesystem directory components, so the grammar is strict and
+anything ambiguous across platforms is rejected up front (never sanitized):
+
+- Non-empty, at most **64 bytes**.
+- Only ASCII letters, digits, `.`, `_`, `-` (this rejects every path separator,
+  `:`, spaces, NUL, and all control characters).
+- Not all dots (`.`, `..`, `...`), no leading `.`, no leading `-`, no trailing `.`.
+- Not a Windows reserved device name (`CON`, `NUL`, `COM1`…, with or without an
+  extension) — rejected on every platform so a profile made on Linux stays
+  usable on Windows.
+- Not `active` (reserved for the control plane).
+
+Names are **case-folded**: `Work` and `work` refer to the same profile on every
+platform.
+
+## Where profiles live
+
+Profiles are stored under a control-plane root:
+
+1. `WAYLAND_PROFILES_ROOT` if set — must be an **absolute**, control-char-free
+   path (a relative override is ignored so the root never depends on the current
+   directory).
+2. Otherwise `<os-native config dir>/wayland-core-profiles/` — a sibling of the
+   legacy home, so the existing single home is untouched and still serves as the
+   default profile.
+
+Each profile is a subdirectory of that root. The **active pointer** is a small
+file named `active` at the root (never inside any profile home), holding the
+name of the profile to use when neither `WAYLAND_HOME` nor `--profile` is given.
+A corrupt or dangling pointer never aborts a launch — it falls through to the
+default home.
+
+> The profiles root is resolved independently of `WAYLAND_HOME` by design: a
+> profile home is a *child* of the root, so the root must never be computed from
+> a home.
+
+## Security and secret handling
+
+- **`export` excludes secrets by default.** `credentials*` files and `oauth/`
+  are skipped unless you pass `--include-secrets`, which prints a stderr warning.
+- **`create --base` copies no state at all** — only an inheritance marker is
+  written. Credentials and OAuth tokens are never inherited at create time.
+- **`show` never prints secret values** — only whether each store is present.
+- **Symlinks are never followed** during export or import, and on Windows NTFS
+  reparse points (junctions) are skipped too, so a hostile tree cannot redirect
+  a copy outside its root.
+- **Profiles are fully isolated.** Each has its own credential and memory store;
+  there is no shared store to cross-write between profiles.
+
+## Isolated profiles vs. the config selector
+
+These are two different features that happen to share the `--profile` flag, and
+they are the most common source of confusion.
+
+| | Isolated profile (this page) | `--profile` config selector |
+|--|------------------------------|------------------------------|
+| What it switches | The entire home: config **and** credentials, OAuth, memory, skills, sessions | Only settings within one config file (provider, model, keys, MCP servers, …) |
+| Where it lives | A separate `WAYLAND_HOME`-rooted directory under the profiles root | A `[profiles.<name>]` section inside a single `config.toml` |
+| How it's defined | `wayland-core profile create <name>` | A TOML section, with optional `extends` inheritance — see [providers.md](providers.md) |
+| How it's selected | Active pointer (`profile use`), `WAYLAND_HOME`, or `--profile` | `--profile <name>` |
+| Isolation | Full — separate credentials and memory | None — same home, same credentials and memory |
+
+The config selector is documented under
+[Custom aliases and profiles in providers.md](providers.md). A `[profiles.*]`
+section bundles provider/model settings for quick switching, for example:
+
+```toml
+[profiles.claude-fast]
+provider = "anthropic"
+model = "claude-haiku-4-5-20251001"
+
+[profiles.claude-deep]
+extends = "claude-fast"
+model = "claude-opus-4-8"
+```
+
+```bash
+wayland-core --profile claude-fast "Quick question"
+```
+
+> **Sharp edge — the `--profile` flag drives *both* mechanisms.** When you pass
+> `--profile <name>`, Wayland Core (1) tries to activate an isolated profile of
+> that name (sets `WAYLAND_HOME` if the directory exists, else warns and uses the
+> default home) **and** (2) selects the `[profiles.<name>]` config section from
+> the resolved config — which **errors** if no such section exists ("Profile
+> '<name>' not found in config"). So `--profile work` for an isolated profile
+> named `work` only works cleanly if the resolved `config.toml` also has a
+> `[profiles.work]` section. To activate an isolated profile **without** also
+> selecting a config section, use the active pointer (`wayland-core profile use
+> work`, then launch bare) or set `WAYLAND_HOME` directly — neither passes
+> `--profile` to the config layer.
+
+## Host / JSON-stream mode
+
+Interactive CLI/TUI use is tolerant: an unresolved `--profile` warns and falls
+through to the default home. **Host mode is stricter.** If a host launches
+`wayland-core --json-stream` with `--profile` but no `WAYLAND_HOME` was
+materialized (the profile could not be resolved to an existing home), the engine
+**refuses to start** rather than silently writing the shared default home and
+cross-writing another profile's credentials and memory. A host that drives
+profiles must set `WAYLAND_HOME` to the profile's isolated home before spawning
+the engine, or create the home first with `wayland-core profile create`.
+
+## See also
+
+- [getting-started.md](getting-started.md) — installation, CLI usage, config cascade
+- [providers.md](providers.md) — provider setup and the `[profiles.*]` config selector

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -30,6 +30,7 @@ to the same built-in. The canonical list lives in `BUILTIN_PROVIDER_NAMES`
 | Cohere | `cohere` | OpenAI-compatible |
 | OpenAI (ChatGPT) | `openai-chatgpt` (`chatgpt`) | OAuth — routes through the ChatGPT Codex backend on your subscription. See [Sign in with ChatGPT](#sign-in-with-chatgpt) |
 | MiniMax | `minimax` (`minimaxi`) | Anthropic-wire provider; region-locked keys |
+| Sakana AI / Fugu | `sakana` (`fugu`) | OpenAI-compatible; multi-agent orchestration router. `fish_`-prefixed keys; `SAKANA_API_KEY` |
 
 ---
 
@@ -104,6 +105,79 @@ sets this by default:
 [providers.my-reasoning-endpoint.compat]
 supports_stop_param = false
 ```
+
+---
+
+## Capability-first tool gating (tool-incapable models)
+
+Some models can't do function calling. A local model pulled into Ollama, a
+`llama.cpp` server started **without** `--jinja`, or a reasoning/embedding/image
+model on Bedrock will reject a request that carries a `tools` array — often with
+a hard HTTP `400` that kills the whole turn. Wayland Core detects these models
+and **degrades gracefully to a text-only turn** instead of surfacing a raw
+provider error. Tool-*capable* models are unaffected: they keep their tools and
+call them exactly as before. (FerroxLabs/wayland#389, shipped 0.12.13.)
+
+Detection runs through four independent signals, all converging on a
+per-provider-instance capability cache (`crates/wcore-providers/src/tool_capability.rs`).
+The cache is **optimistic**: tools are attached unless a model is *positively*
+known to reject them, so an unknown model still gets one chance to use tools
+rather than having them stripped pre-emptively.
+
+1. **Name-gate (static prefix predicate).** Families already known to reject a
+   caller-supplied `tools` array are gated by name before the request is built.
+   For OpenAI-compatible providers this is `model_supports_tool_calling`
+   (`crates/wcore-providers/src/openai_compat.rs`), which currently special-cases
+   only Groq's agentic **Compound** family (`compound-beta`, `compound-beta-mini`,
+   `compound`, `compound-mini`, and the namespaced `groq/compound*` ids — matched
+   case-insensitively, leading-`compound` only so it won't catch e.g.
+   `octo-compound-7b`). Everything else defaults to tool-capable.
+
+2. **Bedrock name-gate.** `bedrock_model_supports_tools`
+   (`crates/wcore-providers/src/bedrock.rs`) drops the `tools` block for models
+   matched by `BEDROCK_NON_TOOL_MODEL_MARKERS` — `deepseek.r1` / `deepseek-r1`
+   (reasoning-only), `stability.` (image), `cohere.embed` and
+   `amazon.titan-embed` (embeddings). Markers are matched as case-insensitive
+   substrings, so regional id prefixes (`us.`, `eu.`) are tolerated
+   (`us.deepseek.r1-v1:0` still matches). Claude, Mistral Large, and Command
+   R/R+ are not listed and keep tools.
+
+3. **Ollama probe (proactive).** On the first turn for an Ollama-served model,
+   the provider issues a best-effort `POST {base}/api/show`
+   (`crates/wcore-providers/src/ollama_probe.rs`) and reads the response's
+   `capabilities` array. If it lists `"tools"` the model keeps its tools; if the
+   array is present but lacks `"tools"`, the `tools` array is stripped **before**
+   the chat request is sent (no failed round-trip). The probe has a hard 2-second
+   wall-clock cap and **fails open**: any error, timeout, non-success status,
+   unparseable body, or missing/malformed `capabilities` resolves to "unknown",
+   leaving tools attached.
+
+4. **Reactive net (learn-from-400).** For backends with no capability endpoint
+   to probe (e.g. `llama.cpp`), the first turn's `tools` request may 400. When
+   the provider sees a tools-unsupported `400` it drops the `tools` array,
+   **retries once** on the same host so the turn still completes, and **records**
+   that the model rejects tools — so every later turn for that model strips tools
+   pre-emptively. Only the very first request for such a model ever carries a
+   `tools` array. The matcher (`is_tools_unsupported_error` in
+   `crates/wcore-providers/src/openai.rs`) is conservative: it fires **only** on
+   status `400`, matches against the provider's `error.message` (not the raw body,
+   which could echo the prompt), and looks for specific markers —
+   `does not support tools` (Ollama), `tools param requires` (llama.cpp without
+   `--jinja`), `unsupported param: tools`, `does not support function calling`,
+   `tool calling is not supported`, `tools are not supported`,
+   `tool use is not supported`. A `500` is never retried (it may be transient).
+
+### What the user sees
+
+Nothing changes in normal operation: the turn completes with a text answer
+instead of erroring out. The model simply won't call tools that turn. The
+proactive paths (name-gate, Ollama probe) avoid the failed round-trip entirely;
+the reactive path costs one extra (failed) request the first time a no-tool
+model is hit, then never again for that model in the session. The retry is logged
+at `warn` level (`model does not support tools; retrying request without tools (#389)`).
+
+> The cache is per-provider-instance and lives in memory for the session — it is
+> not persisted to disk. A fresh process re-probes / re-learns.
 
 ---
 
@@ -284,6 +358,92 @@ the standard `OLLAMA_HOST` environment variable.
 `capabilities.plugins` flips to `true` whenever any plugin (including
 wayland-ollama) is loaded — see W8c.3 H.2 plugin-aware capability
 advertising in `crates/wcore-agent/src/output/protocol_sink.rs`.
+
+---
+
+## Sakana AI (Fugu)
+
+Sakana AI's **Fugu** is a multi-agent orchestration/routing layer that fans a
+task across upstream frontier models behind one OpenAI-compatible
+chat-completions surface — similar in shape to OpenRouter or Flux Router. The
+adapter is a thin newtype over the OpenAI provider
+(`crates/wcore-providers/src/sakana.rs`).
+
+### Configuration
+
+```toml
+[default]
+provider = "sakana"      # alias: fugu
+
+[providers.sakana]
+api_key = "fish_xxx"
+# base_url defaults to https://api.sakana.ai/v1
+```
+
+- **Auth.** Bearer auth with `fish_`-prefixed keys. Set `api_key` in
+  `[providers.sakana]` or the `SAKANA_API_KEY` environment variable. A bare key
+  beginning with `fish_` is auto-detected as Sakana
+  (`crates/wcore-cli/src/provider_keys.rs`).
+- **Slug / alias.** `--provider sakana`, or `--provider fugu` — `fugu` resolves
+  to the same built-in (`crates/wcore-config/src/config.rs`).
+- **Default model.** `fugu`. Other ids: `fugu-ultra`, `fugu-ultra-20260615`.
+  `--provider sakana` with no `--model` just works (it defaults to `fugu`).
+- **Base URL.** `https://api.sakana.ai/v1` (`SAKANA_DEFAULT_BASE_URL`); the
+  base already ends in `/v1`. Override via `base_url` / `--base-url`.
+
+```bash
+wayland-core --provider sakana "explain this repo"            # uses fugu
+wayland-core --provider fugu --model fugu-ultra "deep audit"
+```
+
+> Sakana's API WAFs some datacenter IPs; if requests are blocked from a server
+> host, run from a residential connection or via a permitted egress.
+
+---
+
+## Flux context-routing (#282)
+
+When you target a **Flux Router tier alias** — `flux-auto`, `flux-fast`,
+`flux-standard`, or `flux-reasoning` (i.e. you let Flux pick the upstream model)
+— Wayland Core opts into Flux's **context-aware routing** contract so Flux can
+size and route the turn against the real upstream context window. Pinning a
+**concrete** model id opts OUT (you chose the upstream), and **non-Flux**
+providers never see any of this — the request is left byte-for-byte unchanged.
+Shipped 0.12.7 (#282); implemented in `crates/wcore-providers/src/openai.rs`.
+
+### Request side — Core signals to Flux (`x-wl-*` headers)
+
+On a tier-alias turn, `apply_flux_context_headers` attaches:
+
+| Header | Value |
+|--------|-------|
+| `x-wl-context-tokens` | Assembled-prompt token estimate (skipped if not available) |
+| `x-wl-expected-output` | The output budget (`max_tokens`) |
+| `x-wl-context-managed` | Literal `true` (opts into the managed path) |
+| `x-wl-conversation-id` | Stable conversation id (skipped if absent) |
+
+### Response side — Flux signals back (`x-flux-*` headers)
+
+Flux returns routing telemetry on every response. `parse_flux_response_meta`
+reads it and emits a single `ProviderMeta` event at stream start; non-Flux
+providers send none of these headers, so nothing is emitted and the SSE path is
+unchanged.
+
+| Header | Field | Type |
+|--------|-------|------|
+| `x-flux-routed-model` | `routed_model` | string |
+| `x-flux-model-window` | `model_window` | int |
+| `x-flux-context-pressure` | `context_pressure` | float (counted/window) |
+| `x-flux-context-tokens-counted` | `tokens_counted` | int |
+
+Each field parses independently — an absent or unparsable single header is just
+`None`, never an error. This lets a host (e.g. the Wayland desktop app) surface
+which upstream Flux actually routed to and how close the turn is to that model's
+context window.
+
+> Flux also returns structured `402` (spend/upgrade) and `409`/`413`
+> (context-overflow) error envelopes that the engine decodes into typed provider
+> errors — see `parse_flux_402` / `parse_flux_overflow` in the same module.
 
 ---
 


### PR DESCRIPTION
Documentation update closing the gap between shipped features (0.12.7→0.12.14) and the user docs, which were last meaningfully touched 2026-06-19. Every page was researched and **verified against the shipped code on `main`** (a verify pass re-checked every config field, flag, command, and default against source; fabrications fixed inline).

## New pages
- **`docs/crucible.md`** — the Mixture-of-Providers council: opt-in/BYO-keys framing, `[crucible]` config, the `wayland-core crucible` CLI + every flag, manual vs auto assembly, the Low/Med/High stakes gate, provider-pinning spec format, proposers/aggregator/fusion, prompt-injection fencing, advisor vs terminal mode, and three-level cost gating. Includes the existing `crucible-run.png` / `crucible-tui.png` screenshots.
- **`docs/profiles.md`** — isolated `WAYLAND_HOME` profiles: the full `profile` command family (create/use/list/show/rename/delete/export/import), activation precedence, what's isolated, secret-handling guarantees, and an isolated-profile vs `--profile` config-selector disambiguation.
- **`docs/cost-governance.md`** — token-spend governance + Crucible council caps in one place.

## Updated pages
- **`docs/providers.md`** — capability-first tool gating (#389), Flux context-routing, Sakana/Fugu provider.
- **`docs/mcp.md`** — smart tool curation (`max_tools`, BM25 ranking, server provenance).
- **`docs/README.md`** — rebuilt the index to link all 20 user-facing docs (was 7).

## Notes for review
- **Draft** pending sign-off — not for merge yet.
- Honest caveats kept in the prose where code and intent diverge: e.g. Crucible's `daily_cap_usd` accumulates per-process within one CLI invocation (cross-process daily persistence is a later stage); cost-governance tree counters roll up to the immediate parent, not transitively.
- Surfaced a real UX trap (not a doc bug): `--profile <name>` is overloaded — it points `WAYLAND_HOME` at an isolated profile *and* feeds the config-section selector, which errors if there's no matching `[profiles.<name>]` section. Documented as a "sharp edge"; may warrant a product fix.
- No new screenshots captured for profiles/MCP curation (would need a TUI run); flag if wanted.