### PR TITLE
test(providers): #139 universal tool-name round-trip coverage — codec verified already-universal

### DIFF
--- a/crates/wcore-providers/src/deepseek.rs
+++ b/crates/wcore-providers/src/deepseek.rs
@@ -156,9 +156,7 @@ mod tests {
     /// the codec, this test fails.
     #[tokio::test]
     async fn dirty_tool_names_are_encoded_on_the_deepseek_wire() {
-        use wcore_types::llm::Message;
-        use wcore_types::llm::Role;
-        use wcore_types::message::ContentBlock;
+        use wcore_types::message::{ContentBlock, Message, Role};
         use wcore_types::tool::ToolDef;
         use wiremock::matchers::{method, path};
         use wiremock::{Mock, MockServer, ResponseTemplate};

--- a/crates/wcore-providers/src/deepseek.rs
+++ b/crates/wcore-providers/src/deepseek.rs
@@ -148,6 +148,106 @@ mod tests {
         assert!(result.is_err(), "expected error from unreachable host");
     }
 
+    /// #139 escalation pin: the desktop's direct-DeepSeek selection resolves
+    /// THIS provider. Prove the newtype delegation reaches OpenAIProvider's
+    /// ENCODED request build — a dirty `Browser::execute` tool must hit the
+    /// wire as its `wct_`-encoded form, and a clean name byte-identical. If a
+    /// future refactor gives DeepSeekProvider its own body builder without
+    /// the codec, this test fails.
+    #[tokio::test]
+    async fn dirty_tool_names_are_encoded_on_the_deepseek_wire() {
+        use wcore_types::llm::Message;
+        use wcore_types::llm::Role;
+        use wcore_types::message::ContentBlock;
+        use wcore_types::tool::ToolDef;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let sse_body = concat!(
+            "data: {\"id\":\"x\",\"object\":\"chat.completion.chunk\",\"model\":\"m\",",
+            "\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"ok\"},\"finish_reason\":null}]}\n\n",
+            "data: {\"id\":\"x\",\"object\":\"chat.completion.chunk\",\"model\":\"m\",",
+            "\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n",
+            "data: [DONE]\n\n"
+        );
+        Mock::given(method("POST"))
+            .and(path("/v1/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_string(sse_body)
+                    .insert_header("content-type", "text/event-stream"),
+            )
+            .mount(&server)
+            .await;
+
+        let p = DeepSeekProvider::new(
+            "sk-test",
+            &server.uri(),
+            ProviderCompat::default(),
+            DebugConfig::default(),
+        );
+        let req = LlmRequest {
+            model: "deepseek-v4-flash".into(),
+            messages: vec![Message::new(
+                Role::User,
+                vec![ContentBlock::Text { text: "hi".into() }],
+            )],
+            tools: vec![
+                ToolDef {
+                    name: "Browser::execute".into(),
+                    description: "dirty".into(),
+                    input_schema: serde_json::json!({"type":"object","properties":{}}),
+                    deferred: false,
+                    server: None,
+                },
+                ToolDef {
+                    name: "get_weather".into(),
+                    description: "clean".into(),
+                    input_schema: serde_json::json!({"type":"object","properties":{}}),
+                    deferred: false,
+                    server: None,
+                },
+            ],
+            max_tokens: 16,
+            ..Default::default()
+        };
+        let mut rx = p.stream(&req).await.expect("stream ok");
+        while rx.recv().await.is_some() {}
+
+        let reqs = server.received_requests().await.expect("requests recorded");
+        assert_eq!(reqs.len(), 1, "exactly one wire request");
+        let body: serde_json::Value = serde_json::from_slice(&reqs[0].body).expect("json body");
+        let names: Vec<&str> = body["tools"]
+            .as_array()
+            .expect("tools array")
+            .iter()
+            .map(|t| t["function"]["name"].as_str().expect("name"))
+            .collect();
+        let legal = |n: &str| {
+            !n.is_empty()
+                && n.len() <= 64
+                && n.chars()
+                    .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+        };
+        assert!(
+            names.contains(&"wct_Browser_3A_3Aexecute"),
+            "dirty name must be wct_-encoded on the DeepSeek wire, got {names:?}"
+        );
+        assert!(
+            names.contains(&"get_weather"),
+            "clean name must pass through byte-identical, got {names:?}"
+        );
+        assert!(
+            !names.iter().any(|n| n.contains("::") || n.contains('.')),
+            "no raw dirty name may reach the wire: {names:?}"
+        );
+        assert!(
+            names.iter().all(|n| legal(n)),
+            "every wire name must match ^[a-zA-Z0-9_-]{{1,64}}$: {names:?}"
+        );
+    }
+
     #[test]
     fn register_uses_lowercase_id() {
         let mut r = WaylandProviderRegistry::new();

--- a/crates/wcore-providers/src/openai.rs
+++ b/crates/wcore-providers/src/openai.rs
@@ -4388,6 +4388,146 @@ mod tests {
         );
     }
 
+    /// #139: plugin fq_names (`Browser::execute`) must be wire-legal at EVERY
+    /// name-emitting site of the full chat request body — the `tools[]`
+    /// definitions AND replayed assistant-history `tool_calls`. Flux forwards
+    /// both verbatim to strict downstreams (DeepSeek enforces
+    /// `^[a-zA-Z0-9_-]+$` and 400s the whole request), and the engine cannot
+    /// see past Flux to the real downstream, so encoding must be universal.
+    #[test]
+    fn build_request_body_emits_wire_legal_names_everywhere_issue_139() {
+        let raw = "Browser::execute";
+        let mut req = stop_req();
+        req.tools = vec![
+            ToolDef {
+                name: raw.into(),
+                description: "run a browser action".into(),
+                input_schema: json!({"type": "object", "properties": {}}),
+                deferred: false,
+                server: None,
+            },
+            ToolDef {
+                name: "get_weather".into(),
+                description: "w".into(),
+                input_schema: json!({"type": "object", "properties": {}}),
+                deferred: false,
+                server: None,
+            },
+        ];
+        req.messages = vec![
+            Message::new(Role::User, vec![ContentBlock::Text { text: "go".into() }]),
+            Message::new(
+                Role::Assistant,
+                vec![ContentBlock::ToolUse {
+                    id: "tc_1".into(),
+                    name: raw.into(),
+                    input: json!({"cmd": "ls"}),
+                    extra: None,
+                }],
+            ),
+            Message::new(
+                Role::Tool,
+                vec![ContentBlock::ToolResult {
+                    tool_use_id: "tc_1".into(),
+                    content: "ok".into(),
+                    is_error: false,
+                }],
+            ),
+            Message::new(
+                Role::User,
+                vec![ContentBlock::Text {
+                    text: "and?".into(),
+                }],
+            ),
+        ];
+
+        let body = stop_provider().build_request_body(&req);
+        let wire_legal = |s: &str| {
+            !s.is_empty()
+                && s.len() <= 64
+                && s.bytes()
+                    .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_')
+        };
+
+        // Tool definitions: every emitted name satisfies the strict pattern;
+        // the dirty one decodes back to the canonical fq_name.
+        let tools = body["tools"].as_array().expect("tools array");
+        assert_eq!(tools.len(), 2);
+        for t in tools {
+            let name = t["function"]["name"].as_str().unwrap();
+            assert!(
+                wire_legal(name),
+                "illegal tool-def name on the wire: {name}"
+            );
+        }
+        let wire_name = tools[0]["function"]["name"].as_str().unwrap();
+        assert_ne!(wire_name, raw, "fq_name must not leak raw");
+        assert_eq!(decode_tool_name(wire_name), raw);
+        assert_eq!(tools[1]["function"]["name"], json!("get_weather"));
+
+        // Replayed assistant-history tool_calls carry the SAME encoded
+        // spelling (a mismatch would also 400 or desync the transcript).
+        let messages = body["messages"].as_array().expect("messages array");
+        let assistant = messages
+            .iter()
+            .find(|m| m["role"] == "assistant" && m.get("tool_calls").is_some())
+            .expect("assistant tool_calls message survived history lowering");
+        let hist_name = assistant["tool_calls"][0]["function"]["name"]
+            .as_str()
+            .unwrap();
+        assert!(wire_legal(hist_name), "illegal history name: {hist_name}");
+        assert_eq!(hist_name, wire_name, "history and tools[] must agree");
+    }
+
+    /// #139 inbound half of the round-trip: the model calls back with the
+    /// SANITIZED wire name; the chat stream parser must emit
+    /// `LlmEvent::ToolUse` carrying the ORIGINAL registry fq_name, or the
+    /// engine dispatches into a void ("unknown tool").
+    #[test]
+    fn streamed_sanitized_tool_call_dispatches_original_name_issue_139() {
+        let raw = "Browser::execute";
+        let wire = encode_tool_name(raw);
+        assert_ne!(wire, raw, "fixture must actually be encoded");
+
+        let mut state = StreamState::new();
+        let delta = json!({
+            "choices": [{
+                "index": 0,
+                "delta": {
+                    "tool_calls": [{
+                        "index": 0,
+                        "id": "tc_1",
+                        "type": "function",
+                        "function": { "name": wire, "arguments": "{\"cmd\":\"ls\"}" }
+                    }]
+                }
+            }]
+        })
+        .to_string();
+        assert!(
+            parse_sse_chunk(&delta, &mut state).is_empty(),
+            "no events until finish_reason"
+        );
+
+        let finish = json!({
+            "choices": [{ "index": 0, "delta": {}, "finish_reason": "tool_calls" }]
+        })
+        .to_string();
+        let events = parse_sse_chunk(&finish, &mut state);
+        let (name, input) = events
+            .iter()
+            .find_map(|e| match e {
+                LlmEvent::ToolUse { name, input, .. } => Some((name.clone(), input.clone())),
+                _ => None,
+            })
+            .expect("ToolUse event on finish");
+        assert_eq!(
+            name, raw,
+            "inbound tool_call must decode to the canonical fq_name"
+        );
+        assert_eq!(input, json!({"cmd": "ls"}));
+    }
+
     #[test]
     fn test_build_tools_normalizes_bare_object_schema_issue_24() {
         // Built-in and MCP tools that declare no structured args carry a bare

--- a/crates/wcore-providers/src/openai_responses.rs
+++ b/crates/wcore-providers/src/openai_responses.rs
@@ -753,6 +753,125 @@ mod tests {
         assert!(tools[0].get("function").is_none());
     }
 
+    /// #139 (Responses path): plugin fq_names must be wire-legal in the FLAT
+    /// tool definitions AND in replayed history `function_call` items — same
+    /// contract as the chat path, since strict backends enforce
+    /// `^[a-zA-Z0-9_-]+$` on both.
+    #[test]
+    fn build_body_encodes_plugin_fq_tool_names_issue_139() {
+        let raw = "Browser::execute";
+        let request = LlmRequest {
+            model: "gpt-5".into(),
+            system: String::new(),
+            messages: vec![
+                Message::new(
+                    Role::Assistant,
+                    vec![ContentBlock::ToolUse {
+                        id: "call_1".into(),
+                        name: raw.into(),
+                        input: json!({"cmd": "ls"}),
+                        extra: None,
+                    }],
+                ),
+                Message::new(
+                    Role::Tool,
+                    vec![ContentBlock::ToolResult {
+                        tool_use_id: "call_1".into(),
+                        content: "ok".into(),
+                        is_error: false,
+                    }],
+                ),
+            ],
+            max_tokens: 256,
+            tools: vec![
+                ToolDef {
+                    name: raw.into(),
+                    description: "run a browser action".into(),
+                    input_schema: json!({ "type": "object", "properties": {} }),
+                    deferred: false,
+                    server: None,
+                },
+                ToolDef {
+                    name: "get_weather".into(),
+                    description: "w".into(),
+                    input_schema: json!({ "type": "object", "properties": {} }),
+                    deferred: false,
+                    server: None,
+                },
+            ],
+            ..Default::default()
+        };
+        let body = build_responses_body(&request, &ProviderCompat::default());
+        let wire_legal = |s: &str| {
+            !s.is_empty()
+                && s.len() <= 64
+                && s.bytes()
+                    .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_')
+        };
+
+        // FLAT tool defs: every name legal; the dirty one decodes back.
+        let tools = body["tools"].as_array().expect("tools array");
+        assert_eq!(tools.len(), 2);
+        for t in tools {
+            let name = t["name"].as_str().unwrap();
+            assert!(
+                wire_legal(name),
+                "illegal tool-def name on the wire: {name}"
+            );
+        }
+        let wire_name = tools[0]["name"].as_str().unwrap();
+        assert_ne!(wire_name, raw, "fq_name must not leak raw");
+        assert_eq!(decode_tool_name(wire_name), raw);
+        assert_eq!(tools[1]["name"], json!("get_weather"));
+
+        // History function_call items carry the SAME encoded spelling.
+        let input = body["input"].as_array().expect("input array");
+        let call = input
+            .iter()
+            .find(|i| i["type"] == "function_call")
+            .expect("function_call item");
+        assert_eq!(call["name"].as_str().unwrap(), wire_name);
+    }
+
+    /// #139 inbound half on the Responses path: a `function_call` streamed
+    /// under the SANITIZED wire name must surface as `LlmEvent::ToolUse` with
+    /// the ORIGINAL registry fq_name for dispatch.
+    #[test]
+    fn parse_sanitized_tool_call_dispatches_original_name_issue_139() {
+        let raw = "Browser::execute";
+        let wire = encode_tool_name(raw);
+        assert_ne!(wire, raw, "fixture must actually be encoded");
+
+        let mut state = ResponsesStreamState::new();
+        let mut got: Vec<LlmEvent> = Vec::new();
+        let frames = [
+            format!(
+                r#"{{"type":"response.output_item.added","item":{{"type":"function_call","call_id":"call_1","name":"{wire}","arguments":""}}}}"#
+            ),
+            r#"{"type":"response.function_call_arguments.delta","delta":"{\"cmd\":\"ls\"}"}"#
+                .to_string(),
+            format!(
+                r#"{{"type":"response.output_item.done","item":{{"type":"function_call","call_id":"call_1","name":"{wire}"}}}}"#
+            ),
+        ];
+        for f in &frames {
+            got.extend(parse_responses_event(f, &mut state));
+        }
+
+        let (name, input) = got
+            .iter()
+            .find_map(|e| match e {
+                LlmEvent::ToolUse { name, input, .. } => Some((name.clone(), input.clone())),
+                _ => None,
+            })
+            .expect("ToolUse event");
+        assert_eq!(
+            name, raw,
+            "inbound function_call must decode to the canonical fq_name"
+        );
+        assert_eq!(input, json!({"cmd": "ls"}));
+    }
+
     #[test]
     fn build_input_lowers_tool_call_and_result_round_trip() {
         // Assistant tool call + a following tool result lower to

--- a/crates/wcore-providers/src/tool_name.rs
+++ b/crates/wcore-providers/src/tool_name.rs
@@ -252,6 +252,7 @@ mod tests {
             "ai.perplexity-perplexity-mcp",
             "com.microsoft-markitdown",
             "org.wikipedia-wikipedia-mcp",
+            "path/to/tool",
         ];
         for n in bad {
             let enc = encode_tool_name(n);
@@ -301,6 +302,44 @@ mod tests {
     #[test]
     fn decode_passes_through_unknown_plain_names() {
         assert_eq!(decode_tool_name("Hallucinated_Tool"), "Hallucinated_Tool");
+    }
+
+    /// #139 collision safety: two DISTINCT raw names must never share a wire
+    /// spelling, or one tool would shadow the other at dispatch. Adversarial
+    /// set: near-identical dirty names, a plain name that IS another name's
+    /// escape body (`a_2Fb` vs `a/b` → `wct_a_2Fb`), and a raw name carrying
+    /// the sentinel itself. Every pair must encode distinctly and every name
+    /// must round-trip to itself.
+    #[test]
+    fn distinct_raw_names_never_collide_on_the_wire() {
+        let names = [
+            "Browser::execute",
+            "Browser:_execute",
+            "Browser__execute",
+            "Browser._execute",
+            "a/b",
+            "a.b",
+            "a:b",
+            "a_2Fb",
+            "wct_a_2Fb",
+        ];
+        let encoded: Vec<String> = names.iter().map(|n| encode_tool_name(n)).collect();
+        for (i, enc) in encoded.iter().enumerate() {
+            assert!(is_wire_legal(enc), "{} encoded to illegal {enc}", names[i]);
+            assert_eq!(
+                decode_tool_name(enc),
+                names[i],
+                "round-trip failed for {}",
+                names[i]
+            );
+            for j in (i + 1)..encoded.len() {
+                assert_ne!(
+                    *enc, encoded[j],
+                    "{} and {} collided on the wire",
+                    names[i], names[j]
+                );
+            }
+        }
     }
 
     /// A charset-clean but over-length name (real MCP shape) is clamped to a


### PR DESCRIPTION
## The headline finding

**#139 is not a code gap on main or in v0.12.19 — it is the #126 delivery gap wearing a different symptom.** Git archaeology (details on the issue): the `wct_` codec (#297 → #130 universal charset+64-len) is inside the v0.12.19 tag at every name-emitting site on the OpenAI-compatible path, and Flux is a pure newtype over `OpenAIProvider`. The reported WARN signature (`fq_name=Browser::execute` from `plugins/apply.rs`) combined with a raw `::` on the wire only fits an engine ≤0.12.8 — the codec landed on this path in 0.12.9. A stale npx cache (#126/#134) or an old desktop bundle explains a "latest" user running ≤0.12.8.

## What this PR adds (tests only, +298 lines)

The real gap was **zero inbound round-trip regression coverage** — nothing pinned that a sanitized wire name dispatches back to the original tool:

- openai.rs: full request-body test (dirty `Browser::execute` + clean names + replayed history `tool_calls` — every wire name matches `^[a-zA-Z0-9_-]{1,64}$`, clean names byte-identical) + streamed tool_call under the sanitized name dispatches as the ORIGINAL name.
- openai_responses.rs: the same pair for the Responses shape.
- tool_name.rs: adversarial no-collision set (near-identical dirty names, `a_2Fb` vs `a/b`, sentinel-prefixed raws) — pairwise distinct + self-round-trip; slash fixture.

## Verification (live, on real binaries)

- Real-registry wire capture: box main-line binary (45 tools) and the **shipped 0.12.19 npm artifact** with a real MCP-loaded registry (63 tools) → **zero pattern-illegal names on the wire**.
- Live strict-provider e2e: shipped 0.12.19 → Groq (`openai/gpt-oss-120b`, same `^[a-zA-Z0-9_-]+$` enforcement class) → real Read tool call round-tripped, exact file content returned.
- Hetzner gate: fmt/clippy clean, nextest 855/855 (wcore-providers).
- Outstanding: the literal Flux→deepseek-v4-flash leg needs a **chat-scoped** Flux key (the available burn key is image/voice-scoped, 401s on chat models).

Addresses #139 (close is a release/Sean action).
