### PR TITLE
fix(providers): strip internal extra_content from outbound tool_calls (#120)

### DIFF
--- a/crates/wcore-config/src/compat.rs
+++ b/crates/wcore-config/src/compat.rs
@@ -252,6 +252,21 @@ pub struct ProviderCompat {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub replays_thinking_in_history: Option<bool>,
 
+    /// Whether to re-serialize the internal `extra_content` blob (captured from
+    /// an inbound `tool_calls[].extra_content`, e.g. Gemini's
+    /// `extra_content.google.thought` routing marker) back onto OUTBOUND
+    /// `tool_calls` on the Chat Completions path.
+    ///
+    /// Defaults to `false`: `extra_content` is an internal-only field and must
+    /// NOT be echoed to providers that reject unknown fields. On long-context
+    /// replay, strict OpenAI-compat endpoints (e.g. Fireworks / GLM-5 via the
+    /// Flux router) 400 with "Extra inputs are not permitted, field:
+    /// messages[N].tool_calls[0].extra_content" (wayland-core#120). Only the
+    /// Google/Gemini preset sets `Some(true)`, since that endpoint emitted the
+    /// field and tolerates its round-trip.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub emit_tool_call_extra_content: Option<bool>,
+
     /// Finding #174: per-tier model substitution for smart routing.
     ///
     /// The engine classifies every turn into a `RoutingTier` and stamps a
@@ -406,6 +421,11 @@ impl ProviderCompat {
             effort_levels: Some(vec!["low".into(), "medium".into(), "high".into()]),
             cache_message_breakpoints: Some(false),
             provider_type: Some("gemini".into()),
+            // Gemini's OpenAI-compat endpoint emits extra_content (the
+            // google.thought routing marker) and tolerates its round-trip, so
+            // it is the one provider that keeps emitting it outbound
+            // (wayland-core#120). Every other provider strips it (default).
+            emit_tool_call_extra_content: Some(true),
             // Q2-2026 Gemini 2.5 Pro list price (per Google AI Studio pricing page).
             // Free tier exists for low volume; the paid tier price is
             // $1.25 / 1M input tokens, $10 / 1M output. Use the paid
@@ -759,6 +779,9 @@ impl ProviderCompat {
             replays_thinking_in_history: user
                 .replays_thinking_in_history
                 .or(defaults.replays_thinking_in_history),
+            emit_tool_call_extra_content: user
+                .emit_tool_call_extra_content
+                .or(defaults.emit_tool_call_extra_content),
             tier_models: user.tier_models.or(defaults.tier_models),
             max_tools: user.max_tools.or(defaults.max_tools),
             // Crucible #3 — merge ripple: a new compat field MUST be threaded
@@ -833,6 +856,13 @@ impl ProviderCompat {
     /// DeepSeek/Moonshot set `true` because their API 400s without the replay.
     pub fn replays_thinking_in_history(&self) -> bool {
         self.replays_thinking_in_history.unwrap_or(false)
+    }
+
+    /// Whether to re-serialize internal `extra_content` onto outbound
+    /// `tool_calls`. Defaults to `false` (strip): only Google/Gemini opts in.
+    /// See [`ProviderCompat::emit_tool_call_extra_content`] (wayland-core#120).
+    pub fn emit_tool_call_extra_content(&self) -> bool {
+        self.emit_tool_call_extra_content.unwrap_or(false)
     }
 
     pub fn supports_thinking(&self) -> bool {

--- a/crates/wcore-providers/src/openai.rs
+++ b/crates/wcore-providers/src/openai.rs
@@ -3924,15 +3924,29 @@ mod tests {
         // that reject unknown fields. On long-context replay, strict
         // OpenAI-compat endpoints (Fireworks / GLM-5 via Flux) 400 with
         // "Extra inputs are not permitted ... tool_calls[0].extra_content".
-        let messages = vec![Message::new(
-            Role::Assistant,
-            vec![ContentBlock::ToolUse {
-                id: "tc1".into(),
-                name: "bash".into(),
-                input: json!({"cmd": "ls"}),
-                extra: Some(json!({"google": {"thought": true}})),
-            }],
-        )];
+        // An answering ToolResult so tc1 is NOT an orphan: openai_compat() sets
+        // clean_orphan_tool_calls, which would otherwise prune the lone tool_call
+        // and make the assertions below vacuous. A real long-context replay always
+        // carries the matching result, so this mirrors the customer scenario.
+        let messages = vec![
+            Message::new(
+                Role::Assistant,
+                vec![ContentBlock::ToolUse {
+                    id: "tc1".into(),
+                    name: "bash".into(),
+                    input: json!({"cmd": "ls"}),
+                    extra: Some(json!({"google": {"thought": true}})),
+                }],
+            ),
+            Message::new(
+                Role::Tool,
+                vec![ContentBlock::ToolResult {
+                    tool_use_id: "tc1".into(),
+                    content: "ok".into(),
+                    is_error: false,
+                }],
+            ),
+        ];
 
         let result = OpenAIProvider::build_messages(&messages, "", &openai_compat());
         let assistant = result.iter().find(|m| m["role"] == "assistant").unwrap();

--- a/crates/wcore-providers/src/openai.rs
+++ b/crates/wcore-providers/src/openai.rs
@@ -374,7 +374,16 @@ impl OpenAIProvider {
                                         "arguments": serde_json::to_string(input).unwrap_or_default()
                                     }
                                 });
-                                if let Some(extra_val) = extra {
+                                // `extra_content` is an internal-only field
+                                // (e.g. Gemini's google.thought routing marker
+                                // captured inbound). Only echo it outbound for
+                                // providers that emitted it and tolerate the
+                                // round-trip; strict OpenAI-compat endpoints
+                                // (Fireworks / GLM-5 via Flux) 400 on it during
+                                // long-context replay (wayland-core#120).
+                                if compat.emit_tool_call_extra_content()
+                                    && let Some(extra_val) = extra
+                                {
                                     tc_json["extra_content"] = extra_val.clone();
                                 }
                                 Some(tc_json)
@@ -3903,6 +3912,61 @@ mod tests {
         let result = OpenAIProvider::build_messages(&messages, "", &no_compat());
         let tool_msgs: Vec<_> = result.iter().filter(|m| m["role"] == "tool").collect();
         assert_eq!(tool_msgs.len(), 2);
+    }
+
+    // --- outbound extra_content stripping (wayland-core#120) ---
+
+    #[test]
+    fn test_tool_call_extra_content_stripped_for_strict_provider() {
+        // wayland-core#120: the internal extra_content blob (captured from an
+        // inbound tool_calls[].extra_content, e.g. Gemini's google.thought
+        // marker) must NOT be echoed onto outbound tool_calls for providers
+        // that reject unknown fields. On long-context replay, strict
+        // OpenAI-compat endpoints (Fireworks / GLM-5 via Flux) 400 with
+        // "Extra inputs are not permitted ... tool_calls[0].extra_content".
+        let messages = vec![Message::new(
+            Role::Assistant,
+            vec![ContentBlock::ToolUse {
+                id: "tc1".into(),
+                name: "bash".into(),
+                input: json!({"cmd": "ls"}),
+                extra: Some(json!({"google": {"thought": true}})),
+            }],
+        )];
+
+        let result = OpenAIProvider::build_messages(&messages, "", &openai_compat());
+        let assistant = result.iter().find(|m| m["role"] == "assistant").unwrap();
+        let tc = &assistant["tool_calls"][0];
+
+        assert!(
+            tc.get("extra_content").is_none(),
+            "extra_content must be stripped from outbound tool_calls for strict providers"
+        );
+        // The tool call itself is otherwise intact.
+        assert_eq!(tc["id"], "tc1");
+        assert_eq!(tc["function"]["name"], "bash");
+    }
+
+    #[test]
+    fn test_tool_call_extra_content_preserved_for_gemini() {
+        // Google/Gemini's OpenAI-compat endpoint emitted extra_content and
+        // tolerates its round-trip, so it (and only it) keeps emitting it.
+        let messages = vec![Message::new(
+            Role::Assistant,
+            vec![ContentBlock::ToolUse {
+                id: "tc1".into(),
+                name: "bash".into(),
+                input: json!({}),
+                extra: Some(json!({"google": {"thought": true}})),
+            }],
+        )];
+
+        let result =
+            OpenAIProvider::build_messages(&messages, "", &ProviderCompat::gemini_defaults());
+        let assistant = result.iter().find(|m| m["role"] == "assistant").unwrap();
+        let tc = &assistant["tool_calls"][0];
+
+        assert_eq!(tc["extra_content"], json!({"google": {"thought": true}}));
     }
 
     // --- dedup_tool_results ---


### PR DESCRIPTION
## Problem (customer-blocking, long context)

The OpenAI-compat message builder captures an inbound tool_calls[].extra_content (e.g. Gemini's google.thought routing marker) onto the ToolUse block and then re-serialized it onto OUTBOUND tool_calls for every provider (openai.rs build_messages). On long-context replay to a strict OpenAI-compat endpoint (Fireworks / GLM-5 via the Flux router) the request 400s:

    Extra inputs are not permitted, field: messages[N].tool_calls[0].extra_content

## Fix

extra_content is an internal-only field. Gate its outbound emission behind a new ProviderCompat flag, emit_tool_call_extra_content (default false = strip). Only the Google/Gemini preset opts in, since that endpoint emitted the field and tolerates its round-trip. This is the surgical change: behavior is unchanged for Gemini, and every other provider (including strict ones reached via Flux) now strips it.

Same class as the #417 reasoning_content replay fix. Threaded through ProviderCompat::merge() per the compat merge-ripple rule.

## Tests

- test_tool_call_extra_content_stripped_for_strict_provider: default/openai compat drops extra_content from outbound tool_calls (the 400 repro).
- test_tool_call_extra_content_preserved_for_gemini: gemini_defaults() preserves it.

Rides into the 0.12.17 release alongside #117 (#116) and #118 (#115).