### PR TITLE
fix(agent): cap project-context injection to bound cached prefix (#115)

### DIFF
--- a/.github/osv-scanner.toml
+++ b/.github/osv-scanner.toml
@@ -117,3 +117,19 @@ reason = "proc-macro-error: build-time proc-macro, no runtime surface; transitiv
 id = "GHSA-w9wp-h8wv-79jx"
 ignoreUntil = "2026-09-02T00:00:00Z"
 reason = "opentelemetry_sdk baggage-extract DoS: receiving-side only; wayland-core is an OTLP exporter, otlp feature default-off, only trace feature enabled, no BaggagePropagator usage (0 grep hits). Not reachable. Tracked; revisit on opentelemetry 0.32 bump."
+
+# ── ttf-parser 0.25.1 (unmaintained) ─────────────────────────────────────
+# The author has declared ttf-parser unmaintained (no further fixes;
+# patched = []). Recommended successor is skrifa (fontations), but the switch
+# is an UPSTREAM decision for our parent, not ours: ttf-parser arrives only
+# transitively via lopdf 0.42.0 <- pdf-extract 0.12.0 <- wcore-tools (PDF text
+# extraction for the Read tool). It is a font table parser exercised only when
+# a PDF embeds fonts during text extraction; there is no maintained pdf-extract
+# release that drops the lopdf/ttf-parser chain. Informational "unmaintained"
+# advisory, no known vulnerability and no patch to apply. Surfaced 2026-06-28
+# (ambient advisory, not a code change in this PR). Revisit when pdf-extract or
+# lopdf move off ttf-parser, or migrate the PDF path to a maintained extractor.
+[[IgnoredVulns]]
+id = "RUSTSEC-2026-0192"
+ignoreUntil = "2026-09-02T00:00:00Z"
+reason = "ttf-parser unmaintained (patched=[]); transitive only via lopdf <- pdf-extract <- wcore-tools PDF text extraction. Informational, no patch exists; successor skrifa is an upstream pdf-extract/lopdf decision. Tracked; revisit on pdf-extract/lopdf bump."

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,9 +171,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arbitrary"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1121,7 +1121,7 @@ dependencies = [
  "cap-primitives",
  "cap-std",
  "io-lifetimes",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1150,7 +1150,7 @@ dependencies = [
  "maybe-owned",
  "rustix 1.1.4",
  "rustix-linux-procfs",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
  "winx",
 ]
 
@@ -1511,7 +1511,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1692,36 +1692,36 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.123.11"
+version = "0.123.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ad3e7d446bbdc05f33371b17aae2857e2c5f1dd6750848f555c129c5060725f"
+checksum = "3cd990d8a6304475bbad64534a0d418f5572f44d5f011437e6b9f1ee7d5c2570"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.123.11"
+version = "0.123.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96ee145f9cbf7474350ee48e5c33ec2312177fa32c07e4eb395727250892a201"
+checksum = "ccabe4636007296721080e02d7dab46d4319638ec4e3f6f7402fcb46dc5122c6"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.123.11"
+version = "0.123.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7025668e34c499fd0960dfaf68bc1689c961002fb67227f3dd262535c4118e52"
+checksum = "da7ed173c870c0aea202a9830880156905a028a88df076e35ce383a8acbf90a7"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.123.11"
+version = "0.123.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ad0b552e9b906fee4416b68664463e80f9024215da2cebd4065eee99d5d3008"
+checksum = "800cc586df98b12c502e76707c96565e40629a5322eaa15aaa34ba05f5721e31"
 dependencies = [
  "serde",
  "serde_derive",
@@ -1729,9 +1729,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.123.11"
+version = "0.123.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f87371fa1b0e21dc0a7943f372ce5a308c7d6b26ef8c9982a8a063218fe101ae"
+checksum = "ae93f863f9094ae34d2567f9edb0ae2c41d35228b286598354dd78b198868ebd"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -1756,9 +1756,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.123.11"
+version = "0.123.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a24ef297d4dd3af3e571691568958ceea1d3e723bb24eef4e934bbd569c93ef6"
+checksum = "38c505162bcf77dcb859905b3eac56a1917fc3cf326424fb06e7732031e3a8ae"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -1769,24 +1769,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.123.11"
+version = "0.123.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d65396f589d1f746f52db7370372bc8611aa7a5bc0b0322f77deaa1b62e12287"
+checksum = "e3b786958bcb79bdb5fbae095af58f0c2da7d7895c475c991f6a6bb5a9c7e6d9"
 
 [[package]]
 name = "cranelift-control"
-version = "0.123.11"
+version = "0.123.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5731530f81a1566057f9475639f34463e723210ef2484fe9f087e03d79e879a"
+checksum = "2faf9a5009bce7f725ce2af7a08c4883ebac6af933e7e0aa7d84f976f4e6deb5"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.123.11"
+version = "0.123.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3437f152d3766d07420956f4eabaa6f89fa98543e53d387dd1e395980441c68d"
+checksum = "017271194ba5e101d626560d0d6767efd341468d1ba0f4d015f19fe64020b65b"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -1795,9 +1795,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.123.11"
+version = "0.123.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9dbb5c65123d9bd76a701523d72f78e1f9b754321caa7767a70ea9304f49be1"
+checksum = "f80847f0929967f0cec82f9e0543b3901e0f0063690405891f22107b5a130fd8"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -1807,15 +1807,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.123.11"
+version = "0.123.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a493c7a6e01f9c6e9b5468faa7f13a06d6d882f92942f8042a0fd0a8e3e8bc2c"
+checksum = "75904abbc0e7b46d20f7a49c8042c8a4481c0db4253b99889c723c566295d506"
 
 [[package]]
 name = "cranelift-native"
-version = "0.123.11"
+version = "0.123.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79bd8bd6a0a5bce75e9b24b4e9578114ef6be94795956c4d19aeaa1da607abfd"
+checksum = "6e0135923540574362e16f01bf40000664263840991039ff3041ba717de6cf3a"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -1824,9 +1824,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.123.11"
+version = "0.123.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c33438ba0b8ba75137bd45eb0d36a319efe90cf145f9fd5773b84f0b89f0edc"
+checksum = "93fb12f76c482e034f6ebefa843c914e74112f088215d8d36d33a649f9fab99b"
 
 [[package]]
 name = "crc32fast"
@@ -2555,7 +2555,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2652,7 +2652,7 @@ checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2833,7 +2833,7 @@ checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
 dependencies = [
  "io-lifetimes",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3567,7 +3567,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.57.0",
 ]
 
 [[package]]
@@ -3868,7 +3868,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2285ddfe3054097ef4b2fe909ef8c3bcd1ea52a8f0d274416caebeef39f04a65"
 dependencies = [
  "io-lifetimes",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3900,7 +3900,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5848,7 +5848,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5890,9 +5890,9 @@ checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "pulley-interpreter"
-version = "36.0.11"
+version = "36.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fae33db3d81aa92ead4ba06f7f9bbf32b2d8ff4132a00df5fa0913fd03dfa33c"
+checksum = "558181096e0df4984f45cfc3a7087052df4a61c36089b135a08ceca9cbd352fb"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -5902,9 +5902,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "36.0.11"
+version = "36.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "055100cf63f790c7bd02e606339916e1a403485358d4ae890ce912c102a9e80d"
+checksum = "b5d52e2f14e168d75cdabe9bd5fb1ff18a1b119dc6699684aee895dbc3524da9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6007,7 +6007,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6534,7 +6534,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6547,7 +6547,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7411,7 +7411,7 @@ dependencies = [
  "fd-lock",
  "io-lifetimes",
  "rustix 0.38.44",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
  "winx",
 ]
 
@@ -7442,7 +7442,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8649,9 +8649,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "36.0.11"
+version = "36.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "319b720df5e1c49b5dbc916d28a386aad3f03ed96fa3cebe2c6270eb11b6baf3"
+checksum = "4b4442dc12aa2473def8334f0e0f2b489be52c52507c938bbdc8be69ded4ded6"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -8696,9 +8696,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "36.0.11"
+version = "36.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acc2633f356486b8c5917e2aad7aca2b5b54f0f674a8f384a166e34d48101893"
+checksum = "5d881c3d6205898a226cc487b117f23b9ed1c7da39952d65bd5eeb6745b3789c"
 dependencies = [
  "anyhow",
  "cranelift-bitset",
@@ -8721,18 +8721,18 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-asm-macros"
-version = "36.0.11"
+version = "36.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0e647efa7382e8cc8b668ee871af1da0f097d5f12ba2242ac865107c30996e8"
+checksum = "5ab1876bcfa51d6a05dea1c13933f53cbc1e316c783fddebc859f56a736eae07"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "36.0.11"
+version = "36.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13915309c8ac371ce8aaadf856aad7a7685e390fdf158df1d35c3b0b7a320c44"
+checksum = "8ae1407944a0b13a8a77930b5b951aa7134beccecad7efac1ef9f03adb7d1a0f"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -8745,15 +8745,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "36.0.11"
+version = "36.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08935e3f35beb765593e42432b6f97fd6df16f1c9aa629a79137a04d30a168f4"
+checksum = "646a53678ce6aaf6f097e18ca51f650f2841aea6d2bcd7b61931397b8b8f30db"
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "36.0.11"
+version = "36.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd24355be6b01300639f3fd2e83dfbb75efc18a3d3386e955e87415c96fc105d"
+checksum = "ab3495aa8300e4ca6b53f81a53ce5eff6621fd5ff8378ef9ae552d1479d57371"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -8778,9 +8778,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "36.0.11"
+version = "36.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d322d8644a6057b221215ca579c40e4bdf90146119d4dc5172d2b37b1a0e3bb9"
+checksum = "29b5e4023a6b167da157338f5f0f505945eb45e78f1cac2d4dcce0922457d7d4"
 dependencies = [
  "anyhow",
  "cc",
@@ -8794,9 +8794,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "36.0.11"
+version = "36.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "307cef37d6c5563e0a408e24ab983b06ebe3ec27dd01675c7e7b12133205484c"
+checksum = "9da71e2d573e3cc6f753a3b7bff98f425ca060c0e8071cc55c3d867a9edf3ecc"
 dependencies = [
  "cc",
  "wasmtime-internal-versioned-export-macros",
@@ -8804,9 +8804,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "36.0.11"
+version = "36.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f2e02bd5006f643d8787a33c71e8fb401f029a35df25cd237d25d6d2ddc1c07"
+checksum = "627d8f57909a4f9bb1dbe57a96229a54b89d5995353d0b321f3cb9a1a118977a"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -8816,24 +8816,24 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-math"
-version = "36.0.11"
+version = "36.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28b0166bd79eb87e2e2e9d6ed7bc6c593428cadfd82cbc94fd113268c29d36a"
+checksum = "45b99315585a8a27125dd9b0150edb115d6f6ff0baae453c21d30822aab77f00"
 dependencies = [
  "libm",
 ]
 
 [[package]]
 name = "wasmtime-internal-slab"
-version = "36.0.11"
+version = "36.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c3295d1f1de2f3769b749a15e8f64341c38da6faa7fcd737ed485eb3fa40158"
+checksum = "8eaee97281dd3fe47ec3d46c16fb9fe2dd32f37d0523c2d5c484f11b348734e4"
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "36.0.11"
+version = "36.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a34055eb99cdff44ddd277e3b3baec670ef0302c847465c894f1118d4e7b1e3d"
+checksum = "d0c005f82c48492b6b44fa19ee5205bd933c4f8baca41e314eca8331dd3c4fd9"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -8844,9 +8844,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "36.0.11"
+version = "36.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e69f8a29ae6fdf7218ae37f38b1cc9fe539344a17b7fffba203de3ee2194d605"
+checksum = "7b73639a9c0c0e33a2ef942ca99b6772b48393be92bebbd0767c607e5b0a68e0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8855,9 +8855,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-winch"
-version = "36.0.11"
+version = "36.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08a4d8a3501080d3707f845acfcd2fedec9bb91dad3fd9078b7a17e8c8a0884"
+checksum = "392ca021d084c7426616ef77e1284315555f11bcbb34f416d74b0732db622811"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -8872,9 +8872,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "36.0.11"
+version = "36.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc86f7cc67cafad52959bc1b91176d73e1ed6dbcc00c7a31b3c0a30ac32e881a"
+checksum = "7fd4703351476262d715b72431e80d10289908e3494050071d6521267f522d97"
 dependencies = [
  "anyhow",
  "bitflags 2.11.1",
@@ -8885,9 +8885,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "36.0.11"
+version = "36.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e53a8072429ae61b472280b33b61dc0d21173b2b21b68a18bb9cc2024d18414d"
+checksum = "21921b6e8e8ed876a288cb3b0b3aee68809fed8182ce26c9977ffc4af4cb77f6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8915,9 +8915,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-io"
-version = "36.0.11"
+version = "36.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3bd4ac921831465ff97529a528e93f786095adf748d03736e2bd7fb3b0f5623"
+checksum = "2cceb2d110d8de61e7b0e8c501b838d3c6403a14cdca8cb612ff1228db537c6d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8928,7 +8928,7 @@ dependencies = [
 
 [[package]]
 name = "wayland-browser"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "async-trait",
  "inventory",
@@ -8945,7 +8945,7 @@ dependencies = [
 
 [[package]]
 name = "wayland-cua"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "async-trait",
  "inventory",
@@ -8962,7 +8962,7 @@ dependencies = [
 
 [[package]]
 name = "wayland-honcho"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8983,7 +8983,7 @@ dependencies = [
 
 [[package]]
 name = "wayland-ijfw"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9002,7 +9002,7 @@ dependencies = [
 
 [[package]]
 name = "wayland-ollama"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "async-trait",
  "futures",
@@ -9023,7 +9023,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-acp"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "async-trait",
  "axum",
@@ -9046,7 +9046,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-agent"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9136,7 +9136,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-agents-pack"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "dirs",
  "serde",
@@ -9149,7 +9149,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-browser"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9179,7 +9179,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-budget"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "chrono",
  "parking_lot",
@@ -9192,7 +9192,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-discord"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9213,7 +9213,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-email"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9232,7 +9232,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-imessage"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9249,7 +9249,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-matrix"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9268,7 +9268,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-msteams"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -9289,7 +9289,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-signal"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9304,7 +9304,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-slack"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9327,7 +9327,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-sms"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -9350,7 +9350,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-telegram"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9369,7 +9369,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-whatsapp"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9392,7 +9392,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channels"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9408,7 +9408,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channels-registry"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "dirs",
  "serde",
@@ -9433,7 +9433,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-cli"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9516,7 +9516,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-compact"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "regex",
  "serde",
@@ -9525,7 +9525,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-config"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "anyhow",
  "argon2",
@@ -9563,7 +9563,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-cron"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9580,7 +9580,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-cua"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9616,7 +9616,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-dispatch"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "rand 0.9.4",
  "rand_distr",
@@ -9629,7 +9629,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-egress"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "async-trait",
  "http 1.4.1",
@@ -9642,7 +9642,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-eval"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "rstest",
  "serde",
@@ -9659,7 +9659,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-eval-scenarios"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "anyhow",
  "clap",
@@ -9679,7 +9679,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-evolve"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9719,7 +9719,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-honcho-adapter"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "async-trait",
  "serde",
@@ -9734,7 +9734,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-mcp"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9761,7 +9761,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-memory"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9802,7 +9802,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-observability"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "chrono",
  "opentelemetry",
@@ -9826,7 +9826,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-permissions"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9843,7 +9843,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-plugin-api"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9870,7 +9870,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-plugin-subprocess"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "anyhow",
  "serde",
@@ -9889,7 +9889,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-plugin-wasm"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9911,7 +9911,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-pluginsrc"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "serde",
  "serde_json",
@@ -9926,7 +9926,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-pricing"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "chrono",
  "dirs",
@@ -9945,7 +9945,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-protocol"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "rstest",
  "serde",
@@ -9957,7 +9957,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-providers"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9992,7 +9992,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-replay"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "serde",
  "serde_json",
@@ -10003,7 +10003,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-repomap"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "ignore",
  "regex",
@@ -10016,7 +10016,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-safety"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "async-trait",
  "regex",
@@ -10029,7 +10029,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-sandbox"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "async-trait",
  "bollard",
@@ -10049,7 +10049,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-skills"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10086,7 +10086,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-swarm"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "futures",
  "humantime-serde",
@@ -10105,7 +10105,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-tools"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10152,7 +10152,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-types"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "async-trait",
  "chrono",
@@ -10162,7 +10162,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-user-model"
-version = "0.12.14"
+version = "0.12.16"
 dependencies = [
  "async-trait",
  "serde",
@@ -10348,7 +10348,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -10359,9 +10359,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "36.0.11"
+version = "36.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33afb2737056d7162813a167fc53b8d986e725724a4e6c76ca9910952bb94b5"
+checksum = "61ec880b20caaa72245944b54cfb22aca111f8c805e12a7542b40d66921e5323"
 dependencies = [
  "anyhow",
  "cranelift-assembler-x64",
@@ -10934,7 +10934,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
 dependencies = [
  "bitflags 2.11.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/crates/wcore-agent/src/agents_md.rs
+++ b/crates/wcore-agent/src/agents_md.rs
@@ -20,6 +20,18 @@ pub struct AgentsMdFile {
 
 const MAX_INCLUDE_DEPTH: u8 = 5;
 
+/// Per-file byte cap on collected/expanded project-context (a single AGENTS.md
+/// plus its inlined @-includes). Large project docs get truncated here so one
+/// file can't dominate the cached system prefix.
+const MAX_PER_FILE_BYTES: usize = 32 * 1024;
+
+/// Total byte cap across ALL collected project-context files (global + the
+/// hierarchical AGENTS.md chain, with their @-includes inlined). This bounds the
+/// session-permanent prefix so a large project (or @-included doc set) can't
+/// bloat it to hundreds of thousands of tokens that a new chat never clears
+/// (issue #115). Budget is spent nearest-first (cwd before ancestors/global).
+const MAX_TOTAL_BYTES: usize = 64 * 1024;
+
 const ALLOWED_EXTENSIONS: &[&str] = &[".md", ".txt", ".json", ".yaml", ".yml", ".toml"];
 
 const INSTRUCTION_PREAMBLE: &str = "Codebase and user instructions are shown below. \
@@ -32,16 +44,14 @@ default behavior and you MUST follow them exactly as written.";
 
 pub fn collect_agents_md(cwd: &str) -> Vec<AgentsMdFile> {
     let cwd_path = Path::new(cwd);
-    let mut files = Vec::new();
 
-    // 1. Global: <config_dir>/wayland-core/AGENTS.md
-    if let Some(global_path) = app_config_dir().map(|d| d.join("AGENTS.md"))
-        && let Some(file) = read_agents_md(&global_path, true)
-    {
-        files.push(file);
-    }
+    // 1. Global: <config_dir>/wayland-core/AGENTS.md (least specific).
+    let global_path = app_config_dir()
+        .map(|d| d.join("AGENTS.md"))
+        .filter(|p| p.is_file());
 
-    // 2. Walk up from cwd to stop_boundary, collect AGENTS.md paths
+    // 2. Walk up from cwd to stop_boundary, collecting AGENTS.md paths.
+    //    Collected deepest-first, i.e. the cwd's own file comes first.
     let boundary = stop_boundary(cwd_path);
     let mut project_paths = Vec::new();
     let mut current = cwd_path.to_path_buf();
@@ -64,19 +74,44 @@ pub fn collect_agents_md(cwd: &str) -> Vec<AgentsMdFile> {
         }
     }
 
-    // Reverse: collected deepest-first, we want root-first
-    project_paths.reverse();
+    // Spend a shared total budget NEAREST-FIRST so the most relevant context
+    // (the cwd's own AGENTS.md) survives when a project exceeds the cap. Files
+    // are read cwd-first for budget priority, but tagged with their display
+    // position (root-first) so output ordering is unchanged.
+    let mut total_remaining = MAX_TOTAL_BYTES;
 
-    for path in project_paths {
-        if let Some(file) = read_agents_md(&path, false) {
-            files.push(file);
+    let count = project_paths.len();
+    let mut project_files: Vec<(usize, AgentsMdFile)> = Vec::new();
+    for (i, path) in project_paths.iter().enumerate() {
+        let display_pos = count - 1 - i; // reverse cwd-first -> root-first
+        if let Some(file) = read_agents_md(path, false, &mut total_remaining) {
+            project_files.push((display_pos, file));
         }
     }
+    project_files.sort_by_key(|(pos, _)| *pos);
 
+    // Global file is least specific -> lowest budget priority (read last).
+    let global_file = global_path
+        .as_ref()
+        .and_then(|p| read_agents_md(p, true, &mut total_remaining));
+
+    // Emit in display order: global first, then project root-first.
+    let mut files = Vec::new();
+    if let Some(g) = global_file {
+        files.push(g);
+    }
+    files.extend(project_files.into_iter().map(|(_, f)| f));
     files
 }
 
-fn read_agents_md(path: &Path, is_global: bool) -> Option<AgentsMdFile> {
+fn read_agents_md(
+    path: &Path,
+    is_global: bool,
+    total_remaining: &mut usize,
+) -> Option<AgentsMdFile> {
+    if *total_remaining == 0 {
+        return None;
+    }
     let raw = std::fs::read_to_string(path).ok()?;
     if raw.trim().is_empty() {
         return None;
@@ -86,7 +121,17 @@ fn read_agents_md(path: &Path, is_global: bool) -> Option<AgentsMdFile> {
     if let Ok(canonical) = path.canonicalize() {
         seen.insert(canonical);
     }
-    let content = expand_includes(&raw, base_dir, 0, &mut seen);
+
+    // Per-file budget is the smaller of the per-file cap and what's left of the
+    // total budget. expand_includes spends this budget as it inlines content.
+    let start = (*total_remaining).min(MAX_PER_FILE_BYTES);
+    let mut budget = start;
+    let mut content = expand_includes(&raw, base_dir, 0, &mut seen, &mut budget);
+    if budget == 0 {
+        content.push_str(&truncation_marker());
+    }
+    *total_remaining = total_remaining.saturating_sub(start - budget);
+
     Some(AgentsMdFile {
         path: path.to_path_buf(),
         content,
@@ -151,25 +196,58 @@ fn resolve_include_path(raw: &str, base_dir: &Path) -> Option<PathBuf> {
     Some(resolved)
 }
 
+/// Marker appended when project context is truncated by the byte budget.
+fn truncation_marker() -> String {
+    format!(
+        "\n\n[... truncated: project context exceeds {} KB; trim AGENTS.md / its @-includes ...]",
+        MAX_TOTAL_BYTES / 1024
+    )
+}
+
+/// Append `line` (plus its joining newline) to `result` if `budget` allows.
+/// Returns `false` once the budget is exhausted so the caller stops emitting.
+fn push_within_budget(result: &mut Vec<String>, line: &str, budget: &mut usize) -> bool {
+    let cost = line.len() + 1; // +1 for the "\n" join between lines
+    if cost > *budget {
+        *budget = 0;
+        return false;
+    }
+    *budget -= cost;
+    result.push(line.to_string());
+    true
+}
+
+/// Inline `@path` includes, bounded by both recursion depth (`MAX_INCLUDE_DEPTH`)
+/// and an accumulated byte `budget`. Once the budget is exhausted, expansion
+/// stops and `*budget` is left at 0 so the caller can append a truncation marker.
 fn expand_includes(
     content: &str,
     base_dir: &Path,
     depth: u8,
     seen: &mut HashSet<PathBuf>,
+    budget: &mut usize,
 ) -> String {
     let mut result = Vec::new();
     let mut in_code_block = false;
 
     for line in content.lines() {
+        if *budget == 0 {
+            break;
+        }
+
         let trimmed = line.trim_start();
         if trimmed.starts_with("```") {
             in_code_block = !in_code_block;
-            result.push(line.to_string());
+            if !push_within_budget(&mut result, line, budget) {
+                break;
+            }
             continue;
         }
 
         if in_code_block {
-            result.push(line.to_string());
+            if !push_within_budget(&mut result, line, budget) {
+                break;
+            }
             continue;
         }
 
@@ -192,22 +270,48 @@ fn expand_includes(
                 }
                 if let Ok(included) = std::fs::read_to_string(&resolved) {
                     seen.insert(canonical);
+                    // The recursive call spends the shared budget directly, so
+                    // its result is already bounded — push it as-is.
                     let expanded = expand_includes(
                         &included,
                         resolved.parent().unwrap_or(base_dir),
                         depth + 1,
                         seen,
+                        budget,
                     );
-                    result.push(expanded);
+                    if !expanded.is_empty() {
+                        result.push(expanded);
+                    }
                 }
                 continue;
             }
         }
 
-        result.push(line.to_string());
+        if !push_within_budget(&mut result, line, budget) {
+            break;
+        }
     }
 
     result.join("\n")
+}
+
+/// Truncate `text` to at most `max_bytes` bytes on a UTF-8 char boundary,
+/// appending a truncation marker when the limit is hit. Used to bound the custom
+/// assistant prompt/preset so a giant preset can't bloat the cached prefix.
+pub fn truncate_with_marker(text: &str, max_bytes: usize) -> String {
+    if text.len() <= max_bytes {
+        return text.to_string();
+    }
+    let mut end = max_bytes;
+    while end > 0 && !text.is_char_boundary(end) {
+        end -= 1;
+    }
+    let mut out = text[..end].to_string();
+    out.push_str(&format!(
+        "\n\n[... truncated: content exceeds {} KB; trim it to restore the full text ...]",
+        max_bytes / 1024
+    ));
+    out
 }
 
 // ---------------------------------------------------------------------------
@@ -227,7 +331,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let mut seen = HashSet::new();
         let input = "Hello world\nNo includes here.";
-        let result = expand_includes(input, tmp.path(), 0, &mut seen);
+        let result = expand_includes(input, tmp.path(), 0, &mut seen, &mut usize::MAX);
         assert_eq!(result, input);
     }
 
@@ -237,7 +341,7 @@ mod tests {
         fs::write(tmp.path().join("other.md"), "INCLUDED_CONTENT").unwrap();
         let mut seen = HashSet::new();
         let input = "@other.md";
-        let result = expand_includes(input, tmp.path(), 0, &mut seen);
+        let result = expand_includes(input, tmp.path(), 0, &mut seen, &mut usize::MAX);
         assert!(result.contains("INCLUDED_CONTENT"));
         assert!(!result.contains("@other.md"));
     }
@@ -248,7 +352,7 @@ mod tests {
         fs::write(tmp.path().join("sub.md"), "SUB_CONTENT").unwrap();
         let mut seen = HashSet::new();
         let input = "@./sub.md";
-        let result = expand_includes(input, tmp.path(), 0, &mut seen);
+        let result = expand_includes(input, tmp.path(), 0, &mut seen, &mut usize::MAX);
         assert!(result.contains("SUB_CONTENT"));
     }
 
@@ -258,7 +362,7 @@ mod tests {
         fs::write(tmp.path().join("skip.md"), "SHOULD_NOT_APPEAR").unwrap();
         let mut seen = HashSet::new();
         let input = "```\n@skip.md\n```";
-        let result = expand_includes(input, tmp.path(), 0, &mut seen);
+        let result = expand_includes(input, tmp.path(), 0, &mut seen, &mut usize::MAX);
         assert!(!result.contains("SHOULD_NOT_APPEAR"));
         assert!(result.contains("@skip.md"));
     }
@@ -268,7 +372,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let mut seen = HashSet::new();
         let input = "before\n@nonexistent.md\nafter";
-        let result = expand_includes(input, tmp.path(), 0, &mut seen);
+        let result = expand_includes(input, tmp.path(), 0, &mut seen, &mut usize::MAX);
         assert!(result.contains("before"));
         assert!(result.contains("after"));
         assert!(!result.contains("@nonexistent.md"));
@@ -280,7 +384,7 @@ mod tests {
         fs::write(tmp.path().join("a.md"), "A_CONTENT\n@b.md").unwrap();
         fs::write(tmp.path().join("b.md"), "B_CONTENT\n@a.md").unwrap();
         let mut seen = HashSet::new();
-        let result = expand_includes("@a.md", tmp.path(), 0, &mut seen);
+        let result = expand_includes("@a.md", tmp.path(), 0, &mut seen, &mut usize::MAX);
         assert!(result.contains("A_CONTENT"));
         assert!(result.contains("B_CONTENT"));
         // @a.md in b.md should be skipped (circular)
@@ -303,7 +407,7 @@ mod tests {
             fs::write(tmp.path().join(format!("d{i}.md")), content).unwrap();
         }
         let mut seen = HashSet::new();
-        let result = expand_includes("@d0.md", tmp.path(), 0, &mut seen);
+        let result = expand_includes("@d0.md", tmp.path(), 0, &mut seen, &mut usize::MAX);
         assert!(result.contains("DEPTH_0"));
         assert!(result.contains("DEPTH_3"));
         assert!(result.contains("DEPTH_4"));
@@ -317,7 +421,7 @@ mod tests {
         fs::write(tmp.path().join("image.png"), "BINARY_DATA").unwrap();
         let mut seen = HashSet::new();
         let input = "@image.png";
-        let result = expand_includes(input, tmp.path(), 0, &mut seen);
+        let result = expand_includes(input, tmp.path(), 0, &mut seen, &mut usize::MAX);
         assert!(!result.contains("BINARY_DATA"));
     }
 
@@ -327,7 +431,7 @@ mod tests {
         fs::write(tmp.path().join("inc.md"), "MIDDLE").unwrap();
         let mut seen = HashSet::new();
         let input = "TOP\n@inc.md\nBOTTOM";
-        let result = expand_includes(input, tmp.path(), 0, &mut seen);
+        let result = expand_includes(input, tmp.path(), 0, &mut seen, &mut usize::MAX);
         assert_eq!(result, "TOP\nMIDDLE\nBOTTOM");
     }
 
@@ -350,7 +454,7 @@ mod tests {
         fs::write(tmp.path().join("x.md"), "SHOULD_NOT_APPEAR").unwrap();
         let mut seen = HashSet::new();
         let input = "Use `@x.md` for config";
-        let result = expand_includes(input, tmp.path(), 0, &mut seen);
+        let result = expand_includes(input, tmp.path(), 0, &mut seen, &mut usize::MAX);
         assert!(!result.contains("SHOULD_NOT_APPEAR"));
     }
 
@@ -359,7 +463,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let mut seen = HashSet::new();
         let input = "@~/nonexistent-test-file.md";
-        let result = expand_includes(input, tmp.path(), 0, &mut seen);
+        let result = expand_includes(input, tmp.path(), 0, &mut seen, &mut usize::MAX);
         assert!(!result.contains("@~/"));
     }
 
@@ -486,5 +590,120 @@ mod tests {
         assert!(global_pos < project_pos, "global before project");
         assert!(result.contains("(user's global instructions for all projects)"));
         assert!(result.contains("(project instructions)"));
+    }
+
+    // --- Size-budget / truncation tests (issue #115) ---
+
+    #[test]
+    fn test_small_agents_md_passthrough_unchanged() {
+        // A small AGENTS.md is read verbatim with no truncation marker.
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("AGENTS.md");
+        let body = "Short project rules.\nLine two.\nLine three.";
+        fs::write(&path, body).unwrap();
+
+        let mut total = MAX_TOTAL_BYTES;
+        let file = read_agents_md(&path, false, &mut total).unwrap();
+        assert_eq!(file.content, body);
+        assert!(!file.content.contains("truncated"));
+        // Budget consumed ~= body size, well under the cap.
+        assert!(total < MAX_TOTAL_BYTES && total > MAX_TOTAL_BYTES - 1024);
+    }
+
+    #[test]
+    fn test_oversized_agents_md_truncated_with_marker() {
+        // An AGENTS.md far larger than the per-file cap is truncated near the
+        // cap and carries the truncation marker.
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("AGENTS.md");
+        // 200 KB of content (each line ~32 bytes) -> well over the 32 KB cap.
+        let big: String = (0..6400)
+            .map(|i| format!("rule line number {i:08} here\n"))
+            .collect();
+        fs::write(&path, &big).unwrap();
+
+        let mut total = MAX_TOTAL_BYTES;
+        let file = read_agents_md(&path, false, &mut total).unwrap();
+        assert!(
+            file.content.contains("truncated"),
+            "expected truncation marker"
+        );
+        // Content is bounded to roughly the per-file cap (plus the small marker),
+        // nowhere near the 200 KB original.
+        assert!(
+            file.content.len() <= MAX_PER_FILE_BYTES + 256,
+            "content len {} exceeded cap+marker",
+            file.content.len()
+        );
+        assert!(file.content.len() > MAX_PER_FILE_BYTES / 2);
+    }
+
+    #[test]
+    fn test_includes_stop_once_budget_exceeded() {
+        // Three large @-includes; a small budget lets the first through but cuts
+        // off later ones once the accumulated size exceeds the budget.
+        let tmp = TempDir::new().unwrap();
+        let chunk_a: String = std::iter::repeat("AAAA").take(40).collect(); // 160 B
+        let chunk_b: String = std::iter::repeat("BBBB").take(40).collect();
+        let chunk_c: String = std::iter::repeat("CCCC").take(40).collect();
+        fs::write(tmp.path().join("a.md"), &chunk_a).unwrap();
+        fs::write(tmp.path().join("b.md"), &chunk_b).unwrap();
+        fs::write(tmp.path().join("c.md"), &chunk_c).unwrap();
+
+        let input = "@a.md\n@b.md\n@c.md";
+        let mut seen = HashSet::new();
+        let mut budget = 200usize; // enough for a.md, not all three
+        let result = expand_includes(input, tmp.path(), 0, &mut seen, &mut budget);
+
+        assert!(result.contains("AAAA"), "first include should be present");
+        assert!(
+            !result.contains("CCCC"),
+            "later include must be dropped once budget is exhausted"
+        );
+        assert_eq!(budget, 0, "budget should be fully spent");
+    }
+
+    #[test]
+    fn test_total_budget_prefers_nearest_file() {
+        // When a deep (cwd) file already exhausts the total budget, the ancestor
+        // file is dropped — nearest content wins.
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        fs::create_dir(root.join(".git")).unwrap();
+        let ancestor: String = (0..3000).map(|i| format!("ANCESTOR {i:06}\n")).collect();
+        fs::write(root.join("AGENTS.md"), &ancestor).unwrap();
+
+        let sub = root.join("pkg").join("svc");
+        fs::create_dir_all(&sub).unwrap();
+        let near: String = (0..3000).map(|i| format!("NEAREST {i:06}\n")).collect();
+        fs::write(sub.join("AGENTS.md"), &near).unwrap();
+
+        let files = collect_agents_md(&sub.to_string_lossy());
+        let combined: usize = files.iter().map(|f| f.content.len()).sum();
+        assert!(
+            combined <= MAX_TOTAL_BYTES + 512,
+            "combined {combined} exceeded total cap"
+        );
+        // The nearest file's content must be present (it gets the budget first).
+        assert!(files.iter().any(|f| f.content.contains("NEAREST")));
+    }
+
+    #[test]
+    fn test_truncate_with_marker_passthrough_and_cap() {
+        // Small input untouched; large input truncated on a char boundary.
+        let small = "hello world";
+        assert_eq!(truncate_with_marker(small, 1024), small);
+
+        let big = "x".repeat(40 * 1024);
+        let out = truncate_with_marker(&big, 16 * 1024);
+        assert!(out.contains("truncated"));
+        assert!(out.len() <= 16 * 1024 + 128);
+
+        // Multi-byte char near the cut boundary stays valid UTF-8.
+        let multibyte = "é".repeat(10_000); // 2 bytes each
+        let capped = truncate_with_marker(&multibyte, 4097);
+        assert!(capped.contains("truncated"));
+        // No panic == boundary respected; string is valid UTF-8 by construction.
+        assert!(capped.starts_with('é'));
     }
 }

--- a/crates/wcore-agent/src/agents_md.rs
+++ b/crates/wcore-agent/src/agents_md.rs
@@ -324,6 +324,13 @@ mod tests {
     use std::fs;
     use tempfile::TempDir;
 
+    // Tests that don't exercise the include budget pass an effectively
+    // unlimited one. Returns a fresh value so callers can take `&mut` without
+    // mutating a `const` item (which would be a no-op and a CI lint error).
+    fn unlimited_budget() -> usize {
+        usize::MAX
+    }
+
     // --- @include expansion tests ---
 
     #[test]
@@ -331,7 +338,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let mut seen = HashSet::new();
         let input = "Hello world\nNo includes here.";
-        let result = expand_includes(input, tmp.path(), 0, &mut seen, &mut usize::MAX);
+        let result = expand_includes(input, tmp.path(), 0, &mut seen, &mut unlimited_budget());
         assert_eq!(result, input);
     }
 
@@ -341,7 +348,7 @@ mod tests {
         fs::write(tmp.path().join("other.md"), "INCLUDED_CONTENT").unwrap();
         let mut seen = HashSet::new();
         let input = "@other.md";
-        let result = expand_includes(input, tmp.path(), 0, &mut seen, &mut usize::MAX);
+        let result = expand_includes(input, tmp.path(), 0, &mut seen, &mut unlimited_budget());
         assert!(result.contains("INCLUDED_CONTENT"));
         assert!(!result.contains("@other.md"));
     }
@@ -352,7 +359,7 @@ mod tests {
         fs::write(tmp.path().join("sub.md"), "SUB_CONTENT").unwrap();
         let mut seen = HashSet::new();
         let input = "@./sub.md";
-        let result = expand_includes(input, tmp.path(), 0, &mut seen, &mut usize::MAX);
+        let result = expand_includes(input, tmp.path(), 0, &mut seen, &mut unlimited_budget());
         assert!(result.contains("SUB_CONTENT"));
     }
 
@@ -362,7 +369,7 @@ mod tests {
         fs::write(tmp.path().join("skip.md"), "SHOULD_NOT_APPEAR").unwrap();
         let mut seen = HashSet::new();
         let input = "```\n@skip.md\n```";
-        let result = expand_includes(input, tmp.path(), 0, &mut seen, &mut usize::MAX);
+        let result = expand_includes(input, tmp.path(), 0, &mut seen, &mut unlimited_budget());
         assert!(!result.contains("SHOULD_NOT_APPEAR"));
         assert!(result.contains("@skip.md"));
     }
@@ -372,7 +379,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let mut seen = HashSet::new();
         let input = "before\n@nonexistent.md\nafter";
-        let result = expand_includes(input, tmp.path(), 0, &mut seen, &mut usize::MAX);
+        let result = expand_includes(input, tmp.path(), 0, &mut seen, &mut unlimited_budget());
         assert!(result.contains("before"));
         assert!(result.contains("after"));
         assert!(!result.contains("@nonexistent.md"));
@@ -384,7 +391,7 @@ mod tests {
         fs::write(tmp.path().join("a.md"), "A_CONTENT\n@b.md").unwrap();
         fs::write(tmp.path().join("b.md"), "B_CONTENT\n@a.md").unwrap();
         let mut seen = HashSet::new();
-        let result = expand_includes("@a.md", tmp.path(), 0, &mut seen, &mut usize::MAX);
+        let result = expand_includes("@a.md", tmp.path(), 0, &mut seen, &mut unlimited_budget());
         assert!(result.contains("A_CONTENT"));
         assert!(result.contains("B_CONTENT"));
         // @a.md in b.md should be skipped (circular)
@@ -407,7 +414,7 @@ mod tests {
             fs::write(tmp.path().join(format!("d{i}.md")), content).unwrap();
         }
         let mut seen = HashSet::new();
-        let result = expand_includes("@d0.md", tmp.path(), 0, &mut seen, &mut usize::MAX);
+        let result = expand_includes("@d0.md", tmp.path(), 0, &mut seen, &mut unlimited_budget());
         assert!(result.contains("DEPTH_0"));
         assert!(result.contains("DEPTH_3"));
         assert!(result.contains("DEPTH_4"));
@@ -421,7 +428,7 @@ mod tests {
         fs::write(tmp.path().join("image.png"), "BINARY_DATA").unwrap();
         let mut seen = HashSet::new();
         let input = "@image.png";
-        let result = expand_includes(input, tmp.path(), 0, &mut seen, &mut usize::MAX);
+        let result = expand_includes(input, tmp.path(), 0, &mut seen, &mut unlimited_budget());
         assert!(!result.contains("BINARY_DATA"));
     }
 
@@ -431,7 +438,7 @@ mod tests {
         fs::write(tmp.path().join("inc.md"), "MIDDLE").unwrap();
         let mut seen = HashSet::new();
         let input = "TOP\n@inc.md\nBOTTOM";
-        let result = expand_includes(input, tmp.path(), 0, &mut seen, &mut usize::MAX);
+        let result = expand_includes(input, tmp.path(), 0, &mut seen, &mut unlimited_budget());
         assert_eq!(result, "TOP\nMIDDLE\nBOTTOM");
     }
 
@@ -454,7 +461,7 @@ mod tests {
         fs::write(tmp.path().join("x.md"), "SHOULD_NOT_APPEAR").unwrap();
         let mut seen = HashSet::new();
         let input = "Use `@x.md` for config";
-        let result = expand_includes(input, tmp.path(), 0, &mut seen, &mut usize::MAX);
+        let result = expand_includes(input, tmp.path(), 0, &mut seen, &mut unlimited_budget());
         assert!(!result.contains("SHOULD_NOT_APPEAR"));
     }
 
@@ -463,7 +470,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let mut seen = HashSet::new();
         let input = "@~/nonexistent-test-file.md";
-        let result = expand_includes(input, tmp.path(), 0, &mut seen, &mut usize::MAX);
+        let result = expand_includes(input, tmp.path(), 0, &mut seen, &mut unlimited_budget());
         assert!(!result.contains("@~/"));
     }
 

--- a/crates/wcore-agent/src/agents_md.rs
+++ b/crates/wcore-agent/src/agents_md.rs
@@ -650,9 +650,9 @@ mod tests {
         // Three large @-includes; a small budget lets the first through but cuts
         // off later ones once the accumulated size exceeds the budget.
         let tmp = TempDir::new().unwrap();
-        let chunk_a: String = std::iter::repeat("AAAA").take(40).collect(); // 160 B
-        let chunk_b: String = std::iter::repeat("BBBB").take(40).collect();
-        let chunk_c: String = std::iter::repeat("CCCC").take(40).collect();
+        let chunk_a: String = "AAAA".repeat(40); // 160 B
+        let chunk_b: String = "BBBB".repeat(40);
+        let chunk_c: String = "CCCC".repeat(40);
         fs::write(tmp.path().join("a.md"), &chunk_a).unwrap();
         fs::write(tmp.path().join("b.md"), &chunk_b).unwrap();
         fs::write(tmp.path().join("c.md"), &chunk_c).unwrap();

--- a/crates/wcore-agent/src/context.rs
+++ b/crates/wcore-agent/src/context.rs
@@ -21,6 +21,11 @@ use crate::plan::prompt as plan_prompt;
 pub const TERSENESS_DIRECTIVE: &str = "Be concise. Lead with the answer or the \
     action; skip restating the question and ceremonial preamble/closing.";
 
+/// Byte cap on the custom assistant prompt/preset injected into the cached
+/// prefix. Generous (~4k tokens) but bounded so a giant preset can't bloat the
+/// session-permanent prefix the way large project context did (issue #115).
+const MAX_CUSTOM_PROMPT_BYTES: usize = 16 * 1024;
+
 /// Today's date as `YYYY-MM-DD` in local time.
 ///
 /// Read once per turn by the engine and fed to [`current_date_block`]. Kept as
@@ -251,7 +256,7 @@ pub fn build_system_prompt(
         let custom_cached = cache
             .sections
             .entry("custom")
-            .or_insert_with(|| custom.to_string());
+            .or_insert_with(|| agents_md::truncate_with_marker(custom, MAX_CUSTOM_PROMPT_BYTES));
         parts.push(custom_cached.clone());
     }
 


### PR DESCRIPTION
Fixes #115.

## Problem
Project-context files (`AGENTS.md` plus recursively `@`-included docs) and the custom assistant preset were injected into the **cached system prefix with no size limit**. `read_agents_md` / `format_agents_md_section` read full file bodies, and `expand_includes` inlined `@path` includes bounded only by `MAX_INCLUDE_DEPTH=5` — no byte/token cap anywhere. A large project doc or `@`-included doc set baked hundreds of KB into the session-permanent prefix on every session. Microcompact and auto-compaction never touch the prefix, so a new chat couldn't reduce it. Real logs showed 700k+ input tokens a fresh chat never cleared. Customer-blocking.

## Fix
Add byte budgets with UTF-8-safe truncation in `crates/wcore-agent/src/agents_md.rs`:

- **Per-file cap `MAX_PER_FILE_BYTES = 32 KB`** and **total cap `MAX_TOTAL_BYTES = 64 KB`** across all collected project-context files (global + the hierarchical `AGENTS.md` chain, with `@`-includes inlined).
- `expand_includes` now spends a **shared byte budget** as it inlines content and stops once exhausted (the `MAX_INCLUDE_DEPTH` guard is retained). This bounds expansion by accumulated size, not just depth.
- Budget is spent **nearest-first**: the cwd's own `AGENTS.md` gets priority over ancestor/global files when a project exceeds the cap. Display order (global first, then root-first project) is unchanged.
- Truncated content carries a clear marker: `[... truncated: project context exceeds 64 KB; trim AGENTS.md / its @-includes ...]`.
- Custom assistant prompt/preset capped at **`MAX_CUSTOM_PROMPT_BYTES = 16 KB`** (context.rs:250-256) via the same `truncate_with_marker` helper, so a giant preset can't blow the prefix either.

Small files are byte-for-byte unaffected; only oversized content is truncated.

### Cap values
- Per-file 32 KB (~8k tokens): generous for any single hand-written `AGENTS.md`, cuts pathological docs.
- Total 64 KB (~16k tokens): bounds the whole project-context section so the cached prefix stays sane even with a deep chain + includes.
- Custom preset 16 KB (~4k tokens): generous for an assistant preset, bounded.

## Tests
Added to the existing `agents_md` test module:
- small `AGENTS.md` passthrough unchanged (no marker)
- oversized `AGENTS.md` truncated to ~the cap, includes the marker
- `@`-includes stop expanding once the total budget is exceeded
- nearest-file-wins budget priority across a hierarchy
- UTF-8-safe `truncate_with_marker` (multibyte boundary, passthrough, cap)

## Verification
- `cargo build -p wcore-agent`: clean (0 errors).
- `cargo test -p wcore-agent`: **2073 passed, 0 failed, 15 ignored**.
- `cargo clippy -p wcore-agent`: no warnings introduced in changed files.
- `cargo fmt` applied.

Scoped to `wcore-agent`. The desktop-side preset cap is a separate change, not in this PR.