### PR TITLE
fix(tool-pairs): never strand an orphaned tool result (DeepSeek 400) #123

### DIFF
--- a/crates/wcore-agent/src/compact/auto.rs
+++ b/crates/wcore-agent/src/compact/auto.rs
@@ -244,15 +244,43 @@ async fn collect_stream_text(
     Err(CompactError::EmptyResponse)
 }
 
+/// True when `msg` carries a tool result — either a dedicated `Role::Tool`
+/// message or a user-role message threading `ToolResult` blocks (both shapes
+/// occur in the conversation history). Such a message is only valid when its
+/// parent assistant `tool_calls` turn precedes it; on its own it is an orphan.
+fn is_tool_result(msg: &Message) -> bool {
+    msg.role == Role::Tool
+        || msg
+            .content
+            .iter()
+            .any(|b| matches!(b, ContentBlock::ToolResult { .. }))
+}
+
 /// Truncate the oldest ~20% of messages for PTL retry.
 ///
 /// Returns `None` if there are too few messages to truncate meaningfully.
+///
+/// Tool-pair aware (FerroxLabs/wayland-core#123): the cut never lands between
+/// an assistant `tool_calls` turn and its tool results. Dropping the assistant
+/// while keeping its result leaves an orphaned `role:"tool"` message that
+/// strict OpenAI endpoints (DeepSeek via Flux) reject with HTTP 400. After
+/// computing the nominal boundary we advance it forward past any leading
+/// tool-result messages so `remaining` always begins at a clean turn boundary.
 fn truncate_for_retry(messages: &[Message]) -> Option<Vec<Message>> {
     if messages.len() < 2 {
         return None;
     }
 
-    let drop_count = (messages.len() / 5).max(1);
+    let mut drop_count = (messages.len() / 5).max(1);
+
+    // Snap the boundary to a turn start: if it would leave a tool result at the
+    // front of `remaining` (its parent assistant turn dropped), drop that
+    // orphaned result too. Parallel tool calls produce several consecutive
+    // results, so advance past the whole run.
+    while drop_count < messages.len() && is_tool_result(&messages[drop_count]) {
+        drop_count += 1;
+    }
+
     if drop_count >= messages.len() {
         return None;
     }
@@ -548,6 +576,91 @@ mod tests {
             ContentBlock::Text { text } => assert_eq!(text, "msg-2"),
             _ => panic!("expected Text"),
         }
+    }
+
+    /// #123 lock: the nominal 20% boundary lands on a tool result whose parent
+    /// assistant turn would be dropped. The cut must advance past the orphan so
+    /// `remaining` never starts with a tool result, and a later intact tool
+    /// pair (in the kept tail) must survive whole.
+    #[test]
+    fn truncate_never_splits_a_tool_pair() {
+        let tool_use = |id: &str| {
+            Message::new(
+                Role::Assistant,
+                vec![ContentBlock::ToolUse {
+                    id: id.into(),
+                    name: "bash".into(),
+                    input: serde_json::json!({}),
+                    extra: None,
+                }],
+            )
+        };
+        let tool_result = |id: &str| {
+            Message::new(
+                Role::Tool,
+                vec![ContentBlock::ToolResult {
+                    tool_use_id: id.into(),
+                    content: "out".into(),
+                    is_error: false,
+                }],
+            )
+        };
+        let text =
+            |role: Role, t: &str| Message::new(role, vec![ContentBlock::Text { text: t.into() }]);
+
+        // 12 msgs → nominal drop_count = 2, which is the tool result for tc1
+        // (its assistant tool_use is index 1, inside the drop window).
+        let msgs = vec![
+            text(Role::User, "u0"),
+            tool_use("tc1"),    // 1 — dropped
+            tool_result("tc1"), // 2 — naive boundary: orphan
+            text(Role::User, "u3"),
+            text(Role::Assistant, "a4"),
+            text(Role::User, "u5"),
+            text(Role::Assistant, "a6"),
+            text(Role::User, "u7"),
+            tool_use("tc2"), // 8 — intact pair, in kept tail
+            tool_result("tc2"),
+            text(Role::User, "u10"),
+            text(Role::Assistant, "a11"),
+        ];
+
+        let result = truncate_for_retry(&msgs).unwrap();
+
+        // The cut advanced past the orphaned tc1 result → no leading tool result.
+        assert!(
+            !is_tool_result(&result[0]),
+            "remaining must not start with a tool result: {:?}",
+            result[0].role
+        );
+
+        // Every surviving tool result has its parent tool_use earlier in the
+        // result (no orphans of either id).
+        let mut seen_calls = std::collections::HashSet::new();
+        for m in &result {
+            for b in &m.content {
+                match b {
+                    ContentBlock::ToolUse { id, .. } => {
+                        seen_calls.insert(id.clone());
+                    }
+                    ContentBlock::ToolResult { tool_use_id, .. } => {
+                        assert!(
+                            seen_calls.contains(tool_use_id),
+                            "orphaned tool result for id {tool_use_id} survived truncation"
+                        );
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        // The intact tc2 pair survived whole.
+        let has_tc2_result = result.iter().any(|m| {
+            m.content.iter().any(
+                |b| matches!(b, ContentBlock::ToolResult { tool_use_id, .. } if tool_use_id == "tc2"),
+            )
+        });
+        assert!(has_tc2_result, "intact tc2 pair must survive in the tail");
     }
 
     // ── boundary detection / extraction ─────────────────────────────────

--- a/crates/wcore-providers/src/openai.rs
+++ b/crates/wcore-providers/src/openai.rs
@@ -977,14 +977,20 @@ fn clean_orphaned_tool_results(messages: &mut Vec<Value>) {
         .collect();
 
     messages.retain(|m| {
-        if m["role"].as_str() == Some("tool")
-            && let Some(id) = m["tool_call_id"].as_str()
-        {
-            // Keep only results whose call survives in the array.
-            called_ids.contains(id)
+        if m["role"].as_str() == Some("tool") {
+            // Keep a tool result only when it answers an assistant tool_calls
+            // entry that survives in the array. A result whose tool_call_id is
+            // unmatched — OR missing/non-string entirely — is an orphan that
+            // strict OpenAI endpoints (DeepSeek via Flux) 400 on, so drop it
+            // (FerroxLabs/wayland-core#123). The empty/missing-id case is also
+            // caught upstream by `strip_empty_tool_call_ids`; handling it here
+            // too keeps this pass correct in isolation, independent of call
+            // order or compat gating.
+            m["tool_call_id"]
+                .as_str()
+                .is_some_and(|id| called_ids.contains(id))
         } else {
-            // Non-tool messages, and any malformed tool message without a
-            // tool_call_id, are out of scope for this pass.
+            // Non-tool messages are out of scope for this pass.
             true
         }
     });
@@ -4087,6 +4093,78 @@ mod tests {
         assert_eq!(tool_msgs.len(), 1);
         assert_eq!(tool_msgs[0]["tool_call_id"], "tc_good");
         assert_eq!(tool_msgs[0]["content"], "kept");
+    }
+
+    // --- #123: orphaned tool result hardening ---
+
+    /// `clean_orphaned_tool_results` must drop a `role:"tool"` message whose
+    /// `tool_call_id` is unmatched OR missing entirely — the latter is the
+    /// "out of scope" gap that previously let a no-id tool message survive to
+    /// the provider and 400 DeepSeek via Flux (parity-sweep rank 8).
+    #[test]
+    fn clean_orphaned_tool_results_strips_missing_and_unmatched_ids() {
+        let mut messages = vec![
+            // Surviving pair.
+            json!({
+                "role": "assistant",
+                "tool_calls": [{ "id": "tc_ok", "type": "function",
+                    "function": { "name": "bash", "arguments": "{}" } }]
+            }),
+            json!({ "role": "tool", "tool_call_id": "tc_ok", "content": "kept" }),
+            // Orphan: id present but no matching assistant tool_call.
+            json!({ "role": "tool", "tool_call_id": "tc_gone", "content": "unmatched" }),
+            // Orphan: no tool_call_id at all (the previously-"out of scope" case).
+            json!({ "role": "tool", "content": "no id" }),
+        ];
+
+        clean_orphaned_tool_results(&mut messages);
+
+        let tool_msgs: Vec<_> = messages.iter().filter(|m| m["role"] == "tool").collect();
+        assert_eq!(tool_msgs.len(), 1, "only the matched result survives");
+        assert_eq!(tool_msgs[0]["tool_call_id"], "tc_ok");
+    }
+
+    /// End-to-end contract: a history whose assistant `tool_calls` turn was
+    /// trimmed away (leaving the result orphaned) must serialize to ZERO
+    /// `role:"tool"` messages lacking a matching `tool_call_id`
+    /// (parity-sweep rank 7).
+    #[test]
+    fn split_tool_pair_serializes_without_orphans() {
+        // Only the result survives; its parent assistant tool_use is gone, as
+        // a context trim that split the pair would leave it.
+        let messages = vec![
+            Message::new(
+                Role::User,
+                vec![ContentBlock::Text {
+                    text: "earlier turn".into(),
+                }],
+            ),
+            Message::new(
+                Role::Tool,
+                vec![ContentBlock::ToolResult {
+                    tool_use_id: "tc_orphan".into(),
+                    content: "orphaned result".into(),
+                    is_error: false,
+                }],
+            ),
+        ];
+
+        let result = OpenAIProvider::build_messages(&messages, "", &openai_compat());
+
+        for m in &result {
+            if m["role"] == "tool" {
+                let id = m["tool_call_id"].as_str().unwrap_or("");
+                let matched = result.iter().any(|a| {
+                    a["tool_calls"]
+                        .as_array()
+                        .is_some_and(|tcs| tcs.iter().any(|tc| tc["id"] == id))
+                });
+                assert!(
+                    matched && !id.is_empty(),
+                    "orphaned tool result must not reach the provider: {m}"
+                );
+            }
+        }
     }
 
     // --- usage token parsing ---

--- a/crates/wcore-providers/src/openai.rs
+++ b/crates/wcore-providers/src/openai.rs
@@ -456,6 +456,14 @@ impl OpenAIProvider {
             merge_consecutive_assistant(&mut result);
         }
 
+        // An assistant message must carry `content` or `tool_calls`. The orphan
+        // and empty-id passes above can strip the last tool_call from a
+        // tool-call-only (text-less) assistant turn — leaving `{"role":
+        // "assistant"}`, which native DeepSeek 400s ("content or tool_calls
+        // must be set"). Stamp an empty-string content in that case so the
+        // request stays valid (FerroxLabs/wayland-core#123).
+        ensure_assistant_content_present(&mut result);
+
         result
     }
 
@@ -1073,6 +1081,28 @@ fn clean_orphaned_tool_calls(messages: &mut [Value]) {
                 // children). `as_object_mut` is therefore always Some.
                 msg.as_object_mut().unwrap().remove("tool_calls");
             }
+        }
+    }
+}
+
+/// Guarantee every assistant message carries `content` or `tool_calls`.
+///
+/// `build_messages` omits `content` for a tool-call-only assistant turn (its
+/// text is empty), and the orphan/empty-id cleanup passes can then strip that
+/// turn's only `tool_calls` entry — leaving `{"role":"assistant"}` with
+/// neither field. Strict OpenAI endpoints reject it: native DeepSeek returns
+/// HTTP 400 "Invalid assistant message: content or tool_calls must be set".
+/// Stamping an empty-string content (the same value `build_messages` uses for
+/// a genuinely empty assistant turn) keeps the request valid without inventing
+/// text (FerroxLabs/wayland-core#123).
+fn ensure_assistant_content_present(messages: &mut [Value]) {
+    for msg in messages.iter_mut() {
+        if msg["role"].as_str() == Some("assistant")
+            && msg.get("tool_calls").is_none()
+            && !msg["content"].is_string()
+            && let Some(obj) = msg.as_object_mut()
+        {
+            obj.insert("content".to_string(), json!(""));
         }
     }
 }
@@ -4162,6 +4192,47 @@ mod tests {
                 assert!(
                     matched && !id.is_empty(),
                     "orphaned tool result must not reach the provider: {m}"
+                );
+            }
+        }
+    }
+
+    /// #123: when the orphan cleanup strips a tool-call-only assistant's only
+    /// `tool_calls` entry, the resulting message must still carry `content`
+    /// (native DeepSeek 400s on an assistant with neither content nor
+    /// tool_calls). Here the assistant's tool call is never answered, so
+    /// `clean_orphaned_tool_calls` removes it.
+    #[test]
+    fn stripped_tool_call_leaves_valid_assistant_content() {
+        let messages = vec![
+            Message::new(Role::User, vec![ContentBlock::Text { text: "go".into() }]),
+            // Text-less assistant turn: a single tool call, no answering result.
+            Message::new(
+                Role::Assistant,
+                vec![ContentBlock::ToolUse {
+                    id: "call_unanswered".into(),
+                    name: "get".into(),
+                    input: json!({}),
+                    extra: None,
+                }],
+            ),
+            Message::new(
+                Role::User,
+                vec![ContentBlock::Text {
+                    text: "never answered".into(),
+                }],
+            ),
+        ];
+
+        let result = OpenAIProvider::build_messages(&messages, "", &openai_compat());
+
+        for m in &result {
+            if m["role"] == "assistant" {
+                let has_calls = m["tool_calls"].as_array().is_some_and(|a| !a.is_empty());
+                let has_content = m["content"].is_string();
+                assert!(
+                    has_calls || has_content,
+                    "assistant must carry content or tool_calls (would 400 DeepSeek): {m}"
                 );
             }
         }

--- a/crates/wcore-providers/src/openai_responses.rs
+++ b/crates/wcore-providers/src/openai_responses.rs
@@ -157,14 +157,17 @@ fn clean_orphaned_function_call_outputs(input: &mut Vec<Value>) {
         .collect();
 
     input.retain(|item| {
-        if item["type"].as_str() == Some("function_call_output")
-            && let Some(id) = item["call_id"].as_str()
-        {
-            // Keep only outputs whose call survives in the input set.
-            called_ids.contains(id)
+        if item["type"].as_str() == Some("function_call_output") {
+            // Keep only outputs whose call survives in the input set. An output
+            // whose call_id is unmatched — OR missing/non-string entirely — is
+            // an orphan the Responses API 400s on, so drop it
+            // (FerroxLabs/wayland-core#123). Unlike the Chat path there is no
+            // separate empty-id guard here, so this pass must be self-sufficient.
+            item["call_id"]
+                .as_str()
+                .is_some_and(|id| called_ids.contains(id))
         } else {
-            // Non-output items, and any malformed output without a call_id,
-            // are out of scope for this pass.
+            // Non-output items are out of scope for this pass.
             true
         }
     });
@@ -834,6 +837,32 @@ mod tests {
         assert!(input.iter().any(|item| {
             item["type"] == json!("function_call_output") && item["call_id"] == json!("call_live")
         }));
+    }
+
+    /// #123: `clean_orphaned_function_call_outputs` must drop a
+    /// `function_call_output` whose `call_id` is missing/non-string, not just
+    /// the present-but-unmatched case. The Responses path has no separate
+    /// empty-id guard, so this pass must be self-sufficient.
+    #[test]
+    fn clean_orphaned_outputs_strips_missing_call_id() {
+        let mut input = vec![
+            json!({ "type": "function_call", "call_id": "ok",
+                "name": "read", "arguments": "{}" }),
+            json!({ "type": "function_call_output", "call_id": "ok", "output": "kept" }),
+            // Unmatched id.
+            json!({ "type": "function_call_output", "call_id": "gone", "output": "x" }),
+            // Missing call_id entirely (previously "out of scope").
+            json!({ "type": "function_call_output", "output": "no id" }),
+        ];
+
+        clean_orphaned_function_call_outputs(&mut input);
+
+        let outputs: Vec<_> = input
+            .iter()
+            .filter(|i| i["type"] == json!("function_call_output"))
+            .collect();
+        assert_eq!(outputs.len(), 1, "only the matched output survives");
+        assert_eq!(outputs[0]["call_id"], json!("ok"));
     }
 
     #[test]


### PR DESCRIPTION
Fixes FerroxLabs/wayland-core#123 — revert-blocker for Flux mitigation TradeCanyon/flux-router#91 (DeepSeek pulled from rotation).

## Symptom
Long agentic conversations could ship a `role:"tool"` message with no matching assistant `tool_calls` id to strict OpenAI endpoints (DeepSeek via Flux), which 400 the whole request and strand the conversation.

## Root cause — two sites
1. **`compact::auto::truncate_for_retry`** dropped the oldest ~20% of messages with **no tool-pair awareness**. A `PromptTooLong` retry could drop an assistant `tool_calls` turn while keeping its following tool result → orphan.
2. **`clean_orphaned_tool_results`** (chat) and **`clean_orphaned_function_call_outputs`** (responses) explicitly left tool messages with a *missing* `tool_call_id` "out of scope", relying on `strip_empty_tool_call_ids` running first.

## Fix
1. `truncate_for_retry` is now **tool-pair aware**: after the nominal 20% boundary, advance forward past any leading tool-result message so `remaining` always begins at a clean turn start. Fixing it at the source keeps history well-formed for **every** provider — not only those whose serializer happens to run orphan cleanup (`clean_orphan_tool_calls` defaults to `false` for non-OpenAI-family providers).
2. Both cleanup passes are now **self-sufficient**: drop any tool result whose id is **missing OR unmatched**, independent of call order / compat gating.

## Note on existing coverage
At the chat serializer for flux-router/deepseek, the no-id case was *already* caught by `strip_empty_tool_call_ids` (#170, ungated) and the unmatched case by `clean_orphaned_tool_results` (#85). The genuinely new protection here is **site 1** (source-level pair awareness, which protects providers without orphan cleanup) plus **defense-in-depth** making the cleanup passes correct in isolation.

## Tests (parity-sweep ranks 7 & 8)
- `truncate_never_splits_a_tool_pair` — boundary lands on an orphan; cut advances past it, later intact pair survives.
- `split_tool_pair_serializes_without_orphans` — end-to-end `build_messages` contract: zero orphan tool messages.
- `clean_orphaned_tool_results_strips_missing_and_unmatched_ids` + `clean_orphaned_outputs_strips_missing_call_id`.

## Verification
Hetzner gate green: `fmt --check` (workspace), `clippy --all-targets -D warnings`, `nextest` **2915 passed / 0 failed** (wcore-agent + wcore-providers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)