### PR TITLE
fix(agent): resolve send_message channel by platform family (#116)

### DIFF
--- a/.github/osv-scanner.toml
+++ b/.github/osv-scanner.toml
@@ -117,3 +117,19 @@ reason = "proc-macro-error: build-time proc-macro, no runtime surface; transitiv
 id = "GHSA-w9wp-h8wv-79jx"
 ignoreUntil = "2026-09-02T00:00:00Z"
 reason = "opentelemetry_sdk baggage-extract DoS: receiving-side only; wayland-core is an OTLP exporter, otlp feature default-off, only trace feature enabled, no BaggagePropagator usage (0 grep hits). Not reachable. Tracked; revisit on opentelemetry 0.32 bump."
+
+# ── ttf-parser 0.25.1 (unmaintained) ─────────────────────────────────────
+# The author has declared ttf-parser unmaintained (no further fixes;
+# patched = []). Recommended successor is skrifa (fontations), but the switch
+# is an UPSTREAM decision for our parent, not ours: ttf-parser arrives only
+# transitively via lopdf 0.42.0 <- pdf-extract 0.12.0 <- wcore-tools (PDF text
+# extraction for the Read tool). It is a font table parser exercised only when
+# a PDF embeds fonts during text extraction; there is no maintained pdf-extract
+# release that drops the lopdf/ttf-parser chain. Informational "unmaintained"
+# advisory, no known vulnerability and no patch to apply. Surfaced 2026-06-28
+# (ambient advisory, not a code change in this PR). Revisit when pdf-extract or
+# lopdf move off ttf-parser, or migrate the PDF path to a maintained extractor.
+[[IgnoredVulns]]
+id = "RUSTSEC-2026-0192"
+ignoreUntil = "2026-09-02T00:00:00Z"
+reason = "ttf-parser unmaintained (patched=[]); transitive only via lopdf <- pdf-extract <- wcore-tools PDF text extraction. Informational, no patch exists; successor skrifa is an upstream pdf-extract/lopdf decision. Tracked; revisit on pdf-extract/lopdf bump."

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,9 +171,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arbitrary"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1121,7 +1121,7 @@ dependencies = [
  "cap-primitives",
  "cap-std",
  "io-lifetimes",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1150,7 +1150,7 @@ dependencies = [
  "maybe-owned",
  "rustix 1.1.4",
  "rustix-linux-procfs",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
  "winx",
 ]
 
@@ -1511,7 +1511,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1692,36 +1692,36 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.123.11"
+version = "0.123.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ad3e7d446bbdc05f33371b17aae2857e2c5f1dd6750848f555c129c5060725f"
+checksum = "3cd990d8a6304475bbad64534a0d418f5572f44d5f011437e6b9f1ee7d5c2570"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.123.11"
+version = "0.123.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96ee145f9cbf7474350ee48e5c33ec2312177fa32c07e4eb395727250892a201"
+checksum = "ccabe4636007296721080e02d7dab46d4319638ec4e3f6f7402fcb46dc5122c6"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.123.11"
+version = "0.123.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7025668e34c499fd0960dfaf68bc1689c961002fb67227f3dd262535c4118e52"
+checksum = "da7ed173c870c0aea202a9830880156905a028a88df076e35ce383a8acbf90a7"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.123.11"
+version = "0.123.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ad0b552e9b906fee4416b68664463e80f9024215da2cebd4065eee99d5d3008"
+checksum = "800cc586df98b12c502e76707c96565e40629a5322eaa15aaa34ba05f5721e31"
 dependencies = [
  "serde",
  "serde_derive",
@@ -1729,9 +1729,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.123.11"
+version = "0.123.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f87371fa1b0e21dc0a7943f372ce5a308c7d6b26ef8c9982a8a063218fe101ae"
+checksum = "ae93f863f9094ae34d2567f9edb0ae2c41d35228b286598354dd78b198868ebd"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -1756,9 +1756,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.123.11"
+version = "0.123.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a24ef297d4dd3af3e571691568958ceea1d3e723bb24eef4e934bbd569c93ef6"
+checksum = "38c505162bcf77dcb859905b3eac56a1917fc3cf326424fb06e7732031e3a8ae"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -1769,24 +1769,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.123.11"
+version = "0.123.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d65396f589d1f746f52db7370372bc8611aa7a5bc0b0322f77deaa1b62e12287"
+checksum = "e3b786958bcb79bdb5fbae095af58f0c2da7d7895c475c991f6a6bb5a9c7e6d9"
 
 [[package]]
 name = "cranelift-control"
-version = "0.123.11"
+version = "0.123.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5731530f81a1566057f9475639f34463e723210ef2484fe9f087e03d79e879a"
+checksum = "2faf9a5009bce7f725ce2af7a08c4883ebac6af933e7e0aa7d84f976f4e6deb5"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.123.11"
+version = "0.123.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3437f152d3766d07420956f4eabaa6f89fa98543e53d387dd1e395980441c68d"
+checksum = "017271194ba5e101d626560d0d6767efd341468d1ba0f4d015f19fe64020b65b"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -1795,9 +1795,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.123.11"
+version = "0.123.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9dbb5c65123d9bd76a701523d72f78e1f9b754321caa7767a70ea9304f49be1"
+checksum = "f80847f0929967f0cec82f9e0543b3901e0f0063690405891f22107b5a130fd8"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -1807,15 +1807,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.123.11"
+version = "0.123.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a493c7a6e01f9c6e9b5468faa7f13a06d6d882f92942f8042a0fd0a8e3e8bc2c"
+checksum = "75904abbc0e7b46d20f7a49c8042c8a4481c0db4253b99889c723c566295d506"
 
 [[package]]
 name = "cranelift-native"
-version = "0.123.11"
+version = "0.123.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79bd8bd6a0a5bce75e9b24b4e9578114ef6be94795956c4d19aeaa1da607abfd"
+checksum = "6e0135923540574362e16f01bf40000664263840991039ff3041ba717de6cf3a"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -1824,9 +1824,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.123.11"
+version = "0.123.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c33438ba0b8ba75137bd45eb0d36a319efe90cf145f9fd5773b84f0b89f0edc"
+checksum = "93fb12f76c482e034f6ebefa843c914e74112f088215d8d36d33a649f9fab99b"
 
 [[package]]
 name = "crc32fast"
@@ -2555,7 +2555,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2652,7 +2652,7 @@ checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2833,7 +2833,7 @@ checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
 dependencies = [
  "io-lifetimes",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3567,7 +3567,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.57.0",
 ]
 
 [[package]]
@@ -3868,7 +3868,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2285ddfe3054097ef4b2fe909ef8c3bcd1ea52a8f0d274416caebeef39f04a65"
 dependencies = [
  "io-lifetimes",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3900,7 +3900,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5848,7 +5848,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5890,9 +5890,9 @@ checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "pulley-interpreter"
-version = "36.0.11"
+version = "36.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fae33db3d81aa92ead4ba06f7f9bbf32b2d8ff4132a00df5fa0913fd03dfa33c"
+checksum = "558181096e0df4984f45cfc3a7087052df4a61c36089b135a08ceca9cbd352fb"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -5902,9 +5902,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "36.0.11"
+version = "36.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "055100cf63f790c7bd02e606339916e1a403485358d4ae890ce912c102a9e80d"
+checksum = "b5d52e2f14e168d75cdabe9bd5fb1ff18a1b119dc6699684aee895dbc3524da9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6007,7 +6007,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6534,7 +6534,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6547,7 +6547,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7411,7 +7411,7 @@ dependencies = [
  "fd-lock",
  "io-lifetimes",
  "rustix 0.38.44",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
  "winx",
 ]
 
@@ -7442,7 +7442,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8649,9 +8649,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "36.0.11"
+version = "36.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "319b720df5e1c49b5dbc916d28a386aad3f03ed96fa3cebe2c6270eb11b6baf3"
+checksum = "4b4442dc12aa2473def8334f0e0f2b489be52c52507c938bbdc8be69ded4ded6"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -8696,9 +8696,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "36.0.11"
+version = "36.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acc2633f356486b8c5917e2aad7aca2b5b54f0f674a8f384a166e34d48101893"
+checksum = "5d881c3d6205898a226cc487b117f23b9ed1c7da39952d65bd5eeb6745b3789c"
 dependencies = [
  "anyhow",
  "cranelift-bitset",
@@ -8721,18 +8721,18 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-asm-macros"
-version = "36.0.11"
+version = "36.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0e647efa7382e8cc8b668ee871af1da0f097d5f12ba2242ac865107c30996e8"
+checksum = "5ab1876bcfa51d6a05dea1c13933f53cbc1e316c783fddebc859f56a736eae07"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "36.0.11"
+version = "36.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13915309c8ac371ce8aaadf856aad7a7685e390fdf158df1d35c3b0b7a320c44"
+checksum = "8ae1407944a0b13a8a77930b5b951aa7134beccecad7efac1ef9f03adb7d1a0f"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -8745,15 +8745,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "36.0.11"
+version = "36.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08935e3f35beb765593e42432b6f97fd6df16f1c9aa629a79137a04d30a168f4"
+checksum = "646a53678ce6aaf6f097e18ca51f650f2841aea6d2bcd7b61931397b8b8f30db"
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "36.0.11"
+version = "36.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd24355be6b01300639f3fd2e83dfbb75efc18a3d3386e955e87415c96fc105d"
+checksum = "ab3495aa8300e4ca6b53f81a53ce5eff6621fd5ff8378ef9ae552d1479d57371"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -8778,9 +8778,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "36.0.11"
+version = "36.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d322d8644a6057b221215ca579c40e4bdf90146119d4dc5172d2b37b1a0e3bb9"
+checksum = "29b5e4023a6b167da157338f5f0f505945eb45e78f1cac2d4dcce0922457d7d4"
 dependencies = [
  "anyhow",
  "cc",
@@ -8794,9 +8794,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "36.0.11"
+version = "36.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "307cef37d6c5563e0a408e24ab983b06ebe3ec27dd01675c7e7b12133205484c"
+checksum = "9da71e2d573e3cc6f753a3b7bff98f425ca060c0e8071cc55c3d867a9edf3ecc"
 dependencies = [
  "cc",
  "wasmtime-internal-versioned-export-macros",
@@ -8804,9 +8804,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "36.0.11"
+version = "36.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f2e02bd5006f643d8787a33c71e8fb401f029a35df25cd237d25d6d2ddc1c07"
+checksum = "627d8f57909a4f9bb1dbe57a96229a54b89d5995353d0b321f3cb9a1a118977a"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -8816,24 +8816,24 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-math"
-version = "36.0.11"
+version = "36.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28b0166bd79eb87e2e2e9d6ed7bc6c593428cadfd82cbc94fd113268c29d36a"
+checksum = "45b99315585a8a27125dd9b0150edb115d6f6ff0baae453c21d30822aab77f00"
 dependencies = [
  "libm",
 ]
 
 [[package]]
 name = "wasmtime-internal-slab"
-version = "36.0.11"
+version = "36.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c3295d1f1de2f3769b749a15e8f64341c38da6faa7fcd737ed485eb3fa40158"
+checksum = "8eaee97281dd3fe47ec3d46c16fb9fe2dd32f37d0523c2d5c484f11b348734e4"
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "36.0.11"
+version = "36.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a34055eb99cdff44ddd277e3b3baec670ef0302c847465c894f1118d4e7b1e3d"
+checksum = "d0c005f82c48492b6b44fa19ee5205bd933c4f8baca41e314eca8331dd3c4fd9"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -8844,9 +8844,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "36.0.11"
+version = "36.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e69f8a29ae6fdf7218ae37f38b1cc9fe539344a17b7fffba203de3ee2194d605"
+checksum = "7b73639a9c0c0e33a2ef942ca99b6772b48393be92bebbd0767c607e5b0a68e0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8855,9 +8855,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-winch"
-version = "36.0.11"
+version = "36.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08a4d8a3501080d3707f845acfcd2fedec9bb91dad3fd9078b7a17e8c8a0884"
+checksum = "392ca021d084c7426616ef77e1284315555f11bcbb34f416d74b0732db622811"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -8872,9 +8872,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "36.0.11"
+version = "36.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc86f7cc67cafad52959bc1b91176d73e1ed6dbcc00c7a31b3c0a30ac32e881a"
+checksum = "7fd4703351476262d715b72431e80d10289908e3494050071d6521267f522d97"
 dependencies = [
  "anyhow",
  "bitflags 2.11.1",
@@ -8885,9 +8885,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "36.0.11"
+version = "36.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e53a8072429ae61b472280b33b61dc0d21173b2b21b68a18bb9cc2024d18414d"
+checksum = "21921b6e8e8ed876a288cb3b0b3aee68809fed8182ce26c9977ffc4af4cb77f6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8915,9 +8915,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-io"
-version = "36.0.11"
+version = "36.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3bd4ac921831465ff97529a528e93f786095adf748d03736e2bd7fb3b0f5623"
+checksum = "2cceb2d110d8de61e7b0e8c501b838d3c6403a14cdca8cb612ff1228db537c6d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8928,7 +8928,7 @@ dependencies = [
 
 [[package]]
 name = "wayland-browser"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "async-trait",
  "inventory",
@@ -8945,7 +8945,7 @@ dependencies = [
 
 [[package]]
 name = "wayland-cua"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "async-trait",
  "inventory",
@@ -8962,7 +8962,7 @@ dependencies = [
 
 [[package]]
 name = "wayland-honcho"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8983,7 +8983,7 @@ dependencies = [
 
 [[package]]
 name = "wayland-ijfw"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9002,7 +9002,7 @@ dependencies = [
 
 [[package]]
 name = "wayland-ollama"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "async-trait",
  "futures",
@@ -9023,7 +9023,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-acp"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "async-trait",
  "axum",
@@ -9046,7 +9046,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-agent"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9136,7 +9136,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-agents-pack"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "dirs",
  "serde",
@@ -9149,7 +9149,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-browser"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9179,7 +9179,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-budget"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "chrono",
  "parking_lot",
@@ -9192,7 +9192,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-discord"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9213,7 +9213,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-email"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9232,7 +9232,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-imessage"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9249,7 +9249,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-matrix"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9268,7 +9268,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-msteams"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -9289,7 +9289,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-signal"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9304,7 +9304,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-slack"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9327,7 +9327,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-sms"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -9350,7 +9350,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-telegram"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9369,7 +9369,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-whatsapp"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9392,7 +9392,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channels"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9408,7 +9408,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channels-registry"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "dirs",
  "serde",
@@ -9433,7 +9433,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-cli"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9516,7 +9516,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-compact"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "regex",
  "serde",
@@ -9525,7 +9525,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-config"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "anyhow",
  "argon2",
@@ -9563,7 +9563,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-cron"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9580,7 +9580,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-cua"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9616,7 +9616,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-dispatch"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "rand 0.9.4",
  "rand_distr",
@@ -9629,7 +9629,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-egress"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "async-trait",
  "http 1.4.1",
@@ -9642,7 +9642,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-eval"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "rstest",
  "serde",
@@ -9659,7 +9659,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-eval-scenarios"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "anyhow",
  "clap",
@@ -9679,7 +9679,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-evolve"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9719,7 +9719,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-honcho-adapter"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "async-trait",
  "serde",
@@ -9734,7 +9734,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-mcp"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9761,7 +9761,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-memory"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9802,7 +9802,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-observability"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "chrono",
  "opentelemetry",
@@ -9826,7 +9826,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-permissions"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9843,7 +9843,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-plugin-api"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9870,7 +9870,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-plugin-subprocess"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "anyhow",
  "serde",
@@ -9889,7 +9889,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-plugin-wasm"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9911,7 +9911,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-pluginsrc"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "serde",
  "serde_json",
@@ -9926,7 +9926,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-pricing"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "chrono",
  "dirs",
@@ -9945,7 +9945,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-protocol"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "rstest",
  "serde",
@@ -9957,7 +9957,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-providers"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9992,7 +9992,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-replay"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "serde",
  "serde_json",
@@ -10003,7 +10003,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-repomap"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "ignore",
  "regex",
@@ -10016,7 +10016,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-safety"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "async-trait",
  "regex",
@@ -10029,7 +10029,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-sandbox"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "async-trait",
  "bollard",
@@ -10049,7 +10049,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-skills"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10086,7 +10086,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-swarm"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "futures",
  "humantime-serde",
@@ -10105,7 +10105,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-tools"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10152,7 +10152,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-types"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "async-trait",
  "chrono",
@@ -10162,7 +10162,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-user-model"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "async-trait",
  "serde",
@@ -10348,7 +10348,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -10359,9 +10359,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "36.0.11"
+version = "36.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33afb2737056d7162813a167fc53b8d986e725724a4e6c76ca9910952bb94b5"
+checksum = "61ec880b20caaa72245944b54cfb22aca111f8c805e12a7542b40d66921e5323"
 dependencies = [
  "anyhow",
  "cranelift-assembler-x64",
@@ -10934,7 +10934,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
 dependencies = [
  "bitflags 2.11.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/crates/wcore-agent/src/channel_send_transport.rs
+++ b/crates/wcore-agent/src/channel_send_transport.rs
@@ -13,12 +13,15 @@
 //!
 //! Mapping convention: `ParsedTarget::platform` (one of the
 //! `MessagingPlatform` enum's `as_str()` values: "telegram", "discord",
-//! "slack", …) is used directly as the `ChannelManager::send_to` channel
-//! name. Operators register their channels under those platform names
-//! (the default convention auto-`register` follows). When a user runs
-//! multiple bots on the same platform, they MUST register them under
-//! distinct names and the LLM must target the named instance — that
-//! addressing layer is a separate piece of work.
+//! "slack", …) is resolved to a registered `ChannelManager` channel name
+//! by platform FAMILY (see [`resolve_channel_name`]). Default-named
+//! channels register under the platform token itself ("telegram"), so the
+//! exact-match arm preserves the original behavior. Instance-named channels
+//! register under a `platform-suffix` key — e.g. the IMAP email connector
+//! registers as "email-imap" while its platform is "email" (issue #116) —
+//! so the family arm maps the "email" token onto the registered
+//! "email-imap"/"email-agentmail" instance. Without this, `send_to("email")`
+//! missed and every IMAP email user's `send_message` failed.
 
 use std::sync::Arc;
 
@@ -38,10 +41,33 @@ impl ChannelManagerTransport {
     }
 }
 
+/// Resolve a `send_message` platform token to a registered channel name.
+///
+/// Channels register under their instance name, which is not always the
+/// platform token: the default convention uses the token itself ("telegram"),
+/// but instance-named connectors use a `platform-suffix` key (the IMAP email
+/// connector registers as "email-imap" with platform "email" — issue #116).
+///
+/// Resolution order:
+/// 1. Exact match on the platform token (preserves default-named channels).
+/// 2. Family match: the first registered channel whose name starts with the
+///    platform token (covers "email-imap"/"email-agentmail" for "email").
+/// 3. No match: return the token unchanged so `send_to` yields its existing
+///    "unknown channel" error.
+fn resolve_channel_name(names: &[String], platform_token: &str) -> String {
+    if names.iter().any(|n| n == platform_token) {
+        return platform_token.to_string();
+    }
+    if let Some(name) = names.iter().find(|n| n.starts_with(platform_token)) {
+        return name.clone();
+    }
+    platform_token.to_string()
+}
+
 #[async_trait]
 impl MessageTransport for ChannelManagerTransport {
     async fn send(&self, target: &ParsedTarget, message: &str) -> SendOutcome {
-        let channel_name = target.platform.as_str();
+        let platform_token = target.platform.as_str();
         let conversation_id = target.chat_id.clone().unwrap_or_default();
         let outgoing = OutgoingMessage {
             conversation_id,
@@ -50,13 +76,89 @@ impl MessageTransport for ChannelManagerTransport {
             attachments: Vec::new(),
         };
         let guard = self.mgr.read().await;
-        match guard.send_to(channel_name, outgoing).await {
+        // Channels register under their instance name (e.g. "email-imap"),
+        // which may differ from the platform token ("email"). Resolve by
+        // platform family before dispatching (issue #116).
+        let channel_name = resolve_channel_name(&guard.list_names(), platform_token);
+        match guard.send_to(&channel_name, outgoing).await {
             Ok(receipt) => SendOutcome::Ok {
                 message_id: Some(receipt.id),
             },
             Err(e) => SendOutcome::Err {
                 message: e.to_string(),
             },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wcore_channels::MockChannel;
+    use wcore_tools::send_message::MessagingPlatform;
+
+    fn target(platform: MessagingPlatform, chat_id: &str) -> ParsedTarget {
+        ParsedTarget {
+            platform,
+            chat_id: Some(chat_id.to_string()),
+            thread_id: None,
+        }
+    }
+
+    #[test]
+    fn resolve_prefers_exact_name_then_family_prefix() {
+        // Exact platform-token match wins (default-named channels).
+        let names = vec!["email".to_string(), "email-imap".to_string()];
+        assert_eq!(resolve_channel_name(&names, "email"), "email");
+
+        // No exact token, but a family member exists: resolve to it.
+        let names = vec!["telegram".to_string(), "email-imap".to_string()];
+        assert_eq!(resolve_channel_name(&names, "email"), "email-imap");
+
+        // Nothing in the family: return the token unchanged so send_to errors.
+        let names = vec!["telegram".to_string()];
+        assert_eq!(resolve_channel_name(&names, "email"), "email");
+    }
+
+    /// Issue #116: an email channel registered under its instance name
+    /// ("email-imap") must be reachable when send_message targets the "email"
+    /// platform token.
+    #[tokio::test]
+    async fn send_reaches_named_email_channel_via_platform_family() {
+        let mut mgr = ChannelManager::new();
+        // Registered under the instance name, NOT the bare platform token —
+        // exactly what the desktop ChannelManager does for IMAP email.
+        mgr.register(Box::new(MockChannel::new("email-imap"))).await;
+        mgr.start_all().await.expect("start channels");
+        let transport = ChannelManagerTransport::new(Arc::new(RwLock::new(mgr)));
+
+        let outcome = transport
+            .send(&target(MessagingPlatform::Email, "inbox@example.com"), "hi")
+            .await;
+
+        match outcome {
+            SendOutcome::Ok { message_id } => assert!(message_id.is_some()),
+            SendOutcome::Err { message } => panic!("expected Ok, got Err: {message}"),
+        }
+    }
+
+    /// A genuinely absent platform still surfaces the unknown-channel error.
+    #[tokio::test]
+    async fn send_to_absent_platform_still_errors() {
+        let mut mgr = ChannelManager::new();
+        mgr.register(Box::new(MockChannel::new("telegram"))).await;
+        let transport = ChannelManagerTransport::new(Arc::new(RwLock::new(mgr)));
+
+        let outcome = transport
+            .send(&target(MessagingPlatform::Email, "inbox@example.com"), "hi")
+            .await;
+
+        match outcome {
+            SendOutcome::Err { message } => assert!(
+                message.contains("unknown channel"),
+                "expected unknown-channel error, got: {message}"
+            ),
+            SendOutcome::Ok { .. } => panic!("expected Err for an absent platform"),
         }
     }
 }

--- a/crates/wcore-agent/src/channel_send_transport.rs
+++ b/crates/wcore-agent/src/channel_send_transport.rs
@@ -50,15 +50,22 @@ impl ChannelManagerTransport {
 ///
 /// Resolution order:
 /// 1. Exact match on the platform token (preserves default-named channels).
-/// 2. Family match: the first registered channel whose name starts with the
-///    platform token (covers "email-imap"/"email-agentmail" for "email").
+/// 2. Family match: the first registered channel whose name is the platform
+///    token followed by the `-` instance separator (covers "email-imap"/
+///    "email-agentmail" for "email"). The separator is required so a bare
+///    prefix can't cross distinct platforms — e.g. "wecom" must NOT resolve
+///    to a "wecom_callback" channel ('_', not '-'), and "email" must not
+///    match an unrelated "emailfoo".
 /// 3. No match: return the token unchanged so `send_to` yields its existing
 ///    "unknown channel" error.
 fn resolve_channel_name(names: &[String], platform_token: &str) -> String {
     if names.iter().any(|n| n == platform_token) {
         return platform_token.to_string();
     }
-    if let Some(name) = names.iter().find(|n| n.starts_with(platform_token)) {
+    if let Some(name) = names.iter().find(|n| {
+        n.strip_prefix(platform_token)
+            .is_some_and(|r| r.starts_with('-'))
+    }) {
         return name.clone();
     }
     platform_token.to_string()
@@ -118,6 +125,19 @@ mod tests {
         // Nothing in the family: return the token unchanged so send_to errors.
         let names = vec!["telegram".to_string()];
         assert_eq!(resolve_channel_name(&names, "email"), "email");
+
+        // Separator guard: the family arm requires the platform token followed
+        // by '-'. "wecom" and "wecom_callback" are DISTINCT platforms (the
+        // separator is '_'), so a "wecom_callback" channel must NOT satisfy a
+        // "wecom" target — that would re-introduce the cross-family misroute
+        // this fix exists to prevent. Token returned unchanged → unknown channel.
+        let names = vec!["wecom_callback".to_string()];
+        assert_eq!(resolve_channel_name(&names, "wecom"), "wecom");
+
+        // An unrelated name that merely shares the prefix without the separator
+        // ("emailfoo") must not match either.
+        let names = vec!["emailfoo".to_string()];
+        assert_eq!(resolve_channel_name(&names, "email"), "email");
     }
 
     /// Issue #116: an email channel registered under its instance name
@@ -159,6 +179,33 @@ mod tests {
                 "expected unknown-channel error, got: {message}"
             ),
             SendOutcome::Ok { .. } => panic!("expected Err for an absent platform"),
+        }
+    }
+
+    /// Cross-family guard (end-to-end): "wecom" and "wecom_callback" are
+    /// distinct platforms. Targeting "wecom" with only a "wecom_callback"
+    /// channel registered must NOT misroute to it — it must surface the
+    /// unknown-channel error, the exact bug class this fix prevents.
+    #[tokio::test]
+    async fn send_to_wecom_does_not_misroute_to_wecom_callback() {
+        let mut mgr = ChannelManager::new();
+        mgr.register(Box::new(MockChannel::new("wecom_callback")))
+            .await;
+        mgr.start_all().await.expect("start channels");
+        let transport = ChannelManagerTransport::new(Arc::new(RwLock::new(mgr)));
+
+        let outcome = transport
+            .send(&target(MessagingPlatform::Wecom, "room1"), "hi")
+            .await;
+
+        match outcome {
+            SendOutcome::Err { message } => assert!(
+                message.contains("unknown channel"),
+                "expected unknown-channel error, got: {message}"
+            ),
+            SendOutcome::Ok { .. } => {
+                panic!("wecom must NOT resolve to a wecom_callback channel")
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #116. Customer-blocking: IMAP email channel configured + running, but `send_message` fails to reach it.

## Root cause
`ChannelManagerTransport::send` set the channel name to the platform token (`target.platform.as_str()` → `"email"`) and called `ChannelManager::send_to("email")`. Channels register under their **instance name** (`ch.name()`), and the IMAP email connector registers as `"email-imap"` while its `platform()` is `"email"`. No alias mapped `email` → `email-imap`, so `send_to("email")` missed and returned `unknown channel: email`. This broke email send for every non-default channel name (`email-imap`, `email-agentmail`).

## Fix (transport-side family resolution)
`crates/wcore-agent/src/channel_send_transport.rs` now resolves the platform token to a registered channel name via a small `resolve_channel_name` helper, using `ChannelManager::list_names()`:
1. **Exact match** on the platform token — preserves the existing behavior for default-named channels.
2. **Family match** — first registered channel whose name starts with the platform token (covers `email-imap` and `email-agentmail` for `email`).
3. **No match** — return the token unchanged so `send_to` still yields the existing `unknown channel` error.

No change to the `send_message` tool's platform enum.

## Tests (added to the transport module)
- `resolve_prefers_exact_name_then_family_prefix` — exact > family-prefix > unchanged-on-miss.
- `send_reaches_named_email_channel_via_platform_family` — a channel registered as `email-imap` is reachable when targeting platform `email`.
- `send_to_absent_platform_still_errors` — a genuinely absent platform still surfaces the unknown-channel error.

## Verification
- `cargo build -p wcore-agent`: 0 errors, 1 pre-existing warning (`imap-proto` future-incompat, unrelated).
- `cargo test -p wcore-agent`: **2071 passed, 15 ignored** (full crate suite).
- `cargo fmt` applied; `cargo clippy -p wcore-agent`: no new warnings (only the pre-existing `imap-proto` note).