### PR TITLE
fix(npm): staleness self-heal in the npx launcher + pin doc specs (#126)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Most agents are frozen the day you install them, and married to one model. Wayla
 ## The 30-second proof
 
 ```bash
-npx @ferroxlabs/wayland-core "read Cargo.toml, list the workspace crates, and explain the dependency layering"
+npx @ferroxlabs/wayland-core@latest "read Cargo.toml, list the workspace crates, and explain the dependency layering"
 ```
 
 One command. The agent reads the file, runs `grep`/`glob` across the tree, reasons, and answers, with every tool call gated and streamed. Or run `wayland-core` with no arguments and it detects your provider keys and drops you into the TUI:
@@ -61,7 +61,7 @@ wayland-core --version
 
 ```bash
 # or run it once, no install
-npx @ferroxlabs/wayland-core "summarize the TODOs in this repo and draft a triage plan"
+npx @ferroxlabs/wayland-core@latest "summarize the TODOs in this repo and draft a triage plan"
 ```
 
 **Prebuilt binaries** for macOS (arm64/x64), Linux (arm64/x64), and Windows (arm64/x64) are on the [Releases](https://github.com/FerroxLabs/wayland-core/releases) page, each verifiable against `wayland-core-checksums.txt`.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -9,7 +9,7 @@ npm install -g @ferroxlabs/wayland-core
 wayland-core --version
 
 # or run it once with no install
-npx @ferroxlabs/wayland-core "summarize the TODOs in this repo"
+npx @ferroxlabs/wayland-core@latest "summarize the TODOs in this repo"
 ```
 
 **Prebuilt signed binaries** for macOS (arm64/x64), Linux (arm64/x64), and

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,5 +1,34 @@
 # Troubleshooting
 
+## Stale Engine via npx (already-fixed bugs reappear)
+
+```
+API error 400: ... tools[0].function.name ...   # or any bug fixed releases ago
+```
+
+If you launch the engine with `npx @ferroxlabs/wayland-core` (or `@latest`),
+npx caches the resolved package **by spec string** and never re-queries the
+registry (npm/cli#2329) — the box freezes on whatever `latest` was the *first*
+time you ran it. Check with:
+
+```bash
+npx @ferroxlabs/wayland-core --version   # what you're actually running
+npm view @ferroxlabs/wayland-core version  # what's actually latest
+```
+
+Only an **exact-version** spec is a guaranteed cache miss:
+
+```bash
+npx @ferroxlabs/wayland-core@<latest-version> ...
+# or install globally and stop depending on the npx cache:
+npm i -g @ferroxlabs/wayland-core@latest
+```
+
+The launcher also self-heals: it checks the registry in the background (at
+most once a day, never blocking a launch) and prints a warning with the exact
+pinned command when the cached engine is behind. Opt out with
+`WAYLAND_CORE_SKIP_UPDATE_CHECK=1`.
+
 ## API Key Not Configured
 
 ```

--- a/npm/README.md
+++ b/npm/README.md
@@ -8,7 +8,7 @@ ship the right platform binary with zero friction:
 - **Wayland desktop** (Electron) resolves it from `node_modules` in
   `app/scripts/prepareWaylandCore.js` (the script's documented path 0) instead
   of hand-placing or downloading-by-tag.
-- **End users** can `npx @ferroxlabs/wayland-core …` or `npm i -g`.
+- **End users** can `npx @ferroxlabs/wayland-core@latest …` or `npm i -g`.
 
 ## Layout — launcher + per-platform packages (the esbuild/Biome pattern)
 
@@ -31,6 +31,28 @@ the same key the desktop uses for `bundled-wayland-core/<key>/`.
 
 > **Linux is glibc** (`*-unknown-linux-gnu`), matching the desktop's
 > AppImage/deb/rpm targets and AionCLI's (non-Docker) audience. No musl.
+
+## Staleness self-heal (the npx cache trap, #126)
+
+npx caches the resolved tree by **spec string** and never re-queries the
+registry for an unpinned / `@latest` spec (npm/cli#2329) — a box that once ran
+`npx @ferroxlabs/wayland-core` freezes on that first-resolved version forever.
+The bin shim (`bin/wayland-core.js`) therefore ships a deliberately minimal
+self-heal (`bin/stale-check.js`):
+
+- on launch it reads a cached state file
+  (`$WAYLAND_HOME/npx-update-check.json`, default `~/.wayland/`) and, if the
+  running version is behind the registry's `latest`, prints a stderr warning
+  with the **exact-version** `npx` command (an exact spec is the only
+  guaranteed cache miss);
+- it refreshes that state in a **detached background process** (5s fetch
+  timeout), at most once per 24h — a launch is never blocked and never fails
+  because of the check;
+- warning and registry query are throttled to once per 24h; every path is
+  fail-safe (any error → no warning, launch proceeds);
+- opt out with `WAYLAND_CORE_SKIP_UPDATE_CHECK=1`; skipped automatically when
+  `CI` is set. Hosts that spawn via `binaryPath()` bypass the shim and are
+  unaffected.
 
 ## How consumers use it
 

--- a/npm/generate.mjs
+++ b/npm/generate.mjs
@@ -163,6 +163,7 @@ const BIN_JS = `#!/usr/bin/env node
 // binary directly instead of going through this shim.
 const { spawnSync } = require("node:child_process");
 const { binaryPath } = require("../index.js");
+const staleCheck = require("./stale-check.js");
 
 let bin;
 try {
@@ -172,12 +173,168 @@ try {
   process.exit(1);
 }
 
+// npx caches this package by SPEC STRING and never re-queries the registry for
+// an unpinned / @latest spec, so a box can silently freeze on an old engine
+// forever (#126). Warn from cached state (never block, never fail the launch)
+// and refresh that state in a detached background process at most once a day.
+try {
+  staleCheck.warnIfStale();
+} catch (_e) {
+  // fail-safe: the update check must never break a launch
+}
+
 const result = spawnSync(bin, process.argv.slice(2), { stdio: "inherit" });
 if (result.error) {
   console.error("wayland-core: failed to launch: " + result.error.message);
   process.exit(1);
 }
 process.exit(result.status === null ? 1 : result.status);
+`;
+
+const STALE_CHECK_JS = `"use strict";
+// Staleness self-heal for the npx launcher (#126). npx caches the resolved
+// package tree by SPEC STRING and does not reliably re-query the registry even
+// for \`@latest\` (npm/cli#2329, npm/cli#7838, npm/rfcs#700), so a machine that
+// once ran \`npx ${LAUNCHER}\` stays frozen on whatever \`latest\`
+// was at first run — users keep hitting bugs the current engine already fixed.
+// Only an EXACT-version spec is a guaranteed cache miss, so the warning below
+// prints one.
+//
+// Design constraints (deliberate — this wraps every user invocation):
+//   - never blocks the launch: the registry query runs in a detached child
+//     that outlives this process; the foreground only reads the cached state
+//   - fail-safe: every path is wrapped; any error means "no warning", never a
+//     broken launch
+//   - throttled: registry queried at most once per CHECK_INTERVAL_MS, warning
+//     printed at most once per WARN_INTERVAL_MS
+//   - opt-out: WAYLAND_CORE_SKIP_UPDATE_CHECK=1; also skipped when CI is set
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const PKG = "${LAUNCHER}";
+const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
+const WARN_INTERVAL_MS = 24 * 60 * 60 * 1000;
+const FETCH_TIMEOUT_MS = 5000;
+
+// Launcher-private state; co-located with the engine's home dir convention
+// (WAYLAND_HOME override honored, matching wcore-config resolution order).
+function stateFile() {
+  const home = process.env.WAYLAND_HOME || path.join(os.homedir(), ".wayland");
+  return path.join(home, "npx-update-check.json");
+}
+
+function readState() {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(stateFile(), "utf8"));
+    return parsed && typeof parsed === "object" ? parsed : {};
+  } catch (_e) {
+    return {};
+  }
+}
+
+function writeState(state) {
+  try {
+    const file = stateFile();
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, JSON.stringify(state));
+  } catch (_e) {
+    // best-effort
+  }
+}
+
+function parseVersion(v) {
+  const m = /^(\\d+)\\.(\\d+)\\.(\\d+)/.exec(String(v || ""));
+  return m ? [Number(m[1]), Number(m[2]), Number(m[3])] : null;
+}
+
+function isBehind(current, latest) {
+  const a = parseVersion(current);
+  const b = parseVersion(latest);
+  if (!a || !b) return false;
+  for (let i = 0; i < 3; i++) {
+    if (a[i] < b[i]) return true;
+    if (a[i] > b[i]) return false;
+  }
+  return false;
+}
+
+function skipped() {
+  return Boolean(process.env.WAYLAND_CORE_SKIP_UPDATE_CHECK || process.env.CI);
+}
+
+/** Foreground half: warn from cached state, kick off a background refresh. */
+function warnIfStale() {
+  if (skipped()) return;
+  let current;
+  try {
+    current = require("../package.json").version;
+  } catch (_e) {
+    return;
+  }
+  const state = readState();
+  const now = Date.now();
+
+  const warnThrottled =
+    typeof state.warnedAt === "number" && now - state.warnedAt < WARN_INTERVAL_MS;
+  if (state.latest && isBehind(current, state.latest) && !warnThrottled) {
+    console.error(
+      "wayland-core: v" + current + " is stale — latest is v" + state.latest + ".\\n" +
+        "  npx caches this package by spec string and never refreshes it; run the\\n" +
+        "  exact version to bust the cache:  npx " + PKG + "@" + state.latest + "\\n" +
+        "  (or: npm i -g " + PKG + "@latest — suppress this check with\\n" +
+        "  WAYLAND_CORE_SKIP_UPDATE_CHECK=1)"
+    );
+    state.warnedAt = now;
+    writeState(state);
+  }
+
+  const checkThrottled =
+    typeof state.checkedAt === "number" && now - state.checkedAt < CHECK_INTERVAL_MS;
+  if (!checkThrottled) {
+    try {
+      const { spawn } = require("node:child_process");
+      const child = spawn(process.execPath, [__filename, "--refresh"], {
+        detached: true,
+        stdio: "ignore",
+        windowsHide: true,
+      });
+      child.unref();
+    } catch (_e) {
+      // best-effort
+    }
+  }
+}
+
+/** Background half: query the registry dist-tags and persist the result. */
+async function refresh() {
+  const state = readState();
+  state.checkedAt = Date.now();
+  try {
+    if (typeof fetch === "function") {
+      const ctl = new AbortController();
+      const timer = setTimeout(() => ctl.abort(), FETCH_TIMEOUT_MS);
+      const res = await fetch(
+        "https://registry.npmjs.org/-/package/" + PKG + "/dist-tags",
+        { signal: ctl.signal, headers: { accept: "application/json" } }
+      );
+      clearTimeout(timer);
+      if (res.ok) {
+        const tags = await res.json();
+        if (tags && parseVersion(tags.latest)) state.latest = tags.latest;
+      }
+    }
+  } catch (_e) {
+    // offline / registry down — keep the previous \`latest\`, still throttle
+  }
+  writeState(state);
+}
+
+module.exports = { warnIfStale };
+
+if (require.main === module && process.argv[2] === "--refresh") {
+  refresh();
+}
 `;
 
 function emitLauncher(out, version, present) {
@@ -205,6 +362,7 @@ function emitLauncher(out, version, present) {
   mkdirSync(dirname(binPath), { recursive: true });
   writeFileSync(binPath, BIN_JS);
   chmodSync(binPath, 0o755);
+  writeFileSync(join(dir, "bin", "stale-check.js"), STALE_CHECK_JS);
   writeFileSync(join(dir, "index.js"), INDEX_JS);
 
   if (present.length !== TARGETS.length) {

--- a/npm/generate.mjs
+++ b/npm/generate.mjs
@@ -163,7 +163,15 @@ const BIN_JS = `#!/usr/bin/env node
 // binary directly instead of going through this shim.
 const { spawnSync } = require("node:child_process");
 const { binaryPath } = require("../index.js");
-const staleCheck = require("./stale-check.js");
+
+// Belt-and-suspenders: a load-time failure in the self-heal module must never
+// take the launcher down with it.
+let staleCheck = { warnIfStale() {} };
+try {
+  staleCheck = require("./stale-check.js");
+} catch (_e) {
+  // fail-safe: launch without the update check
+}
 
 let bin;
 try {
@@ -237,10 +245,22 @@ function writeState(state) {
   try {
     const file = stateFile();
     fs.mkdirSync(path.dirname(file), { recursive: true });
-    fs.writeFileSync(file, JSON.stringify(state));
+    // temp-file + rename: concurrent launches must never leave a torn file
+    const tmp = file + "." + process.pid + ".tmp";
+    fs.writeFileSync(tmp, JSON.stringify(state));
+    fs.renameSync(tmp, file);
   } catch (_e) {
     // best-effort
   }
+}
+
+// STRICT full-match, stable-only. The registry response (and the state file it
+// is persisted to) is UNTRUSTED: a loose prefix match would let a compromised
+// response smuggle ANSI escapes or an attacker-controlled command string into
+// the printed "run this to fix" warning, and a prerelease dist-tag would tell
+// stable users to pin a prerelease. Returns the validated string or null.
+function validStableVersion(v) {
+  return typeof v === "string" && /^\\d+\\.\\d+\\.\\d+$/.test(v) ? v : null;
 }
 
 function parseVersion(v) {
@@ -277,11 +297,13 @@ function warnIfStale() {
 
   const warnThrottled =
     typeof state.warnedAt === "number" && now - state.warnedAt < WARN_INTERVAL_MS;
-  if (state.latest && isBehind(current, state.latest) && !warnThrottled) {
+  // re-validate on READ: the state file is as untrusted as the registry
+  const latest = validStableVersion(state.latest);
+  if (latest && isBehind(current, latest) && !warnThrottled) {
     console.error(
-      "wayland-core: v" + current + " is stale — latest is v" + state.latest + ".\\n" +
+      "wayland-core: v" + current + " is stale — latest is v" + latest + ".\\n" +
         "  npx caches this package by spec string and never refreshes it; run the\\n" +
-        "  exact version to bust the cache:  npx " + PKG + "@" + state.latest + "\\n" +
+        "  exact version to bust the cache:  npx " + PKG + "@" + latest + "\\n" +
         "  (or: npm i -g " + PKG + "@latest — suppress this check with\\n" +
         "  WAYLAND_CORE_SKIP_UPDATE_CHECK=1)"
     );
@@ -310,24 +332,32 @@ function warnIfStale() {
 async function refresh() {
   const state = readState();
   state.checkedAt = Date.now();
+  // Persist the throttle stamp BEFORE the network call: if the fetch hangs or
+  // this process dies, the next launch must still see a fresh checkedAt and
+  // NOT spawn another checker (otherwise a slow registry accumulates orphans).
+  writeState(state);
   try {
-    if (typeof fetch === "function") {
-      const ctl = new AbortController();
-      const timer = setTimeout(() => ctl.abort(), FETCH_TIMEOUT_MS);
-      const res = await fetch(
-        "https://registry.npmjs.org/-/package/" + PKG + "/dist-tags",
-        { signal: ctl.signal, headers: { accept: "application/json" } }
-      );
-      clearTimeout(timer);
-      if (res.ok) {
-        const tags = await res.json();
-        if (tags && parseVersion(tags.latest)) state.latest = tags.latest;
+    if (typeof fetch !== "function") return;
+    // AbortSignal.timeout covers headers AND the body read (a plain
+    // clearTimeout-after-fetch would leave res.json() unbounded against a
+    // trickled body). fetch implies Node >= 18, which has AbortSignal.timeout.
+    const res = await fetch(
+      "https://registry.npmjs.org/-/package/" + PKG + "/dist-tags",
+      {
+        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+        headers: { accept: "application/json" },
       }
+    );
+    if (!res.ok) return;
+    const tags = await res.json();
+    const latest = validStableVersion(tags && tags.latest);
+    if (latest) {
+      state.latest = latest;
+      writeState(state);
     }
   } catch (_e) {
-    // offline / registry down — keep the previous \`latest\`, still throttle
+    // offline / registry down / timeout — keep the previous \`latest\`
   }
-  writeState(state);
 }
 
 module.exports = { warnIfStale };


### PR DESCRIPTION
## Summary

Core-side fix for #126 (Overwatch-elevated): boxes running `npx @ferroxlabs/wayland-core` freeze on whatever `latest` was at first run because npx caches the resolved tree **by spec string** and never re-queries the registry for an unpinned / `@latest` spec (npm/cli#2329, npm/cli#7838, npm/rfcs#700). Latest live recurrence: the DeepSeek `tools[].function.name` 400 — fixed in 0.12.19, still biting a box cached on 0.12.9.

## What this ships

**Launcher self-heal** — new `bin/stale-check.js` emitted by `npm/generate.mjs`, required by the bin shim:
- reads a cached state file (`$WAYLAND_HOME/npx-update-check.json`, default `~/.wayland/`) and warns on stderr when the running version is behind registry `latest`, printing the **exact-version** `npx` command (an exact spec is the only guaranteed npx cache miss)
- refreshes state in a **detached, unref'd background process** (5s fetch timeout) at most once per 24h — a launch is never blocked and never fails because of the check
- warning throttled to once per 24h; every path fail-safe (any error → no warning, launch proceeds)
- opt-out `WAYLAND_CORE_SKIP_UPDATE_CHECK=1`; auto-skipped under `CI`; hosts spawning via `binaryPath()` (desktop) bypass the shim entirely

**Doc pins** — bare `npx @ferroxlabs/wayland-core` → `@latest` in README/getting-started/npm-README (a *different* spec string = at least a one-time cache miss for boxes cached on the bare spec), plus a troubleshooting entry for the stale-npx symptom and design notes in `npm/README.md`.

## Blast radius

This wraps every `npx`/global-install invocation (the elevated reason #126 asked for a deliberate, reviewed design rather than a blind fold-in). Constraints chosen accordingly: non-blocking, fail-safe, throttled, opt-out, and inert for `binaryPath()` hosts.

## Verification (on the generated tree, real registry)

- clean first run: zero stderr noise, engine output byte-identical, detached refresher wrote `{"checkedAt":…,"latest":"0.12.19"}` from the real registry
- stale state (0.12.9 vs 0.12.19): one warning with `npx @ferroxlabs/wayland-core@0.12.19`, engine still ran
- immediate rerun: warning throttled (silent)
- `WAYLAND_CORE_SKIP_UPDATE_CHECK=1` and `CI=1`: silent with warn un-throttled
- `latest == current`: silent
- corrupted state file: no crash, exit 0
- exit-code relay preserved

Remaining halves tracked elsewhere: desktop getwayland postinstall refresh (routed to desktop lane per issue thread) and FerroxLabs/wayland#492 (perMachine EACCES, desktop repo).

Addresses #126 (close is a release/Sean action).

