### PR TITLE
feat(agent): host-delegated send_message hook — host-send-transport with hard approval gate (#141)

### DIFF
--- a/crates/wcore-agent/src/bootstrap.rs
+++ b/crates/wcore-agent/src/bootstrap.rs
@@ -23,6 +23,14 @@ pub struct BootstrapResult {
     pub provider: Arc<dyn LlmProvider>,
     pub mcp_managers: Vec<Arc<McpManager>>,
     pub has_mcp: bool,
+    /// #537/#141 — correlation bridge for host-delegated `send_message`.
+    /// Always constructed (cheap empty map); only populated when the engine
+    /// runs with `WAYLAND_SEND_MESSAGE_HOST_DELEGATE=1` and the registered
+    /// `SendMessageTool` holds a `HostDelegatedTransport`. The CLI command
+    /// loop resolves `host_send_message_result` commands through this
+    /// handle — including MID-turn, where the awaiting tool is parked
+    /// (same pattern as the `ApprovalResume` mid-turn arm).
+    pub host_send_bridge: std::sync::Arc<crate::host_send_transport::HostSendBridge>,
     /// True iff at least one plugin successfully registered during boot
     /// (design spec §5.17 — flips `Capabilities.plugins` in the Ready event).
     pub has_plugins: bool,
@@ -633,9 +641,40 @@ impl AgentBootstrap {
         // the LLM but every send call fails loudly until a host wires a
         // real transport (Telegram/Discord/Slack/etc.). Mirrors the
         // conditional-registration precedent set by RepoMapTool below.
-        registry.register(Box::new(
-            wcore_tools::send_message::SendMessageTool::default(),
-        ));
+        //
+        // #537/#141 host-send-transport hook (spec variant A): when the host
+        // opted in via `WAYLAND_SEND_MESSAGE_HOST_DELEGATE=1`, install
+        // `HostDelegatedTransport` as the PRIMARY transport instead — every
+        // send is fulfilled by the HOST over the json-stream protocol
+        // (`host_send_message_request` / `host_send_message_result`,
+        // correlated through `host_send_bridge` by the CLI command loop).
+        // The later `ChannelManagerTransport` upgrade is skipped in this
+        // mode. Env unset → byte-identical to before.
+        //
+        // SECURITY: this transport only runs inside the tool's `execute`,
+        // which the orchestration approval gate fronts — `send_message` is
+        // Exec-category and in no auto-approve default, so the request
+        // event can never be emitted for an unapproved call (wayland#543
+        // audit finding 4; pinned by tests/host_send_delegation.rs).
+        let host_send_bridge =
+            std::sync::Arc::new(crate::host_send_transport::HostSendBridge::new());
+        if crate::host_send_transport::host_delegated_send_enabled() {
+            registry.register(Box::new(wcore_tools::send_message::SendMessageTool::new(
+                std::sync::Arc::new(crate::host_send_transport::HostDelegatedTransport::new(
+                    host_send_bridge.clone(),
+                    self.output.clone(),
+                )),
+            )));
+            tracing::info!(
+                target: "wcore_agent::bootstrap",
+                "send_message runs host-delegated (WAYLAND_SEND_MESSAGE_HOST_DELEGATE=1): \
+                 sends are fulfilled by the host, not the engine channel table"
+            );
+        } else {
+            registry.register(Box::new(
+                wcore_tools::send_message::SendMessageTool::default(),
+            ));
+        }
         // W6 A1: GitTool — typed wrapper over git ops. Read-only ops route
         // through the concurrency-safe path automatically via
         // `is_concurrency_safe(input)`. Mutating ops (add/commit/checkout/stash)
@@ -2535,7 +2574,19 @@ impl AgentBootstrap {
             // LLM's `send_message` calls route through user-configured channels
             // (Telegram/Discord/Slack/Email/etc.) instead of returning the Null
             // transport's loud "no transport configured" error on every call.
-            if let Some(reg) = engine.registry_mut() {
+            //
+            // #537/#141: in host-delegated mode the tool already holds the
+            // `HostDelegatedTransport` (installed at registration above) —
+            // do NOT overwrite it with the channel-table adapter, which is
+            // empty under the desktop and would reintroduce the exact
+            // "unknown channel: email" failure this hook exists to fix.
+            if crate::host_send_transport::host_delegated_send_enabled() {
+                tracing::debug!(
+                    target: "wcore_agent::bootstrap",
+                    "send_message transport upgrade skipped: host-delegated mode keeps \
+                     HostDelegatedTransport as the primary transport"
+                );
+            } else if let Some(reg) = engine.registry_mut() {
                 let transport = std::sync::Arc::new(
                     crate::channel_send_transport::ChannelManagerTransport::new(
                         std::sync::Arc::clone(&lifted),
@@ -2706,6 +2757,7 @@ impl AgentBootstrap {
             provider,
             mcp_managers,
             has_mcp,
+            host_send_bridge,
             has_plugins,
             plugin_capabilities,
             loaded_plugin_names,

--- a/crates/wcore-agent/src/host_send_transport.rs
+++ b/crates/wcore-agent/src/host_send_transport.rs
@@ -230,10 +230,14 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
     use wcore_tools::send_message::MessagingPlatform;
 
+    /// One captured request frame:
+    /// `(call_id, platform, chat_id, thread_id, body)`.
+    type CapturedRequest = (String, String, Option<String>, Option<String>, String);
+
     /// Capturing sink that records every host-send request frame.
     #[derive(Default)]
     struct CaptureSink {
-        requests: Mutex<Vec<(String, String, Option<String>, Option<String>, String)>>,
+        requests: Mutex<Vec<CapturedRequest>>,
     }
 
     impl crate::output::OutputSink for CaptureSink {
@@ -389,14 +393,12 @@ mod tests {
         let sink = Arc::new(CaptureSink::default());
         let transport = HostDelegatedTransport::new(bridge.clone(), sink.clone());
 
-        let send = transport.send(
-            &ParsedTarget {
-                platform: MessagingPlatform::Email,
-                chat_id: Some("mike@example.com".to_string()),
-                thread_id: Some("t-1".to_string()),
-            },
-            "body text",
-        );
+        let target = ParsedTarget {
+            platform: MessagingPlatform::Email,
+            chat_id: Some("mike@example.com".to_string()),
+            thread_id: Some("t-1".to_string()),
+        };
+        let send = transport.send(&target, "body text");
         tokio::pin!(send);
         // Drive the send until the request frame is emitted.
         let outcome = tokio::select! {
@@ -441,7 +443,8 @@ mod tests {
         let sink = Arc::new(CaptureSink::default());
         let transport = HostDelegatedTransport::new(bridge.clone(), sink.clone());
 
-        let send = transport.send(&email_target(), "hi");
+        let target = email_target();
+        let send = transport.send(&target, "hi");
         tokio::pin!(send);
         tokio::select! {
             biased;
@@ -482,7 +485,8 @@ mod tests {
         let sink = Arc::new(CaptureSink::default());
         let transport = HostDelegatedTransport::new(bridge.clone(), sink.clone());
 
-        let send = transport.send(&email_target(), "hi");
+        let target = email_target();
+        let send = transport.send(&target, "hi");
         tokio::pin!(send);
         tokio::select! {
             biased;
@@ -548,7 +552,8 @@ mod tests {
         let transport = HostDelegatedTransport::new(bridge.clone(), sink.clone());
 
         {
-            let send = transport.send(&email_target(), "hi");
+            let target = email_target();
+            let send = transport.send(&target, "hi");
             tokio::pin!(send);
             tokio::select! {
                 biased;

--- a/crates/wcore-agent/src/host_send_transport.rs
+++ b/crates/wcore-agent/src/host_send_transport.rs
@@ -1,0 +1,563 @@
+//! #537/#141 — `HostDelegatedTransport`: host-send-transport hook for the
+//! `send_message` tool.
+//!
+//! Under the desktop the engine's channel table is empty (the desktop writes
+//! no channel `.toml` into `$WAYLAND_HOME/channels`), so every agent
+//! `send_message` failed with "unknown channel: email". Per the Overwatch
+//! decision on wayland#537 (Option 1, host-send-transport-hook variant A),
+//! when the host spawns the engine with `WAYLAND_SEND_MESSAGE_HOST_DELEGATE=1`
+//! the tool keeps its schema but the transport routes every send to the HOST:
+//! it emits a `host_send_message_request` protocol event and awaits the
+//! host's `host_send_message_result` command, correlated by `call_id`. The
+//! host fulfils the send through its own outbound channel plugins — one SMTP
+//! path, the engine owns no channel credentials.
+//!
+//! Without the env var nothing changes: `ChannelManagerTransport` stays the
+//! transport and standalone/CLI engines with hand-authored channel toml are
+//! byte-identical to before.
+//!
+//! **SECURITY (wayland#543 audit finding 4):** the desktop performs the send
+//! WITHOUT re-gating, trusting that the engine already gated the tool call.
+//! That holds structurally: this transport only runs inside
+//! `SendMessageTool::execute`, which orchestration's approval gate fronts
+//! (`send_message` is `Exec`-category, absent from the default allow-list,
+//! and never mode-auto-approved outside Force). The integration tests in
+//! `tests/host_send_delegation.rs` pin all three properties.
+//!
+//! **Race discipline (BridgeApprover precedent):** the waiter is registered
+//! on the [`HostSendBridge`] BEFORE the request event is emitted, so a host
+//! that replies instantly can never race a not-yet-registered `call_id`.
+//!
+//! **Never hang:** the await is bounded by [`HOST_SEND_TIMEOUT`] (mirroring
+//! the bounded approval-bridge waits); a timeout is a loud `SendOutcome::Err`
+//! surfaced to the model, and the pending entry is cleaned up.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use tokio::sync::oneshot;
+
+use wcore_tools::send_message::{MessageTransport, ParsedTarget, SendOutcome};
+
+/// How long a delegated send waits for the host's
+/// `host_send_message_result` before failing loudly. 30s per the #537 Core
+/// spec — an SMTP handshake fits comfortably; a host that never answers must
+/// not park the tool call anywhere near the 5-minute approval TTL.
+pub const HOST_SEND_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Activation check for host-delegated `send_message`. The desktop sets
+/// `WAYLAND_SEND_MESSAGE_HOST_DELEGATE=1` in the engine child's environment
+/// (`envBuilder.buildEngineSpawnEnv`); anything other than exactly `"1"`
+/// leaves the engine's behavior byte-identical to today.
+pub fn host_delegated_send_enabled() -> bool {
+    std::env::var("WAYLAND_SEND_MESSAGE_HOST_DELEGATE").as_deref() == Ok("1")
+}
+
+/// The host's answer to one `host_send_message_request`, as carried by the
+/// `host_send_message_result` protocol command.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HostSendResult {
+    pub ok: bool,
+    pub message_id: Option<String>,
+    pub error: Option<String>,
+}
+
+/// Correlation bridge between the awaiting transport and the CLI command
+/// loop. `register` (transport side) parks a oneshot under the `call_id`;
+/// `resolve` (command-loop side, on `host_send_message_result`) completes it.
+///
+/// Locking: a synchronous `Mutex` with no await inside any critical section,
+/// so the transport's cancel-safety guard can clean up from a `Drop` impl.
+/// Unlike the `ApprovalBridge` there is no TTL reaper — the ONLY requester is
+/// the transport itself, which always removes its entry on timeout/completion
+/// (and via the drop guard on turn cancellation), so entries cannot outlive
+/// their send.
+#[derive(Default)]
+pub struct HostSendBridge {
+    pending: Mutex<HashMap<String, oneshot::Sender<HostSendResult>>>,
+}
+
+impl HostSendBridge {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a waiter for `call_id`. MUST be called BEFORE the
+    /// corresponding `host_send_message_request` is emitted (the
+    /// register-before-emit rule) so an instant host reply always finds
+    /// its entry.
+    pub fn register(&self, call_id: String) -> oneshot::Receiver<HostSendResult> {
+        let (tx, rx) = oneshot::channel();
+        if let Ok(mut map) = self.pending.lock() {
+            map.insert(call_id, tx);
+        }
+        rx
+    }
+
+    /// Resolve the waiter registered under `call_id`. Returns `false` when
+    /// the id is unknown (stale, mistyped, or already timed out) — a wrong
+    /// `call_id` never completes somebody else's send.
+    pub fn resolve(&self, call_id: &str, result: HostSendResult) -> bool {
+        let sender = match self.pending.lock() {
+            Ok(mut map) => map.remove(call_id),
+            Err(_) => None,
+        };
+        match sender {
+            Some(tx) => tx.send(result).is_ok(),
+            None => false,
+        }
+    }
+
+    /// Drop the waiter registered under `call_id` without resolving it
+    /// (timeout / cancellation cleanup).
+    fn remove(&self, call_id: &str) {
+        if let Ok(mut map) = self.pending.lock() {
+            map.remove(call_id);
+        }
+    }
+
+    /// Number of in-flight delegated sends. Test/diagnostic helper.
+    pub fn pending_count(&self) -> usize {
+        self.pending.lock().map(|m| m.len()).unwrap_or(0)
+    }
+}
+
+/// RAII cleanup: if the awaiting send future is dropped mid-flight (turn
+/// cancelled via Esc/Stop), the pending entry is removed so a late host
+/// reply resolves nothing and the map never leaks.
+struct PendingGuard<'a> {
+    bridge: &'a HostSendBridge,
+    call_id: &'a str,
+    armed: bool,
+}
+
+impl Drop for PendingGuard<'_> {
+    fn drop(&mut self) {
+        if self.armed {
+            self.bridge.remove(self.call_id);
+        }
+    }
+}
+
+/// `MessageTransport` impl that delegates delivery to the host. Installed
+/// as the PRIMARY transport (spec variant A — deterministic, table-state
+/// independent) when [`host_delegated_send_enabled`] is true at bootstrap.
+pub struct HostDelegatedTransport {
+    bridge: Arc<HostSendBridge>,
+    output: Arc<dyn crate::output::OutputSink>,
+    timeout: Duration,
+}
+
+impl HostDelegatedTransport {
+    pub fn new(bridge: Arc<HostSendBridge>, output: Arc<dyn crate::output::OutputSink>) -> Self {
+        Self {
+            bridge,
+            output,
+            timeout: HOST_SEND_TIMEOUT,
+        }
+    }
+
+    /// Test hook: shrink the host-reply timeout so timeout-path tests run
+    /// in milliseconds. Production callers use [`Self::new`].
+    pub fn with_timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = timeout;
+        self
+    }
+}
+
+#[async_trait]
+impl MessageTransport for HostDelegatedTransport {
+    async fn send(&self, target: &ParsedTarget, message: &str) -> SendOutcome {
+        let call_id = format!("hsm-{}", uuid::Uuid::new_v4());
+        // Register BEFORE emit — an instant host reply must find the waiter.
+        let rx = self.bridge.register(call_id.clone());
+        let mut guard = PendingGuard {
+            bridge: self.bridge.as_ref(),
+            call_id: &call_id,
+            armed: true,
+        };
+        self.output.emit_host_send_message_request(
+            &call_id,
+            target.platform.as_str(),
+            target.chat_id.as_deref(),
+            target.thread_id.as_deref(),
+            message,
+            None, // subject: no subject input on the send_message schema today
+            None, // conversation_id: session id not threaded to transports
+        );
+        match tokio::time::timeout(self.timeout, rx).await {
+            Ok(Ok(result)) => {
+                // Resolved normally — resolve() already removed the entry.
+                guard.armed = false;
+                if result.ok {
+                    SendOutcome::Ok {
+                        message_id: result.message_id,
+                    }
+                } else {
+                    SendOutcome::Err {
+                        message: result.error.unwrap_or_else(|| {
+                            "host reported the send failed (no error detail)".to_string()
+                        }),
+                    }
+                }
+            }
+            // Sender dropped without a result — only possible if the bridge
+            // entry was removed out-of-band; fail loudly.
+            Ok(Err(_)) => SendOutcome::Err {
+                message: "host send channel closed before a result arrived".to_string(),
+            },
+            Err(_) => {
+                // Timeout: the guard cleans the entry on drop; a late host
+                // reply then resolves nothing (resolve returns false).
+                SendOutcome::Err {
+                    message: format!(
+                        "host did not answer the delegated send within {}s \
+                         (no host_send_message_result); the message was NOT \
+                         confirmed sent",
+                        self.timeout.as_secs()
+                    ),
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use wcore_tools::send_message::MessagingPlatform;
+
+    /// Capturing sink that records every host-send request frame.
+    #[derive(Default)]
+    struct CaptureSink {
+        requests: Mutex<Vec<(String, String, Option<String>, Option<String>, String)>>,
+    }
+
+    impl crate::output::OutputSink for CaptureSink {
+        fn emit_text_delta(&self, _text: &str, _msg_id: &str) {}
+        fn emit_thinking(&self, _text: &str, _msg_id: &str) {}
+        fn emit_tool_call(&self, _name: &str, _input: &str) {}
+        fn emit_tool_result(&self, _name: &str, _is_error: bool, _content: &str) {}
+        fn emit_stream_start(&self, _msg_id: &str) {}
+        fn emit_stream_end(
+            &self,
+            _msg_id: &str,
+            _turns: usize,
+            _input_tokens: u64,
+            _output_tokens: u64,
+            _cache_creation_tokens: u64,
+            _cache_read_tokens: u64,
+            _finish_reason: wcore_protocol::events::FinishReason,
+        ) {
+        }
+        fn emit_error(&self, _msg: &str, _retryable: bool) {}
+        fn emit_info(&self, _msg: &str) {}
+        fn emit_host_send_message_request(
+            &self,
+            call_id: &str,
+            platform: &str,
+            chat_id: Option<&str>,
+            thread_id: Option<&str>,
+            body: &str,
+            _subject: Option<&str>,
+            _conversation_id: Option<&str>,
+        ) {
+            if let Ok(mut v) = self.requests.lock() {
+                v.push((
+                    call_id.to_string(),
+                    platform.to_string(),
+                    chat_id.map(str::to_string),
+                    thread_id.map(str::to_string),
+                    body.to_string(),
+                ));
+            }
+        }
+    }
+
+    /// Sink that resolves the bridge SYNCHRONOUSLY from inside `emit` —
+    /// proves the register-before-emit rule: if the waiter were registered
+    /// after emission this instant reply would be lost and the send would
+    /// time out.
+    struct InstantReplySink {
+        bridge: Arc<HostSendBridge>,
+        resolved_ok: AtomicUsize,
+    }
+
+    impl crate::output::OutputSink for InstantReplySink {
+        fn emit_text_delta(&self, _text: &str, _msg_id: &str) {}
+        fn emit_thinking(&self, _text: &str, _msg_id: &str) {}
+        fn emit_tool_call(&self, _name: &str, _input: &str) {}
+        fn emit_tool_result(&self, _name: &str, _is_error: bool, _content: &str) {}
+        fn emit_stream_start(&self, _msg_id: &str) {}
+        fn emit_stream_end(
+            &self,
+            _msg_id: &str,
+            _turns: usize,
+            _input_tokens: u64,
+            _output_tokens: u64,
+            _cache_creation_tokens: u64,
+            _cache_read_tokens: u64,
+            _finish_reason: wcore_protocol::events::FinishReason,
+        ) {
+        }
+        fn emit_error(&self, _msg: &str, _retryable: bool) {}
+        fn emit_info(&self, _msg: &str) {}
+        fn emit_host_send_message_request(
+            &self,
+            call_id: &str,
+            _platform: &str,
+            _chat_id: Option<&str>,
+            _thread_id: Option<&str>,
+            _body: &str,
+            _subject: Option<&str>,
+            _conversation_id: Option<&str>,
+        ) {
+            let resolved = self.bridge.resolve(
+                call_id,
+                HostSendResult {
+                    ok: true,
+                    message_id: Some("instant-1".to_string()),
+                    error: None,
+                },
+            );
+            if resolved {
+                self.resolved_ok.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+    }
+
+    fn email_target() -> ParsedTarget {
+        ParsedTarget {
+            platform: MessagingPlatform::Email,
+            chat_id: Some("mike@example.com".to_string()),
+            thread_id: None,
+        }
+    }
+
+    #[test]
+    fn env_gate_requires_exactly_one() {
+        // Uses a scoped set/remove; the var name is unique to this feature so
+        // no other test in this crate races it.
+        // SAFETY (Rust 2024 set_var): single-threaded test context for this
+        // env var; no concurrent readers of this name.
+        unsafe {
+            std::env::remove_var("WAYLAND_SEND_MESSAGE_HOST_DELEGATE");
+        }
+        assert!(!host_delegated_send_enabled());
+        unsafe {
+            std::env::set_var("WAYLAND_SEND_MESSAGE_HOST_DELEGATE", "0");
+        }
+        assert!(!host_delegated_send_enabled());
+        unsafe {
+            std::env::set_var("WAYLAND_SEND_MESSAGE_HOST_DELEGATE", "1");
+        }
+        assert!(host_delegated_send_enabled());
+        unsafe {
+            std::env::remove_var("WAYLAND_SEND_MESSAGE_HOST_DELEGATE");
+        }
+    }
+
+    /// Register-before-emit: a host that answers from INSIDE the emit call
+    /// (the fastest possible reply) still resolves the send.
+    #[tokio::test]
+    async fn instant_host_reply_cannot_race_registration() {
+        let bridge = Arc::new(HostSendBridge::new());
+        let sink = Arc::new(InstantReplySink {
+            bridge: bridge.clone(),
+            resolved_ok: AtomicUsize::new(0),
+        });
+        let transport = HostDelegatedTransport::new(bridge.clone(), sink.clone());
+        let outcome = transport.send(&email_target(), "hello").await;
+        assert_eq!(sink.resolved_ok.load(Ordering::SeqCst), 1);
+        match outcome {
+            SendOutcome::Ok { message_id } => {
+                assert_eq!(message_id.as_deref(), Some("instant-1"))
+            }
+            SendOutcome::Err { message } => panic!("expected Ok, got Err: {message}"),
+        }
+        assert_eq!(bridge.pending_count(), 0);
+    }
+
+    /// The request frame carries the ParsedTarget verbatim, and a host
+    /// `ok=true` result resolves into `SendOutcome::Ok` with the receipt.
+    #[tokio::test]
+    async fn ok_result_resolves_send_with_receipt() {
+        let bridge = Arc::new(HostSendBridge::new());
+        let sink = Arc::new(CaptureSink::default());
+        let transport = HostDelegatedTransport::new(bridge.clone(), sink.clone());
+
+        let send = transport.send(
+            &ParsedTarget {
+                platform: MessagingPlatform::Email,
+                chat_id: Some("mike@example.com".to_string()),
+                thread_id: Some("t-1".to_string()),
+            },
+            "body text",
+        );
+        tokio::pin!(send);
+        // Drive the send until the request frame is emitted.
+        let outcome = tokio::select! {
+            biased;
+            out = &mut send => Some(out),
+            _ = tokio::task::yield_now() => None,
+        };
+        assert!(outcome.is_none(), "send must park awaiting the host");
+
+        let (call_id, platform, chat_id, thread_id, body) = {
+            let reqs = sink.requests.lock().unwrap();
+            assert_eq!(reqs.len(), 1, "exactly one request frame");
+            reqs[0].clone()
+        };
+        assert!(call_id.starts_with("hsm-"), "engine-minted call_id");
+        assert_eq!(platform, "email");
+        assert_eq!(chat_id.as_deref(), Some("mike@example.com"));
+        assert_eq!(thread_id.as_deref(), Some("t-1"));
+        assert_eq!(body, "body text");
+
+        assert!(bridge.resolve(
+            &call_id,
+            HostSendResult {
+                ok: true,
+                message_id: Some("smtp-250".to_string()),
+                error: None,
+            },
+        ));
+        match send.await {
+            SendOutcome::Ok { message_id } => {
+                assert_eq!(message_id.as_deref(), Some("smtp-250"))
+            }
+            SendOutcome::Err { message } => panic!("expected Ok, got Err: {message}"),
+        }
+    }
+
+    /// A WRONG call_id must not resolve the waiter; the correct one still
+    /// does afterwards.
+    #[tokio::test]
+    async fn wrong_call_id_does_not_resolve() {
+        let bridge = Arc::new(HostSendBridge::new());
+        let sink = Arc::new(CaptureSink::default());
+        let transport = HostDelegatedTransport::new(bridge.clone(), sink.clone());
+
+        let send = transport.send(&email_target(), "hi");
+        tokio::pin!(send);
+        tokio::select! {
+            biased;
+            _ = &mut send => panic!("send must still be pending"),
+            _ = tokio::task::yield_now() => {}
+        }
+        let call_id = sink.requests.lock().unwrap()[0].0.clone();
+
+        assert!(
+            !bridge.resolve(
+                "hsm-not-the-right-id",
+                HostSendResult {
+                    ok: true,
+                    message_id: None,
+                    error: None,
+                },
+            ),
+            "unknown call_id must resolve nothing"
+        );
+        assert_eq!(bridge.pending_count(), 1, "real waiter still pending");
+
+        assert!(bridge.resolve(
+            &call_id,
+            HostSendResult {
+                ok: true,
+                message_id: None,
+                error: None,
+            },
+        ));
+        assert!(matches!(send.await, SendOutcome::Ok { .. }));
+    }
+
+    /// A host-reported failure surfaces as a real `SendOutcome::Err`
+    /// carrying the host's error string — never a false success.
+    #[tokio::test]
+    async fn host_failure_surfaces_as_error() {
+        let bridge = Arc::new(HostSendBridge::new());
+        let sink = Arc::new(CaptureSink::default());
+        let transport = HostDelegatedTransport::new(bridge.clone(), sink.clone());
+
+        let send = transport.send(&email_target(), "hi");
+        tokio::pin!(send);
+        tokio::select! {
+            biased;
+            _ = &mut send => panic!("send must still be pending"),
+            _ = tokio::task::yield_now() => {}
+        }
+        let call_id = sink.requests.lock().unwrap()[0].0.clone();
+        assert!(bridge.resolve(
+            &call_id,
+            HostSendResult {
+                ok: false,
+                message_id: None,
+                error: Some("SMTP 550: mailbox unavailable".to_string()),
+            },
+        ));
+        match send.await {
+            SendOutcome::Err { message } => assert!(
+                message.contains("SMTP 550"),
+                "host error must reach the model, got: {message}"
+            ),
+            SendOutcome::Ok { .. } => panic!("host failure must not become success"),
+        }
+    }
+
+    /// No host reply → bounded timeout → loud error, no hang, pending
+    /// entry cleaned up (a late reply then resolves nothing).
+    #[tokio::test]
+    async fn timeout_is_a_loud_error_not_a_hang() {
+        let bridge = Arc::new(HostSendBridge::new());
+        let sink = Arc::new(CaptureSink::default());
+        let transport = HostDelegatedTransport::new(bridge.clone(), sink.clone())
+            .with_timeout(Duration::from_millis(50));
+
+        let outcome = transport.send(&email_target(), "hi").await;
+        match outcome {
+            SendOutcome::Err { message } => assert!(
+                message.contains("did not answer") && message.contains("NOT"),
+                "timeout error must be explicit about non-delivery, got: {message}"
+            ),
+            SendOutcome::Ok { .. } => panic!("timeout must not be a success"),
+        }
+        assert_eq!(bridge.pending_count(), 0, "timed-out entry cleaned up");
+        let call_id = sink.requests.lock().unwrap()[0].0.clone();
+        assert!(
+            !bridge.resolve(
+                &call_id,
+                HostSendResult {
+                    ok: true,
+                    message_id: None,
+                    error: None,
+                },
+            ),
+            "a late host reply after timeout must resolve nothing"
+        );
+    }
+
+    /// Cancel-safety: dropping the in-flight send future (turn cancelled)
+    /// removes the pending entry via the drop guard.
+    #[tokio::test]
+    async fn dropped_send_future_cleans_pending_entry() {
+        let bridge = Arc::new(HostSendBridge::new());
+        let sink = Arc::new(CaptureSink::default());
+        let transport = HostDelegatedTransport::new(bridge.clone(), sink.clone());
+
+        {
+            let send = transport.send(&email_target(), "hi");
+            tokio::pin!(send);
+            tokio::select! {
+                biased;
+                _ = &mut send => panic!("send must still be pending"),
+                _ = tokio::task::yield_now() => {}
+            }
+            assert_eq!(bridge.pending_count(), 1);
+            // `send` dropped here — simulates Esc/Stop cancelling the turn.
+        }
+        assert_eq!(bridge.pending_count(), 0, "drop guard must clean the entry");
+    }
+}

--- a/crates/wcore-agent/src/host_send_transport.rs
+++ b/crates/wcore-agent/src/host_send_transport.rs
@@ -55,6 +55,22 @@ pub fn host_delegated_send_enabled() -> bool {
     std::env::var("WAYLAND_SEND_MESSAGE_HOST_DELEGATE").as_deref() == Ok("1")
 }
 
+/// #141 audit item 3 — upper bound on host-supplied result strings
+/// (`error`, `message_id`). Both land in the tool result and thus in the
+/// model context; an unbounded string from a hostile/buggy host would be a
+/// context-stuffing vector. 4096 chars carries any real SMTP diagnostic.
+pub const MAX_HOST_RESULT_FIELD_CHARS: usize = 4096;
+
+fn clamp_host_field(s: Option<String>) -> Option<String> {
+    s.map(|v| {
+        if v.chars().count() > MAX_HOST_RESULT_FIELD_CHARS {
+            v.chars().take(MAX_HOST_RESULT_FIELD_CHARS).collect()
+        } else {
+            v
+        }
+    })
+}
+
 /// The host's answer to one `host_send_message_request`, as carried by the
 /// `host_send_message_result` protocol command.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -99,7 +115,17 @@ impl HostSendBridge {
     /// Resolve the waiter registered under `call_id`. Returns `false` when
     /// the id is unknown (stale, mistyped, or already timed out) — a wrong
     /// `call_id` never completes somebody else's send.
+    ///
+    /// #141 audit item 3: `message_id` / `error` are host-supplied wire
+    /// strings headed for the tool result (model context); they are clamped
+    /// to [`MAX_HOST_RESULT_FIELD_CHARS`] here — the single chokepoint every
+    /// CLI arm routes through — so a hostile host cannot stuff the context.
     pub fn resolve(&self, call_id: &str, result: HostSendResult) -> bool {
+        let result = HostSendResult {
+            ok: result.ok,
+            message_id: clamp_host_field(result.message_id),
+            error: clamp_host_field(result.error),
+        };
         let sender = match self.pending.lock() {
             Ok(mut map) => map.remove(call_id),
             Err(_) => None,
@@ -121,6 +147,16 @@ impl HostSendBridge {
     /// Number of in-flight delegated sends. Test/diagnostic helper.
     pub fn pending_count(&self) -> usize {
         self.pending.lock().map(|m| m.len()).unwrap_or(0)
+    }
+
+    /// Snapshot of in-flight `call_id`s. Test/diagnostic helper (mirrors
+    /// `ApprovalBridge::pending_tokens`); production resolution always uses
+    /// the id carried by the wire command.
+    pub fn pending_ids(&self) -> Vec<String> {
+        self.pending
+            .lock()
+            .map(|m| m.keys().cloned().collect())
+            .unwrap_or_default()
     }
 }
 
@@ -211,11 +247,19 @@ impl MessageTransport for HostDelegatedTransport {
             Err(_) => {
                 // Timeout: the guard cleans the entry on drop; a late host
                 // reply then resolves nothing (resolve returns false).
+                //
+                // #141 audit Fix B: the host has no send-timeout of its own —
+                // a slow SMTP handshake can outlast this bound and STILL
+                // deliver. The error text below instructs the model not to
+                // auto-retry (a retry could double-send); keep the wording
+                // model-readable and verbatim-ish.
                 SendOutcome::Err {
                     message: format!(
                         "host did not answer the delegated send within {}s \
                          (no host_send_message_result); the message was NOT \
-                         confirmed sent",
+                         confirmed sent. The host may still complete this \
+                         delivery — do NOT automatically retry; ask the user \
+                         before re-sending.",
                         self.timeout.as_secs()
                     ),
                 }
@@ -523,8 +567,14 @@ mod tests {
         let outcome = transport.send(&email_target(), "hi").await;
         match outcome {
             SendOutcome::Err { message } => assert!(
-                message.contains("did not answer") && message.contains("NOT"),
-                "timeout error must be explicit about non-delivery, got: {message}"
+                message.contains("did not answer")
+                    && message.contains("NOT confirmed sent")
+                    // #141 audit Fix B: the double-send advisory must reach
+                    // the model verbatim — the host may still deliver after
+                    // our bound, so an auto-retry could double-send.
+                    && message.contains("do NOT automatically retry")
+                    && message.contains("ask the user before re-sending"),
+                "timeout error must pin non-delivery + the no-retry advisory, got: {message}"
             ),
             SendOutcome::Ok { .. } => panic!("timeout must not be a success"),
         }
@@ -540,6 +590,35 @@ mod tests {
                 },
             ),
             "a late host reply after timeout must resolve nothing"
+        );
+    }
+
+    /// #141 audit item 3: host-supplied `error` / `message_id` strings are
+    /// clamped at the bridge chokepoint so a hostile host can't stuff the
+    /// model context through the tool result.
+    #[tokio::test]
+    async fn oversized_host_result_strings_are_clamped() {
+        let bridge = Arc::new(HostSendBridge::new());
+        let rx = bridge.register("hsm-clamp".to_string());
+        let huge = "x".repeat(MAX_HOST_RESULT_FIELD_CHARS + 5000);
+        assert!(bridge.resolve(
+            "hsm-clamp",
+            HostSendResult {
+                ok: false,
+                message_id: Some(huge.clone()),
+                error: Some(huge),
+            },
+        ));
+        let result = rx.await.expect("resolved");
+        assert_eq!(
+            result.error.as_ref().map(|s| s.chars().count()),
+            Some(MAX_HOST_RESULT_FIELD_CHARS),
+            "error must be clamped to the cap"
+        );
+        assert_eq!(
+            result.message_id.as_ref().map(|s| s.chars().count()),
+            Some(MAX_HOST_RESULT_FIELD_CHARS),
+            "message_id must be clamped to the cap"
         );
     }
 

--- a/crates/wcore-agent/src/lib.rs
+++ b/crates/wcore-agent/src/lib.rs
@@ -54,6 +54,12 @@ pub mod file_history;
 // `/v1/models` with 5s cap) for the `/doctor` TUI diagnostics surface.
 pub mod health;
 pub mod hooks;
+// #537/#141 — host-delegated `send_message` transport: when the host
+// spawns the engine with `WAYLAND_SEND_MESSAGE_HOST_DELEGATE=1`, sends are
+// fulfilled by the host over the json-stream protocol
+// (`host_send_message_request` event / `host_send_message_result` command)
+// instead of the engine's own channel table.
+pub mod host_send_transport;
 // Inbound webhook HTTP host — routes platform webhook POSTs (Slack /
 // WhatsApp / Twilio SMS) to each channel's signature-verifying
 // `Channel::ingest_webhook` via the `ChannelManager`.

--- a/crates/wcore-agent/src/output/mod.rs
+++ b/crates/wcore-agent/src/output/mod.rs
@@ -170,6 +170,28 @@ pub trait OutputSink: Send + Sync {
     /// no-op.
     fn emit_approval_resume(&self, _resume_token: &str, _approved: bool) {}
 
+    /// #537/#141: emit `host_send_message_request` — an APPROVED
+    /// `send_message` tool call running host-delegated
+    /// (`WAYLAND_SEND_MESSAGE_HOST_DELEGATE=1`) asks the host to perform
+    /// the actual delivery; the host replies with the
+    /// `host_send_message_result` command, correlated by `call_id`.
+    /// Always-on additive event (no capability flag) per the W0
+    /// forward-additive baseline. Default no-op for non-protocol sinks —
+    /// a delegated send under such a sink times out into a loud tool
+    /// error rather than reaching a host that doesn't exist.
+    #[allow(clippy::too_many_arguments)]
+    fn emit_host_send_message_request(
+        &self,
+        _call_id: &str,
+        _platform: &str,
+        _chat_id: Option<&str>,
+        _thread_id: Option<&str>,
+        _body: &str,
+        _subject: Option<&str>,
+        _conversation_id: Option<&str>,
+    ) {
+    }
+
     /// W8a A.7: emit `budget_exceeded` (singular per session, fires
     /// once when the first ExecutionBudget cap trips). Always-emitted
     /// host-tolerated additive variant per audit F5 — no capability

--- a/crates/wcore-agent/src/output/protocol_sink.rs
+++ b/crates/wcore-agent/src/output/protocol_sink.rs
@@ -706,6 +706,33 @@ impl OutputSink for ProtocolSink {
         });
     }
 
+    /// #537/#141: emit `ProtocolEvent::HostSendMessageRequest`
+    /// unconditionally — always-on additive variant (same rationale as
+    /// `BudgetExceeded` / `ToolPanicked`): the event only ever fires when
+    /// the host itself opted in by spawning the engine with
+    /// `WAYLAND_SEND_MESSAGE_HOST_DELEGATE=1`, and hosts that don't
+    /// recognise the `type` drop the line per the W0 decoder contract.
+    fn emit_host_send_message_request(
+        &self,
+        call_id: &str,
+        platform: &str,
+        chat_id: Option<&str>,
+        thread_id: Option<&str>,
+        body: &str,
+        subject: Option<&str>,
+        conversation_id: Option<&str>,
+    ) {
+        let _ = self.writer.emit(&ProtocolEvent::HostSendMessageRequest {
+            call_id: call_id.to_string(),
+            platform: platform.to_string(),
+            chat_id: chat_id.map(str::to_string),
+            thread_id: thread_id.map(str::to_string),
+            body: body.to_string(),
+            subject: subject.map(str::to_string),
+            conversation_id: conversation_id.map(str::to_string),
+        });
+    }
+
     /// W7 S4: emit `ProtocolEvent::ApprovalResume`. Gated by hitl_suspend.
     fn emit_approval_resume(&self, resume_token: &str, approved: bool) {
         if !self.hitl_suspend_enabled {

--- a/crates/wcore-agent/tests/bootstrap_test.rs
+++ b/crates/wcore-agent/tests/bootstrap_test.rs
@@ -88,6 +88,124 @@ async fn bootstrap_builds_engine_with_model_in_prompt() {
     assert!(result.mcp_managers.is_empty());
 }
 
+/// #141 audit item 5 — prove the env flag actually installs
+/// `HostDelegatedTransport` at the registration site: with
+/// `WAYLAND_SEND_MESSAGE_HOST_DELEGATE=1`, an executed `send_message` parks
+/// a waiter on the SAME `HostSendBridge` exposed on `BootstrapResult`, and
+/// resolving that bridge completes the tool call with the host's receipt.
+/// (The `#[serial]` + `EnvGuard` discipline mirrors the backend-gating
+/// tests above; the env var is process-global.)
+#[tokio::test]
+#[serial]
+async fn host_delegate_env_installs_host_delegated_send_transport() {
+    let (_plugins, _plugins_env) = isolated_plugins();
+    let _env = EnvGuard::set(&[("WAYLAND_SEND_MESSAGE_HOST_DELEGATE", "1")]);
+
+    let config = minimal_config();
+    let workdir = tempfile::TempDir::new().expect("workdir");
+    let result = AgentBootstrap::new(config, workdir.path().to_str().unwrap(), null_output())
+        .build()
+        .await
+        .expect("bootstrap should succeed");
+
+    let bridge = result.host_send_bridge.clone();
+    assert_eq!(bridge.pending_count(), 0);
+
+    // Play host: wait for the delegated send to register its waiter on the
+    // result's bridge, then resolve it with a receipt.
+    let resolver_bridge = bridge.clone();
+    let resolver = tokio::spawn(async move {
+        for _ in 0..400 {
+            let ids = resolver_bridge.pending_ids();
+            if let Some(id) = ids.first() {
+                assert!(resolver_bridge.resolve(
+                    id,
+                    wcore_agent::host_send_transport::HostSendResult {
+                        ok: true,
+                        message_id: Some("bootstrap-wired-ok".into()),
+                        error: None,
+                    },
+                ));
+                return;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+        panic!("send_message never registered a waiter on the BootstrapResult bridge");
+    });
+
+    let tools = result.engine.tools();
+    let tool = tools.get("send_message").expect("send_message registered");
+    let out = tool
+        .execute(serde_json::json!({
+            "target": "email:mike@example.com",
+            "message": "wiring probe"
+        }))
+        .await;
+    resolver.await.expect("resolver task");
+
+    assert!(
+        !out.is_error,
+        "delegated send resolved by the result's bridge must succeed, got: {}",
+        out.content
+    );
+    assert!(
+        out.content.contains("bootstrap-wired-ok"),
+        "the host receipt must flow through — proves HostDelegatedTransport \
+         is bound to BootstrapResult.host_send_bridge, got: {}",
+        out.content
+    );
+}
+
+/// #141 backward-compat control: WITHOUT the env flag the delegated
+/// transport is NOT wired — `send_message` fails through the channel path
+/// immediately (no waiter ever appears on the result's bridge).
+#[tokio::test]
+#[serial]
+async fn without_host_delegate_env_send_message_keeps_channel_path() {
+    let (_plugins, _plugins_env) = isolated_plugins();
+    // Explicitly ensure the flag is absent for this test.
+    struct Unset(Option<String>);
+    impl Drop for Unset {
+        fn drop(&mut self) {
+            if let Some(v) = &self.0 {
+                // SAFETY: `#[serial]` — no concurrent env access.
+                unsafe { std::env::set_var("WAYLAND_SEND_MESSAGE_HOST_DELEGATE", v) };
+            }
+        }
+    }
+    let _unset = Unset(std::env::var("WAYLAND_SEND_MESSAGE_HOST_DELEGATE").ok());
+    // SAFETY: `#[serial]` — no concurrent env access.
+    unsafe { std::env::remove_var("WAYLAND_SEND_MESSAGE_HOST_DELEGATE") };
+
+    let config = minimal_config();
+    let workdir = tempfile::TempDir::new().expect("workdir");
+    let result = AgentBootstrap::new(config, workdir.path().to_str().unwrap(), null_output())
+        .build()
+        .await
+        .expect("bootstrap should succeed");
+
+    let bridge = result.host_send_bridge.clone();
+    let tools = result.engine.tools();
+    let tool = tools.get("send_message").expect("send_message registered");
+    let out = tool
+        .execute(serde_json::json!({
+            "target": "email:mike@example.com",
+            "message": "control probe"
+        }))
+        .await;
+
+    assert!(
+        out.is_error,
+        "flag off: send must fail through the channel/null path, got: {}",
+        out.content
+    );
+    assert_eq!(
+        bridge.pending_count(),
+        0,
+        "flag off: the delegated bridge must never see a waiter"
+    );
+}
+
 #[tokio::test]
 async fn bootstrap_registers_all_expected_tools() {
     let config = minimal_config();

--- a/crates/wcore-agent/tests/host_send_delegation.rs
+++ b/crates/wcore-agent/tests/host_send_delegation.rs
@@ -1,0 +1,432 @@
+//! #537/#141 — HARD SECURITY GATE tests for host-delegated `send_message`
+//! (wayland#543 audit finding 4).
+//!
+//! The desktop performs the actual delivery for `host_send_message_request`
+//! WITHOUT re-gating — it trusts that the engine's tool-approval flow
+//! already ran. These tests pin the three properties that make that trust
+//! sound:
+//!
+//! 1. `send_message` is `Exec`-category (never the auto-approvable `Info`)
+//!    and absent from the default allow-list, so a default-mode agent turn
+//!    can NOT send a message without an explicit approval.
+//! 2. A DENIED approval produces a tool-error result and emits ZERO
+//!    `host_send_message_request` frames — the host is never asked to send
+//!    anything the user refused.
+//! 3. AutoEdit mode (which auto-approves `info` + `edit` categories) still
+//!    gates `send_message`.
+//!
+//! Plus the positive path: an APPROVED call emits exactly one request frame
+//! and the host's `host_send_message_result` (same `call_id`) resolves the
+//! parked tool call — the mid-turn unblocking semantics the CLI's
+//! `HostSendMessageResult` arm relies on.
+
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use serde_json::json;
+use wcore_agent::host_send_transport::{HostDelegatedTransport, HostSendBridge, HostSendResult};
+use wcore_agent::orchestration::execute_tool_calls_with_approval;
+use wcore_protocol::commands::{ApprovalScope, SessionMode};
+use wcore_protocol::events::{ProtocolEvent, ToolCategory};
+use wcore_protocol::{ToolApprovalManager, ToolApprovalResult};
+use wcore_tools::registry::ToolRegistry;
+use wcore_tools::send_message::SendMessageTool;
+use wcore_types::message::ContentBlock;
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+/// ProtocolEmitter that records every emitted event (tool_request /
+/// tool_cancelled / tool_result / ...).
+#[derive(Default)]
+struct CaptureEmitter {
+    events: Mutex<Vec<ProtocolEvent>>,
+}
+
+impl wcore_protocol::writer::ProtocolEmitter for CaptureEmitter {
+    fn emit(&self, event: &ProtocolEvent) -> std::io::Result<()> {
+        if let Ok(mut v) = self.events.lock() {
+            v.push(event.clone());
+        }
+        Ok(())
+    }
+}
+
+impl CaptureEmitter {
+    fn tool_request_names(&self) -> Vec<String> {
+        self.events
+            .lock()
+            .map(|v| {
+                v.iter()
+                    .filter_map(|e| match e {
+                        ProtocolEvent::ToolRequest { tool, .. } => Some(tool.name.clone()),
+                        _ => None,
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+}
+
+/// OutputSink that records every `host_send_message_request` frame the
+/// transport emits. The gate assertion is on THIS capture: a denied call
+/// must leave it empty.
+#[derive(Default)]
+struct HostRequestCapture {
+    requests: Mutex<Vec<(String, String, Option<String>, String)>>,
+}
+
+impl HostRequestCapture {
+    fn snapshot(&self) -> Vec<(String, String, Option<String>, String)> {
+        self.requests.lock().map(|v| v.clone()).unwrap_or_default()
+    }
+}
+
+impl wcore_agent::output::OutputSink for HostRequestCapture {
+    fn emit_text_delta(&self, _text: &str, _msg_id: &str) {}
+    fn emit_thinking(&self, _text: &str, _msg_id: &str) {}
+    fn emit_tool_call(&self, _name: &str, _input: &str) {}
+    fn emit_tool_result(&self, _name: &str, _is_error: bool, _content: &str) {}
+    fn emit_stream_start(&self, _msg_id: &str) {}
+    #[allow(clippy::too_many_arguments)]
+    fn emit_stream_end(
+        &self,
+        _msg_id: &str,
+        _turns: usize,
+        _input_tokens: u64,
+        _output_tokens: u64,
+        _cache_creation_tokens: u64,
+        _cache_read_tokens: u64,
+        _finish_reason: wcore_protocol::events::FinishReason,
+    ) {
+    }
+    fn emit_error(&self, _msg: &str, _retryable: bool) {}
+    fn emit_info(&self, _msg: &str) {}
+    fn emit_host_send_message_request(
+        &self,
+        call_id: &str,
+        platform: &str,
+        chat_id: Option<&str>,
+        _thread_id: Option<&str>,
+        body: &str,
+        _subject: Option<&str>,
+        _conversation_id: Option<&str>,
+    ) {
+        if let Ok(mut v) = self.requests.lock() {
+            v.push((
+                call_id.to_string(),
+                platform.to_string(),
+                chat_id.map(str::to_string),
+                body.to_string(),
+            ));
+        }
+    }
+}
+
+struct Harness {
+    registry: ToolRegistry,
+    bridge: Arc<HostSendBridge>,
+    sink: Arc<HostRequestCapture>,
+    mgr: Arc<ToolApprovalManager>,
+    emitter: Arc<CaptureEmitter>,
+}
+
+fn harness() -> Harness {
+    let bridge = Arc::new(HostSendBridge::new());
+    let sink = Arc::new(HostRequestCapture::default());
+    let mut registry = ToolRegistry::new();
+    registry.register(Box::new(SendMessageTool::new(Arc::new(
+        HostDelegatedTransport::new(bridge.clone(), sink.clone()),
+    ))));
+    Harness {
+        registry,
+        bridge,
+        sink,
+        mgr: Arc::new(ToolApprovalManager::new()),
+        emitter: Arc::new(CaptureEmitter::default()),
+    }
+}
+
+fn send_message_call(call_id: &str) -> ContentBlock {
+    ContentBlock::ToolUse {
+        id: call_id.into(),
+        name: "send_message".into(),
+        input: json!({
+            "target": "email:mike@example.com",
+            "message": "hello from the agent"
+        }),
+        extra: None,
+    }
+}
+
+async fn run_turn(h: &Harness, call: ContentBlock) -> ContentBlock {
+    let writer: Arc<dyn wcore_protocol::writer::ProtocolEmitter> = h.emitter.clone();
+    let outcome = execute_tool_calls_with_approval(
+        &h.registry,
+        &[call],
+        &h.mgr,
+        &writer,
+        "msg-1",
+        false, // auto_approve OFF — the gate must fire
+        &[],   // allow_list empty (mirrors: send_message not allow-listed)
+        None,
+        wcore_compact::CompactionLevel::Off,
+        false,
+        &tokio_util::sync::CancellationToken::new(),
+        None,
+    )
+    .await
+    .expect("should not return ExecutionControl");
+    assert_eq!(outcome.results.len(), 1, "one result expected");
+    outcome.results.into_iter().next().expect("one result")
+}
+
+// ---------------------------------------------------------------------------
+// Gate property 1: categorization + defaults
+// ---------------------------------------------------------------------------
+
+/// `send_message` must be `Exec`, never the auto-approvable `Info` — the
+/// exact miscategorization wayland#543's audit finding 4 warns about.
+#[test]
+fn send_message_category_is_exec_not_info() {
+    use wcore_tools::Tool;
+    let tool = SendMessageTool::default();
+    assert_eq!(tool.category(), ToolCategory::Exec);
+}
+
+/// `send_message` must be absent from the config default allow-list (the
+/// read-only auto-approve set) — presence there would skip the approval
+/// gate entirely for every default install.
+#[test]
+fn send_message_absent_from_default_allow_list() {
+    let defaults = wcore_config::config::ToolsConfig::default().allow_list;
+    assert!(
+        !defaults.iter().any(|t| t == "send_message"),
+        "send_message must NOT be in the default allow-list, got: {defaults:?}"
+    );
+    // Belt-and-suspenders: nothing in the default list may be Exec-category
+    // messaging by another spelling either.
+    assert!(
+        !defaults.iter().any(
+            |t| t.eq_ignore_ascii_case("sendmessage") || t.eq_ignore_ascii_case("send_message")
+        ),
+        "no spelling variant of send_message may be auto-approved: {defaults:?}"
+    );
+}
+
+/// The manager's mode-level auto-approval must not cover `exec` in any
+/// non-Force mode: Default approves nothing, AutoEdit approves only
+/// `info`/`edit`. This is what keeps an Exec-category send_message gated.
+#[test]
+fn no_default_or_autoedit_mode_auto_approves_exec() {
+    let mgr = ToolApprovalManager::new();
+    assert!(!mgr.is_auto_approved("exec"), "Default mode gates exec");
+    mgr.set_mode(SessionMode::AutoEdit);
+    assert!(
+        mgr.is_auto_approved("info"),
+        "sanity: AutoEdit auto-approves info"
+    );
+    assert!(
+        !mgr.is_auto_approved("exec"),
+        "AutoEdit must NOT auto-approve exec (send_message's category)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Gate property 2: denial emits NO host_send_message_request
+// ---------------------------------------------------------------------------
+
+/// THE GATE: a denied `send_message` produces a tool-error result and the
+/// transport never emits `host_send_message_request` — the host (which
+/// sends without re-gating) is never asked to deliver a refused message.
+#[tokio::test]
+async fn denied_send_message_emits_no_host_request() {
+    let h = harness();
+    let call_id = "call-deny-1";
+
+    let mgr = h.mgr.clone();
+    let id = call_id.to_string();
+    tokio::spawn(async move {
+        tokio::task::yield_now().await;
+        mgr.resolve(
+            &id,
+            ToolApprovalResult::Denied {
+                reason: "user refused the send".into(),
+            },
+        );
+    });
+
+    let result = run_turn(&h, send_message_call(call_id)).await;
+    let ContentBlock::ToolResult {
+        content, is_error, ..
+    } = result
+    else {
+        panic!("expected ToolResult");
+    };
+    assert!(is_error, "denied send must surface as a tool error");
+    assert!(
+        content.contains("denied"),
+        "denial reason must reach the model, got: {content}"
+    );
+    assert!(
+        h.sink.snapshot().is_empty(),
+        "NO host_send_message_request may be emitted for a denied call"
+    );
+    // The gate DID fire: a tool_request for send_message was emitted first.
+    assert_eq!(h.emitter.tool_request_names(), vec!["send_message"]);
+}
+
+/// Same gate under AutoEdit — the mode that auto-approves Info/Edit. The
+/// Exec-category send_message must still park on the approval and a denial
+/// must still suppress the host request.
+#[tokio::test]
+async fn autoedit_mode_still_gates_send_message() {
+    let h = harness();
+    h.mgr.set_mode(SessionMode::AutoEdit);
+    let call_id = "call-deny-autoedit";
+
+    let mgr = h.mgr.clone();
+    let id = call_id.to_string();
+    tokio::spawn(async move {
+        tokio::task::yield_now().await;
+        mgr.resolve(
+            &id,
+            ToolApprovalResult::Denied {
+                reason: "refused".into(),
+            },
+        );
+    });
+
+    let result = run_turn(&h, send_message_call(call_id)).await;
+    let ContentBlock::ToolResult { is_error, .. } = result else {
+        panic!("expected ToolResult");
+    };
+    assert!(is_error, "AutoEdit must not auto-approve send_message");
+    assert!(
+        h.sink.snapshot().is_empty(),
+        "AutoEdit + denial: no host request may be emitted"
+    );
+    assert_eq!(
+        h.emitter.tool_request_names(),
+        vec!["send_message"],
+        "the approval gate must have fired under AutoEdit"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Positive path: approval → request frame → host result unblocks the tool
+// ---------------------------------------------------------------------------
+
+/// Approved call: exactly one `host_send_message_request` (emitted AFTER
+/// the tool_request approval round-trip) carrying the ParsedTarget, and a
+/// `host_send_message_result` with the SAME call_id resolves the parked
+/// tool into a success result — the same unblocking the CLI's mid-turn
+/// `HostSendMessageResult` arm performs on a live json-stream session.
+#[tokio::test]
+async fn approved_send_resolves_via_host_result_same_call_id() {
+    let h = harness();
+    let call_id = "call-approve-1";
+
+    // Approve once the gate parks, then play host: wait for the request
+    // frame and resolve the bridge under its call_id.
+    let mgr = h.mgr.clone();
+    let sink = h.sink.clone();
+    let bridge = h.bridge.clone();
+    let id = call_id.to_string();
+    tokio::spawn(async move {
+        tokio::task::yield_now().await;
+        mgr.approve(&id, ApprovalScope::Once, None);
+        for _ in 0..200 {
+            if let Some((hsm_id, platform, chat_id, body)) = sink.snapshot().first().cloned() {
+                assert_eq!(platform, "email");
+                assert_eq!(chat_id.as_deref(), Some("mike@example.com"));
+                assert_eq!(body, "hello from the agent");
+                // A wrong call_id must NOT unblock the tool.
+                assert!(!bridge.resolve(
+                    "hsm-wrong-id",
+                    HostSendResult {
+                        ok: true,
+                        message_id: None,
+                        error: None,
+                    },
+                ));
+                assert!(bridge.resolve(
+                    &hsm_id,
+                    HostSendResult {
+                        ok: true,
+                        message_id: Some("smtp-250-ok".into()),
+                        error: None,
+                    },
+                ));
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        panic!("host_send_message_request never appeared");
+    });
+
+    let result = run_turn(&h, send_message_call(call_id)).await;
+    let ContentBlock::ToolResult {
+        content, is_error, ..
+    } = result
+    else {
+        panic!("expected ToolResult");
+    };
+    assert!(!is_error, "approved + host ok must succeed, got: {content}");
+    assert!(
+        content.contains("smtp-250-ok"),
+        "the host receipt must reach the model, got: {content}"
+    );
+    assert_eq!(
+        h.sink.snapshot().len(),
+        1,
+        "exactly one request frame per send"
+    );
+    assert_eq!(h.emitter.tool_request_names(), vec!["send_message"]);
+}
+
+/// Approved call + host failure: the tool result is a REAL error carrying
+/// the host's message (never a false success).
+#[tokio::test]
+async fn approved_send_with_host_failure_is_tool_error() {
+    let h = harness();
+    let call_id = "call-approve-fail";
+
+    let mgr = h.mgr.clone();
+    let sink = h.sink.clone();
+    let bridge = h.bridge.clone();
+    let id = call_id.to_string();
+    tokio::spawn(async move {
+        tokio::task::yield_now().await;
+        mgr.approve(&id, ApprovalScope::Once, None);
+        for _ in 0..200 {
+            if let Some((hsm_id, ..)) = sink.snapshot().first().cloned() {
+                assert!(bridge.resolve(
+                    &hsm_id,
+                    HostSendResult {
+                        ok: false,
+                        message_id: None,
+                        error: Some("SMTP 550: mailbox unavailable".into()),
+                    },
+                ));
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        panic!("host_send_message_request never appeared");
+    });
+
+    let result = run_turn(&h, send_message_call(call_id)).await;
+    let ContentBlock::ToolResult {
+        content, is_error, ..
+    } = result
+    else {
+        panic!("expected ToolResult");
+    };
+    assert!(is_error, "host failure must be a tool error");
+    assert!(
+        content.contains("SMTP 550"),
+        "the host's error must reach the model, got: {content}"
+    );
+}

--- a/crates/wcore-agent/tests/host_send_delegation.rs
+++ b/crates/wcore-agent/tests/host_send_delegation.rs
@@ -69,16 +69,19 @@ impl CaptureEmitter {
     }
 }
 
+/// One captured request frame: `(call_id, platform, chat_id, body)`.
+type CapturedRequest = (String, String, Option<String>, String);
+
 /// OutputSink that records every `host_send_message_request` frame the
 /// transport emits. The gate assertion is on THIS capture: a denied call
 /// must leave it empty.
 #[derive(Default)]
 struct HostRequestCapture {
-    requests: Mutex<Vec<(String, String, Option<String>, String)>>,
+    requests: Mutex<Vec<CapturedRequest>>,
 }
 
 impl HostRequestCapture {
-    fn snapshot(&self) -> Vec<(String, String, Option<String>, String)> {
+    fn snapshot(&self) -> Vec<CapturedRequest> {
         self.requests.lock().map(|v| v.clone()).unwrap_or_default()
     }
 }

--- a/crates/wcore-agent/tests/host_send_delegation.rs
+++ b/crates/wcore-agent/tests/host_send_delegation.rs
@@ -389,6 +389,85 @@ async fn approved_send_resolves_via_host_result_same_call_id() {
     assert_eq!(h.emitter.tool_request_names(), vec!["send_message"]);
 }
 
+/// #141 audit Gap A pin: `ApprovalScope::Always` on the FIRST send_message
+/// must NOT auto-approve the second — Always downgrades to Once for this
+/// tool. The second call emits a fresh tool_request; denying it produces a
+/// tool error and no second host_send_message_request frame. Without the
+/// carve-out, one "Always allow" click would let a prompt-injected turn
+/// message arbitrary recipients silently for the rest of the session.
+#[tokio::test]
+async fn always_scope_does_not_skip_approval_on_second_send() {
+    let h = harness();
+
+    // ── First send: approved with ApprovalScope::Always; host fulfils. ──
+    let first_id = "call-always-1";
+    {
+        let mgr = h.mgr.clone();
+        let sink = h.sink.clone();
+        let bridge = h.bridge.clone();
+        let id = first_id.to_string();
+        tokio::spawn(async move {
+            tokio::task::yield_now().await;
+            mgr.approve(&id, ApprovalScope::Always, None);
+            for _ in 0..200 {
+                if let Some((hsm_id, ..)) = sink.snapshot().first().cloned() {
+                    assert!(bridge.resolve(
+                        &hsm_id,
+                        HostSendResult {
+                            ok: true,
+                            message_id: Some("first-ok".into()),
+                            error: None,
+                        },
+                    ));
+                    return;
+                }
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+            panic!("first host_send_message_request never appeared");
+        });
+    }
+    let first = run_turn(&h, send_message_call(first_id)).await;
+    let ContentBlock::ToolResult { is_error, .. } = &first else {
+        panic!("expected ToolResult");
+    };
+    assert!(!is_error, "first (approved) send must succeed");
+
+    // ── Second send: MUST park on a fresh approval; deny it. ──
+    let second_id = "call-always-2";
+    {
+        let mgr = h.mgr.clone();
+        let id = second_id.to_string();
+        tokio::spawn(async move {
+            tokio::task::yield_now().await;
+            mgr.resolve(
+                &id,
+                ToolApprovalResult::Denied {
+                    reason: "second send refused".into(),
+                },
+            );
+        });
+    }
+    let second = run_turn(&h, send_message_call(second_id)).await;
+    let ContentBlock::ToolResult { is_error, .. } = &second else {
+        panic!("expected ToolResult");
+    };
+    assert!(
+        is_error,
+        "second send must have required (and here been denied) approval — \
+         Always on send_message must downgrade to Once"
+    );
+    assert_eq!(
+        h.emitter.tool_request_names(),
+        vec!["send_message", "send_message"],
+        "BOTH sends must emit their own tool_request card"
+    );
+    assert_eq!(
+        h.sink.snapshot().len(),
+        1,
+        "only the first (approved) send may reach the host"
+    );
+}
+
 /// Approved call + host failure: the tool result is a REAL error carrying
 /// the host's message (never a false success).
 #[tokio::test]

--- a/crates/wcore-cli/src/main.rs
+++ b/crates/wcore-cli/src/main.rs
@@ -2711,6 +2711,12 @@ async fn run_json_stream_mode(
     // Bootstrap builds one bridge and hands it to both engine + ScriptTool.
     let approval_bridge = engine.approval_bridge().clone();
 
+    // #537/#141: the host-delegated send_message correlation bridge. The
+    // `HostSendMessageResult` command arms below (top-level AND mid-turn)
+    // resolve through this handle so a `send_message` tool call parked on
+    // `HostDelegatedTransport::send` unblocks with the host's outcome.
+    let host_send_bridge = result.host_send_bridge.clone();
+
     // Wave SC SECURITY MAJOR: share the bridge's active-token redactor
     // with the protocol sink. The sink was built before the bridge
     // existed; `share_with` swaps the inner Arc<RwLock> pointer so
@@ -3029,6 +3035,32 @@ async fn run_json_stream_mode(
                                             });
                                         }
                                     }
+                                    ProtocolCommand::HostSendMessageResult { call_id, ok, message_id, error } => {
+                                        // #537/#141: a host-delegated send_message parks
+                                        // DURING the active turn (the tool call awaits the
+                                        // host's result), so this arm is the one that
+                                        // actually unblocks it — mirroring the
+                                        // ApprovalResume mid-turn handling above
+                                        // (GHSA-8r7g pattern). An unknown call_id resolves
+                                        // nothing (stale reply after timeout, or a peer
+                                        // guessing ids) and is surfaced as Info.
+                                        let resolved = host_send_bridge.resolve(
+                                            &call_id,
+                                            wcore_agent::host_send_transport::HostSendResult {
+                                                ok,
+                                                message_id,
+                                                error,
+                                            },
+                                        );
+                                        if !resolved {
+                                            let _ = writer.emit(&wcore_protocol::events::ProtocolEvent::Info {
+                                                msg_id: String::new(),
+                                                message: format!(
+                                                    "host_send_message_result received for unknown call_id: {call_id} (stale or timed-out send?)"
+                                                ),
+                                            });
+                                        }
+                                    }
                                     _ => {
                                         eprintln!("[protocol] Ignoring command during active message processing");
                                     }
@@ -3202,6 +3234,35 @@ async fn run_json_stream_mode(
                         msg_id: String::new(),
                         message: format!(
                             "approval_resume received for unknown token: {resume_token} (stale resume?)"
+                        ),
+                    });
+                }
+            }
+            ProtocolCommand::HostSendMessageResult {
+                call_id,
+                ok,
+                message_id,
+                error,
+            } => {
+                // #537/#141: a delegated send awaits its result DURING the
+                // turn (handled by the mid-turn arm above); a result arriving
+                // here, between turns, is almost always stale — the send
+                // already timed out into a tool error. Still attempt the
+                // resolve (harmless if the id is gone) and surface unknown
+                // ids as Info, mirroring the ApprovalResume arm.
+                let resolved = host_send_bridge.resolve(
+                    &call_id,
+                    wcore_agent::host_send_transport::HostSendResult {
+                        ok,
+                        message_id,
+                        error,
+                    },
+                );
+                if !resolved {
+                    let _ = writer.emit(&wcore_protocol::events::ProtocolEvent::Info {
+                        msg_id: String::new(),
+                        message: format!(
+                            "host_send_message_result received for unknown call_id: {call_id} (stale or timed-out send?)"
                         ),
                     });
                 }

--- a/crates/wcore-cli/src/tui/protocol_bridge.rs
+++ b/crates/wcore-cli/src/tui/protocol_bridge.rs
@@ -887,6 +887,9 @@ fn apply_event_inner(app: &mut App, event: ProtocolEvent) {
         // These variants carry diagnostics or capability handshakes that
         // no Wave-0 `App` field models. They are explicit no-ops so an
         // unknown-but-valid event can never crash the bridge.
+        // #537/#141 `HostSendMessageRequest` is host-delegation plumbing for
+        // json-stream hosts; the in-process TUI never runs delegated (no
+        // host to fulfil the send), so it has no view impact here.
         ProtocolEvent::Ready { .. }
         | ProtocolEvent::TraceEvent { .. }
         | ProtocolEvent::PluginEvent { .. }
@@ -896,6 +899,7 @@ fn apply_event_inner(app: &mut App, event: ProtocolEvent) {
         | ProtocolEvent::Suspend { .. }
         | ProtocolEvent::ApprovalResume { .. }
         | ProtocolEvent::CompactOffload { .. }
+        | ProtocolEvent::HostSendMessageRequest { .. }
         | ProtocolEvent::Pong => {}
     }
 }

--- a/crates/wcore-protocol/src/commands.rs
+++ b/crates/wcore-protocol/src/commands.rs
@@ -80,6 +80,22 @@ pub enum ProtocolCommand {
         #[serde(default)]
         modifications: Option<serde_json::Value>,
     },
+    /// #537/#141 host-send-transport hook: the host's reply to a
+    /// `host_send_message_request` event, correlated by `call_id`.
+    /// `ok = true` resolves the awaiting `send_message` tool call as sent
+    /// (with the optional `message_id` receipt); `ok = false` surfaces
+    /// `error` as a real tool failure to the model — never a false
+    /// success. Routed through the shared `HostSendBridge` by the CLI
+    /// command loop (including MID-turn, where the tool is parked — same
+    /// pattern as the `ApprovalResume` mid-turn arm from GHSA-8r7g).
+    HostSendMessageResult {
+        call_id: String,
+        ok: bool,
+        #[serde(default)]
+        message_id: Option<String>,
+        #[serde(default)]
+        error: Option<String>,
+    },
     Ping,
 }
 
@@ -438,6 +454,64 @@ mod tests {
                 assert_eq!(answer, Some("Choice C".to_string()));
             }
             _ => panic!("Expected ToolApprove"),
+        }
+    }
+
+    /// #537/#141: success reply as the desktop emits it —
+    /// `{"type":"host_send_message_result","call_id":...,"ok":true,
+    /// "message_id":...}` (error omitted).
+    #[test]
+    fn host_send_message_result_ok_deserialize() {
+        let json = r#"{"type":"host_send_message_result","call_id":"hsm-1","ok":true,"message_id":"msg-123"}"#;
+        let cmd: ProtocolCommand = serde_json::from_str(json).unwrap();
+        match cmd {
+            ProtocolCommand::HostSendMessageResult {
+                call_id,
+                ok,
+                message_id,
+                error,
+            } => {
+                assert_eq!(call_id, "hsm-1");
+                assert!(ok);
+                assert_eq!(message_id.as_deref(), Some("msg-123"));
+                assert!(error.is_none());
+            }
+            _ => panic!("expected HostSendMessageResult"),
+        }
+    }
+
+    /// #537/#141: failure reply — `ok:false` with `error`, no `message_id`.
+    /// Both optionals are serde-default so the minimal shape
+    /// (`call_id` + `ok` only) also parses.
+    #[test]
+    fn host_send_message_result_err_and_minimal_deserialize() {
+        let json = r#"{"type":"host_send_message_result","call_id":"hsm-2","ok":false,"error":"SMTP 550: mailbox unavailable"}"#;
+        let cmd: ProtocolCommand = serde_json::from_str(json).unwrap();
+        match cmd {
+            ProtocolCommand::HostSendMessageResult {
+                call_id,
+                ok,
+                message_id,
+                error,
+            } => {
+                assert_eq!(call_id, "hsm-2");
+                assert!(!ok);
+                assert!(message_id.is_none());
+                assert_eq!(error.as_deref(), Some("SMTP 550: mailbox unavailable"));
+            }
+            _ => panic!("expected HostSendMessageResult"),
+        }
+
+        let minimal = r#"{"type":"host_send_message_result","call_id":"hsm-3","ok":true}"#;
+        let cmd: ProtocolCommand = serde_json::from_str(minimal).unwrap();
+        match cmd {
+            ProtocolCommand::HostSendMessageResult {
+                message_id, error, ..
+            } => {
+                assert!(message_id.is_none());
+                assert!(error.is_none());
+            }
+            _ => panic!("expected HostSendMessageResult"),
         }
     }
 

--- a/crates/wcore-protocol/src/events.rs
+++ b/crates/wcore-protocol/src/events.rs
@@ -422,6 +422,50 @@ pub enum ProtocolEvent {
         app: String,
         reason: String,
     },
+    /// #537/#141 host-send-transport hook: the engine runs host-delegated
+    /// (`WAYLAND_SEND_MESSAGE_HOST_DELEGATE=1` at spawn) and an approved
+    /// `send_message` tool call is asking the HOST to perform the actual
+    /// delivery through its own outbound channel plugins (the engine's
+    /// channel table is empty under the desktop). The host fulfils the send
+    /// and replies with the `host_send_message_result` command, correlated
+    /// by `call_id`. `platform` / `chat_id` / `thread_id` mirror the
+    /// engine's `ParsedTarget`; `body` is the message text.
+    ///
+    /// SECURITY (wayland#543 audit finding 4): the host performs the send
+    /// WITHOUT re-gating — it trusts that the engine's tool-approval flow
+    /// (`tool_request` / allow-list / mode gate) already ran. This event is
+    /// only ever emitted from inside `SendMessageTool::execute`, which the
+    /// orchestration approval gate fronts; `send_message` is `Exec`-category
+    /// and absent from every auto-approve default (see
+    /// `wcore-agent/tests/host_send_delegation.rs`).
+    ///
+    /// Always-on additive variant (no capability flag) — hosts that don't
+    /// recognise `host_send_message_request` drop it silently per the W0
+    /// host decoder contract; only hosts that opted in via the env var
+    /// ever receive it.
+    HostSendMessageRequest {
+        call_id: String,
+        /// `MessagingPlatform::as_str()` token, e.g. `"email"`.
+        platform: String,
+        /// Recipient (for email: the destination address). Omitted when the
+        /// target string carried no chat id.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        chat_id: Option<String>,
+        /// Reply-to / thread handle. Omitted when absent.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        thread_id: Option<String>,
+        /// The message text.
+        body: String,
+        /// Optional subject line. The current `send_message` schema carries
+        /// no subject input, so the engine omits this today; the field is
+        /// part of the wire contract (the desktop host threads it into the
+        /// outgoing message when present).
+        #[serde(skip_serializing_if = "Option::is_none")]
+        subject: Option<String>,
+        /// Session id of the emitting engine, when known. Omitted otherwise.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        conversation_id: Option<String>,
+    },
     /// W5 M6 / #279(d) + #280: a context compaction occurred. Gated by
     /// capabilities.non_destructive_compact; hosts that don't recognise
     /// compact_offload MUST drop it per the host decoder contract.
@@ -756,6 +800,59 @@ mod tests {
         assert_eq!(json["text"], "");
         assert_eq!(json["msg_id"], "m1");
         assert_eq!(json["subject"], "Reasoning through the problem");
+    }
+
+    /// #537/#141: the host-send frame must serialize with EXACTLY the field
+    /// names the desktop's `protocol.ts` union declares
+    /// (`host_send_message_request` / call_id / platform / chat_id /
+    /// thread_id / body / subject / conversation_id) — the desktop half
+    /// (wayland PR #543) is already shipped against this spelling.
+    #[test]
+    fn test_host_send_message_request_full_serialization() {
+        let event = ProtocolEvent::HostSendMessageRequest {
+            call_id: "hsm-1".to_string(),
+            platform: "email".to_string(),
+            chat_id: Some("mike@example.com".to_string()),
+            thread_id: Some("t-9".to_string()),
+            body: "hello".to_string(),
+            subject: Some("Re: invoice".to_string()),
+            conversation_id: Some("abc123".to_string()),
+        };
+        let json = serde_json::to_value(&event).unwrap();
+        assert_eq!(json["type"], "host_send_message_request");
+        assert_eq!(json["call_id"], "hsm-1");
+        assert_eq!(json["platform"], "email");
+        assert_eq!(json["chat_id"], "mike@example.com");
+        assert_eq!(json["thread_id"], "t-9");
+        assert_eq!(json["body"], "hello");
+        assert_eq!(json["subject"], "Re: invoice");
+        assert_eq!(json["conversation_id"], "abc123");
+    }
+
+    /// #537/#141: optional fields are OMITTED (not null) when absent — the
+    /// desktop types them as optional (`chat_id?` / `thread_id?` /
+    /// `subject?` / `conversation_id?`).
+    #[test]
+    fn test_host_send_message_request_omits_absent_optionals() {
+        let event = ProtocolEvent::HostSendMessageRequest {
+            call_id: "hsm-2".to_string(),
+            platform: "telegram".to_string(),
+            chat_id: None,
+            thread_id: None,
+            body: "ping".to_string(),
+            subject: None,
+            conversation_id: None,
+        };
+        let json = serde_json::to_value(&event).unwrap();
+        assert_eq!(json["type"], "host_send_message_request");
+        assert_eq!(json["platform"], "telegram");
+        assert_eq!(json["body"], "ping");
+        for key in ["chat_id", "thread_id", "subject", "conversation_id"] {
+            assert!(
+                json.get(key).is_none(),
+                "{key} must be omitted when None, got {json}"
+            );
+        }
     }
 
     #[test]

--- a/crates/wcore-protocol/src/lib.rs
+++ b/crates/wcore-protocol/src/lib.rs
@@ -287,6 +287,18 @@ impl ToolApprovalManager {
         })
     }
 
+    /// #141 audit Gap A — tools whose `ApprovalScope::Always` silently
+    /// downgrades to `Once`. `send_message` has observable external effects
+    /// on ARBITRARY recipients: a single "Always allow" click on one send
+    /// would otherwise auto-approve every later send in the session (any
+    /// platform, any recipient), letting a prompt-injected turn message
+    /// arbitrary recipients with zero confirmation. Each send gets its own
+    /// card. Mirrors the AskUserQuestion always-needs-approval carve-out in
+    /// `orchestration::execute_tool_calls_with_approval`.
+    fn always_scope_ineligible(tool_name: &str) -> bool {
+        tool_name == "send_message"
+    }
+
     /// Resolve a pending approval as `Approved`, honouring the scope
     /// (Once / Always / AlwaysPrefix) for auto-approval registration and
     /// threading `answer` into the resolved `ToolApprovalResult::Approved`.
@@ -310,8 +322,13 @@ impl ToolApprovalManager {
                 // which caused "always allow Bash" to auto-approve every Exec
                 // tool (Write, Edit, etc). Now only the specific tool name is
                 // registered so approval is scoped to that tool only.
+                //
+                // #141 audit Gap A: per-recipient-effect tools
+                // (send_message) are ineligible — Always downgrades to Once.
                 ApprovalScope::Always => {
-                    if let Ok(mut names) = self.auto_approved_tool_names.lock() {
+                    if !Self::always_scope_ineligible(&pending.tool_name)
+                        && let Ok(mut names) = self.auto_approved_tool_names.lock()
+                    {
                         names.insert(pending.tool_name.clone());
                     }
                 }
@@ -376,8 +393,12 @@ impl ToolApprovalManager {
 
         if approved {
             match scope {
+                // #141 audit Gap A: same downgrade-to-Once carve-out as
+                // `approve` — the host path must not be a side door.
                 ApprovalScope::Always => {
-                    if let Ok(mut names) = self.auto_approved_tool_names.lock() {
+                    if !Self::always_scope_ineligible(&pending.tool_name)
+                        && let Ok(mut names) = self.auto_approved_tool_names.lock()
+                    {
                         names.insert(pending.tool_name.clone());
                     }
                 }
@@ -483,6 +504,13 @@ impl ToolApprovalManager {
     ///                       && !is_tool_name_auto_approved(tool_name)
     /// ```
     pub fn is_tool_name_auto_approved(&self, tool_name: &str) -> bool {
+        // #141 audit Gap A belt-and-suspenders: an Always-ineligible tool
+        // (send_message) is never auto-approved by name even if a future
+        // code path writes it into the set — both registration sites skip
+        // it, and this read-side guard makes the invariant unconditional.
+        if Self::always_scope_ineligible(tool_name) {
+            return false;
+        }
         self.auto_approved_tool_names
             .lock()
             .map(|names| names.contains(tool_name))
@@ -582,6 +610,52 @@ mod tests {
         assert!(!mgr.is_auto_approved("edit"));
         assert!(!mgr.is_auto_approved("exec"));
         assert!(!mgr.is_auto_approved("mcp"));
+    }
+
+    // --- #141 audit Gap A: Always-scope carve-out for send_message ---
+
+    /// `ApprovalScope::Always` on send_message must DOWNGRADE to Once:
+    /// no tool-name auto-approve registration, via BOTH resolution paths
+    /// (`approve` and `resolve_host`). A comparison tool (Bash) still
+    /// registers, proving the carve-out is send_message-specific.
+    #[test]
+    fn always_scope_on_send_message_downgrades_to_once() {
+        let mgr = ToolApprovalManager::new();
+
+        // Path 1: approve().
+        let _rx = mgr.request_approval("c-1", &ToolCategory::Exec, "send_message");
+        mgr.approve("c-1", ApprovalScope::Always, None);
+        assert!(
+            !mgr.is_tool_name_auto_approved("send_message"),
+            "Always on send_message must not persist a tool-name allow"
+        );
+
+        // Path 2: resolve_host().
+        let _rx = mgr.request_approval("c-2", &ToolCategory::Exec, "send_message");
+        assert!(mgr.resolve_host("c-2", true, ApprovalScope::Always, None));
+        assert!(
+            !mgr.is_tool_name_auto_approved("send_message"),
+            "resolve_host Always must not be a side door for send_message"
+        );
+
+        // Control: Bash Always still registers (W5.6 H-2 behavior intact).
+        let _rx = mgr.request_approval("c-3", &ToolCategory::Exec, "Bash");
+        mgr.approve("c-3", ApprovalScope::Always, None);
+        assert!(mgr.is_tool_name_auto_approved("Bash"));
+    }
+
+    /// Read-side belt-and-suspenders: even a directly poisoned set must not
+    /// auto-approve send_message by name.
+    #[test]
+    fn send_message_never_name_auto_approved_even_if_set_poisoned() {
+        let mgr = ToolApprovalManager::new();
+        if let Ok(mut names) = mgr.auto_approved_tool_names.lock() {
+            names.insert("send_message".to_string());
+        }
+        assert!(
+            !mgr.is_tool_name_auto_approved("send_message"),
+            "read-side guard must hold even against a poisoned set"
+        );
     }
 
     #[test]

--- a/docs/json-stream-protocol.md
+++ b/docs/json-stream-protocol.md
@@ -829,6 +829,11 @@ Rationale: `BudgetExceeded` is a singular event per session (fires
 once when the first budget cap trips); the flag-per-variant overhead
 exceeds the wire-surface savings.
 
+#537/#141 adds `host_send_message_request` (§1.N+12) to this list:
+it is only ever emitted when the host itself opted in by spawning the
+engine with `WAYLAND_SEND_MESSAGE_HOST_DELEGATE=1`, so a flag would be
+redundant with the env-var opt-in.
+
 W10B's `gepa_enabled` flag is INDEPENDENT of `structured_traces` — F6 audit
 fix in the W10B revision. Hosts that want only W1 turn traces aren't forced
 to accept thousands of W10B per-child evolution events per `wcore-evolve`
@@ -1294,3 +1299,72 @@ about `budget_exceeded` drop the line silently per W0.
   "limit": "10000"
 }
 ```
+
+### 1.N+12 host_send_message_request (#537/#141)
+
+Host-delegated `send_message`: when the host spawned the engine with
+`WAYLAND_SEND_MESSAGE_HOST_DELEGATE=1`, an **approved** `send_message`
+tool call is fulfilled by the HOST — the engine emits this request and
+parks the tool call awaiting the host's `host_send_message_result`
+command (§2.11), correlated by `call_id`. The wait is bounded (30s);
+no reply resolves the tool call as a loud error, never a hang or a
+false success.
+
+**Host-tolerated, no dedicated capability flag** — only hosts that
+opted in via the env var ever receive it; others never see it (and
+would drop it silently per W0).
+
+> **Security invariant (wayland#543 audit finding 4).** The host
+> performs the delivery WITHOUT re-gating: it trusts that the engine's
+> tool-approval flow (`tool_request` / allow-list / mode gate) already
+> ran for this `send_message` call. The engine guarantees this — the
+> event is only emitted from inside the tool's `execute`, which the
+> orchestration approval gate fronts; `send_message` is Exec-category
+> and in no auto-approve default
+> (`crates/wcore-agent/tests/host_send_delegation.rs` pins it).
+
+```json
+{
+  "type": "host_send_message_request",
+  "call_id": "hsm-3f6c…",
+  "platform": "email",
+  "chat_id": "mike@example.com",
+  "thread_id": "t-17",
+  "body": "hello from the agent",
+  "subject": "Re: invoice",
+  "conversation_id": "abc123"
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `call_id` | string | yes | Engine-minted correlation id (`hsm-{uuid}`). Echo it back verbatim on the result. |
+| `platform` | string | yes | `MessagingPlatform::as_str()` token (`"email"`, `"telegram"`, …). |
+| `chat_id` | string | no | Recipient (for email: the destination address). Omitted when the target carried none. |
+| `thread_id` | string | no | Reply-to / thread handle. Omitted when absent. |
+| `body` | string | yes | The message text. |
+| `subject` | string | no | Subject line. The current `send_message` schema has no subject input, so the engine omits it today; part of the wire contract for forward-compat. |
+| `conversation_id` | string | no | Session id of the emitting engine, when known. |
+
+### 2.11 `host_send_message_result` (#537/#141)
+
+The host's reply to `host_send_message_request` (§1.N+12). Accepted
+both between turns and MID-turn (the tool call is parked inside the
+active turn — same mid-turn routing as `approval_resume`). An unknown
+/ stale `call_id` resolves nothing and is surfaced as an `info` event.
+
+```json
+{
+  "type": "host_send_message_result",
+  "call_id": "hsm-3f6c…",
+  "ok": true,
+  "message_id": "smtp-250-2.0.0"
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `call_id` | string | yes | Echoed verbatim from the request. |
+| `ok` | bool | yes | `true` → the tool call resolves as sent; `false` → the tool call fails with `error`. |
+| `message_id` | string | no | Platform-assigned receipt for a successful send. |
+| `error` | string | no | Human-readable failure reason; surfaced verbatim to the model when `ok` is `false`. |

--- a/docs/json-stream-protocol.md
+++ b/docs/json-stream-protocol.md
@@ -1322,6 +1322,13 @@ would drop it silently per W0).
 > orchestration approval gate fronts; `send_message` is Exec-category
 > and in no auto-approve default
 > (`crates/wcore-agent/tests/host_send_delegation.rs` pins it).
+> `ApprovalScope::Always` on `send_message` deliberately downgrades to
+> `Once` — every send gets its own confirmation card.
+>
+> The approval gate IS the delegation contract: a host that spawns the
+> engine with `--auto-approve` / `--force` (or grants wire-force via
+> `WAYLAND_ALLOW_WIRE_FORCE=1`) is opting out of that gate and MUST
+> supply its own confirmation UX before fulfilling these requests.
 
 ```json
 {


### PR DESCRIPTION
## Summary

Engine half of the host-send-transport for wayland#537 (agent `send_message(email)` fails "unknown channel: email" under the desktop). Desktop half (wayland#543) is implemented + cross-audited and dormant until this lands; merge order is engine-first per Overwatch.

## What this ships

- With `WAYLAND_SEND_MESSAGE_HOST_DELEGATE=1` (exactly `"1"`), `send_message` emits a json-stream `host_send_message_request` (engine→host: `call_id` + ParsedTarget) instead of hitting the empty engine ChannelManager, and parks on a `HostSendBridge` awaiting `host_send_message_result` correlated by `call_id`. Frame spellings copied byte-for-byte from the desktop's shipped `protocol.ts` (optionals omitted, not null) and pinned by serde tests.
- **Never hangs:** register-before-emit (BridgeApprover precedent), 30s bounded wait; timeout / host failure / channel close are loud tool errors. The timeout error carries verbatim anti-double-send guidance ("the host may still complete this delivery — do NOT automatically retry; ask the user before re-sending"). Handled in BOTH the mid-turn select arm (mirrors the GHSA-8r7g ApprovalResume fix) and the top-level arm.
- **The hard security gate (the #141 non-negotiable):** `host_send_message_request` has exactly one emission site, inside `SendMessageTool::execute`, fronted by `execute_tool_calls_with_approval`. `send_message` is `ToolCategory::Exec`, absent from the default allow-list, and AutoEdit auto-approves only info/edit — all pinned by tests. Per the independent security audit: **`ApprovalScope::Always` is carved out for `send_message`** (downgrades to Once at both resolution paths + a read-side guard against a poisoned set) — one habitual "Always" click can never let a prompt-injected turn email arbitrary recipients silently.
- Hostile host-result strings clamped (4096 chars) at the single bridge chokepoint; env-unset behavior byte-identical to today (pinned by a bootstrap control test); TUI unaffected.

## Verification

- Independent adversarial security audit (non-author): verdict MERGE-AFTER-FIXES; approval-bypass hunt found **no path** (sub-agent/Spawn/council registries structurally cannot construct the tool; workflow gate, policy gate, cron, MCP surfaces all verified); both required findings + all advisories applied.
- Hetzner gate green: fmt/clippy clean, nextest 5510/5510 on the audited SHA (21 new tests: protocol serde ×4, transport unit ×8, approval-gate integration ×6, bootstrap wiring ×2, oversize clamp).
- Done-bar note: the live email E2E ("agent sends a real email") requires the desktop half bundled, which per the #537 merge order happens after this ships — the engine-side half of the bar (gate fires before any host frame; denied approval → zero frames; Always → re-approval) is pinned by the integration suite.

Addresses #141 (close is a release/Sean action).
