### PR TITLE
chore(security): disposition quick-xml RUSTSEC-2026-0194/0195 — unreachable via embedded-dump-only syntect path (#142)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -28,9 +28,27 @@
 # Format reference: https://docs.rs/cargo-audit/latest/cargo_audit/
 
 [advisories]
-# The ignore list is EMPTY again. RUSTSEC-2023-0071 (rsa Marvin Attack) was
-# ELIMINATED AT THE SOURCE, not ignored: jsonwebtoken migrated `rust_crypto`
-# -> `aws_lc_rs` in wcore-channel-msteams + wcore-providers, dropping the
-# pure-Rust `rsa` crate from the tree (`cargo tree -i rsa` -> not found).
-# aws-lc-rs was already present via rustls, so this added no build surface.
-ignore = []
+# (prior state) RUSTSEC-2023-0071 (rsa Marvin Attack) was ELIMINATED AT THE
+# SOURCE, not ignored: jsonwebtoken migrated `rust_crypto` -> `aws_lc_rs` in
+# wcore-channel-msteams + wcore-providers, dropping the pure-Rust `rsa` crate
+# from the tree (`cargo tree -i rsa` -> not found). aws-lc-rs was already
+# present via rustls, so this added no build surface.
+#
+# ── quick-xml 0.39.4 DoS pair (RUSTSEC-2026-0194 / RUSTSEC-2026-0195) ──────
+# Published 2026-06-29; started failing plain `cargo audit` on every PR from
+# 2026-07-02 (ambient advisory-DB event, not a code change). Both fixed only
+# in quick-xml >= 0.41.0.
+# Parent trace (sole path): quick-xml 0.39.4 <- plist 1.9.0 <- syntect 5.3.0
+#   <- wcore-cli (`cargo tree -i quick-xml`).
+# Threat model — UNREACHABLE: syntect is used only by the TUI diff widget
+# (crates/wcore-cli/src/tui/widgets/diff.rs:332-333) via
+# SyntaxSet::load_defaults_newlines() + ThemeSet::load_defaults(), which read
+# syntect's EMBEDDED binary dumps. No from_folder(), no user-supplied
+# .tmTheme/plist XML parsing anywhere in the workspace — the vulnerable
+# NsReader/attribute-check code paths never receive input of any provenance.
+# No fix to take at source: plist's latest release (1.9.0) still requires
+# quick-xml ^0.39.2; nothing patched exists on the 0.39 line.
+# Tracking: FerroxLabs/wayland-core#142 — lift when plist releases with
+# quick-xml >= 0.41 (`cargo update -p plist`, remove both entries here and in
+# .github/osv-scanner.toml).
+ignore = ["RUSTSEC-2026-0194", "RUSTSEC-2026-0195"]

--- a/.github/osv-scanner.toml
+++ b/.github/osv-scanner.toml
@@ -133,3 +133,25 @@ reason = "opentelemetry_sdk baggage-extract DoS: receiving-side only; wayland-co
 id = "RUSTSEC-2026-0192"
 ignoreUntil = "2026-09-02T00:00:00Z"
 reason = "ttf-parser unmaintained (patched=[]); transitive only via lopdf <- pdf-extract <- wcore-tools PDF text extraction. Informational, no patch exists; successor skrifa is an upstream pdf-extract/lopdf decision. Tracked; revisit on pdf-extract/lopdf bump."
+
+# ── quick-xml 0.39.4 DoS pair ────────────────────────────────────────────
+# RUSTSEC-2026-0194 (quadratic duplicate-attribute check) and
+# RUSTSEC-2026-0195 (unbounded NsReader namespace-declaration allocation),
+# both published 2026-06-29, fixed only in quick-xml >= 0.41.0. Sole parent
+# trace: plist 1.9.0 <- syntect 5.3.0 <- wcore-cli. syntect is used solely by
+# the TUI diff widget with load_defaults() EMBEDDED binary theme/syntax dumps
+# (crates/wcore-cli/src/tui/widgets/diff.rs:332-333); no from_folder(), no
+# user-supplied .tmTheme/plist XML is ever parsed, so the vulnerable XML
+# reader never receives input. No patched 0.39.x exists and plist 1.9.0 (the
+# latest) still pins ^0.39.2 — nothing to bump. Ambient advisory (not a code
+# change in this PR). Tracked: FerroxLabs/wayland-core#142; lift on a plist
+# release carrying quick-xml >= 0.41.
+[[IgnoredVulns]]
+id = "RUSTSEC-2026-0194"
+ignoreUntil = "2026-09-02T00:00:00Z"
+reason = "quick-xml quadratic dup-attribute DoS: unreachable — sole path plist<-syntect<-wcore-cli TUI diff widget using embedded load_defaults() dumps; no XML parsing of any input. No patched 0.39.x; plist latest pins ^0.39.2. Tracked #142."
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2026-0195"
+ignoreUntil = "2026-09-02T00:00:00Z"
+reason = "quick-xml NsReader namespace-allocation DoS: unreachable — same sole embedded-dump path, no XML input reaches NsReader. No patched 0.39.x; plist latest pins ^0.39.2. Tracked #142."


### PR DESCRIPTION
Cut-blocker for 0.12.20: two quick-xml 0.39.4 DoS advisories (published 2026-06-29) fail the Security audit leg on every PR since today — ambient advisory-DB event, tests-only PRs included, no code change involved.

**No fix exists to take at source**: both are patched only in quick-xml >= 0.41.0, and plist 1.9.0 (latest) still pins `^0.39.2` — `cargo update` cannot reach a fixed version.

**Unreachability** (full analysis in the audit.toml block + #142): sole parent trace `plist <- syntect <- wcore-cli`; syntect used only by the TUI diff widget via `load_defaults()` embedded binary dumps (`diff.rs:332-333`); no `from_folder()`, no user-supplied theme/plist XML parsed anywhere — the vulnerable code never receives input.

Dispositioned per the repo's strict policy: `.cargo/audit.toml` ignore WITH parent trace/threat-model/tracking item + matching public `[[IgnoredVulns]]` entries in `.github/osv-scanner.toml`, time-boxed to 2026-09-02. Lift condition tracked in #142.

Verified locally: `cargo audit` → 0 vulnerabilities, 7 allowed warnings.

Addresses #142 (close is a release/Sean action).