### PR TITLE
fix(engine): never let the reasoning budget starve the visible answer (#426)

### DIFF
--- a/crates/wcore-agent/src/engine.rs
+++ b/crates/wcore-agent/src/engine.rs
@@ -170,6 +170,35 @@ fn select_tier_model(
     compat.tier_model(tier).map(str::to_string)
 }
 
+/// #426 — minimum slice of the output budget reserved for the user-visible
+/// answer whenever extended thinking is on. Anthropic's `max_tokens` (and the
+/// reasoning-model output budget generally) is the TOTAL of reasoning + visible
+/// output, so without a reserved floor a heavy reasoning turn can spend the
+/// whole budget thinking and return an empty, `finish_reason: length` reply
+/// (wayland#422). This floor is never sacrificed to thinking.
+const MIN_VISIBLE_OUTPUT: u32 = 4_096;
+
+/// #426 — Anthropic's minimum accepted `thinking.budget_tokens`. If the output
+/// budget is so small that the reasoning budget cannot be kept at or above this
+/// while still reserving `MIN_VISIBLE_OUTPUT`, thinking is dropped for the turn
+/// rather than sending an invalid request or starving the answer.
+const MIN_THINKING_BUDGET: u32 = 1_024;
+
+/// #426 — reasoning-aware ceiling for an unknown / router-aliased model. The
+/// plain `UNKNOWN_CAP` (8192) cannot hold a real reasoning budget AND a visible
+/// answer, so a reasoning turn on such a model is allowed to grow up to here
+/// (matches the desktop's reasoning default). Still a CAP, with the truncation
+/// auto-continue loop as the net for longer outputs.
+const UNKNOWN_REASONING_CAP: u32 = 32_768;
+
+/// #426 — shrink a requested reasoning budget so the visible answer can never be
+/// starved: the budget may use at most `max_tokens - MIN_VISIBLE_OUTPUT`. Returns
+/// the budget to actually send (0 when no room remains; the caller drops thinking
+/// below `MIN_THINKING_BUDGET`).
+fn fit_thinking_budget(max_tokens: u32, requested_budget: u32) -> u32 {
+    requested_budget.min(max_tokens.saturating_sub(MIN_VISIBLE_OUTPUT))
+}
+
 /// Up-front output sizing (Layer 1). Returns the `max_tokens` to request so a
 /// normal turn finishes in ONE round, sized to the model's real output ceiling
 /// where known and clamped to the room left in the context window. This makes a
@@ -182,7 +211,19 @@ fn select_tier_model(
 /// `model` must be the FINAL model that will actually be sent — i.e. this is
 /// called AFTER the smart-routing tier swap (`request.model = tier_model`) so
 /// the clamp sees the post-swap model's real ceiling, never the pre-swap one.
-fn size_output_cap(config_max: u32, provider: &str, model: &str, est_input_tokens: usize) -> u32 {
+///
+/// `thinking_budget` is the requested reasoning budget for this turn (`None`
+/// when extended thinking is off). For an unknown / router-aliased reasoning
+/// model the conservative 8192 floor cannot hold the reasoning budget plus a
+/// visible answer, so a reasoning turn is allowed to grow to
+/// `UNKNOWN_REASONING_CAP` (#426). Known models already get their real ceiling.
+fn size_output_cap(
+    config_max: u32,
+    provider: &str,
+    model: &str,
+    est_input_tokens: usize,
+    thinking_budget: Option<u32>,
+) -> u32 {
     /// Conservative cap for models with no known output ceiling. Safe for
     /// essentially every modern model (gpt-4o is 16384). Never raised on
     /// guesswork — that is what 400s.
@@ -199,30 +240,44 @@ fn size_output_cap(config_max: u32, provider: &str, model: &str, est_input_token
                 .max(1);
             config_max.min(out_ceiling).min(window_room)
         }
-        None => config_max.min(UNKNOWN_CAP),
+        // Unknown / router-aliased model. Normally clamp to a conservative
+        // floor so a small served model never 400s. But a reasoning turn on
+        // such a model needs room for the reasoning budget AND a visible
+        // answer, so allow it to grow to the reasoning-aware ceiling (#426).
+        None => {
+            let cap = if thinking_budget.is_some() {
+                UNKNOWN_REASONING_CAP
+            } else {
+                UNKNOWN_CAP
+            };
+            config_max.min(cap)
+        }
     }
 }
 
 #[cfg(test)]
 mod output_sizing_tests {
-    use super::size_output_cap;
+    use super::{
+        MIN_THINKING_BUDGET, MIN_VISIBLE_OUTPUT, UNKNOWN_REASONING_CAP, fit_thinking_budget,
+        size_output_cap,
+    };
 
     #[test]
     fn known_model_is_clamped_to_its_real_output_ceiling() {
         // A generous config cap is clamped DOWN to the model's real ceiling,
         // so a large default never 400s a model that allows less.
         assert_eq!(
-            size_output_cap(64_000, "openai", "gpt-4o-mini", 1_000),
+            size_output_cap(64_000, "openai", "gpt-4o-mini", 1_000, None),
             16_384,
             "gpt-4o output ceiling binds"
         );
         assert_eq!(
-            size_output_cap(64_000, "anthropic", "claude-opus-4-7", 1_000),
+            size_output_cap(64_000, "anthropic", "claude-opus-4-7", 1_000, None),
             32_000,
             "opus 4.x output ceiling binds"
         );
         assert_eq!(
-            size_output_cap(64_000, "anthropic", "claude-sonnet-4-6", 1_000),
+            size_output_cap(64_000, "anthropic", "claude-sonnet-4-6", 1_000, None),
             64_000,
             "sonnet can use its full 64k"
         );
@@ -233,11 +288,11 @@ mod output_sizing_tests {
         // A router alias (served model unknown) must NOT receive the generous
         // 64k — it could route to a small model and 400. Clamp to the floor.
         assert_eq!(
-            size_output_cap(64_000, "flux-router", "flux-auto", 1_000),
+            size_output_cap(64_000, "flux-router", "flux-auto", 1_000, None),
             8_192
         );
         assert_eq!(
-            size_output_cap(64_000, "ollama", "some-local-model", 1_000),
+            size_output_cap(64_000, "ollama", "some-local-model", 1_000, None),
             8_192
         );
     }
@@ -246,11 +301,11 @@ mod output_sizing_tests {
     fn explicit_low_user_cap_is_always_respected() {
         // If the user sets a low max_tokens, it binds on known AND unknown.
         assert_eq!(
-            size_output_cap(4_000, "anthropic", "claude-opus-4-7", 1_000),
+            size_output_cap(4_000, "anthropic", "claude-opus-4-7", 1_000, None),
             4_000
         );
         assert_eq!(
-            size_output_cap(4_000, "flux-router", "flux-auto", 1_000),
+            size_output_cap(4_000, "flux-router", "flux-auto", 1_000, None),
             4_000
         );
     }
@@ -259,9 +314,63 @@ mod output_sizing_tests {
     fn near_context_limit_input_shrinks_the_output_cap() {
         // When the prompt nearly fills the window, the remaining room binds
         // below the model's output ceiling (prevents an input+output overflow).
-        let cap = size_output_cap(64_000, "anthropic", "claude-opus-4-7", 199_000);
+        let cap = size_output_cap(64_000, "anthropic", "claude-opus-4-7", 199_000, None);
         assert!(cap < 32_000, "window room must bind near the context limit");
         assert!(cap >= 1, "never zero or negative");
+    }
+
+    #[test]
+    fn unknown_reasoning_model_gets_headroom_not_the_8192_floor() {
+        // #426 / wayland#422: flux-auto with extended thinking on must NOT be
+        // clamped to 8192 (the budget would eat the whole cap and the answer
+        // would be empty). It grows to the reasoning-aware ceiling instead.
+        assert_eq!(
+            size_output_cap(64_000, "flux-router", "flux-auto", 1_000, Some(10_000)),
+            UNKNOWN_REASONING_CAP,
+            "a reasoning turn on a router alias gets reasoning headroom"
+        );
+        // Non-reasoning turn on the same alias still gets the conservative floor.
+        assert_eq!(
+            size_output_cap(64_000, "flux-router", "flux-auto", 1_000, None),
+            8_192
+        );
+    }
+
+    #[test]
+    fn known_reasoning_model_still_bound_by_its_real_ceiling() {
+        // A known model's real ceiling/window always binds, even with thinking
+        // on — the reasoning ceiling only rescues UNKNOWN models from 8192.
+        assert_eq!(
+            size_output_cap(64_000, "anthropic", "claude-opus-4-7", 1_000, Some(20_000)),
+            32_000,
+            "opus 4.x ceiling still binds with thinking on"
+        );
+    }
+
+    #[test]
+    fn fit_thinking_budget_reserves_the_visible_floor() {
+        // Plenty of room: the full requested budget is kept.
+        assert_eq!(fit_thinking_budget(32_768, 10_000), 10_000);
+        // Tight cap: the budget is shrunk so MIN_VISIBLE_OUTPUT survives.
+        assert_eq!(
+            fit_thinking_budget(8_192, 10_000),
+            8_192 - MIN_VISIBLE_OUTPUT,
+            "budget shrinks to leave the visible floor"
+        );
+        // The boundary: visible floor exactly reserved.
+        assert_eq!(
+            fit_thinking_budget(MIN_VISIBLE_OUTPUT + 5_000, 10_000),
+            5_000
+        );
+    }
+
+    #[test]
+    fn fit_thinking_budget_collapses_when_no_room() {
+        // Cap below the visible floor → zero budget (caller drops thinking,
+        // since 0 < MIN_THINKING_BUDGET). The answer is never starved.
+        assert_eq!(fit_thinking_budget(MIN_VISIBLE_OUTPUT, 10_000), 0);
+        assert_eq!(fit_thinking_budget(2_000, 10_000), 0);
+        assert!(fit_thinking_budget(2_000, 10_000) < MIN_THINKING_BUDGET);
     }
 }
 
@@ -4310,12 +4419,53 @@ impl AgentEngine {
             // allows (so the generous default never 400s); an unknown/router
             // model is clamped to a conservative floor. `self.max_tokens` is the
             // user's CAP and always binds.
+            let requested_thinking_budget = match &request.thinking {
+                Some(wcore_types::llm::ThinkingConfig::Enabled { budget_tokens }) => {
+                    Some(*budget_tokens)
+                }
+                _ => None,
+            };
             request.max_tokens = size_output_cap(
                 self.max_tokens,
                 self.compat.provider_type(),
                 &request.model,
                 input_token_estimate,
+                requested_thinking_budget,
             );
+
+            // #426 / wayland#422 — separate the reasoning budget from the output
+            // budget so extended thinking can never starve the visible answer.
+            // For reasoning models `max_tokens` is the TOTAL of reasoning +
+            // visible output; without this a heavy thinking turn (especially on
+            // a router alias clamped low) spends the whole budget thinking and
+            // returns an empty, `finish_reason: length` reply. Shrink the budget
+            // to reserve `MIN_VISIBLE_OUTPUT`; if no usable budget remains, drop
+            // thinking for the turn rather than emit an empty answer.
+            if let Some(budget) = requested_thinking_budget {
+                let fitted = fit_thinking_budget(request.max_tokens, budget);
+                request.thinking = Some(if fitted >= MIN_THINKING_BUDGET {
+                    if fitted < budget {
+                        tracing::debug!(
+                            target: "wcore_agent::engine",
+                            requested = budget,
+                            fitted,
+                            max_tokens = request.max_tokens,
+                            "thinking budget shrunk to reserve visible-output room (#426)"
+                        );
+                    }
+                    wcore_types::llm::ThinkingConfig::Enabled {
+                        budget_tokens: fitted,
+                    }
+                } else {
+                    tracing::debug!(
+                        target: "wcore_agent::engine",
+                        requested = budget,
+                        max_tokens = request.max_tokens,
+                        "output budget too small for thinking + visible answer; thinking dropped for this turn (#426)"
+                    );
+                    wcore_types::llm::ThinkingConfig::Disabled
+                });
+            }
 
             // AUDIT A3 / E-C2 — bounded stream-level retry loop.
             //

--- a/crates/wcore-agent/src/engine.rs
+++ b/crates/wcore-agent/src/engine.rs
@@ -212,17 +212,19 @@ fn fit_thinking_budget(max_tokens: u32, requested_budget: u32) -> u32 {
 /// called AFTER the smart-routing tier swap (`request.model = tier_model`) so
 /// the clamp sees the post-swap model's real ceiling, never the pre-swap one.
 ///
-/// `thinking_budget` is the requested reasoning budget for this turn (`None`
-/// when extended thinking is off). For an unknown / router-aliased reasoning
-/// model the conservative 8192 floor cannot hold the reasoning budget plus a
-/// visible answer, so a reasoning turn is allowed to grow to
-/// `UNKNOWN_REASONING_CAP` (#426). Known models already get their real ceiling.
+/// `is_reasoning_turn` is true when this turn uses extended thinking — either a
+/// numeric Anthropic/DeepSeek-style `thinking.budget_tokens` OR an OpenAI-style
+/// `reasoning_effort` (o-series / gpt-5), both of which spend output tokens on
+/// hidden reasoning. For an unknown / router-aliased reasoning model the
+/// conservative 8192 floor cannot hold the reasoning spend plus a visible
+/// answer, so a reasoning turn is allowed to grow to `UNKNOWN_REASONING_CAP`
+/// (#426). Known models already get their real ceiling.
 fn size_output_cap(
     config_max: u32,
     provider: &str,
     model: &str,
     est_input_tokens: usize,
-    thinking_budget: Option<u32>,
+    is_reasoning_turn: bool,
 ) -> u32 {
     /// Conservative cap for models with no known output ceiling. Safe for
     /// essentially every modern model (gpt-4o is 16384). Never raised on
@@ -245,7 +247,7 @@ fn size_output_cap(
         // such a model needs room for the reasoning budget AND a visible
         // answer, so allow it to grow to the reasoning-aware ceiling (#426).
         None => {
-            let cap = if thinking_budget.is_some() {
+            let cap = if is_reasoning_turn {
                 UNKNOWN_REASONING_CAP
             } else {
                 UNKNOWN_CAP
@@ -267,17 +269,17 @@ mod output_sizing_tests {
         // A generous config cap is clamped DOWN to the model's real ceiling,
         // so a large default never 400s a model that allows less.
         assert_eq!(
-            size_output_cap(64_000, "openai", "gpt-4o-mini", 1_000, None),
+            size_output_cap(64_000, "openai", "gpt-4o-mini", 1_000, false),
             16_384,
             "gpt-4o output ceiling binds"
         );
         assert_eq!(
-            size_output_cap(64_000, "anthropic", "claude-opus-4-7", 1_000, None),
+            size_output_cap(64_000, "anthropic", "claude-opus-4-7", 1_000, false),
             32_000,
             "opus 4.x output ceiling binds"
         );
         assert_eq!(
-            size_output_cap(64_000, "anthropic", "claude-sonnet-4-6", 1_000, None),
+            size_output_cap(64_000, "anthropic", "claude-sonnet-4-6", 1_000, false),
             64_000,
             "sonnet can use its full 64k"
         );
@@ -288,11 +290,11 @@ mod output_sizing_tests {
         // A router alias (served model unknown) must NOT receive the generous
         // 64k — it could route to a small model and 400. Clamp to the floor.
         assert_eq!(
-            size_output_cap(64_000, "flux-router", "flux-auto", 1_000, None),
+            size_output_cap(64_000, "flux-router", "flux-auto", 1_000, false),
             8_192
         );
         assert_eq!(
-            size_output_cap(64_000, "ollama", "some-local-model", 1_000, None),
+            size_output_cap(64_000, "ollama", "some-local-model", 1_000, false),
             8_192
         );
     }
@@ -301,11 +303,11 @@ mod output_sizing_tests {
     fn explicit_low_user_cap_is_always_respected() {
         // If the user sets a low max_tokens, it binds on known AND unknown.
         assert_eq!(
-            size_output_cap(4_000, "anthropic", "claude-opus-4-7", 1_000, None),
+            size_output_cap(4_000, "anthropic", "claude-opus-4-7", 1_000, false),
             4_000
         );
         assert_eq!(
-            size_output_cap(4_000, "flux-router", "flux-auto", 1_000, None),
+            size_output_cap(4_000, "flux-router", "flux-auto", 1_000, false),
             4_000
         );
     }
@@ -314,24 +316,34 @@ mod output_sizing_tests {
     fn near_context_limit_input_shrinks_the_output_cap() {
         // When the prompt nearly fills the window, the remaining room binds
         // below the model's output ceiling (prevents an input+output overflow).
-        let cap = size_output_cap(64_000, "anthropic", "claude-opus-4-7", 199_000, None);
+        let cap = size_output_cap(64_000, "anthropic", "claude-opus-4-7", 199_000, false);
         assert!(cap < 32_000, "window room must bind near the context limit");
         assert!(cap >= 1, "never zero or negative");
     }
 
     #[test]
     fn unknown_reasoning_model_gets_headroom_not_the_8192_floor() {
-        // #426 / wayland#422: flux-auto with extended thinking on must NOT be
-        // clamped to 8192 (the budget would eat the whole cap and the answer
-        // would be empty). It grows to the reasoning-aware ceiling instead.
+        // #426 / wayland#422: flux-auto on a reasoning turn must NOT be clamped
+        // to 8192 (the reasoning would eat the whole cap and the answer would be
+        // empty). It grows to the reasoning-aware ceiling instead. This holds
+        // for BOTH reasoning signals — a numeric thinking budget (Anthropic /
+        // DeepSeek) and an OpenAI reasoning_effort (o-series / gpt-5) — which is
+        // why the parameter is a single `is_reasoning_turn` flag.
         assert_eq!(
-            size_output_cap(64_000, "flux-router", "flux-auto", 1_000, Some(10_000)),
+            size_output_cap(64_000, "flux-router", "flux-auto", 1_000, true),
             UNKNOWN_REASONING_CAP,
             "a reasoning turn on a router alias gets reasoning headroom"
         );
+        // Specifically the reasoning_effort path: an unknown o-series model with
+        // NO numeric budget (only reasoning_effort) must still get the headroom.
+        assert_eq!(
+            size_output_cap(64_000, "openai", "o3-pro-unlisted", 1_000, true),
+            UNKNOWN_REASONING_CAP,
+            "reasoning_effort lifts an unknown o-series model off 8192"
+        );
         // Non-reasoning turn on the same alias still gets the conservative floor.
         assert_eq!(
-            size_output_cap(64_000, "flux-router", "flux-auto", 1_000, None),
+            size_output_cap(64_000, "flux-router", "flux-auto", 1_000, false),
             8_192
         );
     }
@@ -341,7 +353,7 @@ mod output_sizing_tests {
         // A known model's real ceiling/window always binds, even with thinking
         // on — the reasoning ceiling only rescues UNKNOWN models from 8192.
         assert_eq!(
-            size_output_cap(64_000, "anthropic", "claude-opus-4-7", 1_000, Some(20_000)),
+            size_output_cap(64_000, "anthropic", "claude-opus-4-7", 1_000, true),
             32_000,
             "opus 4.x ceiling still binds with thinking on"
         );
@@ -4425,12 +4437,18 @@ impl AgentEngine {
                 }
                 _ => None,
             };
+            // #426 — a turn is "reasoning" if it carries either a numeric
+            // thinking budget (Anthropic/DeepSeek) or an OpenAI reasoning_effort
+            // (o-series / gpt-5). Both spend output tokens on hidden reasoning,
+            // so both must lift an unknown model off the 8192 floor.
+            let is_reasoning_turn =
+                requested_thinking_budget.is_some() || request.reasoning_effort.is_some();
             request.max_tokens = size_output_cap(
                 self.max_tokens,
                 self.compat.provider_type(),
                 &request.model,
                 input_token_estimate,
-                requested_thinking_budget,
+                is_reasoning_turn,
             );
 
             // #426 / wayland#422 — separate the reasoning budget from the output

--- a/crates/wcore-agent/tests/reasoning_budget_test.rs
+++ b/crates/wcore-agent/tests/reasoning_budget_test.rs
@@ -147,6 +147,46 @@ async fn low_cap_shrinks_thinking_to_reserve_the_answer() {
     assert!(max_tokens - budget >= MIN_VISIBLE_OUTPUT);
 }
 
+/// Boundary: the smallest cap that still keeps thinking on. With
+/// MIN_VISIBLE_OUTPUT=4096 and MIN_THINKING_BUDGET=1024, a 5120 cap fits exactly
+/// 1024 thinking + 4096 visible.
+#[tokio::test]
+async fn exact_minimum_cap_keeps_thinking_at_the_floor() {
+    let (mut engine, provider) = reasoning_engine(5_120, 10_000);
+    engine.run("hello", "").await.expect("run should succeed");
+
+    let max_tokens = provider
+        .max_tokens
+        .lock()
+        .unwrap()
+        .expect("a request was sent");
+    let budget = captured_budget(&provider).expect("thinking stayed enabled at the boundary");
+    assert_eq!(max_tokens, 5_120);
+    assert_eq!(budget, 1_024, "exactly the minimum thinking budget fits");
+    assert_eq!(
+        max_tokens - budget,
+        MIN_VISIBLE_OUTPUT,
+        "the visible floor is exactly preserved"
+    );
+}
+
+/// Boundary: one token below the minimum viable cap. The fitted budget would be
+/// 1023 (< MIN_THINKING_BUDGET), so thinking is dropped rather than sent invalid.
+#[tokio::test]
+async fn one_below_minimum_cap_drops_thinking() {
+    let (mut engine, provider) = reasoning_engine(5_119, 10_000);
+    engine.run("hello", "").await.expect("run should succeed");
+
+    assert_eq!(provider.max_tokens.lock().unwrap().unwrap(), 5_119);
+    assert!(
+        matches!(
+            provider.thinking.lock().unwrap().clone(),
+            Some(ThinkingConfig::Disabled)
+        ),
+        "5119 leaves only 1023 budget after the visible floor; thinking must drop"
+    );
+}
+
 /// When the cap is too small to hold any usable reasoning budget plus the floor,
 /// thinking is dropped entirely so the full budget goes to the visible answer.
 #[tokio::test]

--- a/crates/wcore-agent/tests/reasoning_budget_test.rs
+++ b/crates/wcore-agent/tests/reasoning_budget_test.rs
@@ -1,0 +1,170 @@
+//! #426 / wayland#422 — the reasoning budget must never starve the visible
+//! answer. These drive a real `engine.run()` with extended thinking enabled on
+//! an UNKNOWN (router-aliased) model and capture the `LlmRequest` actually sent
+//! to the provider, proving the engine's output-sizing + budget-separation hold
+//! on the wire (not just in the `size_output_cap` / `fit_thinking_budget` unit
+//! tests).
+
+mod common;
+
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use tokio::sync::mpsc;
+use wcore_agent::engine::AgentEngine;
+use wcore_agent::output::OutputSink;
+use wcore_agent::output::terminal::TerminalSink;
+use wcore_providers::{LlmProvider, ProviderError};
+use wcore_tools::registry::ToolRegistry;
+use wcore_types::llm::{LlmEvent, LlmRequest, ThinkingConfig};
+use wcore_types::message::{FinishReason, StopReason, TokenUsage};
+
+use common::test_config;
+
+/// Minimum visible-output floor the engine reserves (mirrors
+/// `engine::MIN_VISIBLE_OUTPUT`, which is private).
+const MIN_VISIBLE_OUTPUT: u32 = 4_096;
+
+/// Records the `max_tokens` and `thinking` of the last request streamed, so a
+/// test can assert what the engine put on the wire after output sizing.
+struct CapturingProvider {
+    max_tokens: Mutex<Option<u32>>,
+    thinking: Mutex<Option<ThinkingConfig>>,
+}
+
+impl CapturingProvider {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            max_tokens: Mutex::new(None),
+            thinking: Mutex::new(None),
+        })
+    }
+}
+
+#[async_trait]
+impl LlmProvider for CapturingProvider {
+    async fn stream(
+        &self,
+        request: &LlmRequest,
+    ) -> Result<mpsc::Receiver<LlmEvent>, ProviderError> {
+        *self.max_tokens.lock().unwrap() = Some(request.max_tokens);
+        *self.thinking.lock().unwrap() = request.thinking.clone();
+        let (tx, rx) = mpsc::channel(8);
+        tokio::spawn(async move {
+            let _ = tx.send(LlmEvent::TextDelta("ok".to_string())).await;
+            let _ = tx
+                .send(LlmEvent::Done {
+                    stop_reason: StopReason::EndTurn,
+                    finish_reason: FinishReason::from_stop_reason(StopReason::EndTurn),
+                    usage: TokenUsage::default(),
+                })
+                .await;
+        });
+        Ok(rx)
+    }
+}
+
+fn silent_output() -> Arc<dyn OutputSink> {
+    Arc::new(TerminalSink::new(true))
+}
+
+/// Build an engine on an unknown/router-aliased model ("flux-auto", which has no
+/// known output ceiling) with extended thinking enabled at `budget`, capping the
+/// output budget at `max_tokens`.
+fn reasoning_engine(max_tokens: u32, budget: u32) -> (AgentEngine, Arc<CapturingProvider>) {
+    let provider = CapturingProvider::new();
+    let mut config = test_config();
+    config.model = "flux-auto".to_string();
+    config.max_tokens = max_tokens;
+    config.thinking = Some(ThinkingConfig::Enabled {
+        budget_tokens: budget,
+    });
+    let engine = AgentEngine::new_with_provider(
+        provider.clone(),
+        config,
+        ToolRegistry::new(),
+        silent_output(),
+    );
+    (engine, provider)
+}
+
+fn captured_budget(provider: &CapturingProvider) -> Option<u32> {
+    match provider.thinking.lock().unwrap().clone() {
+        Some(ThinkingConfig::Enabled { budget_tokens }) => Some(budget_tokens),
+        _ => None,
+    }
+}
+
+/// The reported bug: a generous default (no host budget) on Flux Auto with heavy
+/// thinking. The model must get reasoning headroom (32768, not the 8192 unknown
+/// floor) AND keep room for the answer.
+#[tokio::test]
+async fn flux_auto_thinking_gets_headroom_and_reserves_the_answer() {
+    let (mut engine, provider) = reasoning_engine(64_000, 10_000);
+    engine.run("hello", "").await.expect("run should succeed");
+
+    let max_tokens = provider
+        .max_tokens
+        .lock()
+        .unwrap()
+        .expect("a request was sent");
+    let budget = captured_budget(&provider).expect("thinking stayed enabled");
+
+    assert_eq!(
+        max_tokens, 32_768,
+        "unknown reasoning model must get the reasoning-aware cap, not 8192"
+    );
+    assert_eq!(
+        budget, 10_000,
+        "budget fits comfortably, so it is unchanged"
+    );
+    assert!(
+        max_tokens - budget >= MIN_VISIBLE_OUTPUT,
+        "the visible answer must keep at least the floor: {max_tokens} - {budget}"
+    );
+}
+
+/// A low explicit cap must shrink the thinking budget so the answer survives,
+/// instead of letting thinking consume the whole budget (the empty-answer bug).
+#[tokio::test]
+async fn low_cap_shrinks_thinking_to_reserve_the_answer() {
+    let (mut engine, provider) = reasoning_engine(8_192, 10_000);
+    engine.run("hello", "").await.expect("run should succeed");
+
+    let max_tokens = provider
+        .max_tokens
+        .lock()
+        .unwrap()
+        .expect("a request was sent");
+    let budget = captured_budget(&provider).expect("thinking stayed enabled");
+
+    assert_eq!(max_tokens, 8_192, "explicit low cap binds");
+    assert_eq!(
+        budget,
+        8_192 - MIN_VISIBLE_OUTPUT,
+        "budget shrinks to reserve the visible floor"
+    );
+    assert!(max_tokens - budget >= MIN_VISIBLE_OUTPUT);
+}
+
+/// When the cap is too small to hold any usable reasoning budget plus the floor,
+/// thinking is dropped entirely so the full budget goes to the visible answer.
+#[tokio::test]
+async fn tiny_cap_drops_thinking_so_the_answer_is_never_empty() {
+    let (mut engine, provider) = reasoning_engine(5_000, 10_000);
+    engine.run("hello", "").await.expect("run should succeed");
+
+    let max_tokens = provider
+        .max_tokens
+        .lock()
+        .unwrap()
+        .expect("a request was sent");
+    assert_eq!(max_tokens, 5_000, "tiny cap binds");
+    assert!(
+        matches!(
+            provider.thinking.lock().unwrap().clone(),
+            Some(ThinkingConfig::Disabled)
+        ),
+        "thinking must be dropped when it cannot fit alongside the visible floor"
+    );
+}


### PR DESCRIPTION
## What

Engine half of FerroxLabs/wayland#422: reasoning models could spend the entire output budget on hidden thinking and return an empty answer (finish_reason length, zero content). Tracked as #426. A customer on Flux Auto waited 4m27s ("Thought for 4m 27s") and got no output.

## Root cause (verified by source read)

Two gaps combined in wayland-core:

1. size_output_cap clamped unknown / router-aliased models to a flat 8192 floor. flux-auto returns None from model_output_ceiling, so it got 8192 regardless of the configured budget. 8192 cannot hold a real reasoning budget AND a visible answer.

2. The thinking budget was written into the provider request independently and never checked against max_tokens. For reasoning models max_tokens is the TOTAL of reasoning plus visible output, so a budget near the (clamped) cap left nothing for the answer. The API returns finish_reason length with empty content.

## Fix

- size_output_cap now takes the requested thinking budget. An unknown reasoning turn grows to a reasoning-aware ceiling (UNKNOWN_REASONING_CAP = 32768, matching the desktop reasoning default) instead of 8192. Known models keep their real per-model ceiling and window clamp; the truncation auto-continue loop stays the net for longer outputs.
- After clamping, fit_thinking_budget shrinks the reasoning budget so at least MIN_VISIBLE_OUTPUT (4096) tokens always remain for the visible answer. If no usable budget can be kept at Anthropic's 1024 minimum, thinking is dropped for the turn rather than emitting an empty, length-truncated reply. Thinking can never starve the answer.

Single insertion point: the existing output-sizing site in the engine run loop, after the smart-routing tier swap, so the final model and budget are known.

## Tests

- Unit (engine, output_sizing_tests): reasoning headroom for unknown models, known-model ceiling still binds, fit_thinking_budget reserves the floor / collapses to drop thinking when no room.
- Integration (reasoning_budget_test): drives a real engine.run() with thinking on an unknown model through a capturing provider and asserts the max_tokens plus fitted budget actually put on the wire across three regimes (generous default, low cap, tiny cap).

Verified on the Linux build host: clippy clean (wcore-agent, all targets); full wcore-agent suite green (1479 lib tests plus all integration binaries, 0 failed).

## Scope

Engine-side only. The desktop name-heuristic fix (defaultMaxTokensForModel missing the flux-auto / flux-reasoning aliases) is still needed for defense in depth and is tracked on wayland#422 / #426. #417 (reasoning_content history passback) is a separate mechanism handled on its own track.

Closes nothing automatically; mark #426 state:fixed-pending-release on merge.
