### PR TITLE
fix(security): GHSA-8r7g completion — hooks default-deny, wire AutoEdit gate, resume-token, skill-hooks (H-1)

### DIFF
--- a/crates/wcore-agent/src/approval.rs
+++ b/crates/wcore-agent/src/approval.rs
@@ -88,11 +88,30 @@ impl ApprovalOutcome {
 struct Pending {
     sender: oneshot::Sender<ApprovalOutcome>,
     expires_at: Instant,
+    /// GHSA-8r7g: the public correlation handle (a caller-supplied, possibly
+    /// model-known `call_id`) this entry is indexed under in `by_corr`, if any.
+    /// Stored so removing the entry (resolve/reap) also purges the secondary
+    /// index — never leave a `by_corr` mapping dangling to a freed token.
+    correlation_id: Option<String>,
+}
+
+/// GHSA-8r7g: the bridge's pending state under a SINGLE mutex. The primary
+/// map is keyed by a SECRET `resume_token` (`apr-{uuid}`, unguessable) — that
+/// is the only value a wire/host peer may present to resolve an approval. The
+/// secondary `by_corr` index maps a public `correlation_id` (a caller-supplied
+/// `call_id`, which the model can see) to its secret token, so a LOCAL resolver
+/// (a TUI keypress, an in-process egress event) can resolve by the public
+/// handle without the secret ever reaching a model-reachable surface. Both maps
+/// live under one lock so an entry can never appear in one and not the other.
+#[derive(Default)]
+struct PendingMaps {
+    by_token: HashMap<String, Pending>,
+    by_corr: HashMap<String, String>,
 }
 
 #[derive(Clone)]
 pub struct ApprovalBridge {
-    pending: Arc<Mutex<HashMap<String, Pending>>>,
+    pending: Arc<Mutex<PendingMaps>>,
     ttl: Duration,
     /// Wave SC: shared active-token redactor. The bridge holds an
     /// `Arc<RwLock<...>>` so callers (sinks, tests) can clone the
@@ -101,14 +120,23 @@ pub struct ApprovalBridge {
     /// protocol sink's redaction pass always sees current in-flight
     /// correlation ids.
     redactor: crate::output::protocol_sink::ActiveTokenRedactor,
+    /// GHSA-8r7g: a SYNC-readable snapshot of `by_corr` (public correlation id
+    /// → secret `resume_token`). The approval-frame synthesizers
+    /// (`GatingProtocolWriter`, `ChannelEmitter`) run in a synchronous `emit`
+    /// and cannot lock the async `pending` mutex, so they read this mirror to
+    /// stamp the SECRET token onto the host-visible frame (empty for a
+    /// regular tool with no bridge entry). Refreshed on every mutation
+    /// alongside the redactor snapshot, so it never lags the pending state.
+    corr_secrets: Arc<std::sync::RwLock<HashMap<String, String>>>,
 }
 
 impl Default for ApprovalBridge {
     fn default() -> Self {
         Self {
-            pending: Arc::new(Mutex::new(HashMap::new())),
+            pending: Arc::new(Mutex::new(PendingMaps::default())),
             ttl: DEFAULT_APPROVAL_TTL,
             redactor: crate::output::protocol_sink::ActiveTokenRedactor::new(),
+            corr_secrets: Arc::new(std::sync::RwLock::new(HashMap::new())),
         }
     }
 }
@@ -123,9 +151,10 @@ impl ApprovalBridge {
     /// to assert expiry behavior in < 1s.
     pub fn with_ttl(ttl: Duration) -> Self {
         Self {
-            pending: Arc::new(Mutex::new(HashMap::new())),
+            pending: Arc::new(Mutex::new(PendingMaps::default())),
             ttl,
             redactor: crate::output::protocol_sink::ActiveTokenRedactor::new(),
+            corr_secrets: Arc::new(std::sync::RwLock::new(HashMap::new())),
         }
     }
 
@@ -141,8 +170,33 @@ impl ApprovalBridge {
     /// mutation (request / resolve / reap). The redactor's internal
     /// set replaces atomically — readers never observe a torn state.
     async fn refresh_redactor(&self) {
-        let snapshot: Vec<String> = self.pending.lock().await.keys().cloned().collect();
-        self.redactor.set(snapshot);
+        // GHSA-8r7g: snapshot the SECRET tokens only for the redactor. The
+        // public `by_corr` handles (call_ids) are already model-visible, so
+        // redacting them from tool output would be pointless and could scrub
+        // legitimate content. Also refresh the sync correlation→secret mirror
+        // the frame synthesizers read (under the SAME async lock, so both
+        // snapshots reflect one consistent pending state).
+        let (tokens, corr): (Vec<String>, HashMap<String, String>) = {
+            let map = self.pending.lock().await;
+            (map.by_token.keys().cloned().collect(), map.by_corr.clone())
+        };
+        self.redactor.set(tokens);
+        if let Ok(mut mirror) = self.corr_secrets.write() {
+            *mirror = corr;
+        }
+    }
+
+    /// GHSA-8r7g: sync lookup of the SECRET `resume_token` for a public
+    /// correlation id (a `call_id`). Used by the approval-frame synthesizers to
+    /// stamp the unguessable token onto the host-visible frame. Returns `None`
+    /// for a `call_id` with no bridge-backed approval (a regular tool gated by
+    /// the `ToolApprovalManager`), so the synthesizer emits an EMPTY resume
+    /// token there — a regular tool is never resolved through this bridge.
+    pub fn secret_for_correlation(&self, correlation_id: &str) -> Option<String> {
+        self.corr_secrets
+            .read()
+            .ok()
+            .and_then(|m| m.get(correlation_id).cloned())
     }
 
     /// Spawn the background reaper task. Returns a `tokio::task::JoinHandle`
@@ -179,7 +233,7 @@ impl ApprovalBridge {
         count
     }
 
-    async fn reap_expired(pending: &Arc<Mutex<HashMap<String, Pending>>>) -> usize {
+    async fn reap_expired(pending: &Arc<Mutex<PendingMaps>>) -> usize {
         let now = Instant::now();
         // Wave RB RELIABILITY MAJOR (requester-crash leak): an entry
         // also counts as reapable if its `sender.is_closed()` — that
@@ -192,7 +246,8 @@ impl ApprovalBridge {
         // (every 30s by default) collects the abandoned entry.
         let reapable_keys: Vec<String> = {
             let map = pending.lock().await;
-            map.iter()
+            map.by_token
+                .iter()
                 .filter(|(_, p)| p.expires_at <= now || p.sender.is_closed())
                 .map(|(k, _)| k.clone())
                 .collect()
@@ -201,7 +256,16 @@ impl ApprovalBridge {
         if count > 0 {
             let mut map = pending.lock().await;
             for key in reapable_keys {
-                if let Some(p) = map.remove(&key) {
+                if let Some(p) = map.by_token.remove(&key) {
+                    // GHSA-8r7g: purge the secondary index too, so no
+                    // `by_corr` mapping dangles to a freed secret token — but
+                    // only if it still points to THIS token (a duplicate
+                    // re-registration to a newer secret must survive).
+                    if let Some(corr) = &p.correlation_id
+                        && map.by_corr.get(corr).map(String::as_str) == Some(key.as_str())
+                    {
+                        map.by_corr.remove(corr);
+                    }
                     // For TTL-expired entries the requester is still
                     // waiting on `rx`; surface the cancelled outcome
                     // so it can react. For requester-crashed entries
@@ -238,44 +302,48 @@ impl ApprovalBridge {
         _req: ApprovalRequest,
         ttl: Duration,
     ) -> (String, oneshot::Receiver<ApprovalOutcome>) {
-        let correlation_id = format!("apr-{}", uuid::Uuid::new_v4());
+        // GHSA-8r7g: the token IS a random secret, so it doubles as its own
+        // public handle here — there is no separate model-known correlation id
+        // to protect (the caller emits this same value as both `resume_token`
+        // and `correlation_id`). No `by_corr` entry is needed.
+        let resume_token = format!("apr-{}", uuid::Uuid::new_v4());
         let (tx, rx) = oneshot::channel();
         let expires_at = Instant::now() + ttl;
-        self.pending.lock().await.insert(
-            correlation_id.clone(),
+        self.pending.lock().await.by_token.insert(
+            resume_token.clone(),
             Pending {
                 sender: tx,
                 expires_at,
+                correlation_id: None,
             },
         );
         self.refresh_redactor().await;
-        (correlation_id, rx)
+        (resume_token, rx)
     }
 
-    /// Register a pending approval under a **caller-supplied** correlation id,
-    /// so the producer can resolve the bridge by a stable, self-describing
-    /// handle (e.g. the egress-consent `call_id`) instead of threading the
-    /// randomly-generated id through the UI. The supplied id is also what the
-    /// producer emits as the `ApprovalRequired.resume_token`, so a host's
-    /// `ApprovalResume{resume_token}` and a TUI keypress carrying the same
-    /// `call_id` both resolve the same entry. Callers MUST supply a unique id
-    /// (a duplicate overwrites the prior pending entry — last writer wins).
+    /// Register a pending approval indexed by a **caller-supplied** public
+    /// `correlation_id` (e.g. the egress-consent `call_id`), so a LOCAL resolver
+    /// can resolve by that stable, self-describing handle.
+    ///
+    /// GHSA-8r7g: the pending entry is keyed internally by a fresh SECRET
+    /// `resume_token` (`apr-{uuid}`), which is returned and is the ONLY value a
+    /// wire/host peer may present to [`resolve`](Self::resolve). The public
+    /// `correlation_id` (which a model can see — it appears in the tool_calls
+    /// the model itself emitted) is indexed in `by_corr` and only ever resolves
+    /// via [`resolve_by_correlation`](Self::resolve_by_correlation), the local
+    /// path. This severs the old "resume_token == call_id" identity where a
+    /// model-known id could self-approve over the wire. Callers MUST emit the
+    /// returned secret as `ApprovalRequired.resume_token` and the
+    /// `correlation_id` as `ApprovalRequired.correlation_id`. A duplicate
+    /// `correlation_id` re-points `by_corr` to the newer token (last writer
+    /// wins); the older token remains resolvable by the wire until it is reaped.
     pub async fn request_with_id(
         &self,
         correlation_id: String,
         _req: ApprovalRequest,
-    ) -> oneshot::Receiver<ApprovalOutcome> {
-        let (tx, rx) = oneshot::channel();
-        let expires_at = Instant::now() + self.ttl;
-        self.pending.lock().await.insert(
-            correlation_id,
-            Pending {
-                sender: tx,
-                expires_at,
-            },
-        );
-        self.refresh_redactor().await;
-        rx
+    ) -> (String, oneshot::Receiver<ApprovalOutcome>) {
+        self.request_with_id_and_ttl(correlation_id, _req, self.ttl)
+            .await
     }
 
     /// Like [`request_with_id`](Self::request_with_id) but with an explicit TTL
@@ -287,29 +355,79 @@ impl ApprovalBridge {
         correlation_id: String,
         _req: ApprovalRequest,
         ttl: Duration,
-    ) -> oneshot::Receiver<ApprovalOutcome> {
+    ) -> (String, oneshot::Receiver<ApprovalOutcome>) {
+        let resume_token = format!("apr-{}", uuid::Uuid::new_v4());
         let (tx, rx) = oneshot::channel();
         let expires_at = Instant::now() + ttl;
-        self.pending.lock().await.insert(
-            correlation_id,
-            Pending {
-                sender: tx,
-                expires_at,
-            },
-        );
+        {
+            let mut map = self.pending.lock().await;
+            map.by_token.insert(
+                resume_token.clone(),
+                Pending {
+                    sender: tx,
+                    expires_at,
+                    correlation_id: Some(correlation_id.clone()),
+                },
+            );
+            map.by_corr.insert(correlation_id, resume_token.clone());
+        }
         self.refresh_redactor().await;
-        rx
+        (resume_token, rx)
     }
 
-    /// Consumer side: called from the engine's command loop when
-    /// `ApprovalResume` arrives. Returns false if the correlation id
-    /// is unknown (host sent a stale or expired resume).
-    pub async fn resolve(&self, correlation_id: &str, outcome: ApprovalOutcome) -> bool {
+    /// Consumer side for the WIRE/host path: called from the engine's command
+    /// loop when `ApprovalResume { resume_token }` arrives off the JSON stream.
+    /// The argument MUST be the SECRET `resume_token` (`apr-{uuid}`) the bridge
+    /// minted and emitted — GHSA-8r7g: a model-known `call_id` is NOT accepted
+    /// here (it is a `correlation_id`, resolvable only via the local
+    /// [`resolve_by_correlation`](Self::resolve_by_correlation)). Returns false
+    /// if the token is unknown (host sent a stale, expired, or guessed value).
+    pub async fn resolve(&self, resume_token: &str, outcome: ApprovalOutcome) -> bool {
         let resolved = {
             let mut map = self.pending.lock().await;
-            if let Some(pending) = map.remove(correlation_id) {
+            if let Some(pending) = map.by_token.remove(resume_token) {
+                // Purge the secondary index — but only if it still points to
+                // THIS token. GHSA-8r7g duplicate-overwrite: if the same
+                // correlation id was re-registered to a newer secret, that
+                // newer mapping must survive resolution of the stale token.
+                if let Some(corr) = &pending.correlation_id
+                    && map.by_corr.get(corr).map(String::as_str) == Some(resume_token)
+                {
+                    map.by_corr.remove(corr);
+                }
                 let _ = pending.sender.send(outcome);
                 true
+            } else {
+                false
+            }
+        };
+        if resolved {
+            self.refresh_redactor().await;
+        }
+        resolved
+    }
+
+    /// Consumer side for the LOCAL path: resolve by the public `correlation_id`
+    /// (a caller-supplied, possibly model-known `call_id`). Used by in-process
+    /// resolvers that hold the correlation handle — a TUI keypress or an egress
+    /// event — NOT by anything reading the wire. GHSA-8r7g: this is safe
+    /// precisely because it is unreachable from the protocol ingress; a wire
+    /// peer can only present a `resume_token`, which routes to [`resolve`].
+    /// Returns false if the correlation id has no pending entry.
+    pub async fn resolve_by_correlation(
+        &self,
+        correlation_id: &str,
+        outcome: ApprovalOutcome,
+    ) -> bool {
+        let resolved = {
+            let mut map = self.pending.lock().await;
+            if let Some(token) = map.by_corr.remove(correlation_id) {
+                if let Some(pending) = map.by_token.remove(&token) {
+                    let _ = pending.sender.send(outcome);
+                    true
+                } else {
+                    false
+                }
             } else {
                 false
             }
@@ -326,7 +444,7 @@ impl ApprovalBridge {
     /// already carries the same ids, but tool output streams MUST
     /// NOT echo them back where a snooping tool could lift them).
     pub async fn active_tokens(&self) -> Vec<String> {
-        self.pending.lock().await.keys().cloned().collect()
+        self.pending.lock().await.by_token.keys().cloned().collect()
     }
 
     /// Test helper: snapshot the currently-pending correlation ids.
@@ -338,7 +456,7 @@ impl ApprovalBridge {
 
     /// Test helper: number of currently-pending entries.
     pub async fn pending_count(&self) -> usize {
-        self.pending.lock().await.len()
+        self.pending.lock().await.by_token.len()
     }
 }
 
@@ -452,7 +570,7 @@ mod tests {
         // the per-request TTL is honored: a zero-TTL entry is reaped while a
         // long-TTL entry survives the SAME reap.
         let bridge = ApprovalBridge::new();
-        let rx_short = bridge
+        let (_tok_short, rx_short) = bridge
             .request_with_id_and_ttl(
                 "short".into(),
                 ApprovalRequest {
@@ -463,7 +581,7 @@ mod tests {
                 Duration::from_secs(0),
             )
             .await;
-        let rx_long = bridge
+        let (tok_long, rx_long) = bridge
             .request_with_id_and_ttl(
                 "long".into(),
                 ApprovalRequest {
@@ -483,11 +601,13 @@ mod tests {
             !rx_short.await.unwrap().approved,
             "the reaped entry resolves to cancelled (no spend)"
         );
-        // The long-TTL crucible card must still be pending + resolvable.
+        // The long-TTL crucible card must still be pending + resolvable by its
+        // SECRET token (the wire/host path). GHSA-8r7g: the correlation string
+        // ("long") no longer resolves via `resolve` — only the secret does.
         assert!(
             bridge
                 .resolve(
-                    "long",
+                    &tok_long,
                     ApprovalOutcome {
                         approved: true,
                         modifications: None

--- a/crates/wcore-agent/src/bootstrap.rs
+++ b/crates/wcore-agent/src/bootstrap.rs
@@ -1647,7 +1647,10 @@ impl AgentBootstrap {
             };
         registry.register(Box::new(
             crate::skill_tool::SkillTool::new(Arc::clone(&catalog), cwd.to_string(), skill_checker)
-                .with_telemetry_sink(skill_telemetry_sink),
+                .with_telemetry_sink(skill_telemetry_sink)
+                // GHSA-8r7g H-1: gate project/legacy skill frontmatter hooks
+                // behind the operator's global opt-in (default-deny otherwise).
+                .with_trust_project_hooks(self.config.hooks.trust_project_hooks),
         ));
 
         // T3-3.1.7: SessionSearchTool — cross-session conversation recall via

--- a/crates/wcore-agent/src/egress/bridge_doorbell.rs
+++ b/crates/wcore-agent/src/egress/bridge_doorbell.rs
@@ -53,11 +53,14 @@ fn scope_is_always(modifications: &Option<serde_json::Value>) -> bool {
 #[async_trait::async_trait]
 impl ConsentDoorbell for BridgeConsentDoorbell {
     async fn ask(&self, host: &str, registrable: &str, reason: &str) -> ConsentDecision {
-        // The `call_id` doubles as the bridge correlation id (`request_with_id`),
-        // so a resolver only needs the `call_id` it already has — no separate
-        // token to thread through the UI. A uuid keeps concurrent asks (even to
-        // the same host) from colliding in the bridge's pending map. The `egress:`
-        // prefix lets the TUI/host recognize this as an egress-consent request.
+        // The `call_id` is the PUBLIC correlation handle (`request_with_id`
+        // indexes the pending entry under it), so a LOCAL resolver (a TUI
+        // keypress) resolves via `resolve_by_correlation(call_id)` with the id
+        // it already has. GHSA-8r7g: the bridge mints a SEPARATE secret
+        // `resume_token`, returned below, which is what the host/wire echoes to
+        // resolve — a model-known `call_id` can no longer self-approve. A uuid
+        // keeps concurrent asks (even to the same host) from colliding. The
+        // `egress:` prefix lets the TUI/host recognize this as egress consent.
         let call_id = format!("egress:{}", uuid::Uuid::new_v4());
         let prompt = format!("Allow network access to `{registrable}`? ({reason})");
         // Structured context so a host UI can render richly and a resolver can
@@ -69,7 +72,7 @@ impl ConsentDoorbell for BridgeConsentDoorbell {
         })
         .to_string();
 
-        let rx = self
+        let (resume_token, rx) = self
             .bridge
             .request_with_id(
                 call_id.clone(),
@@ -81,12 +84,13 @@ impl ConsentDoorbell for BridgeConsentDoorbell {
             )
             .await;
 
-        // Surface the prompt. The resume_token IS the call_id (see above). A
-        // no-op on sinks without an approval surface (then the request only
-        // resolves via TTL → deny), so this doorbell is only installed where a
-        // real surface exists.
+        // Surface the prompt. GHSA-8r7g: emit the secret `resume_token` (what
+        // the host echoes back to resolve over the wire), with `call_id` as the
+        // public correlation handle. A no-op on sinks without an approval
+        // surface (then the request only resolves via TTL → deny), so this
+        // doorbell is only installed where a real surface exists.
         self.sink
-            .emit_approval_required(&call_id, &call_id, &prompt, &context);
+            .emit_approval_required(&call_id, &resume_token, &prompt, &context);
 
         match rx.await {
             Ok(outcome) if outcome.approved => {

--- a/crates/wcore-agent/src/engine.rs
+++ b/crates/wcore-agent/src/engine.rs
@@ -6074,6 +6074,26 @@ impl AgentEngine {
         // (`TuiEngine::approve`/`deny`) route this approval to the ApprovalBridge
         // instead of the ToolApprovalManager — mirroring the `egress:` precedent.
         let call_id = format!("crucible:{}", uuid::Uuid::new_v4());
+        // GHSA-8r7g: register the bridge approval entry (minting the SECRET
+        // resume_token) BEFORE emitting the ToolRequest, so the frame
+        // synthesizer (Gating/Channel emitter) reads that secret from the
+        // bridge's sync mirror and stamps it onto the host-visible gate frame.
+        // Registering after the emit (the old order) left the mirror empty at
+        // synthesis time → an empty token → the council was unresolvable on a
+        // JSON-stream host and hung until the 24h TTL. The receiver is threaded
+        // into the approver, which no longer registers a second entry.
+        let (_resume_token, council_rx) = self
+            .approval_bridge
+            .request_with_id_and_ttl(
+                call_id.clone(),
+                crate::approval::ApprovalRequest {
+                    call_id: call_id.clone(),
+                    reason: "Run Crucible council?".to_string(),
+                    context: String::new(),
+                },
+                crate::approval::CRUCIBLE_APPROVAL_TTL,
+            )
+            .await;
         let _ = writer.emit(&ProtocolEvent::ToolRequest {
             msg_id: self.current_msg_id.clone(),
             call_id: call_id.clone(),
@@ -6090,6 +6110,7 @@ impl AgentEngine {
             bridge: std::sync::Arc::clone(&self.approval_bridge),
             cancel: self.cancel_token.clone(),
             call_id: call_id.clone(),
+            rx: std::sync::Mutex::new(Some(council_rx)),
         };
         let base_refilter = base.clone();
         let providers_refilter = providers.clone();
@@ -12354,6 +12375,13 @@ struct BridgeApprover {
     bridge: std::sync::Arc<crate::approval::ApprovalBridge>,
     cancel: tokio_util::sync::CancellationToken,
     call_id: String,
+    /// GHSA-8r7g: the pending-approval receiver. The bridge entry is minted +
+    /// registered in `try_crucible_council` BEFORE the `ToolRequest` frame is
+    /// emitted, so the frame synthesizer reads the secret from the bridge mirror
+    /// and stamps it onto the host-visible gate frame. Registering inside
+    /// `approve()` (after the emit) stamped an EMPTY token and hung the council
+    /// on a JSON-stream host. Taken exactly once in `approve`.
+    rx: std::sync::Mutex<Option<tokio::sync::oneshot::Receiver<crate::approval::ApprovalOutcome>>>,
 }
 
 #[async_trait::async_trait]
@@ -12369,36 +12397,31 @@ impl crate::orchestration::council::CouncilApprover for BridgeApprover {
             .ceiling_usd()
             .map(|u| format!("${u:.4}"))
             .unwrap_or_else(|| "price unknown".to_string());
-        // Stage 4b: key the bridge by the stable, `crucible:`-prefixed call_id —
-        // NOT a throwaway per-round uuid. The approval dedupe (TUI ChannelEmitter
-        // + JSON-stream GatingProtocolWriter) SUPPRESSES this explicit
-        // ApprovalRequired and keeps the ToolRequest-synthesized frame, whose
-        // `resume_token` IS the call_id. So every host can only resolve the
-        // bridge by call_id: the TUI via `resolve_crucible(call_id)` and the
-        // JSON host via `ApprovalResume{resume_token}` → `bridge.resolve(call_id)`
-        // (main.rs). Keying by a fresh uuid here left the council unresolvable on
-        // ALL hosts — it hung until the 24h TTL.
-        //
-        // Register the pending entry BEFORE emitting the card so a fast host
-        // response can never arrive before the bridge can resolve it.
+        // GHSA-8r7g: the pending entry was registered in `try_crucible_council`
+        // BEFORE the ToolRequest was emitted (so the synthesized gate frame
+        // carries the SECRET resume_token). Take the receiver minted there; the
+        // approval dedupe SUPPRESSES the explicit frame below whenever the
+        // ToolRequest already synthesized one, so it stands in only for a writer
+        // that did not synthesize. Look the secret up from the bridge's sync
+        // mirror (populated by that pre-registration) so the explicit frame,
+        // when it is the surviving gate, also carries the secret — never the
+        // model-known call_id. The JSON host then resolves via
+        // `ApprovalResume{resume_token=secret}` → `bridge.resolve(secret)`, and
+        // the TUI via `resolve_crucible(call_id)` →
+        // `bridge.resolve_by_correlation(call_id)`.
         let rx = self
+            .rx
+            .lock()
+            .expect("BridgeApprover rx mutex poisoned")
+            .take()
+            .expect("BridgeApprover::approve called exactly once");
+        let resume_token = self
             .bridge
-            .request_with_id_and_ttl(
-                self.call_id.clone(),
-                crate::approval::ApprovalRequest {
-                    call_id: self.call_id.clone(),
-                    reason: "Run Crucible council?".to_string(),
-                    context: format!("council ceiling {ceiling}"),
-                },
-                // Long/no-expire TTL (spec §7): a multi-vendor cost card is a
-                // deliberation-worthy decision and must not be reaped by the
-                // 5-minute default while the user reads it.
-                crate::approval::CRUCIBLE_APPROVAL_TTL,
-            )
-            .await;
+            .secret_for_correlation(&self.call_id)
+            .unwrap_or_default();
         let _ = self.writer.emit(&ProtocolEvent::ApprovalRequired {
             call_id: self.call_id.clone(),
-            resume_token: self.call_id.clone(),
+            resume_token,
             correlation_id: self.call_id.clone(),
             reason: "Run Crucible council?".to_string(),
             context: format!("Crucible council — you're approving up to {ceiling}."),
@@ -12652,11 +12675,14 @@ mod approval_bridge_engine_tests {
         }
     }
 
-    /// Run `BridgeApprover::approve` on a fresh bridge, then have a "host" resolve
-    /// the council by the `crucible:` call_id (the only token any host can send,
-    /// since the approval dedupe collapses every resume token to the call_id).
-    /// Returns the decision the approver derived. Polls `resolve` so the test does
-    /// not race the spawned approve() before it registers the pending entry.
+    /// Run `BridgeApprover::approve` on a fresh bridge, then have a local "TUI"
+    /// resolver resolve the council by the `crucible:` call_id. GHSA-8r7g: the
+    /// bridge entry is registered (secret minted) BEFORE the approver runs —
+    /// mirroring `try_crucible_council`'s register-before-emit order — and the
+    /// receiver is threaded into the approver. The in-process resolver uses
+    /// `resolve_by_correlation` (the wire path would require the secret
+    /// `resume_token`, which a NullEmitter test never surfaces). Returns the
+    /// decision the approver derived. Polls so the test does not race the spawn.
     async fn drive_crucible_approver(
         approved: bool,
         modifications: Option<serde_json::Value>,
@@ -12667,18 +12693,41 @@ mod approval_bridge_engine_tests {
         let bridge = Arc::new(ApprovalBridge::new());
         let call_id = "crucible:fixed-id".to_string();
         let writer: Arc<dyn wcore_protocol::writer::ProtocolEmitter> = Arc::new(NullEmitter);
+        // Register-before-emit: mint the secret + register the entry, then hand
+        // the receiver to the approver (exactly what the front door does).
+        let (_secret, rx) = bridge
+            .request_with_id_and_ttl(
+                call_id.clone(),
+                crate::approval::ApprovalRequest {
+                    call_id: call_id.clone(),
+                    reason: "Run Crucible council?".to_string(),
+                    context: String::new(),
+                },
+                crate::approval::CRUCIBLE_APPROVAL_TTL,
+            )
+            .await;
+        // The synthesizer-facing invariant the blocker violated: the secret is
+        // in the mirror as soon as the entry is registered, so a gate frame
+        // emitted now (via the ToolRequest synthesizer) reads the real token.
+        assert_eq!(
+            bridge.secret_for_correlation(&call_id).as_deref(),
+            Some(_secret.as_str()),
+            "GHSA-8r7g: secret must be in the sync mirror after registration \
+             (register-before-emit) so the frame synthesizer stamps it"
+        );
         let approver = super::BridgeApprover {
             writer,
             bridge: bridge.clone(),
             cancel: CancellationToken::new(),
             call_id: call_id.clone(),
+            rx: std::sync::Mutex::new(Some(rx)),
         };
         let handle = tokio::spawn(async move { approver.approve(&crucible_test_plan()).await });
 
         let mut resolved = false;
         for _ in 0..512 {
             if bridge
-                .resolve(
+                .resolve_by_correlation(
                     &call_id,
                     ApprovalOutcome {
                         approved,
@@ -12694,9 +12743,10 @@ mod approval_bridge_engine_tests {
         }
         assert!(
             resolved,
-            "ApprovalBridge MUST be resolvable by the `crucible:` call_id — keying \
-             the bridge by a throwaway uuid (the pre-4b bug) makes every host's \
-             resolve-by-call_id miss and the council hangs until the 24h TTL"
+            "ApprovalBridge MUST be resolvable by the `crucible:` call_id via \
+             resolve_by_correlation (the local/TUI path) — indexing the bridge \
+             by a throwaway uuid (the pre-4b bug) makes resolve-by-correlation \
+             miss and the council hangs until the 24h TTL"
         );
         handle
             .await
@@ -12705,7 +12755,7 @@ mod approval_bridge_engine_tests {
     }
 
     #[tokio::test]
-    async fn crucible_approver_keys_bridge_by_call_id_and_maps_approve() {
+    async fn crucible_approver_resolvable_by_correlation_and_maps_approve() {
         let decision = drive_crucible_approver(true, None).await;
         assert_eq!(
             decision,

--- a/crates/wcore-agent/src/skill_tool.rs
+++ b/crates/wcore-agent/src/skill_tool.rs
@@ -49,6 +49,11 @@ pub struct SkillTool {
     /// `memory.enabled` or `observability.skills_lifecycle` is on so the
     /// procedural-memory loop (M3.5) actually receives events.
     telemetry_sink: Arc<dyn SkillTelemetrySink>,
+    /// GHSA-8r7g H-1: operator opt-in to run frontmatter hooks defined by a
+    /// PROJECT/LEGACY skill (repo-local, untrusted). Default `false`
+    /// (default-deny); bootstrap sets it from the global
+    /// `[hooks] trust_project_hooks`. A project can never self-authorize.
+    trust_project_hooks: bool,
 }
 
 impl SkillTool {
@@ -60,6 +65,7 @@ impl SkillTool {
             session_id: None,
             spawner: None,
             telemetry_sink: Arc::new(NullTelemetrySink),
+            trust_project_hooks: false,
         }
     }
 
@@ -77,6 +83,7 @@ impl SkillTool {
             session_id,
             spawner: None,
             telemetry_sink: Arc::new(NullTelemetrySink),
+            trust_project_hooks: false,
         }
     }
 
@@ -95,6 +102,7 @@ impl SkillTool {
             session_id,
             spawner,
             telemetry_sink: Arc::new(NullTelemetrySink),
+            trust_project_hooks: false,
         }
     }
 
@@ -106,6 +114,15 @@ impl SkillTool {
     /// default [`NullTelemetrySink`] is a no-op.
     pub fn with_telemetry_sink(mut self, sink: Arc<dyn SkillTelemetrySink>) -> Self {
         self.telemetry_sink = sink;
+        self
+    }
+
+    /// GHSA-8r7g H-1 — opt in to running frontmatter hooks from PROJECT/LEGACY
+    /// (repo-local, untrusted) skills. Builder method; bootstrap chains this
+    /// with the operator's global `[hooks] trust_project_hooks`. Default-deny
+    /// (`false`) when unset, so a cloned repo's skill hooks never run silently.
+    pub fn with_trust_project_hooks(mut self, trust: bool) -> Self {
+        self.trust_project_hooks = trust;
         self
     }
 
@@ -375,7 +392,12 @@ impl Tool for SkillTool {
     fn skill_hooks_for(&self, input: &serde_json::Value) -> Option<HooksConfig> {
         let skill_name = input["skill"].as_str()?;
         let skill = self.catalog.find_metadata_sync(skill_name)?;
-        let config = parse_skill_hooks(skill.hooks_raw.as_ref(), &skill.name, skill.source)?;
+        let config = parse_skill_hooks(
+            skill.hooks_raw.as_ref(),
+            &skill.name,
+            skill.source,
+            self.trust_project_hooks,
+        )?;
         Some(to_hook_defs(&config, &skill.name))
     }
 

--- a/crates/wcore-agent/tests/approval_ghsa_resume.rs
+++ b/crates/wcore-agent/tests/approval_ghsa_resume.rs
@@ -1,0 +1,275 @@
+//! GHSA-8r7g part (a) — secret resume_token vs public correlation_id separation.
+//!
+//! Each test asserts one security property of the `ApprovalBridge` fix:
+//! the bridge now mints an opaque `apr-{uuid}` secret for every pending
+//! entry and maps a caller-supplied, possibly model-known `correlation_id`
+//! (the `call_id`) to it via a secondary index. A wire/host peer MUST
+//! present the secret; presenting the model-known `call_id` to `resolve`
+//! returns false. The local TUI path resolves by `correlation_id` via
+//! `resolve_by_correlation`, which is unreachable from the wire ingress.
+
+use std::time::Duration;
+
+use wcore_agent::approval::{ApprovalBridge, ApprovalOutcome, ApprovalRequest};
+
+fn req(tag: &str) -> ApprovalRequest {
+    ApprovalRequest {
+        call_id: format!("call-{tag}"),
+        reason: format!("reason-{tag}"),
+        context: format!("ctx-{tag}"),
+    }
+}
+
+fn approved() -> ApprovalOutcome {
+    ApprovalOutcome {
+        approved: true,
+        modifications: None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test 1
+// ---------------------------------------------------------------------------
+
+/// The secret token returned by `request_with_id` must be an opaque
+/// `apr-{uuid}` value and must NOT equal the caller-supplied correlation id.
+/// If they were equal a model-known `call_id` would be its own wire key.
+#[tokio::test]
+async fn request_with_id_returns_secret_distinct_from_correlation() {
+    let bridge = ApprovalBridge::new();
+    let corr = "tool:my-call-id".to_string();
+    let (secret, _rx) = bridge.request_with_id(corr.clone(), req("t1")).await;
+
+    assert!(
+        secret.starts_with("apr-"),
+        "secret token must be an opaque apr-{{uuid}}; got: {secret:?}"
+    );
+    assert_ne!(
+        secret, corr,
+        "secret must NOT equal the correlation id — a model-known call_id must not self-approve"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 2
+// ---------------------------------------------------------------------------
+
+/// GHSA-8r7g core property: the wire `resolve` path only accepts the SECRET
+/// token. Presenting the model-known `call_id` (the `correlation_id`) to
+/// `resolve` must return false; presenting the secret must return true and
+/// deliver `approved=true` to the waiting receiver.
+#[tokio::test]
+async fn wire_resolve_requires_the_secret_not_the_call_id() {
+    let bridge = ApprovalBridge::new();
+    let corr = "egress:abc".to_string();
+    let (secret, rx) = bridge.request_with_id(corr.clone(), req("t2")).await;
+
+    // Attempting wire-resolve with the model-visible call_id must fail.
+    let call_id_resolve = bridge.resolve("egress:abc", approved()).await;
+    assert!(
+        !call_id_resolve,
+        "resolve(call_id) over the wire path must return false — \
+         a model-known id must not act as a self-approval token"
+    );
+
+    // Resolving with the secret must succeed.
+    let secret_resolve = bridge.resolve(&secret, approved()).await;
+    assert!(
+        secret_resolve,
+        "resolve(secret) must return true for a pending entry"
+    );
+
+    let outcome = rx.await.expect("oneshot must deliver an outcome");
+    assert!(
+        outcome.approved,
+        "receiver must observe approved=true after secret-path resolve"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 3
+// ---------------------------------------------------------------------------
+
+/// The LOCAL TUI path (`resolve_by_correlation`) resolves by the public
+/// correlation id and correctly delivers the outcome to the receiver.
+/// This path is unreachable from the wire ingress — it is the safe in-process
+/// resolution surface for keypress / egress-event resolvers.
+#[tokio::test]
+async fn tui_resolves_by_correlation() {
+    let bridge = ApprovalBridge::new();
+    let corr = "tui-handle".to_string();
+    let (_secret, rx) = bridge.request_with_id(corr.clone(), req("t3")).await;
+
+    let result = bridge.resolve_by_correlation(&corr, approved()).await;
+    assert!(
+        result,
+        "resolve_by_correlation must return true for a known correlation id"
+    );
+
+    let outcome = rx.await.expect("oneshot must deliver an outcome");
+    assert!(
+        outcome.approved,
+        "TUI resolve path must deliver approved=true to the waiting receiver"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 4
+// ---------------------------------------------------------------------------
+
+/// The sync `secret_for_correlation` mirror is populated after `request_with_id`
+/// and is cleared (along with the pending count) after the entry is resolved.
+/// Frame synthesizers (GatingProtocolWriter, ChannelEmitter) read this mirror
+/// synchronously to stamp the secret onto outbound frames.
+#[tokio::test]
+async fn secret_for_correlation_maps_then_clears() {
+    let bridge = ApprovalBridge::new();
+    let corr = "lifecycle-corr".to_string();
+    let (secret, rx) = bridge.request_with_id(corr.clone(), req("t4")).await;
+
+    // Mirror is populated immediately after request.
+    assert_eq!(
+        bridge.secret_for_correlation(&corr),
+        Some(secret.clone()),
+        "secret_for_correlation must return the minted secret while entry is pending"
+    );
+    assert_eq!(
+        bridge.secret_for_correlation("unknown-id"),
+        None,
+        "secret_for_correlation must return None for an unregistered correlation id"
+    );
+
+    // Resolve and verify both the pending map and the mirror are cleared.
+    bridge.resolve(&secret, approved()).await;
+    let _ = rx.await;
+
+    assert_eq!(
+        bridge.secret_for_correlation(&corr),
+        None,
+        "secret_for_correlation must return None after the entry is resolved"
+    );
+    assert_eq!(
+        bridge.pending_count().await,
+        0,
+        "pending_count must be 0 after resolve"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 5
+// ---------------------------------------------------------------------------
+
+/// `reap_now` on a zero-TTL entry purges the primary `by_token` map, the
+/// secondary `by_corr` index, and the sync `corr_secrets` mirror in one shot.
+/// The waiting receiver observes a cancelled (approved=false) outcome.
+#[tokio::test]
+async fn reap_purges_secret_and_index_and_mirror() {
+    let bridge = ApprovalBridge::new();
+    let corr = "reap-target".to_string();
+    let (secret, rx) = bridge
+        .request_with_id_and_ttl(corr.clone(), req("t5"), Duration::from_secs(0))
+        .await;
+
+    let reaped = bridge.reap_now().await;
+    assert_eq!(reaped, 1, "reap_now must collect the zero-TTL entry");
+
+    let outcome = rx.await.expect("reaper must send a cancelled outcome");
+    assert!(
+        !outcome.approved,
+        "reaped entry must deliver approved=false (cancelled)"
+    );
+
+    // Both the secret token and its correlation mapping must be gone.
+    assert_eq!(
+        bridge.secret_for_correlation(&corr),
+        None,
+        "corr_secrets mirror must be cleared after reap"
+    );
+    // Attempting wire-resolve with the (now reaped) secret must fail.
+    let stale = bridge.resolve(&secret, approved()).await;
+    assert!(
+        !stale,
+        "resolve on a reaped secret must return false (entry already removed)"
+    );
+    assert_eq!(
+        bridge.pending_count().await,
+        0,
+        "pending_count must be 0 after reap"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 6
+// ---------------------------------------------------------------------------
+
+/// When the same `correlation_id` is registered twice, the `by_corr` mirror
+/// points to the SECOND (newest) secret (last-writer-wins). The FIRST secret
+/// remains resolvable via the wire path — no dangling entry, no use-after-free
+/// of the older `oneshot::Sender`.
+#[tokio::test]
+async fn duplicate_correlation_last_writer_wins_mirror() {
+    let bridge = ApprovalBridge::new();
+    let corr = "shared-corr".to_string();
+
+    let (first_secret, _rx1) = bridge.request_with_id(corr.clone(), req("t6a")).await;
+    let (second_secret, _rx2) = bridge.request_with_id(corr.clone(), req("t6b")).await;
+
+    // Secrets must be distinct (each call mints a fresh uuid).
+    assert_ne!(
+        first_secret, second_secret,
+        "each request_with_id call must mint a distinct secret"
+    );
+
+    // The mirror must point at the most-recent secret (last writer wins).
+    assert_eq!(
+        bridge.secret_for_correlation(&corr),
+        Some(second_secret.clone()),
+        "corr_secrets mirror must point to the second (latest) secret after duplicate registration"
+    );
+
+    // The first secret must still live in by_token and resolve cleanly,
+    // proving the older entry is not dangling.
+    let first_resolved = bridge.resolve(&first_secret, approved()).await;
+    assert!(
+        first_resolved,
+        "first secret must remain resolvable via the wire path after a duplicate registration"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 7
+// ---------------------------------------------------------------------------
+
+/// The plain `request` path (no explicit correlation id) registers no
+/// `by_corr` entry. `secret_for_correlation` returns `None` for any key,
+/// including the secret itself, while `resolve(&secret, …)` works normally.
+#[tokio::test]
+async fn random_request_path_has_no_correlation_entry() {
+    let bridge = ApprovalBridge::new();
+    let (secret, rx) = bridge.request(req("t7")).await;
+
+    // No correlation index entry exists for any key on the random-request path.
+    assert_eq!(
+        bridge.secret_for_correlation("any-call-id"),
+        None,
+        "secret_for_correlation must return None when no correlation was registered"
+    );
+    assert_eq!(
+        bridge.secret_for_correlation(&secret),
+        None,
+        "the secret itself is not a correlation key — secret_for_correlation must return None"
+    );
+
+    // The secret is still the wire-resolve key.
+    let resolved = bridge.resolve(&secret, approved()).await;
+    assert!(
+        resolved,
+        "resolve by secret must work for an entry registered via the plain request() path"
+    );
+
+    let outcome = rx.await.expect("oneshot must deliver an outcome");
+    assert!(
+        outcome.approved,
+        "receiver must observe approved=true after resolve"
+    );
+}

--- a/crates/wcore-cli/src/acp_engine.rs
+++ b/crates/wcore-cli/src/acp_engine.rs
@@ -242,7 +242,10 @@ impl ProtocolEmitter for RelayEmitter {
     fn emit(&self, event: &ProtocolEvent) -> std::io::Result<()> {
         let tx = self.handle.lock().unwrap().clone();
         if let Some(tx) = tx {
-            ChannelEmitter::with_dedupe(tx, self.synthesized.clone()).emit(event)?;
+            // GHSA-8r7g: `None` bridge → legacy resume_token emit on the ACP
+            // relay (its crucible/egress call_ids are already uuids; the ACP
+            // endpoint's secret-token hardening is a separate follow-up).
+            ChannelEmitter::with_dedupe(tx, self.synthesized.clone(), None).emit(event)?;
         }
         Ok(())
     }

--- a/crates/wcore-cli/src/main.rs
+++ b/crates/wcore-cli/src/main.rs
@@ -1948,6 +1948,7 @@ async fn run_tui_mode(
     engine.set_protocol_writer(Arc::new(tui::ChannelEmitter::with_dedupe(
         tx.clone(),
         std::sync::Arc::new(std::sync::Mutex::new(std::collections::HashSet::new())),
+        Some(engine.approval_bridge().clone()),
     )));
 
     // Snapshot the loaded skills + MCP servers for the `/skills` and `/mcp`
@@ -2462,14 +2463,23 @@ struct GatingProtocolWriter {
     /// `ApprovalRequired`, so a later explicit one from the engine for the same
     /// call is not double-emitted.
     synthesized: std::sync::Mutex<std::collections::HashSet<String>>,
+    /// GHSA-8r7g: sync correlation→secret lookup so the synthesized gate frame
+    /// carries the unguessable resume_token for bridge-backed approvals
+    /// (crucible/egress), and EMPTY for a regular tool (no bridge entry).
+    approval_bridge: Option<Arc<wcore_agent::approval::ApprovalBridge>>,
 }
 
 impl GatingProtocolWriter {
-    fn new(inner: Arc<ProtocolWriter>, approval: Arc<ToolApprovalManager>) -> Self {
+    fn new(
+        inner: Arc<ProtocolWriter>,
+        approval: Arc<ToolApprovalManager>,
+        approval_bridge: Option<Arc<wcore_agent::approval::ApprovalBridge>>,
+    ) -> Self {
         Self {
             inner,
             approval,
             synthesized: std::sync::Mutex::new(std::collections::HashSet::new()),
+            approval_bridge,
         }
     }
 }
@@ -2517,9 +2527,17 @@ impl ProtocolEmitter for GatingProtocolWriter {
                 let plan = tool.args.get("plan").and_then(|v| {
                     serde_json::from_value::<wcore_types::crucible::CruciblePlan>(v.clone()).ok()
                 });
+                // GHSA-8r7g: stamp the secret bridge token for bridge-backed
+                // approvals (crucible/egress); EMPTY for a regular tool that
+                // has no bridge entry and is resolved via ToolApprovalManager.
+                let resume_token = self
+                    .approval_bridge
+                    .as_ref()
+                    .and_then(|b| b.secret_for_correlation(call_id))
+                    .unwrap_or_default();
                 self.inner.emit(&ProtocolEvent::ApprovalRequired {
                     call_id: call_id.clone(),
-                    resume_token: call_id.clone(),
+                    resume_token,
                     correlation_id: call_id.clone(),
                     reason: reason.to_string(),
                     context: tool.description.clone(),
@@ -2683,6 +2701,7 @@ async fn run_json_stream_mode(
     let gating_writer: Arc<dyn ProtocolEmitter> = Arc::new(GatingProtocolWriter::new(
         writer.clone(),
         approval_manager.clone(),
+        Some(engine.approval_bridge().clone()),
     ));
     engine.set_protocol_writer(gating_writer);
 
@@ -2975,6 +2994,40 @@ async fn run_json_stream_mode(
                                     }
                                     ProtocolCommand::Ping => {
                                         let _ = writer.emit(&wcore_protocol::events::ProtocolEvent::Pong);
+                                    }
+                                    ProtocolCommand::ApprovalResume {
+                                        resume_token,
+                                        approved,
+                                        modifications,
+                                    } => {
+                                        // GHSA-8r7g: a bridge-backed approval (the
+                                        // Crucible council card, an egress consent) parks
+                                        // DURING an active turn, so its ApprovalResume MUST
+                                        // be handled here — the top-level arm only runs
+                                        // BETWEEN turns and would never see it, leaving the
+                                        // council/consent unresolvable (hang until the TTL)
+                                        // on a JSON-stream host (the desktop app). Route the
+                                        // secret resume_token through the shared bridge.
+                                        let outcome = wcore_agent::approval::ApprovalOutcome {
+                                            approved,
+                                            modifications,
+                                        };
+                                        let resolved =
+                                            approval_bridge.resolve(&resume_token, outcome).await;
+                                        let _ = writer.emit(
+                                            &wcore_protocol::events::ProtocolEvent::ApprovalResume {
+                                                resume_token: resume_token.clone(),
+                                                approved,
+                                            },
+                                        );
+                                        if !resolved {
+                                            let _ = writer.emit(&wcore_protocol::events::ProtocolEvent::Info {
+                                                msg_id: String::new(),
+                                                message: format!(
+                                                    "approval_resume received for unknown token: {resume_token} (stale resume?)"
+                                                ),
+                                            });
+                                        }
                                     }
                                     _ => {
                                         eprintln!("[protocol] Ignoring command during active message processing");

--- a/crates/wcore-cli/src/main.rs
+++ b/crates/wcore-cli/src/main.rs
@@ -2957,7 +2957,9 @@ async fn run_json_stream_mode(
                                     }
                                     ProtocolCommand::SetMode { mode } => {
                                         // GHSA-8r7g: a wire peer may not escalate to
-                                        // Force without a local-operator opt-in.
+                                        // an auto-approving mode (Force or AutoEdit)
+                                        // without a local-operator opt-in.
+                                        let mode_str = format!("{mode:?}").to_lowercase();
                                         if approval_manager.set_mode_from_wire(mode) {
                                             mode_changed = true;
                                             let _ = writer.emit(&wcore_protocol::events::ProtocolEvent::Info {
@@ -2967,7 +2969,7 @@ async fn run_json_stream_mode(
                                         } else {
                                             let _ = writer.emit(&wcore_protocol::events::ProtocolEvent::Info {
                                                 msg_id: String::new(),
-                                                message: "set_mode: 'force' refused — requires a local-operator opt-in (launch with --force or WAYLAND_ALLOW_WIRE_FORCE=1)".to_string(),
+                                                message: format!("set_mode: '{mode_str}' refused — an auto-approving mode (auto_edit/force) requires a local-operator opt-in (launch with --force or WAYLAND_ALLOW_WIRE_FORCE=1)"),
                                             });
                                         }
                                     }
@@ -3051,14 +3053,14 @@ async fn run_json_stream_mode(
             }
             ProtocolCommand::SetMode { mode } => {
                 let mode_str = format!("{mode:?}").to_lowercase();
-                // GHSA-8r7g: a wire peer may not escalate to Force without a
-                // local-operator opt-in.
+                // GHSA-8r7g: a wire peer may not escalate to an auto-approving
+                // mode (Force or AutoEdit) without a local-operator opt-in.
                 if !approval_manager.set_mode_from_wire(mode) {
                     let _ = writer.emit(&wcore_protocol::events::ProtocolEvent::Info {
                         msg_id: String::new(),
-                        message: "set_mode: 'force' refused — requires a local-operator opt-in (launch with --force or WAYLAND_ALLOW_WIRE_FORCE=1)".to_string(),
+                        message: format!("set_mode: '{mode_str}' refused — an auto-approving mode (auto_edit/force) requires a local-operator opt-in (launch with --force or WAYLAND_ALLOW_WIRE_FORCE=1)"),
                     });
-                    eprintln!("[protocol] SetMode refused (force, no local opt-in)");
+                    eprintln!("[protocol] SetMode refused ({mode_str}, no local opt-in)");
                 } else {
                     let _ = writer.emit(&wcore_protocol::events::ProtocolEvent::Info {
                         msg_id: String::new(),

--- a/crates/wcore-cli/src/tui/engine_bridge.rs
+++ b/crates/wcore-cli/src/tui/engine_bridge.rs
@@ -66,6 +66,13 @@ pub struct ChannelEmitter {
     /// path. `None` (the stateless [`ChannelEmitter::new`]) keeps the original
     /// always-synthesize behavior for unit tests and any non-persistent caller.
     synthesized: Option<DedupeSet>,
+    /// GHSA-8r7g: sync correlation→secret lookup so a synthesized gate frame
+    /// carries the unguessable `resume_token` for a bridge-backed approval
+    /// (crucible/egress), and EMPTY for a regular tool (no bridge entry —
+    /// resolved via `ToolApprove`). `None` (ACP relay + unit tests) keeps the
+    /// legacy behavior of emitting the `call_id` as the resume handle; the ACP
+    /// projection's endpoint hardening is a separate follow-up.
+    approval_bridge: Option<Arc<wcore_agent::approval::ApprovalBridge>>,
 }
 
 /// Shared "already-synthesized a gate frame" set, held by the persistent
@@ -82,6 +89,7 @@ impl ChannelEmitter {
         Self {
             tx,
             synthesized: None,
+            approval_bridge: None,
         }
     }
 
@@ -89,10 +97,18 @@ impl ChannelEmitter {
     /// explicit `ApprovalRequired` for an already-synthesized call_id is
     /// suppressed (Wave 6 #24 single-gate dedupe). Use this for the persistent
     /// TUI/ACP emitters where the engine may also emit its own gate frame.
-    pub fn with_dedupe(tx: UnboundedSender<ProtocolEvent>, synthesized: DedupeSet) -> Self {
+    /// GHSA-8r7g: `approval_bridge` supplies the sync correlation→secret lookup
+    /// used to stamp the unguessable `resume_token` onto a bridge-backed gate
+    /// frame (`Some` for the TUI; `None` for the ACP relay keeps legacy emit).
+    pub fn with_dedupe(
+        tx: UnboundedSender<ProtocolEvent>,
+        synthesized: DedupeSet,
+        approval_bridge: Option<Arc<wcore_agent::approval::ApprovalBridge>>,
+    ) -> Self {
         Self {
             tx,
             synthesized: Some(synthesized),
+            approval_bridge,
         }
     }
 }
@@ -156,7 +172,15 @@ impl ProtocolEmitter for ChannelEmitter {
                 wcore_protocol::events::ToolCategory::Info => "info",
             };
             let context = tool.description.clone();
-            let resume_token = call_id.clone();
+            // GHSA-8r7g: stamp the bridge's SECRET resume_token (looked up by
+            // this call_id) onto the host-visible gate frame — EMPTY for a
+            // regular tool (no bridge entry; resolved via `ToolApprove`). With
+            // no bridge (ACP relay / unit tests) fall back to the legacy
+            // behavior of emitting the call_id itself as the resume handle.
+            let resume_token = match &self.approval_bridge {
+                Some(bridge) => bridge.secret_for_correlation(call_id).unwrap_or_default(),
+                None => call_id.clone(),
+            };
             // Record that we synthesized a gate for this call_id so a later
             // explicit `ApprovalRequired` (from a self-gating engine site) is
             // suppressed above. No-op for the stateless `new` emitter.
@@ -175,8 +199,10 @@ impl ProtocolEmitter for ChannelEmitter {
             });
             let _ = self.tx.send(ProtocolEvent::ApprovalRequired {
                 call_id: call_id.clone(),
-                resume_token: resume_token.clone(),
-                correlation_id: resume_token,
+                resume_token,
+                // GHSA-8r7g: the public correlation handle is the call_id, not
+                // the (now possibly secret/empty) resume_token.
+                correlation_id: call_id.clone(),
                 reason: reason.to_string(),
                 context,
                 plan,
@@ -1134,8 +1160,10 @@ impl TuiEngine {
         let modifications =
             (approved && always).then(|| serde_json::json!({ "egress_scope": "always" }));
         tokio::spawn(async move {
+            // GHSA-8r7g: a TUI keypress holds the PUBLIC call_id, so resolve by
+            // correlation (the secret resume_token is only on the wire path).
             bridge
-                .resolve(
+                .resolve_by_correlation(
                     &call_id,
                     wcore_agent::approval::ApprovalOutcome {
                         approved,
@@ -1158,8 +1186,9 @@ impl TuiEngine {
         let bridge = self.approval_bridge.clone();
         let call_id = call_id.to_string();
         tokio::spawn(async move {
+            // GHSA-8r7g: resolve by the PUBLIC correlation id (TUI keypress).
             bridge
-                .resolve(
+                .resolve_by_correlation(
                     &call_id,
                     wcore_agent::approval::ApprovalOutcome {
                         approved,
@@ -2718,7 +2747,7 @@ mod tests {
         // malformed second frame downstream).
         let (tx, mut rx) = mpsc::unbounded_channel();
         let seen: DedupeSet = Arc::new(Mutex::new(HashSet::new()));
-        let emitter = ChannelEmitter::with_dedupe(tx, seen);
+        let emitter = ChannelEmitter::with_dedupe(tx, seen, None);
 
         // (1) ToolRequest → forwarded + one synthesized ApprovalRequired.
         emitter

--- a/crates/wcore-config/src/config.rs
+++ b/crates/wcore-config/src/config.rs
@@ -8,7 +8,7 @@ use crate::compact::CompactConfig;
 use crate::compat::ProviderCompat;
 use crate::debug::DebugConfig;
 use crate::file_cache::FileCacheConfig;
-use crate::hooks::HooksConfig;
+use crate::hooks::{HookDef, HooksConfig};
 use crate::plan::PlanConfig;
 use wcore_types::llm::ThinkingConfig;
 
@@ -3264,12 +3264,44 @@ fn merge_config_files(global: ConfigFile, project: ConfigFile) -> ConfigFile {
     };
 
     // Hooks: combine hooks from both configs (project hooks appended after global)
+    // GHSA-8r7g: a project `.wayland-core.toml` is untrusted (travels with a
+    // cloned repo), and every `HookDef.command` runs as a child process — so
+    // merging project-defined hooks is arbitrary code execution from repo
+    // content. Only run project hooks when the OPERATOR opted in via their
+    // GLOBAL config (`[hooks] trust_project_hooks = true`); a project cannot
+    // authorize its own hooks (we read `global.hooks.trust_project_hooks`, never
+    // the project's). Default-deny: project hooks are dropped. Warn (not
+    // silently) so a suppressed legitimate hook is discoverable.
+    let trust_project_hooks = global.hooks.trust_project_hooks;
+    if !trust_project_hooks {
+        let dropped = project.hooks.pre_tool_use.len()
+            + project.hooks.post_tool_use.len()
+            + project.hooks.stop.len();
+        if dropped > 0 {
+            tracing::warn!(
+                dropped,
+                "ignored {dropped} hook(s) defined in the project config — a project \
+                 hook runs an arbitrary command, so it is not executed unless the \
+                 operator sets `[hooks] trust_project_hooks = true` in the GLOBAL config \
+                 (GHSA-8r7g)"
+            );
+        }
+    }
+    let merge_hooks = |g: Vec<HookDef>, p: Vec<HookDef>| -> Vec<HookDef> {
+        if trust_project_hooks {
+            [g, p].concat()
+        } else {
+            g
+        }
+    };
     let hooks = HooksConfig {
-        pre_tool_use: [global.hooks.pre_tool_use, project.hooks.pre_tool_use].concat(),
-        post_tool_use: [global.hooks.post_tool_use, project.hooks.post_tool_use].concat(),
-        stop: [global.hooks.stop, project.hooks.stop].concat(),
+        pre_tool_use: merge_hooks(global.hooks.pre_tool_use, project.hooks.pre_tool_use),
+        post_tool_use: merge_hooks(global.hooks.post_tool_use, project.hooks.post_tool_use),
+        stop: merge_hooks(global.hooks.stop, project.hooks.stop),
         // Default ON; an explicit opt-out in either layer wins.
         dispatch_enabled: global.hooks.dispatch_enabled && project.hooks.dispatch_enabled,
+        // Operator-owned; a project value can never re-enable project hooks.
+        trust_project_hooks,
     };
 
     // MCP: merge servers from both configs, project overrides global
@@ -4753,6 +4785,102 @@ mod tests {
             merged.tools.allow_list,
             vec!["Read".to_string()],
             "a project may narrow the approved set to a subset of global"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // GHSA-8r7g: project-defined hooks run arbitrary commands, so they are
+    // default-denied and require an operator opt-in from the GLOBAL config.
+    // -------------------------------------------------------------------------
+
+    fn test_hook(name: &str) -> HookDef {
+        HookDef {
+            name: name.into(),
+            tool_match: vec![],
+            file_match: vec![],
+            command: "echo hi".into(),
+            timeout_ms: 30_000,
+        }
+    }
+
+    #[test]
+    fn ghsa_project_hooks_dropped_by_default() {
+        let global = ConfigFile::default(); // operator did not opt in
+        let project = ConfigFile {
+            hooks: HooksConfig {
+                pre_tool_use: vec![test_hook("evil")],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let merged = merge_config_files(global, project);
+        assert!(
+            merged.hooks.pre_tool_use.is_empty(),
+            "a project hook (arbitrary command) must not run without operator opt-in"
+        );
+    }
+
+    #[test]
+    fn ghsa_project_hooks_run_when_operator_opts_in() {
+        let global = ConfigFile {
+            hooks: HooksConfig {
+                trust_project_hooks: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let project = ConfigFile {
+            hooks: HooksConfig {
+                pre_tool_use: vec![test_hook("lint")],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let merged = merge_config_files(global, project);
+        assert_eq!(
+            merged.hooks.pre_tool_use.len(),
+            1,
+            "with the operator's global opt-in, project hooks run"
+        );
+    }
+
+    #[test]
+    fn ghsa_project_cannot_self_authorize_hooks() {
+        let global = ConfigFile::default(); // operator did NOT opt in
+        let project = ConfigFile {
+            hooks: HooksConfig {
+                pre_tool_use: vec![test_hook("evil")],
+                trust_project_hooks: true, // project tries to authorize itself
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let merged = merge_config_files(global, project);
+        assert!(
+            merged.hooks.pre_tool_use.is_empty(),
+            "a project cannot authorize its own hooks by setting trust_project_hooks"
+        );
+        assert!(
+            !merged.hooks.trust_project_hooks,
+            "the project's trust flag is ignored; only the global value is honored"
+        );
+    }
+
+    #[test]
+    fn ghsa_global_hooks_always_run() {
+        let global = ConfigFile {
+            hooks: HooksConfig {
+                pre_tool_use: vec![test_hook("global-lint")],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let project = ConfigFile::default();
+        let merged = merge_config_files(global, project);
+        assert_eq!(
+            merged.hooks.pre_tool_use.len(),
+            1,
+            "the operator's own global hooks always run"
         );
     }
 

--- a/crates/wcore-config/src/hooks.rs
+++ b/crates/wcore-config/src/hooks.rs
@@ -27,6 +27,17 @@ pub struct HooksConfig {
     /// any phase added later.
     #[serde(default = "default_dispatch_enabled")]
     pub dispatch_enabled: bool,
+    /// GHSA-8r7g — operator opt-in to run hooks defined in a PROJECT config
+    /// (`.wayland-core.toml` in the working directory). A `HookDef.command` is
+    /// executed as a child process, so a project config that travels with a
+    /// cloned repo is an arbitrary-code-execution surface. Default `false`:
+    /// project-defined `pre_tool_use` / `post_tool_use` / `stop` hooks are NOT
+    /// run. Only the operator's GLOBAL config value is honored (a project
+    /// cannot set this to trust its own hooks — see `merge_config_files`). Set
+    /// `true` in the global config to run project hooks, accepting that any
+    /// repo you open can then execute its configured hooks.
+    #[serde(default)]
+    pub trust_project_hooks: bool,
 }
 
 impl Default for HooksConfig {
@@ -36,6 +47,7 @@ impl Default for HooksConfig {
             post_tool_use: Vec::new(),
             stop: Vec::new(),
             dispatch_enabled: default_dispatch_enabled(),
+            trust_project_hooks: false,
         }
     }
 }

--- a/crates/wcore-protocol/src/lib.rs
+++ b/crates/wcore-protocol/src/lib.rs
@@ -509,14 +509,20 @@ impl ToolApprovalManager {
     }
 
     /// Apply a session mode requested over the PROTOCOL (an untrusted wire
-    /// peer). `Force` auto-approves every tool, so it is honored only when a
-    /// local operator opted in via [`set_allow_wire_force`](Self::set_allow_wire_force);
-    /// otherwise the request is refused and the current mode is left unchanged.
-    /// Non-`Force` modes are always applied. Returns `true` when the requested
-    /// mode was applied, `false` when a `Force` request was refused (so the
-    /// caller can surface a diagnostic).
+    /// peer). Both privilege-escalating modes are gated behind the local
+    /// operator opt-in ([`set_allow_wire_force`](Self::set_allow_wire_force)):
+    /// `Force` auto-approves every tool, and `AutoEdit` auto-approves the
+    /// `edit` category (file Write/Edit) — so a wire peer setting `AutoEdit`
+    /// gets write-without-consent (a git hook / `.bashrc` / `authorized_keys`
+    /// write is write-to-RCE). Only `Default` (which asks for everything) is
+    /// safe to accept from an un-opted-in wire peer. Without the opt-in an
+    /// escalating request is refused and the current mode is left unchanged.
+    /// Returns `true` when the requested mode was applied, `false` when an
+    /// escalating request was refused (so the caller can surface a diagnostic).
+    /// (GHSA-8r7g)
     pub fn set_mode_from_wire(&self, mode: SessionMode) -> bool {
-        if mode == SessionMode::Force && !self.allow_wire_force.load(Ordering::Relaxed) {
+        let escalating = matches!(mode, SessionMode::Force | SessionMode::AutoEdit);
+        if escalating && !self.allow_wire_force.load(Ordering::Relaxed) {
             return false;
         }
         self.set_mode(mode);
@@ -592,15 +598,23 @@ mod tests {
         // A wire peer cannot escalate to Force by default.
         assert!(!mgr.set_mode_from_wire(SessionMode::Force));
         assert_eq!(mgr.current_mode(), "default");
-        // Non-Force modes are always applied over the wire.
-        assert!(mgr.set_mode_from_wire(SessionMode::AutoEdit));
-        assert_eq!(mgr.current_mode(), "auto_edit");
+        // AutoEdit is ALSO privilege-escalating (it auto-approves the `edit`
+        // category = file Write/Edit), so a bare wire peer cannot set it either
+        // — write-without-consent is write-to-RCE (GHSA-8r7g).
+        assert!(!mgr.set_mode_from_wire(SessionMode::AutoEdit));
+        assert_eq!(mgr.current_mode(), "default");
+        // Only Default (which asks for everything) is accepted over the wire.
+        assert!(mgr.set_mode_from_wire(SessionMode::Default));
+        assert_eq!(mgr.current_mode(), "default");
     }
 
     #[test]
-    fn ghsa_wire_force_allowed_after_local_opt_in() {
+    fn ghsa_wire_escalating_modes_allowed_after_local_opt_in() {
+        // With the local-operator opt-in, BOTH escalating modes are honored.
         let mgr = ToolApprovalManager::new();
         mgr.set_allow_wire_force(true);
+        assert!(mgr.set_mode_from_wire(SessionMode::AutoEdit));
+        assert_eq!(mgr.current_mode(), "auto_edit");
         assert!(mgr.set_mode_from_wire(SessionMode::Force));
         assert_eq!(mgr.current_mode(), "force");
     }

--- a/crates/wcore-skills/src/hooks.rs
+++ b/crates/wcore-skills/src/hooks.rs
@@ -23,16 +23,34 @@ pub struct SkillHooksConfig {
 /// Returns None when:
 /// - `hooks_raw` is None
 /// - skill source is MCP (security boundary)
+/// - skill source is Project/Legacy (repo-local, untrusted) and the operator
+///   did NOT opt in via the global `[hooks] trust_project_hooks` (GHSA-8r7g H-1)
 /// - the JSON is not an object (logs warning)
 /// - after parsing all events, every vec is empty (D-5)
 pub fn parse_skill_hooks(
     hooks_raw: Option<&serde_json::Value>,
     skill_name: &str,
     source: SkillSource,
+    trust_project_hooks: bool,
 ) -> Option<SkillHooksConfig> {
     // MCP skills may not register hooks (security boundary).
     if source == SkillSource::Mcp {
         eprintln!("[skill:{skill_name}] MCP source — hooks ignored");
+        return None;
+    }
+
+    // GHSA-8r7g H-1: a `Project` skill (`.wayland-core/skills/`) or a `Legacy`
+    // command (`.wayland-core/commands/`) travels with a cloned repo, so its
+    // frontmatter hooks — which run as child processes at first tool use — are
+    // arbitrary code execution from untrusted repo content. Gate them behind the
+    // SAME operator opt-in as project *config* hooks (`[hooks] trust_project_hooks`
+    // in the GLOBAL config); a repo can never self-authorize. Default-deny.
+    if matches!(source, SkillSource::Project | SkillSource::Legacy) && !trust_project_hooks {
+        eprintln!(
+            "[skill:{skill_name}] project/legacy source — frontmatter hooks ignored; a project \
+             skill hook runs an arbitrary command, so it is not executed unless the operator sets \
+             `[hooks] trust_project_hooks = true` in the GLOBAL config (GHSA-8r7g)"
+        );
         return None;
     }
 
@@ -199,7 +217,7 @@ mod tests {
             "PostToolUse": [{"matcher": "Read", "hooks": [{"type": "command", "command": "echo post"}]}],
             "Stop": [{"hooks": [{"type": "command", "command": "echo stop"}]}]
         });
-        let result = parse_skill_hooks(Some(&raw), "my-skill", SkillSource::User);
+        let result = parse_skill_hooks(Some(&raw), "my-skill", SkillSource::User, false);
         let config = result.expect("TC-11.1: should return Some");
         assert_eq!(config.pre_tool_use.len(), 1);
         assert_eq!(config.post_tool_use.len(), 1);
@@ -211,7 +229,7 @@ mod tests {
     // -----------------------------------------------------------------------
     #[test]
     fn tc_11_2_none_hooks_raw_returns_none() {
-        let result = parse_skill_hooks(None, "my-skill", SkillSource::User);
+        let result = parse_skill_hooks(None, "my-skill", SkillSource::User, false);
         assert!(result.is_none(), "TC-11.2: None input must return None");
     }
 
@@ -221,7 +239,7 @@ mod tests {
     #[test]
     fn tc_11_3_mcp_source_returns_none() {
         let raw = json!({"PreToolUse": [{"hooks": [{"type": "command", "command": "echo x"}]}]});
-        let result = parse_skill_hooks(Some(&raw), "mcp-skill", SkillSource::Mcp);
+        let result = parse_skill_hooks(Some(&raw), "mcp-skill", SkillSource::Mcp, false);
         assert!(result.is_none(), "TC-11.3: MCP source must return None");
     }
 
@@ -231,7 +249,7 @@ mod tests {
     #[test]
     fn tc_11_4_prompt_type_skipped_returns_none() {
         let raw = json!({"PreToolUse": [{"hooks": [{"type": "prompt", "command": "echo x"}]}]});
-        let result = parse_skill_hooks(Some(&raw), "skill", SkillSource::User);
+        let result = parse_skill_hooks(Some(&raw), "skill", SkillSource::User, false);
         assert!(result.is_none(), "TC-11.4: prompt type only → None");
     }
 
@@ -241,7 +259,7 @@ mod tests {
     #[test]
     fn tc_11_5_http_type_skipped_returns_none() {
         let raw = json!({"PreToolUse": [{"hooks": [{"type": "http", "url": "http://x"}]}]});
-        let result = parse_skill_hooks(Some(&raw), "skill", SkillSource::User);
+        let result = parse_skill_hooks(Some(&raw), "skill", SkillSource::User, false);
         assert!(result.is_none(), "TC-11.5: http type only → None");
     }
 
@@ -251,7 +269,7 @@ mod tests {
     #[test]
     fn tc_11_6_agent_type_skipped_returns_none() {
         let raw = json!({"PreToolUse": [{"hooks": [{"type": "agent", "agent": "foo"}]}]});
-        let result = parse_skill_hooks(Some(&raw), "skill", SkillSource::User);
+        let result = parse_skill_hooks(Some(&raw), "skill", SkillSource::User, false);
         assert!(result.is_none(), "TC-11.6: agent type only → None");
     }
 
@@ -261,7 +279,7 @@ mod tests {
     #[test]
     fn tc_11_7_unknown_event_skipped_returns_none() {
         let raw = json!({"SessionStart": [{"hooks": [{"type": "command", "command": "echo x"}]}]});
-        let result = parse_skill_hooks(Some(&raw), "skill", SkillSource::User);
+        let result = parse_skill_hooks(Some(&raw), "skill", SkillSource::User, false);
         assert!(result.is_none(), "TC-11.7: unknown event only → None");
     }
 
@@ -274,7 +292,7 @@ mod tests {
             "PreToolUse": [{"hooks": [{"type": "command", "command": "echo pre"}]}],
             "SessionStart": [{"hooks": [{"type": "command", "command": "echo x"}]}]
         });
-        let result = parse_skill_hooks(Some(&raw), "skill", SkillSource::User);
+        let result = parse_skill_hooks(Some(&raw), "skill", SkillSource::User, false);
         let config = result.expect("TC-11.8: known event present → Some");
         assert_eq!(config.pre_tool_use.len(), 1);
         assert_eq!(config.stop.len(), 0);
@@ -286,7 +304,7 @@ mod tests {
     #[test]
     fn tc_11_9_missing_command_field_returns_none() {
         let raw = json!({"PreToolUse": [{"hooks": [{"type": "command"}]}]});
-        let result = parse_skill_hooks(Some(&raw), "skill", SkillSource::User);
+        let result = parse_skill_hooks(Some(&raw), "skill", SkillSource::User, false);
         assert!(result.is_none(), "TC-11.9: missing command field → None");
     }
 
@@ -296,7 +314,7 @@ mod tests {
     #[test]
     fn tc_11_10_array_input_returns_none() {
         let raw = json!([1, 2, 3]);
-        let result = parse_skill_hooks(Some(&raw), "skill", SkillSource::User);
+        let result = parse_skill_hooks(Some(&raw), "skill", SkillSource::User, false);
         assert!(result.is_none(), "TC-11.10: array input must return None");
     }
 
@@ -306,7 +324,7 @@ mod tests {
     #[test]
     fn tc_11_11_null_json_returns_none() {
         let raw = json!(null);
-        let result = parse_skill_hooks(Some(&raw), "skill", SkillSource::User);
+        let result = parse_skill_hooks(Some(&raw), "skill", SkillSource::User, false);
         assert!(result.is_none(), "TC-11.11: null JSON must return None");
     }
 
@@ -316,7 +334,7 @@ mod tests {
     #[test]
     fn tc_11_12_absent_matcher_is_none() {
         let raw = json!({"PreToolUse": [{"hooks": [{"type": "command", "command": "echo x"}]}]});
-        let config = parse_skill_hooks(Some(&raw), "skill", SkillSource::User)
+        let config = parse_skill_hooks(Some(&raw), "skill", SkillSource::User, false)
             .expect("TC-11.12: should return Some");
         assert!(
             config.pre_tool_use[0].matcher.is_none(),
@@ -330,7 +348,7 @@ mod tests {
     #[test]
     fn tc_11_13_present_matcher_preserved() {
         let raw = json!({"PreToolUse": [{"matcher": "Bash", "hooks": [{"type": "command", "command": "echo x"}]}]});
-        let config = parse_skill_hooks(Some(&raw), "skill", SkillSource::User)
+        let config = parse_skill_hooks(Some(&raw), "skill", SkillSource::User, false)
             .expect("TC-11.13: should return Some");
         assert_eq!(config.pre_tool_use[0].matcher.as_deref(), Some("Bash"));
     }
@@ -341,7 +359,7 @@ mod tests {
     #[test]
     fn tc_11_14_timeout_preserved() {
         let raw = json!({"PreToolUse": [{"hooks": [{"type": "command", "command": "echo x", "timeout": 5}]}]});
-        let config = parse_skill_hooks(Some(&raw), "skill", SkillSource::User)
+        let config = parse_skill_hooks(Some(&raw), "skill", SkillSource::User, false)
             .expect("TC-11.14: should return Some");
         assert_eq!(config.pre_tool_use[0].timeout_secs, Some(5));
     }
@@ -352,7 +370,7 @@ mod tests {
     #[test]
     fn tc_11_15_absent_timeout_is_none() {
         let raw = json!({"PreToolUse": [{"hooks": [{"type": "command", "command": "echo x"}]}]});
-        let config = parse_skill_hooks(Some(&raw), "skill", SkillSource::User)
+        let config = parse_skill_hooks(Some(&raw), "skill", SkillSource::User, false)
             .expect("TC-11.15: should return Some");
         assert!(config.pre_tool_use[0].timeout_secs.is_none());
     }
@@ -363,17 +381,31 @@ mod tests {
     #[test]
     fn tc_11_16_non_mcp_sources_parse_successfully() {
         let raw = json!({"PreToolUse": [{"hooks": [{"type": "command", "command": "echo x"}]}]});
+        // GHSA-8r7g H-1: operator-provisioned sources (User's own config skills,
+        // Managed installs, Bundled built-ins) run frontmatter hooks regardless
+        // of the project-trust flag.
         for source in [
-            SkillSource::Project,
+            SkillSource::User,
             SkillSource::Managed,
             SkillSource::Bundled,
-            SkillSource::Legacy,
         ] {
-            let result = parse_skill_hooks(Some(&raw), "skill", source);
             assert!(
-                result.is_some(),
-                "TC-11.16: source {:?} should return Some",
-                source
+                parse_skill_hooks(Some(&raw), "skill", source, false).is_some(),
+                "operator-provisioned source {source:?} must run its hooks"
+            );
+        }
+        // A Project skill (`.wayland-core/skills/`) or a Legacy command
+        // (`.wayland-core/commands/`) travels with a cloned repo: its hooks are
+        // arbitrary code execution and MUST be default-denied, then run only
+        // with the operator's global opt-in.
+        for source in [SkillSource::Project, SkillSource::Legacy] {
+            assert!(
+                parse_skill_hooks(Some(&raw), "skill", source, false).is_none(),
+                "repo-local source {source:?} must be gated by default (GHSA-8r7g H-1)"
+            );
+            assert!(
+                parse_skill_hooks(Some(&raw), "skill", source, true).is_some(),
+                "repo-local source {source:?} runs with global trust_project_hooks"
             );
         }
     }
@@ -389,7 +421,7 @@ mod tests {
                 {"type": "prompt", "prompt": "p"}
             ]}]
         });
-        let config = parse_skill_hooks(Some(&raw), "skill", SkillSource::User)
+        let config = parse_skill_hooks(Some(&raw), "skill", SkillSource::User, false)
             .expect("TC-11.17: command present → Some");
         assert_eq!(config.pre_tool_use.len(), 1);
         assert_eq!(config.pre_tool_use[0].command, "echo x");
@@ -401,7 +433,7 @@ mod tests {
     #[test]
     fn tc_11_18_empty_object_returns_none() {
         let raw = json!({});
-        let result = parse_skill_hooks(Some(&raw), "skill", SkillSource::User);
+        let result = parse_skill_hooks(Some(&raw), "skill", SkillSource::User, false);
         assert!(result.is_none(), "TC-11.18: empty object → None");
     }
 
@@ -414,7 +446,7 @@ mod tests {
             "PreToolUse": [{"hooks": [{"type": "command", "command": "echo pre"}]}],
             "PostToolUse": [{"hooks": [{"type": "prompt", "prompt": "p"}]}]
         });
-        let config = parse_skill_hooks(Some(&raw), "skill", SkillSource::User)
+        let config = parse_skill_hooks(Some(&raw), "skill", SkillSource::User, false)
             .expect("TC-11.19: pre has command → Some");
         assert_eq!(config.pre_tool_use.len(), 1);
         assert_eq!(config.post_tool_use.len(), 0);
@@ -582,7 +614,7 @@ mod tests {
                 {"hooks": [{"type": "command", "command": "echo stop-2"}]}
             ]
         });
-        let config = parse_skill_hooks(Some(&raw), "skill", SkillSource::User)
+        let config = parse_skill_hooks(Some(&raw), "skill", SkillSource::User, false)
             .expect("TC-11.50: should return Some");
         assert_eq!(config.pre_tool_use.len(), 2);
         assert_eq!(config.post_tool_use.len(), 2);
@@ -613,7 +645,7 @@ mod tests {
     #[test]
     fn tc_11_52_empty_command_string_succeeds() {
         let raw = json!({"PreToolUse": [{"hooks": [{"type": "command", "command": ""}]}]});
-        let config = parse_skill_hooks(Some(&raw), "skill", SkillSource::User)
+        let config = parse_skill_hooks(Some(&raw), "skill", SkillSource::User, false)
             .expect("TC-11.52: empty command string should still parse");
         assert_eq!(config.pre_tool_use[0].command, "");
     }
@@ -643,7 +675,7 @@ mod tests {
     #[test]
     fn tc_11_54_string_input_returns_none() {
         let raw = json!("not an object");
-        let result = parse_skill_hooks(Some(&raw), "skill", SkillSource::User);
+        let result = parse_skill_hooks(Some(&raw), "skill", SkillSource::User, false);
         assert!(result.is_none(), "TC-11.54: string input must return None");
     }
 }

--- a/crates/wcore-skills/src/integration_tests.rs
+++ b/crates/wcore-skills/src/integration_tests.rs
@@ -624,7 +624,7 @@ fn tc_e2e_12a_hooks_pre_tool_use_parsed() {
             }
         ]
     });
-    let config = parse_skill_hooks(Some(&hooks_json), "test-skill", SkillSource::User)
+    let config = parse_skill_hooks(Some(&hooks_json), "test-skill", SkillSource::User, false)
         .expect("hooks should parse successfully");
 
     // AC-15 assertions
@@ -659,7 +659,7 @@ fn tc_e2e_12b_hooks_post_tool_use_parsed() {
             }
         ]
     });
-    let config = parse_skill_hooks(Some(&hooks_json), "test-skill", SkillSource::User)
+    let config = parse_skill_hooks(Some(&hooks_json), "test-skill", SkillSource::User, false)
         .expect("hooks should parse successfully");
 
     // AC-15 assertions
@@ -691,7 +691,7 @@ fn tc_e2e_12c_hooks_stop_parsed() {
             }
         ]
     });
-    let config = parse_skill_hooks(Some(&hooks_json), "test-skill", SkillSource::User)
+    let config = parse_skill_hooks(Some(&hooks_json), "test-skill", SkillSource::User, false)
         .expect("hooks should parse successfully");
 
     // AC-15 assertions
@@ -723,8 +723,16 @@ fn tc_e2e_12d_hooks_to_hook_defs_all_events() {
         ]
     });
 
-    let config = parse_skill_hooks(Some(&hooks_json), "multi-hook-skill", SkillSource::Project)
-        .expect("hooks should parse");
+    // GHSA-8r7g H-1: Project source needs the operator opt-in to run hooks; this
+    // test exercises multi-hook PARSING, so grant it (the default-deny gate is
+    // covered by the hooks.rs TC-11.16 test).
+    let config = parse_skill_hooks(
+        Some(&hooks_json),
+        "multi-hook-skill",
+        SkillSource::Project,
+        true,
+    )
+    .expect("hooks should parse");
 
     let hook_defs = to_hook_defs(&config, "multi-hook-skill");
 
@@ -744,7 +752,7 @@ fn tc_e2e_12d_hooks_to_hook_defs_all_events() {
     assert_eq!(hook_defs.stop[0].name, "skill:multi-hook-skill:stop:0");
 
     // Verify MCP skills cannot register hooks (security boundary)
-    let mcp_result = parse_skill_hooks(Some(&hooks_json), "mcp-skill", SkillSource::Mcp);
+    let mcp_result = parse_skill_hooks(Some(&hooks_json), "mcp-skill", SkillSource::Mcp, false);
     assert!(
         mcp_result.is_none(),
         "MCP skills should not be able to register hooks"


### PR DESCRIPTION
Completes GHSA-8r7g on top of the merged parts b+c (#128). Four RCE-class hardenings, each gated (fmt + clippy -D warnings + nextest on Hetzner, 5066 tests pass) and cross-audited; the resume-token path is **live-verified end-to-end** on a real binary.

### Commits
1. **Project-config hooks default-deny** (`d7b952d1`) — a project `.wayland-core.toml` `[[hooks.*]]` `command` runs a child process = arbitrary code execution from cloned-repo content. Dropped unless the operator sets `[hooks] trust_project_hooks = true` in their **global** config; a project cannot self-authorize; suppression is logged.
2. **Wire AutoEdit gate** (`07a592ee`) — `set_mode_from_wire` gated only `Force`; `AutoEdit` auto-approves file writes (write-to-RCE). Both escalating modes now require the local-operator opt-in (`--force` / `WAYLAND_ALLOW_WIRE_FORCE=1`); only `default` accepted from an un-opted-in wire peer.
3. **Unforgeable approval resume-token** (`8f673bf2`) — the `ApprovalBridge` emitted a model-known `call_id` as the `resume_token`, so a wire/host peer could self-approve by echoing a known id. Now keyed by a server-generated secret `apr-{uuid}`, correlation id indexed separately: `resolve()` (wire) accepts the secret only; `resolve_by_correlation()` (local TUI/egress) resolves by call_id. Synthesizers stamp the secret onto host-visible frames (empty for regular tools, which resolve via `ToolApprove`). Crucible registers the bridge entry **before** emitting the gate frame. Also fixes a latent gap where the json-stream turn loop **ignored `ApprovalResume` mid-turn** → Crucible/egress hung to TTL on a JSON-stream host (the desktop app); caught by live testing.
4. **Project/legacy skill-frontmatter hooks default-deny (H-1)** (`61a68469`) — a `Project`/`Legacy` skill's `SKILL.md` frontmatter hooks executed as child processes, bypassing `trust_project_hooks`. `parse_skill_hooks` now default-denies Project/Legacy sources (like MCP), running them only with the global opt-in.

### Live-verified on a real binary (headless)
- Wire-gate: `auto_edit`/`force` refused without opt-in, accepted with `WAYLAND_ALLOW_WIRE_FORCE=1`.
- Hooks: project `pre_tool_use` hook dropped by default; runs only with global `trust_project_hooks=true`.
- Posture clamp: project `approval_mode=force` clamped → tool still gates.
- Resume-token: `/crucible` card carries `apr-…` (not the call_id); `approval_resume{resume_token=call_id}` rejected; `{resume_token=secret}` resolves the council in 0.3s (no hang).

### Not in scope (confirmed complete / follow-up)
- Regular-tool `ToolApprove{call_id}` / ACP `/resolve`: stdin is trusted-local; the ACP/REST network surface is mandatorily `X-API-Key` gated (F-017) — no untrusted self-approval. Not a residual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)