### PR TITLE
fix(security): clamp project posture + gate wire Force (GHSA-8r7g, parts b+c)

### DIFF
--- a/crates/wcore-cli/src/main.rs
+++ b/crates/wcore-cli/src/main.rs
@@ -1751,6 +1751,15 @@ fn approval_mode_to_session(
     }
 }
 
+/// GHSA-8r7g: the `WAYLAND_ALLOW_WIRE_FORCE` env opt-in that lets a protocol
+/// peer request `SessionMode::Force`. Mirrors the env-based operator opt-ins
+/// elsewhere (e.g. `WAYLAND_ALLOW_NO_SANDBOX`). Truthy = `1` / `true`.
+fn wire_force_opt_in_env() -> bool {
+    std::env::var("WAYLAND_ALLOW_WIRE_FORCE")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+}
+
 async fn run_tui_mode(
     config: Config,
     cwd: &str,
@@ -1834,6 +1843,9 @@ async fn run_tui_mode(
     let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
     let output: Arc<dyn OutputSink> = Arc::new(tui::ChannelSink::new(tx.clone()));
     let approval_manager = Arc::new(ToolApprovalManager::new());
+    // GHSA-8r7g: a protocol peer may escalate to Force only when this local
+    // operator opted in at launch (--force or WAYLAND_ALLOW_WIRE_FORCE).
+    approval_manager.set_allow_wire_force(force || wire_force_opt_in_env());
     // Seed the initial approval posture from config (`[default] approval_mode`,
     // editable via /config). `--force` below overrides it to Force.
     approval_manager.set_mode(approval_mode_to_session(config.approval_mode));
@@ -2564,6 +2576,9 @@ async fn run_json_stream_mode(
             .with_sub_agent_traces(true),
     );
     let approval_manager = Arc::new(ToolApprovalManager::new());
+    // GHSA-8r7g: a protocol peer may escalate to Force only when this local
+    // operator opted in at launch (--force or WAYLAND_ALLOW_WIRE_FORCE).
+    approval_manager.set_allow_wire_force(force || wire_force_opt_in_env());
     // F-002: plumb --force into json-stream mode. In the TUI path the
     // approval manager is flipped to Force before the engine boots; the
     // json-stream path was missing the same step, causing every mutating
@@ -2941,12 +2956,20 @@ async fn run_json_stream_mode(
                                         });
                                     }
                                     ProtocolCommand::SetMode { mode } => {
-                                        approval_manager.set_mode(mode);
-                                        mode_changed = true;
-                                        let _ = writer.emit(&wcore_protocol::events::ProtocolEvent::Info {
-                                            msg_id: String::new(),
-                                            message: format!("mode updated: {}", approval_manager.current_mode()),
-                                        });
+                                        // GHSA-8r7g: a wire peer may not escalate to
+                                        // Force without a local-operator opt-in.
+                                        if approval_manager.set_mode_from_wire(mode) {
+                                            mode_changed = true;
+                                            let _ = writer.emit(&wcore_protocol::events::ProtocolEvent::Info {
+                                                msg_id: String::new(),
+                                                message: format!("mode updated: {}", approval_manager.current_mode()),
+                                            });
+                                        } else {
+                                            let _ = writer.emit(&wcore_protocol::events::ProtocolEvent::Info {
+                                                msg_id: String::new(),
+                                                message: "set_mode: 'force' refused — requires a local-operator opt-in (launch with --force or WAYLAND_ALLOW_WIRE_FORCE=1)".to_string(),
+                                            });
+                                        }
                                     }
                                     ProtocolCommand::Ping => {
                                         let _ = writer.emit(&wcore_protocol::events::ProtocolEvent::Pong);
@@ -3028,20 +3051,29 @@ async fn run_json_stream_mode(
             }
             ProtocolCommand::SetMode { mode } => {
                 let mode_str = format!("{mode:?}").to_lowercase();
-                approval_manager.set_mode(mode);
-                let _ = writer.emit(&wcore_protocol::events::ProtocolEvent::Info {
-                    msg_id: String::new(),
-                    message: format!("mode updated: {}", approval_manager.current_mode()),
-                });
-                protocol_sink.emit_config_changed_with_plugins(
-                    engine.compat(),
-                    has_mcp,
-                    &approval_manager.current_mode(),
-                    initial_has_plugins,
-                    &initial_plugin_caps,
-                    engine.advertised_capabilities(),
-                );
-                eprintln!("[protocol] SetMode applied: {mode_str}");
+                // GHSA-8r7g: a wire peer may not escalate to Force without a
+                // local-operator opt-in.
+                if !approval_manager.set_mode_from_wire(mode) {
+                    let _ = writer.emit(&wcore_protocol::events::ProtocolEvent::Info {
+                        msg_id: String::new(),
+                        message: "set_mode: 'force' refused — requires a local-operator opt-in (launch with --force or WAYLAND_ALLOW_WIRE_FORCE=1)".to_string(),
+                    });
+                    eprintln!("[protocol] SetMode refused (force, no local opt-in)");
+                } else {
+                    let _ = writer.emit(&wcore_protocol::events::ProtocolEvent::Info {
+                        msg_id: String::new(),
+                        message: format!("mode updated: {}", approval_manager.current_mode()),
+                    });
+                    protocol_sink.emit_config_changed_with_plugins(
+                        engine.compat(),
+                        has_mcp,
+                        &approval_manager.current_mode(),
+                        initial_has_plugins,
+                        &initial_plugin_caps,
+                        engine.advertised_capabilities(),
+                    );
+                    eprintln!("[protocol] SetMode applied: {mode_str}");
+                }
             }
             ProtocolCommand::SetConfig {
                 model,

--- a/crates/wcore-config/src/config.rs
+++ b/crates/wcore-config/src/config.rs
@@ -613,6 +613,24 @@ impl ApprovalMode {
             _ => ApprovalMode::Default,
         }
     }
+
+    /// Restrictiveness rank — higher is stricter (asks for more approvals).
+    /// `Default` (ask before everything) is strictest; `Force` (never ask) is
+    /// loosest. Used to clamp project config tighten-only (GHSA-8r7g).
+    fn strictness(self) -> u8 {
+        match self {
+            ApprovalMode::Default => 2,
+            ApprovalMode::AutoEdit => 1,
+            ApprovalMode::Force => 0,
+        }
+    }
+
+    /// True when `self` is at least as strict as `other` (asks for at least as
+    /// many approvals). A project config may only move the posture to a mode
+    /// satisfying this relative to the global config — never looser.
+    pub fn is_at_least_as_strict_as(self, other: ApprovalMode) -> bool {
+        self.strictness() >= other.strictness()
+    }
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
@@ -3112,8 +3130,17 @@ fn merge_config_files(global: ConfigFile, project: ConfigFile) -> ConfigFile {
             global.default.max_tokens
         },
         max_turns: project.default.max_turns.or(global.default.max_turns),
-        // Project overrides global only when it set a non-default posture.
-        approval_mode: if project.default.approval_mode != ApprovalMode::default() {
+        // GHSA-8r7g: a project config is untrusted (checked into a cloned
+        // repo). It may move the approval posture STRICTER than global, never
+        // looser. So a project value applies only when it is both non-default
+        // AND at least as strict as global; a project attempt to loosen (e.g.
+        // Force when global is Default/AutoEdit) is ignored and global stands.
+        approval_mode: if project.default.approval_mode != ApprovalMode::default()
+            && project
+                .default
+                .approval_mode
+                .is_at_least_as_strict_as(global.default.approval_mode)
+        {
             project.default.approval_mode
         } else {
             global.default.approval_mode
@@ -3142,10 +3169,48 @@ fn merge_config_files(global: ConfigFile, project: ConfigFile) -> ConfigFile {
 
     // Tools: project overrides global for scalar fields; skills deny/allow are concatenated
     // (global first, then project) — consistent with the hooks merge strategy.
+    //
+    // GHSA-8r7g: `auto_approve` and `allow_no_sandbox` are privilege-granting
+    // flags. A project config (untrusted — travels with a cloned repo) must not
+    // be able to raise them beyond the user's global posture. Clamp both
+    // tighten-only, computed once so BOTH allow_list branches below apply it.
+    //
+    // - auto_approve (bool): a project may never enable it; it takes global's
+    //   value. (A project can't silently grant itself blanket tool approval.)
+    // - allow_no_sandbox (Option<bool>): a project may set it only to a value
+    //   no more permissive than global — `Some(true)` is honored only when
+    //   global already allows no-sandbox; otherwise global stands. Note the
+    //   `sandbox = "none"` backend selector is already fail-closed unless
+    //   allow_no_sandbox is true, so clamping this flag also defangs a project
+    //   setting sandbox="none".
+    let clamped_auto_approve = global.tools.auto_approve;
+    let clamped_allow_no_sandbox = match project.tools.allow_no_sandbox {
+        Some(true) if global.tools.allow_no_sandbox != Some(true) => global.tools.allow_no_sandbox,
+        other => other.or(global.tools.allow_no_sandbox),
+    };
+    // GHSA-8r7g: `allow_list` membership SKIPS the approval gate
+    // (orchestration/mod.rs: `!allow_list.contains(name)` short-circuits
+    // needs_approval), so a project EXPANDING it past global is a per-tool
+    // privilege grant — a cloned repo could add "Bash"/"Write" and auto-execute
+    // them. Clamp tighten-only: the effective list is the project's list
+    // intersected with global's, so a project may only NARROW the approved set,
+    // never approve a tool the user's global config didn't. A project that
+    // doesn't customize the list keeps global's list unchanged.
+    let clamped_allow_list: Vec<String> = if project.tools.allow_list != default_allow_list() {
+        project
+            .tools
+            .allow_list
+            .iter()
+            .filter(|t| global.tools.allow_list.contains(t))
+            .cloned()
+            .collect()
+    } else {
+        global.tools.allow_list.clone()
+    };
     let tools = if project.tools.allow_list != default_allow_list() || project.tools.auto_approve {
         ToolsConfig {
-            auto_approve: global.tools.auto_approve || project.tools.auto_approve,
-            allow_list: project.tools.allow_list,
+            auto_approve: clamped_auto_approve,
+            allow_list: clamped_allow_list,
             skills: SkillsPermissionConfig {
                 deny: [global.tools.skills.deny, project.tools.skills.deny].concat(),
                 allow: [global.tools.skills.allow, project.tools.skills.allow].concat(),
@@ -3159,14 +3224,12 @@ fn merge_config_files(global: ConfigFile, project: ConfigFile) -> ConfigFile {
             env_passthrough: [global.tools.env_passthrough, project.tools.env_passthrough].concat(),
             // #327 — project overrides global for the sandbox toggle.
             sandbox: project.tools.sandbox.or(global.tools.sandbox),
-            allow_no_sandbox: project
-                .tools
-                .allow_no_sandbox
-                .or(global.tools.allow_no_sandbox),
+            // GHSA-8r7g: tighten-only (see clamp above).
+            allow_no_sandbox: clamped_allow_no_sandbox,
         }
     } else {
         ToolsConfig {
-            auto_approve: global.tools.auto_approve || project.tools.auto_approve,
+            auto_approve: clamped_auto_approve,
             allow_list: global.tools.allow_list,
             skills: SkillsPermissionConfig {
                 deny: [global.tools.skills.deny, project.tools.skills.deny].concat(),
@@ -3176,10 +3239,8 @@ fn merge_config_files(global: ConfigFile, project: ConfigFile) -> ConfigFile {
             windows_shell: project.tools.windows_shell.or(global.tools.windows_shell),
             env_passthrough: [global.tools.env_passthrough, project.tools.env_passthrough].concat(),
             sandbox: project.tools.sandbox.or(global.tools.sandbox),
-            allow_no_sandbox: project
-                .tools
-                .allow_no_sandbox
-                .or(global.tools.allow_no_sandbox),
+            // GHSA-8r7g: tighten-only (see clamp above).
+            allow_no_sandbox: clamped_allow_no_sandbox,
         }
     };
 
@@ -4542,6 +4603,159 @@ mod tests {
         );
     }
 
+    // -------------------------------------------------------------------------
+    // GHSA-8r7g: a project config must only tighten the security posture,
+    // never loosen it (a checked-in repo config cannot grant itself privilege).
+    // -------------------------------------------------------------------------
+
+    /// Helper: a global config with the given posture flags.
+    fn cfg_with(
+        approval: ApprovalMode,
+        auto_approve: bool,
+        allow_no_sandbox: Option<bool>,
+    ) -> ConfigFile {
+        ConfigFile {
+            default: DefaultConfig {
+                approval_mode: approval,
+                ..Default::default()
+            },
+            tools: ToolsConfig {
+                auto_approve,
+                allow_no_sandbox,
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn ghsa_project_cannot_enable_auto_approve() {
+        let global = cfg_with(ApprovalMode::Default, false, None);
+        let project = cfg_with(ApprovalMode::Default, true, None);
+        let merged = merge_config_files(global, project);
+        assert!(
+            !merged.tools.auto_approve,
+            "a project must not be able to enable auto_approve when global has it off"
+        );
+    }
+
+    #[test]
+    fn ghsa_project_cannot_loosen_approval_mode() {
+        let global = cfg_with(ApprovalMode::Default, false, None);
+        let project = cfg_with(ApprovalMode::Force, false, None);
+        let merged = merge_config_files(global, project);
+        assert_eq!(
+            merged.default.approval_mode,
+            ApprovalMode::Default,
+            "a project Force must not loosen a global Default posture"
+        );
+    }
+
+    #[test]
+    fn ghsa_project_can_tighten_approval_mode() {
+        // Global is loosest (Force); a project may tighten to AutoEdit.
+        let global = cfg_with(ApprovalMode::Force, false, None);
+        let project = cfg_with(ApprovalMode::AutoEdit, false, None);
+        let merged = merge_config_files(global, project);
+        assert_eq!(
+            merged.default.approval_mode,
+            ApprovalMode::AutoEdit,
+            "a project may tighten a looser global posture"
+        );
+    }
+
+    #[test]
+    fn ghsa_project_cannot_enable_allow_no_sandbox() {
+        let global = cfg_with(ApprovalMode::Default, false, None);
+        let project = cfg_with(ApprovalMode::Default, false, Some(true));
+        let merged = merge_config_files(global, project);
+        assert_ne!(
+            merged.tools.allow_no_sandbox,
+            Some(true),
+            "a project must not enable allow_no_sandbox when global does not"
+        );
+    }
+
+    #[test]
+    fn ghsa_project_allow_no_sandbox_honored_when_global_allows() {
+        let global = cfg_with(ApprovalMode::Default, false, Some(true));
+        let project = cfg_with(ApprovalMode::Default, false, Some(true));
+        let merged = merge_config_files(global, project);
+        assert_eq!(
+            merged.tools.allow_no_sandbox,
+            Some(true),
+            "with global consent already granted, the project value is honored"
+        );
+    }
+
+    #[test]
+    fn ghsa_project_can_tighten_allow_no_sandbox() {
+        // Global allows no-sandbox; a project may revoke it (tighten).
+        let global = cfg_with(ApprovalMode::Default, false, Some(true));
+        let project = cfg_with(ApprovalMode::Default, false, Some(false));
+        let merged = merge_config_files(global, project);
+        assert_eq!(
+            merged.tools.allow_no_sandbox,
+            Some(false),
+            "a project may tighten allow_no_sandbox from a permissive global"
+        );
+    }
+
+    #[test]
+    fn ghsa_project_cannot_expand_allow_list() {
+        // allow_list membership SKIPS approval, so adding a tool is a privilege
+        // grant. A project must not add a tool global didn't already approve.
+        let global = ConfigFile {
+            tools: ToolsConfig {
+                allow_list: vec!["Read".into(), "Grep".into()],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let project = ConfigFile {
+            tools: ToolsConfig {
+                allow_list: vec!["Read".into(), "Bash".into(), "Write".into()],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let merged = merge_config_files(global, project);
+        assert!(
+            !merged.tools.allow_list.contains(&"Bash".to_string()),
+            "a project must not add Bash to the approval-skip list"
+        );
+        assert!(!merged.tools.allow_list.contains(&"Write".to_string()));
+        assert!(
+            merged.tools.allow_list.contains(&"Read".to_string()),
+            "a tool approved by both survives"
+        );
+    }
+
+    #[test]
+    fn ghsa_project_can_narrow_allow_list() {
+        // A project may remove tools from the approved set (tighten).
+        let global = ConfigFile {
+            tools: ToolsConfig {
+                allow_list: vec!["Read".into(), "Grep".into(), "Glob".into()],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let project = ConfigFile {
+            tools: ToolsConfig {
+                allow_list: vec!["Read".into()],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let merged = merge_config_files(global, project);
+        assert_eq!(
+            merged.tools.allow_list,
+            vec!["Read".to_string()],
+            "a project may narrow the approved set to a subset of global"
+        );
+    }
+
     #[test]
     fn p5_14_skills_deny_allow_deserialized() {
         let toml_str = r#"
@@ -5229,8 +5443,16 @@ enabled = false
 
     #[test]
     fn approval_mode_parses_from_toml_and_resolves_onto_config() {
-        // The full path: `[default] approval_mode` in TOML → resolved
+        // The full path: `[default] approval_mode` in TOML → merge → resolved
         // Config.approval_mode (what the TUI boot consumer reads).
+        //
+        // GHSA-8r7g: a PROJECT config is untrusted and may only TIGHTEN. Here
+        // there is no global override, so global is the strict default
+        // (`Default`); a project asking for the looser `auto-edit` is a
+        // loosening attempt and is clamped back to `Default`. (Before the fix
+        // this resolved to `AutoEdit` — a checked-in repo silently reducing
+        // approval friction.) A user who wants auto-edit sets it in their own
+        // GLOBAL config or via the CLI, which is explicit local consent.
         let tmp = tempfile::tempdir().unwrap();
         let project = tmp.path().join(".wayland-core.toml");
         std::fs::write(&project, "[default]\napproval_mode = \"auto-edit\"\n").unwrap();
@@ -5247,7 +5469,11 @@ enabled = false
             project_dir: Some(tmp.path().to_path_buf()),
         };
         let config = Config::resolve(&cli).unwrap();
-        assert_eq!(config.approval_mode, ApprovalMode::AutoEdit);
+        assert_eq!(
+            config.approval_mode,
+            ApprovalMode::Default,
+            "a project must not loosen approval_mode below the (default-strict) global"
+        );
     }
 
     #[test]

--- a/crates/wcore-eval-scenarios/src/protocol_scenarios.rs
+++ b/crates/wcore-eval-scenarios/src/protocol_scenarios.rs
@@ -62,11 +62,13 @@ pub fn set_config_model_swap() -> Scenario {
         )
 }
 
-/// SetMode: send `set_mode { mode: "force" }` before the turn, assert the
-/// engine acked `"mode updated: force"` and emitted `config_changed` carrying
-/// `current_mode: "force"`.
+/// GHSA-8r7g: a wire peer must NOT be able to escalate to Force. This runs the
+/// real binary WITHOUT any local-operator opt-in (no --force / no
+/// WAYLAND_ALLOW_WIRE_FORCE), sends `set_mode { mode: "force" }` over the
+/// protocol, and asserts the engine REFUSES it (rather than acking
+/// `mode updated: force`). The plain text turn still completes normally.
 pub fn set_mode_force() -> Scenario {
-    Scenario::new("protocol_set_mode_force", Category::Coverage)
+    Scenario::new("protocol_set_mode_force_refused", Category::Coverage)
         .provider(ProviderChoice::ForceDeepSeek)
         .max_total_time(Duration::from_secs(60))
         .max_total_cost_usd(0.02)
@@ -75,10 +77,8 @@ pub fn set_mode_force() -> Scenario {
                 .max_time(Duration::from_secs(45))
                 .max_steps(2)
                 .pre_command(TurnCommand::SetMode { mode: "force" })
-                // Info ack from the standalone set_mode arm.
-                .assert(Assertion::InfoContains("mode updated: force"))
-                // config_changed capabilities reflect the new current_mode.
-                .assert(Assertion::InfoContains("\"current_mode\":\"force\"")),
+                // The wire Force request is refused for lack of a local opt-in.
+                .assert(Assertion::InfoContains("'force' refused")),
         )
 }
 

--- a/crates/wcore-protocol/src/lib.rs
+++ b/crates/wcore-protocol/src/lib.rs
@@ -10,6 +10,7 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::Arc;
 use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 
 use tokio::sync::oneshot;
@@ -174,6 +175,14 @@ pub struct ToolApprovalManager {
     /// `auto_approved`, which is whole-category (bare `Always`).
     auto_approved_prefixes: Mutex<HashMap<String, Vec<String>>>,
     session_mode: Mutex<SessionMode>,
+    /// GHSA-8r7g — local-operator opt-in gating `SessionMode::Force` requested
+    /// over the protocol. `Force` auto-approves every tool, so an untrusted
+    /// wire peer (remote ACP, or model-influenced data reaching the command
+    /// parser) must NOT be able to set it. Default `false`: a wire `SetMode`
+    /// requesting `Force` (or its `yolo` / `dangerously_*` aliases) is refused
+    /// unless a local operator opted in at launch. Local, in-process surfaces
+    /// (the interactive TUI) call [`set_mode`] directly and are unaffected.
+    allow_wire_force: AtomicBool,
     /// Per-request TTL. Defaults to [`DEFAULT_APPROVAL_TTL`]; tests use
     /// a sub-second TTL via [`ToolApprovalManager::with_ttl`].
     ttl: Duration,
@@ -193,6 +202,7 @@ impl ToolApprovalManager {
             auto_approved_tool_names: Mutex::new(HashSet::new()),
             auto_approved_prefixes: Mutex::new(HashMap::new()),
             session_mode: Mutex::new(SessionMode::Default),
+            allow_wire_force: AtomicBool::new(false),
             ttl,
         }
     }
@@ -480,10 +490,37 @@ impl ToolApprovalManager {
     }
 
     /// Set the session approval mode. Takes effect immediately.
+    ///
+    /// This is the LOCAL, trusted entry point (interactive TUI, CLI). It is
+    /// unrestricted by design. Protocol/wire callers must use
+    /// [`set_mode_from_wire`](Self::set_mode_from_wire) instead.
     pub fn set_mode(&self, mode: SessionMode) {
         if let Ok(mut current) = self.session_mode.lock() {
             *current = mode;
         }
+    }
+
+    /// GHSA-8r7g — grant or revoke the local-operator opt-in that lets a
+    /// protocol peer request [`SessionMode::Force`]. Set from an explicit
+    /// launch-time signal (the `--force` flag / `WAYLAND_ALLOW_WIRE_FORCE`
+    /// env), never from wire data.
+    pub fn set_allow_wire_force(&self, allow: bool) {
+        self.allow_wire_force.store(allow, Ordering::Relaxed);
+    }
+
+    /// Apply a session mode requested over the PROTOCOL (an untrusted wire
+    /// peer). `Force` auto-approves every tool, so it is honored only when a
+    /// local operator opted in via [`set_allow_wire_force`](Self::set_allow_wire_force);
+    /// otherwise the request is refused and the current mode is left unchanged.
+    /// Non-`Force` modes are always applied. Returns `true` when the requested
+    /// mode was applied, `false` when a `Force` request was refused (so the
+    /// caller can surface a diagnostic).
+    pub fn set_mode_from_wire(&self, mode: SessionMode) -> bool {
+        if mode == SessionMode::Force && !self.allow_wire_force.load(Ordering::Relaxed) {
+            return false;
+        }
+        self.set_mode(mode);
+        true
     }
 
     /// Return the current session mode as a string for capability reporting.
@@ -545,6 +582,36 @@ mod tests {
     fn default_mode_current_mode_string() {
         let mgr = ToolApprovalManager::new();
         assert_eq!(mgr.current_mode(), "default");
+    }
+
+    // --- GHSA-8r7g: wire Force requires a local-operator opt-in ---
+
+    #[test]
+    fn ghsa_wire_force_refused_without_local_opt_in() {
+        let mgr = ToolApprovalManager::new();
+        // A wire peer cannot escalate to Force by default.
+        assert!(!mgr.set_mode_from_wire(SessionMode::Force));
+        assert_eq!(mgr.current_mode(), "default");
+        // Non-Force modes are always applied over the wire.
+        assert!(mgr.set_mode_from_wire(SessionMode::AutoEdit));
+        assert_eq!(mgr.current_mode(), "auto_edit");
+    }
+
+    #[test]
+    fn ghsa_wire_force_allowed_after_local_opt_in() {
+        let mgr = ToolApprovalManager::new();
+        mgr.set_allow_wire_force(true);
+        assert!(mgr.set_mode_from_wire(SessionMode::Force));
+        assert_eq!(mgr.current_mode(), "force");
+    }
+
+    #[test]
+    fn ghsa_local_set_mode_force_is_unrestricted() {
+        // The local (in-process) path — used by the interactive TUI — is never
+        // gated by the wire opt-in.
+        let mgr = ToolApprovalManager::new();
+        mgr.set_mode(SessionMode::Force);
+        assert_eq!(mgr.current_mode(), "force");
     }
 
     // --- SessionMode: auto_edit mode ---


### PR DESCRIPTION
Addresses two of the three approval/posture hardenings for **GHSA-8r7g-7556-hj3j**. Part (a) (approval resume-token unpredictability) is a separate follow-up.

> ⚠️ Ties to a **private draft security advisory**. @seandonahoe — confirm the intended merge/disclosure path before this lands publicly.

## (b) Project config → tighten-only posture clamp (`wcore-config`)
A project config (`.wayland-core.toml`) travels with a cloned repo and is untrusted. The merge could **loosen** the user's global posture with no consent. Now every posture-affecting field is clamped tighten-only, mirroring the existing `read_only` clamp:
- `approval_mode` — applies only if at least as strict as global (new `ApprovalMode` strictness ordering).
- `auto_approve` — takes global's value; a project can never raise it.
- `allow_no_sandbox` — a project `Some(true)` honored only if global already allows.
- `allow_list` — **(added after adversarial cross-audit)** membership skips the approval gate, so an expanded list is a per-tool privilege grant. Effective list is now `project ∩ global` — a project may only narrow it.

**Behavior change:** a project posture value *looser* than the user's global is now ignored. Since global defaults to the strict posture, a project can no longer reduce approval friction on its own — the user opts in globally or via CLI.

## (c) Wire `SessionMode::Force` → local-operator opt-in (`wcore-protocol` + `wcore-cli`)
A protocol peer could set `Force` and auto-approve every tool. Now the wire path (`set_mode_from_wire`) refuses `Force` unless a local operator opted in (`--force` / `WAYLAND_ALLOW_WIRE_FORCE`). The interactive TUI is unaffected (in-process `set_mode`).

**Desktop-lane note:** if the desktop app enables a "yolo" toggle by sending `SetMode{force}` over the protocol, it must now launch the engine with the opt-in.

## Verification
- Adversarial security cross-audit run against the diff (it surfaced the `allow_list` vector, now fixed).
- Hetzner gate green: fmt / clippy `-D warnings` / nextest **2417 passed / 0 failed** (`wcore-config`, `wcore-protocol`, `wcore-cli`, `wcore-eval-scenarios`).
- 12 regression tests total; the eval scenario now asserts the wire-Force refusal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)