### PR TITLE
fix(providers): replay reasoning_content for strict reasoners routed via a router (#417)

### DIFF
--- a/crates/wcore-providers/src/openai.rs
+++ b/crates/wcore-providers/src/openai.rs
@@ -218,6 +218,27 @@ impl OpenAIProvider {
         }
     }
 
+    /// #417 — resolve the per-request message compat from the target model. The
+    /// strict-reasoner "must replay reasoning_content" contract is a per-MODEL
+    /// requirement, but a router provider's static compat has the flag off, so a
+    /// DeepSeek/Kimi turn routed through Flux/OpenRouter would drop the history's
+    /// reasoning_content and 400 (wayland#417). When the target model requires
+    /// replay, force the flag on for this request only; otherwise return the base
+    /// compat unchanged, so a non-strict model (e.g. claude-via-Flux) never
+    /// replays an unsigned thinking block. Direct DeepSeek/Kimi already set the
+    /// flag, so this is a no-op clone for them.
+    fn message_compat(compat: &ProviderCompat, model: &str) -> ProviderCompat {
+        if openai_compat::requires_reasoning_content_replay(model)
+            && !compat.replays_thinking_in_history()
+        {
+            let mut c = compat.clone();
+            c.replays_thinking_in_history = Some(true);
+            c
+        } else {
+            compat.clone()
+        }
+    }
+
     fn build_messages(messages: &[Message], system: &str, compat: &ProviderCompat) -> Vec<Value> {
         let mut result: Vec<Value> = Vec::new();
 
@@ -634,9 +655,14 @@ impl OpenAIProvider {
                 .unwrap_or("max_tokens")
         };
 
+        // #417 — resolve the effective message compat for THIS request's target
+        // model, so a router (Flux/OpenRouter) replays reasoning_content when it
+        // routes to a strict reasoner (DeepSeek/Kimi) without 400ing, while a
+        // non-strict model keeps replay off. See `message_compat`.
+        let msg_compat = Self::message_compat(&self.compat, &request.model);
         let mut body = json!({
             "model": request.model,
-            "messages": Self::build_messages(&request.messages, &request.system, &self.compat),
+            "messages": Self::build_messages(&request.messages, &request.system, &msg_compat),
             "stream": true
         });
         // `stream_options: {include_usage: true}` asks for token accounting in
@@ -2897,6 +2923,45 @@ mod tests {
 
     fn openai_compat() -> ProviderCompat {
         ProviderCompat::openai_defaults()
+    }
+
+    // --- message_compat (#417: per-request reasoning_content replay) ---
+
+    #[test]
+    fn message_compat_forces_replay_for_strict_reasoner_via_router() {
+        // Flux's static compat has replay OFF, but routing to DeepSeek must
+        // turn it ON for this request so reasoning_content is replayed (#417).
+        let flux = ProviderCompat::flux_router_defaults();
+        assert!(
+            !flux.replays_thinking_in_history(),
+            "precondition: router compat has replay off"
+        );
+        let resolved = OpenAIProvider::message_compat(&flux, "deepseek-v4-pro");
+        assert!(
+            resolved.replays_thinking_in_history(),
+            "DeepSeek via Flux must replay reasoning_content"
+        );
+    }
+
+    #[test]
+    fn message_compat_does_not_replay_for_non_strict_via_router() {
+        // claude-via-Flux must NOT replay — Anthropic 400s on an unsigned
+        // thinking block. Ordinary OpenAI models stay off too.
+        let flux = ProviderCompat::flux_router_defaults();
+        assert!(
+            !OpenAIProvider::message_compat(&flux, "claude-opus-4-7").replays_thinking_in_history()
+        );
+        assert!(!OpenAIProvider::message_compat(&flux, "gpt-4o").replays_thinking_in_history());
+    }
+
+    #[test]
+    fn message_compat_is_noop_for_direct_deepseek() {
+        // Direct DeepSeek already sets the flag; resolution leaves it on.
+        let ds = ProviderCompat::deepseek_defaults();
+        assert!(ds.replays_thinking_in_history());
+        assert!(
+            OpenAIProvider::message_compat(&ds, "deepseek-v4-pro").replays_thinking_in_history()
+        );
     }
 
     // --- max_tokens_field ---

--- a/crates/wcore-providers/src/openai_compat.rs
+++ b/crates/wcore-providers/src/openai_compat.rs
@@ -59,6 +59,22 @@ pub fn accepts_reasoning_effort(model: &str) -> bool {
     wcore_config::config::openai_model_accepts_effort(model)
 }
 
+/// #417 — true when the TARGET model is a strict reasoner that 400s unless every
+/// historical assistant message carries `reasoning_content` once any turn
+/// produced thinking (DeepSeek Reasoner, Moonshot/Kimi). This is a per-MODEL
+/// contract, so it must be keyed off the model id — not just the provider's
+/// static compat. A router provider (Flux/OpenRouter) carries a generic compat
+/// with `replays_thinking_in_history` off, yet can route to DeepSeek/Kimi, which
+/// is exactly the case wayland#417 hit. Keying off the model lets a router serve
+/// a strict reasoner correctly while NEVER replaying for a non-strict model
+/// (e.g. claude-via-Flux, which would 400 on an unsigned thinking block). The
+/// `has-thinking` gate at the replay site still prevents replay when a turn
+/// produced no reasoning, so a non-reasoning DeepSeek model is unaffected.
+pub fn requires_reasoning_content_replay(model: &str) -> bool {
+    let m = model.to_ascii_lowercase();
+    m.contains("deepseek") || m.contains("moonshot") || m.contains("kimi")
+}
+
 /// True when the model must be served via the OpenAI **Responses API**
 /// (`POST /v1/responses`) instead of Chat Completions
 /// (`POST /v1/chat/completions`).
@@ -319,6 +335,35 @@ mod tests {
     fn accepts_reasoning_effort_case_insensitive() {
         assert!(accepts_reasoning_effort("GPT-5"));
         assert!(accepts_reasoning_effort("O1-Mini"));
+    }
+
+    // --- requires_reasoning_content_replay (#417) -------------------------
+
+    #[test]
+    fn requires_replay_for_strict_reasoners() {
+        // DeepSeek (incl. the wayland#417 model) and Moonshot/Kimi require it.
+        assert!(requires_reasoning_content_replay("deepseek-v4-pro"));
+        assert!(requires_reasoning_content_replay("deepseek-reasoner"));
+        assert!(requires_reasoning_content_replay("deepseek-chat"));
+        assert!(requires_reasoning_content_replay("moonshot-v1-128k"));
+        assert!(requires_reasoning_content_replay("kimi-k2"));
+    }
+
+    #[test]
+    fn no_replay_for_non_strict_models() {
+        // Crucially claude-via-Flux must NOT replay (unsigned thinking 400s
+        // Anthropic), and ordinary OpenAI / router aliases stay off.
+        assert!(!requires_reasoning_content_replay("claude-opus-4-7"));
+        assert!(!requires_reasoning_content_replay("gpt-4o"));
+        assert!(!requires_reasoning_content_replay("gpt-5"));
+        assert!(!requires_reasoning_content_replay("flux-auto"));
+        assert!(!requires_reasoning_content_replay("grok-4"));
+    }
+
+    #[test]
+    fn requires_replay_is_case_insensitive() {
+        assert!(requires_reasoning_content_replay("DeepSeek-V4-Pro"));
+        assert!(requires_reasoning_content_replay("Kimi-K2"));
     }
 
     // --- model_uses_responses_api -----------------------------------------


### PR DESCRIPTION
## What

Fixes FerroxLabs/wayland#417: DeepSeek (deepseek-v4-pro) routed through Flux returns API 400 "The reasoning_content in the thinking mode must be passed back to the API."

## Root cause (verified by source read)

DeepSeek and Moonshot/Kimi are strict reasoners: once any turn produces thinking, every historical assistant message must carry reasoning_content or the request 400s. Direct DeepSeek/Moonshot set replays_thinking_in_history=true in their ProviderCompat, so wcore replays the stored reasoning. But when the same model is reached through a router (Flux/OpenRouter), the provider carries the router's generic compat with the flag OFF, so build_messages drops reasoning_content from history and the request 400s. The replay requirement is a per-MODEL contract, but it was only keyed off the static provider compat.

## Fix

- New openai_compat::requires_reasoning_content_replay(model) detects the strict reasoners (deepseek / moonshot / kimi), mirroring the existing per-model detectors (accepts_reasoning_effort, max_completion_tokens_override) — no hardcoded catalog.
- OpenAIProvider::message_compat resolves the effective compat per request: when the target model requires replay, force replays_thinking_in_history on for that request only; otherwise return the base compat unchanged.

This fixes DeepSeek/Kimi through any path (direct or router) and cannot regress Anthropic-via-Flux: a claude-* model never matches the strict-reasoner detector, so an unsigned thinking block is never replayed to Anthropic. The existing has-thinking gate still prevents replay when a turn produced no reasoning, and direct DeepSeek/Kimi are a no-op (flag already on).

## Known limitation (documented, not regressed)

The fix keys off request.model, so it covers concrete model ids (the reported deepseek-v4-pro). A Flux TIER ALIAS (flux-auto / flux-reasoning) that routes to a strict reasoner server-side still would not match, because wcore cannot know the served model for a tier alias. Closing that needs a Flux-side signal (or Flux normalizing reasoning_content itself) and is out of scope for this report; filing as a follow-up note on the issue.

## Tests

- Unit: requires_reasoning_content_replay (deepseek/moonshot/kimi true; claude/gpt/flux/grok false; case-insensitive).
- Unit: message_compat resolution (DeepSeek-via-Flux forces replay; claude/gpt-via-Flux do not; direct DeepSeek stays on).
- Existing historical_thinking_replayed_for_deepseek still passes (direct path intact).

Verified on the Linux build host: clippy clean (wcore-providers, all targets); full wcore-providers suite green (10 binaries, 0 failed).
