### PR TITLE
fix(web): bound readability extraction, reset breakers per turn, fix telemetry schema (#403)

### DIFF
--- a/crates/wcore-agent/src/engine.rs
+++ b/crates/wcore-agent/src/engine.rs
@@ -3787,6 +3787,12 @@ impl AgentEngine {
             }
         }
         self.current_msg_id = msg_id.to_string();
+        // #403: clear tool circuit breakers at the start of each user turn.
+        // A transient burst of `web`/`WebFetch` failures in one turn opened the
+        // breaker and, with no per-turn reset, left every web tool short-circuited
+        // for the rest of the session — the chat appeared dead. Persistent
+        // failures simply re-open the breaker again within this turn.
+        self.tools.reset_all_breakers();
         // #279(c): mint a stable per-run correlation id on the first run()
         // of the session and reuse it for every subsequent turn/message.
         // Re-minted only when None (fresh engine / cleared session); persists

--- a/crates/wcore-agent/src/tool_backends/http_fetch.rs
+++ b/crates/wcore-agent/src/tool_backends/http_fetch.rs
@@ -15,6 +15,12 @@ use wcore_tools::web_fetch::{
 // WebFetch — simple HTTP GET → readable text.
 // ---------------------------------------------------------------------
 
+/// Dedicated deadline for the synchronous readability extraction stage
+/// (#403). Kept well below the default per-call budget (30s) so a
+/// pathological page that pins the parser falls back to raw text fast
+/// instead of consuming the whole fetch budget with no output.
+const READABILITY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(12);
+
 /// Real `FetchBackend` over `reqwest`. Powers the `WebFetch` tool.
 ///
 /// Built once per session via [`build_fetch_backend`] and registered in
@@ -157,16 +163,48 @@ impl HttpFetchBackend {
         // needs anyway (the meaningful text is near the top of the doc).
         let looks_like_html = content_type.to_ascii_lowercase().starts_with("text/html");
         let body = if req.readable && looks_like_html {
-            let capped = if raw_text.len() > WEB_FETCH_MAX_RESPONSE_BYTES {
+            let capped: String = if raw_text.len() > WEB_FETCH_MAX_RESPONSE_BYTES {
                 let mut end = WEB_FETCH_MAX_RESPONSE_BYTES;
                 while end > 0 && !raw_text.is_char_boundary(end) {
                     end -= 1;
                 }
-                &raw_text[..end]
+                raw_text[..end].to_string()
             } else {
-                raw_text.as_str()
+                raw_text
             };
-            wcore_browser::readability::extract(capped, wcore_browser::op::ReadMode::Article)
+            // #403: readability::extract is a SYNCHRONOUS, CPU-bound DOM walk.
+            // The outer `tokio::time::timeout` cannot interrupt it (a blocking
+            // sync call never yields), so a pathological page pinned a CPU and
+            // surfaced as the full-budget "timed out" with no output. Run the
+            // extractor on a blocking thread and race it against a dedicated,
+            // shorter deadline; if extraction overruns, fall back to the raw
+            // (already byte-capped) body rather than failing the whole fetch.
+            let raw_fallback = capped.clone();
+            let extract_fut = tokio::task::spawn_blocking(move || {
+                wcore_browser::readability::extract(&capped, wcore_browser::op::ReadMode::Article)
+            });
+            match tokio::time::timeout(READABILITY_TIMEOUT, extract_fut).await {
+                Ok(Ok(extracted)) => extracted,
+                Ok(Err(join_err)) => {
+                    tracing::warn!(
+                        target: "wcore_agent",
+                        url = %final_url,
+                        error = %join_err,
+                        "readability extraction task failed; returning raw body"
+                    );
+                    raw_fallback
+                }
+                Err(_) => {
+                    tracing::warn!(
+                        target: "wcore_agent",
+                        url = %final_url,
+                        timeout_s = READABILITY_TIMEOUT.as_secs(),
+                        "readability extraction exceeded its deadline; returning raw body \
+                         (retry with readable:false to skip extraction)"
+                    );
+                    raw_fallback
+                }
+            }
         } else {
             raw_text
         };

--- a/crates/wcore-tools/src/registry.rs
+++ b/crates/wcore-tools/src/registry.rs
@@ -183,6 +183,17 @@ impl ToolRegistry {
         }
     }
 
+    /// #403 — clear every tool circuit breaker back to Closed. Called at the
+    /// start of each new user turn so transient per-turn failures (a flaky
+    /// `web`/`WebFetch` burst that opened the breaker) don't leave tools wedged
+    /// across independent user messages, which made the session look dead.
+    /// Persistent failures simply re-open the breaker within the new turn.
+    pub fn reset_all_breakers(&self) {
+        for breaker in self.breakers.read().values() {
+            breaker.record_success();
+        }
+    }
+
     /// Get all registered tool names
     pub fn tool_names(&self) -> Vec<String> {
         self.tools.iter().map(|t| t.name().to_string()).collect()

--- a/crates/wcore-tools/src/wayland_introspection.rs
+++ b/crates/wcore-tools/src/wayland_introspection.rs
@@ -101,22 +101,14 @@ impl TelemetryQuery {
             .unwrap_or(TELEMETRY_DEFAULT_SINCE)
             .to_string();
 
-        // Filter precedence: explicit `filter` object wins. Otherwise
-        // fold convenience args (event_type / tool_name / success) into
-        // a synthetic filter map; empty fold → None.
+        // #403: only an explicit `filter` object carries a query. The old code
+        // folded `event_type`/`tool_name`/`success` into a synthetic filter, but
+        // the backend requires a `kind`-tagged typed query, so those folded
+        // filters were always rejected ("missing field kind"). A bare call (no
+        // filter) now correctly yields the session-stats snapshot.
         let filter = match input.get("filter") {
             Some(Value::Object(m)) => Some(m.clone()),
-            _ => {
-                let mut fold = Map::new();
-                for key in ["event_type", "tool_name", "success"] {
-                    if let Some(v) = input.get(key)
-                        && !v.is_null()
-                    {
-                        fold.insert(key.to_string(), v.clone());
-                    }
-                }
-                if fold.is_empty() { None } else { Some(fold) }
-            }
+            _ => None,
         };
 
         let raw_limit = input
@@ -279,24 +271,17 @@ fn status_schema() -> JsonSchema {
 }
 
 fn telemetry_schema() -> JsonSchema {
+    // #403: advertise the query the backend actually accepts. The backend
+    // parses a typed, `kind`-tagged enum from the `filter` slot; the previous
+    // schema advertised `event_type`/`tool_name`/`success` convenience args that
+    // the backend ignored, so any query built from them was rejected with
+    // "invalid telemetry query: missing field kind". Describe the real shape.
     json!({
         "type": "object",
         "properties": {
             "since": {
                 "type": "string",
                 "description": "ISO-8601 timestamp or relative window (1h, 24h, 7d). Default: '1h'."
-            },
-            "event_type": {
-                "type": "string",
-                "description": "Filter by event type (e.g. 'tool_call', 'model_call')."
-            },
-            "tool_name": {
-                "type": "string",
-                "description": "Filter by tool name."
-            },
-            "success": {
-                "type": "boolean",
-                "description": "Filter by success flag."
             },
             "limit": {
                 "type": "integer",
@@ -306,8 +291,32 @@ fn telemetry_schema() -> JsonSchema {
             },
             "filter": {
                 "type": "object",
-                "description": "Structured filter object. If supplied, takes precedence over the convenience top-level keys.",
-                "additionalProperties": true
+                "description": "Typed telemetry query. Omit for a session-stats snapshot. When present, `kind` selects the query and the other fields are per-kind.",
+                "properties": {
+                    "kind": {
+                        "type": "string",
+                        "enum": ["session_stats", "tool_usage_over_time", "top_n_tools", "errors_by_provider"],
+                        "description": "Query kind. `session_stats`: current session snapshot. `tool_usage_over_time`: call counts over a window. `top_n_tools`: most-used tools. `errors_by_provider`: error counts per provider."
+                    },
+                    "window_secs": {
+                        "type": "integer",
+                        "description": "For kind=tool_usage_over_time: window size in seconds."
+                    },
+                    "n": {
+                        "type": "integer",
+                        "description": "For kind=top_n_tools: how many tools to return."
+                    },
+                    "by": {
+                        "type": "string",
+                        "enum": ["calls", "tokens", "duration"],
+                        "description": "For kind=top_n_tools: ranking metric (tokens/duration fall back to calls until per-tool token accounting lands)."
+                    },
+                    "provider": {
+                        "type": "string",
+                        "description": "For kind=errors_by_provider: optional provider id to filter to."
+                    }
+                },
+                "required": ["kind"]
             }
         },
         "required": []
@@ -523,9 +532,11 @@ mod tests {
     }
 
     #[test]
-    fn telemetry_folds_convenience_args_into_filter() {
-        // No top-level `filter`, but event_type + tool_name + success
-        // present — Python folds these into a synthetic filter dict.
+    fn telemetry_convenience_args_are_ignored_no_kindless_filter() {
+        // #403: convenience args no longer fold into a synthetic (kind-less)
+        // filter — that produced "invalid telemetry query: missing field kind".
+        // since/limit still apply; with no explicit `filter` the query is None
+        // (the backend then returns a session-stats snapshot).
         let backend = Arc::new(CapturingIntrospectionBackend::new());
         let tool = WaylandTelemetryQueryTool::new(backend.clone());
         let res = run(
@@ -542,13 +553,10 @@ mod tests {
         let q = &backend.snapshot().telemetry[0];
         assert_eq!(q.since, "24h");
         assert_eq!(q.limit, 50);
-        let f = q.filter.as_ref().expect("convenience args ⇒ Some(filter)");
-        assert_eq!(
-            f.get("event_type").and_then(Value::as_str),
-            Some("tool_call")
+        assert!(
+            q.filter.is_none(),
+            "convenience args must not synthesize a kind-less filter"
         );
-        assert_eq!(f.get("tool_name").and_then(Value::as_str), Some("Read"));
-        assert_eq!(f.get("success").and_then(Value::as_bool), Some(true));
     }
 
     #[test]
@@ -595,19 +603,26 @@ mod tests {
 
         let t = telemetry_schema();
         assert_eq!(t["type"], "object");
-        for key in [
-            "since",
-            "event_type",
-            "tool_name",
-            "success",
-            "limit",
-            "filter",
-        ] {
+        for key in ["since", "limit", "filter"] {
             assert!(t["properties"][key].is_object(), "missing property: {key}");
         }
         assert_eq!(t["properties"]["limit"]["minimum"], 1);
         assert_eq!(t["properties"]["limit"]["maximum"], 1000);
         assert_eq!(t["required"].as_array().unwrap().len(), 0);
+        // #403: the filter must advertise the `kind` selector the backend requires.
+        let kind = &t["properties"]["filter"]["properties"]["kind"];
+        assert!(kind.is_object(), "filter must advertise a `kind` selector");
+        let kinds = kind["enum"].as_array().expect("kind enum");
+        assert!(kinds.iter().any(|k| k == "top_n_tools"));
+        assert!(kinds.iter().any(|k| k == "session_stats"));
+        assert_eq!(
+            t["properties"]["filter"]["required"]
+                .as_array()
+                .unwrap()
+                .len(),
+            1,
+            "filter requires `kind`"
+        );
     }
 
     #[test]
@@ -642,22 +657,21 @@ mod tests {
     }
 
     #[test]
-    fn telemetry_null_value_in_convenience_arg_is_dropped() {
-        // The Python `if args[key] is not None` check excludes JSON nulls.
+    fn telemetry_explicit_typed_filter_passes_through() {
+        // #403: an explicit, kind-tagged filter is forwarded verbatim to the
+        // backend (which parses it into the typed enum).
         let backend = Arc::new(CapturingIntrospectionBackend::new());
         let tool = WaylandTelemetryQueryTool::new(backend.clone());
-        let _ = run(
+        let res = run(
             &tool,
-            json!({
-                "event_type": "tool_call",
-                "tool_name": null,
-                "success": null,
-            }),
+            json!({ "filter": {"kind": "top_n_tools", "n": 5, "by": "calls"} }),
         );
+        assert!(!res.is_error);
         let q = &backend.snapshot().telemetry[0];
-        let f = q.filter.as_ref().unwrap();
-        assert_eq!(f.len(), 1);
-        assert!(f.contains_key("event_type"));
+        let f = q.filter.as_ref().expect("explicit filter ⇒ Some");
+        assert_eq!(f.get("kind").and_then(Value::as_str), Some("top_n_tools"));
+        assert_eq!(f.get("n").and_then(Value::as_u64), Some(5));
+        assert_eq!(f.get("by").and_then(Value::as_str), Some("calls"));
     }
 
     // --- v0.9.0 W1 backend gate (per-tool, gated independently) ---

--- a/crates/wcore-tools/src/web_fetch.rs
+++ b/crates/wcore-tools/src/web_fetch.rs
@@ -293,7 +293,12 @@ impl Tool for WebFetchTool {
     }
 
     fn is_concurrency_safe(&self, _input: &Value) -> bool {
-        true
+        // #403: serialize WebFetch calls. Running several fetches in parallel —
+        // especially repeated fetches to the same slow host — multiplied the
+        // load that pinned the readability parser and made the timeout/fallback
+        // cascade worse. The engine runs non-concurrency-safe tools one at a
+        // time, which is a simple, host-agnostic guard against that hammering.
+        false
     }
 
     fn category(&self) -> ToolCategory {
@@ -517,8 +522,10 @@ mod tests {
     }
 
     #[test]
-    fn is_concurrency_safe_returns_true() {
+    fn is_not_concurrency_safe() {
+        // #403: WebFetch is serialized to avoid parallel same-host hammering
+        // that worsened the readability-timeout cascade.
         let tool = WebFetchTool::default();
-        assert!(tool.is_concurrency_safe(&json!({})));
+        assert!(!tool.is_concurrency_safe(&json!({})));
     }
 }

--- a/crates/wcore-tools/tests/tool_circuit_breaker_test.rs
+++ b/crates/wcore-tools/tests/tool_circuit_breaker_test.rs
@@ -240,3 +240,30 @@ async fn success_after_failures_resets_breaker() {
     b.record_failure();
     assert_eq!(b.state(), BreakerState::Closed);
 }
+
+/// #403: reset_all_breakers() clears an opened breaker so a new user turn
+/// starts clean instead of staying short-circuited for the whole session.
+#[tokio::test]
+async fn reset_all_breakers_clears_open_breaker() {
+    let mut reg = ToolRegistry::new();
+    reg.register(Box::new(ErrTool));
+
+    for _ in 0..3 {
+        reg.dispatch("err_tool", input()).await;
+    }
+    assert_eq!(reg.breaker_state("err_tool"), Some(BreakerState::Open));
+
+    // Simulate the start of a new user turn.
+    reg.reset_all_breakers();
+    assert_eq!(
+        reg.breaker_state("err_tool"),
+        Some(BreakerState::Closed),
+        "reset must close a previously-open breaker"
+    );
+
+    // The breaker must be functional again (not wedged): a fresh full
+    // threshold of failures is needed before it re-opens.
+    reg.dispatch("err_tool", input()).await;
+    reg.dispatch("err_tool", input()).await;
+    assert_eq!(reg.breaker_state("err_tool"), Some(BreakerState::Closed));
+}


### PR DESCRIPTION
Addresses four of the five problems in FerroxLabs/wayland#403 (native WebFetch 30s hang → fallback cascade → circuit-open → session looks dead). All four verified on Hetzner (clippy clean; affected tests green).

## Fixes
1. **WebFetch readability hang (root cause).** `readability::extract` is synchronous, CPU-bound work, so the outer `tokio::time::timeout` around the fetch could never interrupt it — a pathological/large page pinned a CPU and surfaced as the full-budget "timed out" with no output. Now the extractor runs on `spawn_blocking`, raced against a dedicated 12s deadline; on overrun it falls back to the raw (byte-capped) body instead of failing the whole fetch. (`http_fetch.rs`)
2. **Serialize WebFetch** (`is_concurrency_safe → false`) so parallel same-host fetches can't compound the parser load (the log showed two parallel fetches to the same host). (`web_fetch.rs`)
4. **Reset tool circuit breakers per user turn.** A transient `web`/`WebFetch` failure burst opened the breaker and, with no per-turn reset, left web tools short-circuited for the rest of the session — the "chat appears dead" symptom. New `ToolRegistry::reset_all_breakers()` called at the top of `Engine::run`. Persistent failures simply re-open within the turn. (`registry.rs`, `engine.rs`)
5. **Telemetry query schema.** The tool advertised `event_type`/`tool_name`/`success` convenience args that the backend ignored (it requires a `kind`-tagged typed query), so queries failed with "invalid telemetry query: missing field kind". The schema now advertises the real typed `filter` (`kind` enum + per-kind fields) and the parser no longer folds convenience args into `kind`-less filters. (`wayland_introspection.rs`)

## Tests
- `web_fetch`: `is_not_concurrency_safe`; existing readability/backend tests green.
- `circuit_breaker`: new `reset_all_breakers_clears_open_breaker` (open → reset → closed → functional).
- `telemetry`: schema advertises `kind`; convenience args ignored (no kind-less filter); explicit typed filter passes through.
- Hetzner: `cargo clippy -p wcore-tools -p wcore-agent --all-targets` clean; targeted tests pass.

## Follow-up (not in this PR)
3. **Cancellation / session-lock release on Stop** ("even after stopping the chat won't continue"). The TUI path already has a terminal-event guard; the customer is on the desktop **JSON-stream/ACP** path (`acp_engine.rs` — "run() never emits a terminal StreamEnd; the caller synthesizes it"), which needs its own root-cause for guaranteed stream/lock release on abort. Tracking separately to avoid a rushed session-lock change.