### PR TITLE
fix(channels): break the email self-reply loop by marking echoed own mail is_self

### DIFF
--- a/crates/wcore-channel-email/src/imap.rs
+++ b/crates/wcore-channel-email/src/imap.rs
@@ -60,6 +60,17 @@ pub(crate) struct ImapPollArgs {
     /// list are dropped before enqueueing. See `ImapConfig::allowed_senders`
     /// for the (lack of) authentication guarantees.
     pub allowed_senders: Vec<String>,
+    /// This channel's own addresses (bare addr-spec, lowercased): the SMTP
+    /// From address plus the IMAP account when it is address-shaped. Inbound
+    /// mail whose `From:` matches is marked `is_self` so the dispatch
+    /// kernel's loop guard drops it instead of starting an agent turn
+    /// (wayland#547 — the agent otherwise replies to its own mail forever).
+    pub own_addresses: Vec<String>,
+    /// Message-IDs this channel has sent (recorded by the SMTP path). An
+    /// inbound whose id matches is the channel's own mail echoing back and
+    /// is likewise marked `is_self`. Precise where the From-match is blunt:
+    /// it never flags mail a human sent from the shared account.
+    pub sent_ids: crate::sent_index::SentIdIndex,
     pub inbox: Arc<Mutex<VecDeque<ChannelEvent>>>,
     pub last_seen_uid: Arc<StdMutex<u32>>,
     /// Shared reply-threading index; the poll task records one entry per
@@ -82,6 +93,8 @@ pub(crate) fn imap_poll_blocking(args: ImapPollArgs) {
         mailbox,
         poll_interval_secs,
         allowed_senders,
+        own_addresses,
+        sent_ids,
         inbox,
         last_seen_uid,
         reply_index,
@@ -123,6 +136,8 @@ pub(crate) fn imap_poll_blocking(args: ImapPollArgs) {
             &pass,
             &mailbox,
             allow_set.as_ref(),
+            &own_addresses,
+            &sent_ids,
             &inbox,
             &last_seen_uid,
             &reply_index,
@@ -166,6 +181,8 @@ fn poll_once(
     pass: &str,
     mailbox: &str,
     allow_set: Option<&std::collections::HashSet<String>>,
+    own_addresses: &[String],
+    sent_ids: &crate::sent_index::SentIdIndex,
     inbox: &Arc<Mutex<VecDeque<ChannelEvent>>>,
     last_seen_uid: &Arc<StdMutex<u32>>,
     reply_index: &ReplyIndex,
@@ -248,7 +265,13 @@ fn poll_once(
                 None => continue,
             };
             match parse_message(uid, body) {
-                Ok((msg, reply_ctx)) => {
+                Ok((mut msg, reply_ctx)) => {
+                    // Loop guard (wayland#547): mark the channel's own mail
+                    // echoing back in — by outbound Message-ID (precise) or
+                    // own-address From (backstop for id-rewriting relays) —
+                    // so the dispatch kernel drops it instead of triggering
+                    // an agent turn that would reply to it forever.
+                    mark_self_inbound(&mut msg, own_addresses, sent_ids);
                     // Sender allow-list. `msg.author` is the raw `From:`
                     // header value (display name + addr-spec); compare its
                     // normalized addr-spec against the configured set.
@@ -1018,6 +1041,39 @@ pub(crate) fn is_sender_allowed(
     }
 }
 
+/// Mark an inbound message `is_self` when it is this channel's own mail
+/// echoing back into the monitored mailbox (wayland#547 loop guard).
+///
+/// Two detectors, either suffices:
+/// 1. **Echoed Message-ID** — the id is one the SMTP path recorded before
+///    sending. Precise: only ever matches mail this process sent, so a
+///    human mailing the bot from the shared account is never flagged.
+/// 2. **Own-address From** — the normalized sender matches the channel's
+///    own address set. Blunt backstop for relays that rewrite Message-IDs;
+///    also catches agent mail sent before the current process started.
+///
+/// Marking (not dropping) keeps the drop decision in the dispatch kernel's
+/// existing loop guard (`classify`: `is_self` → silent drop), the same path
+/// every other channel uses.
+pub(crate) fn mark_self_inbound(
+    msg: &mut IncomingMessage,
+    own_addresses: &[String],
+    sent_ids: &crate::sent_index::SentIdIndex,
+) {
+    if msg.is_self {
+        return;
+    }
+    let echoed = sent_ids
+        .lock()
+        .map(|s| s.contains(&msg.id))
+        .unwrap_or(false);
+    // `sender_id` is already the normalized (bare, lowercased) addr-spec.
+    let from_self = !msg.sender_id.is_empty() && own_addresses.iter().any(|a| a == &msg.sender_id);
+    if echoed || from_self {
+        msg.is_self = true;
+    }
+}
+
 /// Extract the display name from a `From:`-style header value, returning
 /// `None` when no display name is present (bare addr-spec form).
 ///
@@ -1039,7 +1095,7 @@ fn extract_display_name(raw: &str) -> Option<String> {
 
 /// Extract the bare `addr-spec` from a `From:`-style header value and
 /// lowercase it for case-insensitive comparison.
-fn normalize_from_addr(raw: &str) -> String {
+pub(crate) fn normalize_from_addr(raw: &str) -> String {
     let trimmed = raw.trim();
     let inner = match (trimmed.find('<'), trimmed.find('>')) {
         (Some(open), Some(close)) if close > open + 1 => &trimmed[open + 1..close],
@@ -1060,6 +1116,56 @@ fn parse_rfc2822_to_epoch(s: String) -> Option<i64> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ----- wayland#547 loop guard: mark_self_inbound -----
+
+    #[test]
+    fn mark_self_by_own_address() {
+        let idx = crate::sent_index::new_index();
+        let mut m =
+            IncomingMessage::new("some-id@x", "bot@acme.com", "Bot <bot@acme.com>", "hi", 0);
+        m.sender_id = "bot@acme.com".into();
+        mark_self_inbound(&mut m, &["bot@acme.com".to_string()], &idx);
+        assert!(m.is_self);
+    }
+
+    #[test]
+    fn mark_self_by_echoed_message_id_even_from_foreign_address() {
+        // A relay that rewrites the From still can't dodge the id match.
+        let idx = crate::sent_index::new_index();
+        idx.lock().unwrap().record("wl-1-0@acme.com".into());
+        let mut m = IncomingMessage::new(
+            "wl-1-0@acme.com",
+            "conv",
+            "Rewritten <alias@relay.example>",
+            "hi",
+            0,
+        );
+        m.sender_id = "alias@relay.example".into();
+        mark_self_inbound(&mut m, &["bot@acme.com".to_string()], &idx);
+        assert!(m.is_self);
+    }
+
+    #[test]
+    fn unrelated_inbound_is_not_marked_self() {
+        let idx = crate::sent_index::new_index();
+        idx.lock().unwrap().record("wl-1-0@acme.com".into());
+        let mut m = IncomingMessage::new("user-mail@x", "conv", "Alice <alice@x.com>", "hi", 0);
+        m.sender_id = "alice@x.com".into();
+        mark_self_inbound(&mut m, &["bot@acme.com".to_string()], &idx);
+        assert!(!m.is_self);
+    }
+
+    #[test]
+    fn empty_sender_id_never_matches_an_empty_own_address() {
+        // An unconfigured/unparsable from_address normalizes to "" — that
+        // must not flag inbound mail whose sender also failed to parse.
+        let idx = crate::sent_index::new_index();
+        let mut m = IncomingMessage::new("id@x", "conv", "", "hi", 0);
+        m.sender_id = String::new();
+        mark_self_inbound(&mut m, &[String::new()], &idx);
+        assert!(!m.is_self);
+    }
 
     #[test]
     fn parse_basic_message_extracts_from_subject_body() {

--- a/crates/wcore-channel-email/src/imap.rs
+++ b/crates/wcore-channel-email/src/imap.rs
@@ -68,8 +68,9 @@ pub(crate) struct ImapPollArgs {
     pub own_addresses: Vec<String>,
     /// Message-IDs this channel has sent (recorded by the SMTP path). An
     /// inbound whose id matches is the channel's own mail echoing back and
-    /// is likewise marked `is_self`. Precise where the From-match is blunt:
-    /// it never flags mail a human sent from the shared account.
+    /// is likewise marked `is_self`. This detector only ever matches mail
+    /// this process sent; the own-address From match above is the blunter
+    /// backstop — see [`mark_self_inbound`] for the tradeoff.
     pub sent_ids: crate::sent_index::SentIdIndex,
     pub inbox: Arc<Mutex<VecDeque<ChannelEvent>>>,
     pub last_seen_uid: Arc<StdMutex<u32>>,
@@ -264,41 +265,10 @@ fn poll_once(
                 Some(b) => b,
                 None => continue,
             };
-            match parse_message(uid, body) {
-                Ok((mut msg, reply_ctx)) => {
-                    // Loop guard (wayland#547): mark the channel's own mail
-                    // echoing back in — by outbound Message-ID (precise) or
-                    // own-address From (backstop for id-rewriting relays) —
-                    // so the dispatch kernel drops it instead of triggering
-                    // an agent turn that would reply to it forever.
-                    mark_self_inbound(&mut msg, own_addresses, sent_ids);
-                    // Sender allow-list. `msg.author` is the raw `From:`
-                    // header value (display name + addr-spec); compare its
-                    // normalized addr-spec against the configured set.
-                    // NOTE: `From:` is spoofable — this is a delivery-side
-                    // filter, not authentication (see ImapConfig docs).
-                    if !is_sender_allowed(allow_set, &msg.author) {
-                        tracing::info!(
-                            target: "wcore_channel_email::imap",
-                            uid = uid,
-                            "dropping inbound message: From: not in allowed_senders",
-                        );
-                        continue;
-                    }
-                    // Record threading context so a later reply can set
-                    // In-Reply-To / References / Re: subject. Keyed by the
-                    // RFC Message-ID (== msg.id).
-                    record_reply_context(reply_index, msg.id.clone(), reply_ctx);
-                    new_events.push(ChannelEvent::MessageReceived { msg });
-                }
-                Err(e) => {
-                    tracing::warn!(
-                        target: "wcore_channel_email::imap",
-                        uid = uid,
-                        error = %e,
-                        "rfc5322 parse failed; dropping message",
-                    );
-                }
+            if let Some(event) =
+                admit_fetched_message(uid, body, allow_set, own_addresses, sent_ids, reply_index)
+            {
+                new_events.push(event);
             }
         }
         high_water = high_water.max(uid);
@@ -333,6 +303,71 @@ fn poll_once(
     // Best-effort logout; ignore errors.
     let _ = session.logout();
     Ok(())
+}
+
+/// Run the full inbound admission chain for one fetched RFC822 body:
+/// parse → self-mark (wayland#547 loop guard) → sender allow-list →
+/// record reply-threading → wrap as a `MessageReceived` event.
+///
+/// `None` means the message was dropped here (parse failure or allow-list).
+/// Self-marked messages are still returned — the dispatch kernel's loop
+/// guard is the single drop point for `is_self`, the same path every other
+/// channel uses.
+///
+/// Extracted from the `poll_once` fetch loop so the guard wiring is
+/// testable against raw message bytes without a live IMAP session.
+fn admit_fetched_message(
+    uid: u32,
+    body: &[u8],
+    allow_set: Option<&std::collections::HashSet<String>>,
+    own_addresses: &[String],
+    sent_ids: &crate::sent_index::SentIdIndex,
+    reply_index: &ReplyIndex,
+) -> Option<ChannelEvent> {
+    match parse_message(uid, body) {
+        Ok((mut msg, reply_ctx)) => {
+            // Loop guard (wayland#547): mark the channel's own mail echoing
+            // back in so the dispatch kernel drops it instead of triggering
+            // an agent turn that would reply to it forever. INFO (id only,
+            // no content) because the kernel drop itself is silent.
+            if let Some(detector) = mark_self_inbound(&mut msg, own_addresses, sent_ids) {
+                tracing::info!(
+                    target: "wcore_channel_email::imap",
+                    uid = uid,
+                    message_id = %msg.id,
+                    detector = ?detector,
+                    "inbound is this channel's own mail; marked is_self (loop guard)",
+                );
+            }
+            // Sender allow-list. `msg.author` is the raw `From:` header
+            // value (display name + addr-spec); compare its normalized
+            // addr-spec against the configured set. NOTE: `From:` is
+            // spoofable — this is a delivery-side filter, not
+            // authentication (see ImapConfig docs).
+            if !is_sender_allowed(allow_set, &msg.author) {
+                tracing::info!(
+                    target: "wcore_channel_email::imap",
+                    uid = uid,
+                    "dropping inbound message: From: not in allowed_senders",
+                );
+                return None;
+            }
+            // Record threading context so a later reply can set
+            // In-Reply-To / References / Re: subject. Keyed by the
+            // RFC Message-ID (== msg.id).
+            record_reply_context(reply_index, msg.id.clone(), reply_ctx);
+            Some(ChannelEvent::MessageReceived { msg })
+        }
+        Err(e) => {
+            tracing::warn!(
+                target: "wcore_channel_email::imap",
+                uid = uid,
+                error = %e,
+                "rfc5322 parse failed; dropping message",
+            );
+            None
+        }
+    }
 }
 
 /// RFC 5322 / MIME parser — surfaces From, Subject, Message-ID,
@@ -1041,16 +1076,32 @@ pub(crate) fn is_sender_allowed(
     }
 }
 
+/// Which loop-guard detector matched an inbound message as the channel's
+/// own mail. Surfaced so the admission path can log the reason — the
+/// kernel-side drop itself is silent (`record_history: false`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SelfMatch {
+    /// Inbound Message-ID is one this process recorded before sending.
+    MessageId,
+    /// Inbound From matches the channel's own address set.
+    OwnAddress,
+}
+
 /// Mark an inbound message `is_self` when it is this channel's own mail
 /// echoing back into the monitored mailbox (wayland#547 loop guard).
+/// Returns the detector that fired, `None` when the message was left alone
+/// (or was already marked).
 ///
 /// Two detectors, either suffices:
 /// 1. **Echoed Message-ID** — the id is one the SMTP path recorded before
-///    sending. Precise: only ever matches mail this process sent, so a
-///    human mailing the bot from the shared account is never flagged.
+///    sending. Only ever matches mail this process sent.
 /// 2. **Own-address From** — the normalized sender matches the channel's
 ///    own address set. Blunt backstop for relays that rewrite Message-IDs;
 ///    also catches agent mail sent before the current process started.
+///    Tradeoff: a human mailing the monitored account FROM the account's
+///    own address (self-note workflows) is also flagged — indistinguishable
+///    from an agent echo by headers alone, and letting it through would
+///    reinstate the loop on From-rewriting providers.
 ///
 /// Marking (not dropping) keeps the drop decision in the dispatch kernel's
 /// existing loop guard (`classify`: `is_self` → silent drop), the same path
@@ -1059,19 +1110,24 @@ pub(crate) fn mark_self_inbound(
     msg: &mut IncomingMessage,
     own_addresses: &[String],
     sent_ids: &crate::sent_index::SentIdIndex,
-) {
+) -> Option<SelfMatch> {
     if msg.is_self {
-        return;
+        return None;
     }
     let echoed = sent_ids
         .lock()
         .map(|s| s.contains(&msg.id))
         .unwrap_or(false);
-    // `sender_id` is already the normalized (bare, lowercased) addr-spec.
-    let from_self = !msg.sender_id.is_empty() && own_addresses.iter().any(|a| a == &msg.sender_id);
-    if echoed || from_self {
+    if echoed {
         msg.is_self = true;
+        return Some(SelfMatch::MessageId);
     }
+    // `sender_id` is already the normalized (bare, lowercased) addr-spec.
+    if !msg.sender_id.is_empty() && own_addresses.iter().any(|a| a == &msg.sender_id) {
+        msg.is_self = true;
+        return Some(SelfMatch::OwnAddress);
+    }
+    None
 }
 
 /// Extract the display name from a `From:`-style header value, returning
@@ -1125,7 +1181,8 @@ mod tests {
         let mut m =
             IncomingMessage::new("some-id@x", "bot@acme.com", "Bot <bot@acme.com>", "hi", 0);
         m.sender_id = "bot@acme.com".into();
-        mark_self_inbound(&mut m, &["bot@acme.com".to_string()], &idx);
+        let hit = mark_self_inbound(&mut m, &["bot@acme.com".to_string()], &idx);
+        assert_eq!(hit, Some(SelfMatch::OwnAddress));
         assert!(m.is_self);
     }
 
@@ -1142,7 +1199,8 @@ mod tests {
             0,
         );
         m.sender_id = "alias@relay.example".into();
-        mark_self_inbound(&mut m, &["bot@acme.com".to_string()], &idx);
+        let hit = mark_self_inbound(&mut m, &["bot@acme.com".to_string()], &idx);
+        assert_eq!(hit, Some(SelfMatch::MessageId));
         assert!(m.is_self);
     }
 
@@ -1152,7 +1210,10 @@ mod tests {
         idx.lock().unwrap().record("wl-1-0@acme.com".into());
         let mut m = IncomingMessage::new("user-mail@x", "conv", "Alice <alice@x.com>", "hi", 0);
         m.sender_id = "alice@x.com".into();
-        mark_self_inbound(&mut m, &["bot@acme.com".to_string()], &idx);
+        assert_eq!(
+            mark_self_inbound(&mut m, &["bot@acme.com".to_string()], &idx),
+            None
+        );
         assert!(!m.is_self);
     }
 
@@ -1163,8 +1224,69 @@ mod tests {
         let idx = crate::sent_index::new_index();
         let mut m = IncomingMessage::new("id@x", "conv", "", "hi", 0);
         m.sender_id = String::new();
-        mark_self_inbound(&mut m, &[String::new()], &idx);
+        assert_eq!(mark_self_inbound(&mut m, &[String::new()], &idx), None);
         assert!(!m.is_self);
+    }
+
+    // ----- wayland#547 loop guard: the REAL admission path -----
+    // These drive raw RFC822 bytes through `admit_fetched_message` — the
+    // same function `poll_once` calls per fetch — so removing the guard
+    // wiring (not just the helper) fails tests.
+
+    fn empty_reply_index() -> ReplyIndex {
+        Arc::new(StdMutex::new(HashMap::new()))
+    }
+
+    #[test]
+    fn echoed_outbound_is_marked_self_through_the_admission_path() {
+        let idx = crate::sent_index::new_index();
+        idx.lock().unwrap().record("wl-abc-0@acme.com".into());
+        let raw = b"From: Bot <bot@acme.com>\r\nSubject: Re: task\r\nMessage-ID: <wl-abc-0@acme.com>\r\n\r\nself echo\r\n";
+        let ev = admit_fetched_message(7, raw, None, &[], &idx, &empty_reply_index())
+            .expect("echo must still be admitted; the kernel is the drop point");
+        let ChannelEvent::MessageReceived { msg } = ev else {
+            panic!("expected MessageReceived");
+        };
+        assert!(msg.is_self, "echoed outbound must carry is_self");
+    }
+
+    #[test]
+    fn own_address_from_is_marked_self_through_the_admission_path() {
+        let idx = crate::sent_index::new_index();
+        let raw = b"From: Bot <bot@acme.com>\r\nSubject: hello\r\nMessage-ID: <relay-rewrote-this@mta>\r\n\r\nhi\r\n";
+        let ev = admit_fetched_message(
+            8,
+            raw,
+            None,
+            &["bot@acme.com".to_string()],
+            &idx,
+            &empty_reply_index(),
+        )
+        .expect("own-address mail must still be admitted");
+        let ChannelEvent::MessageReceived { msg } = ev else {
+            panic!("expected MessageReceived");
+        };
+        assert!(msg.is_self, "own-address From must carry is_self");
+    }
+
+    #[test]
+    fn ordinary_inbound_is_not_marked_self_through_the_admission_path() {
+        let idx = crate::sent_index::new_index();
+        idx.lock().unwrap().record("wl-abc-0@acme.com".into());
+        let raw = b"From: Alice <alice@x.com>\r\nSubject: question\r\nMessage-ID: <alices-mail@x.com>\r\n\r\nhelp?\r\n";
+        let ev = admit_fetched_message(
+            9,
+            raw,
+            None,
+            &["bot@acme.com".to_string()],
+            &idx,
+            &empty_reply_index(),
+        )
+        .expect("ordinary mail admitted");
+        let ChannelEvent::MessageReceived { msg } = ev else {
+            panic!("expected MessageReceived");
+        };
+        assert!(!msg.is_self, "ordinary inbound must not be flagged");
     }
 
     #[test]

--- a/crates/wcore-channel-email/src/lib.rs
+++ b/crates/wcore-channel-email/src/lib.rs
@@ -29,6 +29,7 @@ pub use crate::smtp::{LettreSender, MailSender, SendError};
 pub mod config;
 pub mod error;
 mod imap;
+mod sent_index;
 pub mod smtp;
 mod uid_store;
 
@@ -56,6 +57,11 @@ pub struct EmailChannel {
     /// In-Reply-To / References / Re: subject on outbound replies. Shared
     /// `std::Mutex` because the poll task is synchronous.
     reply_index: crate::imap::ReplyIndex,
+    /// Outbound Message-ID index: `send_message` records every id it
+    /// stamps; the IMAP poll task marks a matching inbound `is_self` so the
+    /// dispatch kernel's loop guard drops the channel's own echoed mail
+    /// (wayland#547). Shared `std::Mutex` because the poll task is sync.
+    sent_ids: crate::sent_index::SentIdIndex,
     /// Credentials store used to resolve SMTP+IMAP creds at `start()`.
     creds: Arc<dyn CredentialsStore>,
     /// Optional test override — when set, `start()` reuses this sender
@@ -82,6 +88,7 @@ impl EmailChannel {
             shutdown: None,
             last_seen_uid: Arc::new(StdMutex::new(0)),
             reply_index: Arc::new(StdMutex::new(HashMap::new())),
+            sent_ids: crate::sent_index::new_index(),
             creds,
             sender_override: None,
         }
@@ -141,6 +148,17 @@ impl EmailChannel {
                 ))
             })?;
 
+        // Own-address set for the inbound self-mail guard (wayland#547):
+        // the configured From address, plus the IMAP account when it is
+        // address-shaped (some servers use bare usernames — skip those).
+        let mut own_addresses = vec![crate::imap::normalize_from_addr(&self.config.from_address)];
+        if imap_user.contains('@') {
+            let normalized = crate::imap::normalize_from_addr(&imap_user);
+            if !own_addresses.contains(&normalized) {
+                own_addresses.push(normalized);
+            }
+        }
+
         let (tx, rx) = watch::channel(false);
         let args = crate::imap::ImapPollArgs {
             host: imap_cfg.host,
@@ -149,6 +167,8 @@ impl EmailChannel {
             pass: imap_pass,
             mailbox: imap_cfg.mailbox,
             allowed_senders: imap_cfg.allowed_senders,
+            own_addresses,
+            sent_ids: Arc::clone(&self.sent_ids),
             poll_interval_secs: imap_cfg.poll_interval_secs,
             inbox: Arc::clone(&self.inbox),
             last_seen_uid: Arc::clone(&self.last_seen_uid),
@@ -334,6 +354,19 @@ impl Channel for EmailChannel {
             &resolved,
         )
         .map_err(ChannelError::from)?;
+
+        // Loop guard (wayland#547): remember the outbound Message-ID BEFORE
+        // the wire send so the IMAP poll task can never race ahead of the
+        // recording — by the time the mail can possibly be delivered (and
+        // echo back into a monitored mailbox) the id is already indexed. A
+        // failed send leaves a harmless stale entry (that id never reaches
+        // the wild).
+        if let Some(id) = crate::smtp::outbound_message_id(&envelope) {
+            if let Ok(mut idx) = self.sent_ids.lock() {
+                idx.record(id);
+            }
+        }
+
         let response = crate::smtp::send_with_retry(sender, envelope)
             .await
             .map_err(ChannelError::from)?;
@@ -498,6 +531,49 @@ mod tests {
             ch.fetch_media(&att).await.unwrap_err(),
             ChannelError::Rejected(_)
         ));
+    }
+
+    // -----------------------------------------------------------------
+    // wayland#547 loop guard: the outbound Message-ID is stamped on the
+    // wire message, recorded in the sent index, and an inbound echo of it
+    // is marked `is_self` (so the dispatch kernel's loop guard drops it).
+    // -----------------------------------------------------------------
+    #[tokio::test]
+    async fn send_message_records_outbound_id_and_marks_echo_self() {
+        let sender = RecordingSender::new(vec![RecordingSender::ok("QID-9")]);
+        let mut ch = EmailChannel::with_sender(
+            "test",
+            cfg_outbound_only(),
+            creds_for_outbound(),
+            sender.clone(),
+        );
+        ch.start().await.unwrap();
+        ch.send_message(OutgoingMessage::text("bot@acme.com", "note to self"))
+            .await
+            .unwrap();
+
+        // The wire message carries an explicit stamped Message-ID…
+        let stamped = {
+            let sent = sender.sent.lock().unwrap();
+            crate::smtp::outbound_message_id(&sent[0]).expect("outbound Message-ID stamped")
+        };
+        assert!(stamped.starts_with("wl-"), "stamped = {stamped}");
+        assert!(stamped.ends_with("@acme.com"), "stamped = {stamped}");
+        // …and was recorded in the sent index before the send.
+        assert!(ch.sent_ids.lock().unwrap().contains(&stamped));
+
+        // An inbound echo of that id — what the IMAP poll task sees when
+        // the agent's mail lands back in the monitored inbox — is marked
+        // is_self even with no own-address configured.
+        let mut echo = wcore_channels::event::IncomingMessage::new(
+            stamped.clone(),
+            "bot@acme.com",
+            "Bot <bot@acme.com>",
+            "note to self",
+            0,
+        );
+        crate::imap::mark_self_inbound(&mut echo, &[], &ch.sent_ids);
+        assert!(echo.is_self, "echoed outbound mail must be marked is_self");
     }
 
     // -----------------------------------------------------------------

--- a/crates/wcore-channel-email/src/lib.rs
+++ b/crates/wcore-channel-email/src/lib.rs
@@ -361,10 +361,10 @@ impl Channel for EmailChannel {
         // echo back into a monitored mailbox) the id is already indexed. A
         // failed send leaves a harmless stale entry (that id never reaches
         // the wild).
-        if let Some(id) = crate::smtp::outbound_message_id(&envelope) {
-            if let Ok(mut idx) = self.sent_ids.lock() {
-                idx.record(id);
-            }
+        if let Some(id) = crate::smtp::outbound_message_id(&envelope)
+            && let Ok(mut idx) = self.sent_ids.lock()
+        {
+            idx.record(id);
         }
 
         let response = crate::smtp::send_with_retry(sender, envelope)

--- a/crates/wcore-channel-email/src/lib.rs
+++ b/crates/wcore-channel-email/src/lib.rs
@@ -148,16 +148,7 @@ impl EmailChannel {
                 ))
             })?;
 
-        // Own-address set for the inbound self-mail guard (wayland#547):
-        // the configured From address, plus the IMAP account when it is
-        // address-shaped (some servers use bare usernames — skip those).
-        let mut own_addresses = vec![crate::imap::normalize_from_addr(&self.config.from_address)];
-        if imap_user.contains('@') {
-            let normalized = crate::imap::normalize_from_addr(&imap_user);
-            if !own_addresses.contains(&normalized) {
-                own_addresses.push(normalized);
-            }
-        }
+        let own_addresses = own_address_set(&self.config.from_address, &imap_user);
 
         let (tx, rx) = watch::channel(false);
         let args = crate::imap::ImapPollArgs {
@@ -183,6 +174,21 @@ impl EmailChannel {
         self.shutdown = Some(tx);
         Ok(())
     }
+}
+
+/// Own-address set for the inbound self-mail guard (wayland#547): the
+/// configured From address, plus the IMAP account when it is address-shaped
+/// (some servers use bare usernames — skip those). Normalized (bare
+/// addr-spec, lowercased) and deduplicated.
+fn own_address_set(from_address: &str, imap_user: &str) -> Vec<String> {
+    let mut own = vec![crate::imap::normalize_from_addr(from_address)];
+    if imap_user.contains('@') {
+        let normalized = crate::imap::normalize_from_addr(imap_user);
+        if !own.contains(&normalized) {
+            own.push(normalized);
+        }
+    }
+    own
 }
 
 #[async_trait]
@@ -572,8 +578,36 @@ mod tests {
             "note to self",
             0,
         );
-        crate::imap::mark_self_inbound(&mut echo, &[], &ch.sent_ids);
+        let hit = crate::imap::mark_self_inbound(&mut echo, &[], &ch.sent_ids);
+        assert_eq!(hit, Some(crate::imap::SelfMatch::MessageId));
         assert!(echo.is_self, "echoed outbound mail must be marked is_self");
+    }
+
+    // -----------------------------------------------------------------
+    // wayland#547: own-address set construction (fed to the IMAP poll
+    // task by respawn_imap_poll).
+    // -----------------------------------------------------------------
+    #[test]
+    fn own_address_set_normalizes_and_includes_address_shaped_imap_user() {
+        let own = own_address_set("Bot <BOT@Acme.com>", "shared@acme.com");
+        assert_eq!(
+            own,
+            vec!["bot@acme.com".to_string(), "shared@acme.com".to_string()]
+        );
+    }
+
+    #[test]
+    fn own_address_set_skips_bare_username_and_dedups() {
+        // Bare (non-address) IMAP usernames are skipped…
+        assert_eq!(
+            own_address_set("bot@acme.com", "bot"),
+            vec!["bot@acme.com".to_string()]
+        );
+        // …and an IMAP user equal to the From address isn't doubled.
+        assert_eq!(
+            own_address_set("bot@acme.com", "BOT@ACME.COM"),
+            vec!["bot@acme.com".to_string()]
+        );
     }
 
     // -----------------------------------------------------------------

--- a/crates/wcore-channel-email/src/sent_index.rs
+++ b/crates/wcore-channel-email/src/sent_index.rs
@@ -34,10 +34,10 @@ impl SentMessageIds {
         if id.is_empty() || self.set.contains(&id) {
             return;
         }
-        if self.order.len() >= SENT_INDEX_CAP {
-            if let Some(oldest) = self.order.pop_front() {
-                self.set.remove(&oldest);
-            }
+        if self.order.len() >= SENT_INDEX_CAP
+            && let Some(oldest) = self.order.pop_front()
+        {
+            self.set.remove(&oldest);
         }
         self.set.insert(id.clone());
         self.order.push_back(id);

--- a/crates/wcore-channel-email/src/sent_index.rs
+++ b/crates/wcore-channel-email/src/sent_index.rs
@@ -1,0 +1,99 @@
+//! Bounded index of RFC `Message-ID`s this channel has sent.
+//!
+//! Written by the SMTP send path (before the wire send, so the entry is
+//! guaranteed to exist by the time the mail can possibly be delivered) and
+//! read by the IMAP poll task to recognize the channel's own outbound mail
+//! when it echoes back into the monitored mailbox (self-send, forwarding
+//! rules, shared inbox). An echoed message is marked `is_self` so the
+//! dispatch kernel's loop guard drops it instead of triggering a new agent
+//! turn — the wayland#547 unbounded self-reply loop.
+
+use std::collections::{HashSet, VecDeque};
+use std::sync::{Arc, Mutex as StdMutex};
+
+/// Shared handle to the sent-id index. `std::Mutex` because the IMAP poll
+/// task is synchronous.
+pub(crate) type SentIdIndex = Arc<StdMutex<SentMessageIds>>;
+
+/// Upper bound on remembered outbound ids. FIFO eviction: old entries only
+/// matter for as long as an echo of that mail could still arrive, so
+/// forgetting the oldest under sustained send volume is safe.
+pub(crate) const SENT_INDEX_CAP: usize = 512;
+
+/// FIFO set of bare (no angle brackets) outbound `Message-ID`s.
+#[derive(Debug, Default)]
+pub(crate) struct SentMessageIds {
+    set: HashSet<String>,
+    order: VecDeque<String>,
+}
+
+impl SentMessageIds {
+    /// Record an outbound id, evicting the oldest entry past
+    /// [`SENT_INDEX_CAP`]. Empty ids and duplicates are no-ops.
+    pub(crate) fn record(&mut self, id: String) {
+        if id.is_empty() || self.set.contains(&id) {
+            return;
+        }
+        if self.order.len() >= SENT_INDEX_CAP {
+            if let Some(oldest) = self.order.pop_front() {
+                self.set.remove(&oldest);
+            }
+        }
+        self.set.insert(id.clone());
+        self.order.push_back(id);
+    }
+
+    /// Whether `id` is a Message-ID this channel sent (and still remembers).
+    pub(crate) fn contains(&self, id: &str) -> bool {
+        self.set.contains(id)
+    }
+}
+
+/// Fresh shared index.
+pub(crate) fn new_index() -> SentIdIndex {
+    Arc::new(StdMutex::new(SentMessageIds::default()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn record_and_contains_roundtrip() {
+        let mut s = SentMessageIds::default();
+        s.record("a@x".into());
+        assert!(s.contains("a@x"));
+        assert!(!s.contains("b@x"));
+    }
+
+    #[test]
+    fn empty_id_is_ignored() {
+        let mut s = SentMessageIds::default();
+        s.record(String::new());
+        assert!(!s.contains(""));
+        assert!(s.order.is_empty());
+    }
+
+    #[test]
+    fn duplicate_record_does_not_grow_order() {
+        let mut s = SentMessageIds::default();
+        s.record("a@x".into());
+        s.record("a@x".into());
+        assert_eq!(s.order.len(), 1);
+    }
+
+    #[test]
+    fn eviction_is_fifo_and_bounded() {
+        let mut s = SentMessageIds::default();
+        for i in 0..(SENT_INDEX_CAP + 3) {
+            s.record(format!("id-{i}@x"));
+        }
+        assert_eq!(s.order.len(), SENT_INDEX_CAP);
+        assert_eq!(s.set.len(), SENT_INDEX_CAP);
+        // The three oldest fell out; the newest are retained.
+        assert!(!s.contains("id-0@x"));
+        assert!(!s.contains("id-2@x"));
+        assert!(s.contains("id-3@x"));
+        assert!(s.contains(&format!("id-{}@x", SENT_INDEX_CAP + 2)));
+    }
+}

--- a/crates/wcore-channel-email/src/smtp.rs
+++ b/crates/wcore-channel-email/src/smtp.rs
@@ -7,7 +7,8 @@
 //! errors, permanent short-circuit on auth failure.
 
 use std::sync::Arc;
-use std::time::Duration;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use async_trait::async_trait;
 use lettre::message::header::{HeaderName, HeaderValue};
@@ -197,6 +198,39 @@ fn reply_headers(reply: &ReplyContext) -> Vec<HeaderValue> {
 /// so MUAs group the reply with the original. When `reply` is `None` the
 /// subject falls back to `subject_override` (if any) or a bare default,
 /// preserving the prior outbound-only behavior.
+/// Monotonic per-process sequence so two sends in the same nanosecond (or on
+/// a coarse clock) still get distinct Message-IDs.
+static OUTBOUND_ID_SEQ: AtomicU64 = AtomicU64::new(0);
+
+/// Generate a bare (no angle brackets) RFC 5322 `Message-ID` for an outbound
+/// message: `wl-<epoch-nanos>-<seq>@<from-domain>`. The domain comes from the
+/// configured From address so the id is well-formed for strict MTAs; falls
+/// back to a fixed label when the address has no `@` (already rejected later
+/// by the address parse, but never panic here).
+pub(crate) fn make_outbound_message_id(from: &str) -> String {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let seq = OUTBOUND_ID_SEQ.fetch_add(1, Ordering::Relaxed);
+    let domain = from
+        .rsplit_once('@')
+        .map(|(_, d)| d.trim().trim_end_matches('>'))
+        .filter(|d| !d.is_empty())
+        .unwrap_or("wayland.invalid");
+    format!("wl-{nanos:x}-{seq:x}@{domain}")
+}
+
+/// Read the bare `Message-ID` (angle brackets stripped) off a built message.
+/// `build_message` always stamps one, so `None` only happens for messages
+/// built elsewhere.
+pub(crate) fn outbound_message_id(msg: &Message) -> Option<String> {
+    msg.headers()
+        .get_raw("Message-ID")
+        .map(|v| v.trim().trim_matches(|c| c == '<' || c == '>').to_string())
+        .filter(|v| !v.is_empty())
+}
+
 pub(crate) fn build_message(
     from: &str,
     to: &str,
@@ -227,7 +261,13 @@ pub(crate) fn build_message(
     let mut builder = Message::builder()
         .from(from_addr)
         .to(to_addr)
-        .subject(subject);
+        .subject(subject)
+        // Stamp an explicit Message-ID (lettre only generates one when asked;
+        // otherwise the relay assigns it and we never learn the value). The
+        // send path records this id so the IMAP poll task can recognize the
+        // channel's own mail if it echoes back into the monitored mailbox and
+        // mark it `is_self` — breaking the wayland#547 self-reply loop.
+        .message_id(Some(format!("<{}>", make_outbound_message_id(from))));
 
     if let Some(r) = reply {
         for hv in reply_headers(r) {
@@ -539,6 +579,37 @@ mod tests {
             EmailError::Envelope(_) => {}
             other => panic!("expected Envelope, got {other:?}"),
         }
+    }
+
+    // ----- wayland#547 loop guard: outbound Message-ID stamping -----
+
+    #[test]
+    fn build_message_stamps_extractable_message_id() {
+        let msg =
+            build_message("Bot <bot@acme.com>", "ops@acme.com", "hi", None, None, &[]).unwrap();
+        let id = outbound_message_id(&msg).expect("Message-ID stamped");
+        assert!(id.starts_with("wl-"), "id = {id}");
+        // Domain comes from the From addr-spec even in display-name form.
+        assert!(id.ends_with("@acme.com"), "id = {id}");
+        // The bracketed form is what actually hits the wire.
+        let rfc = String::from_utf8_lossy(&msg.formatted()).to_string();
+        assert!(
+            rfc.contains(&format!("Message-ID: <{id}>")),
+            "wire bytes missing stamped Message-ID; rfc = {rfc}"
+        );
+    }
+
+    #[test]
+    fn outbound_message_ids_are_unique_per_send() {
+        let a = make_outbound_message_id("bot@acme.com");
+        let b = make_outbound_message_id("bot@acme.com");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn outbound_message_id_domain_falls_back_when_from_has_no_at() {
+        let id = make_outbound_message_id("garbage");
+        assert!(id.ends_with("@wayland.invalid"), "id = {id}");
     }
 
     #[test]


### PR DESCRIPTION
Addresses FerroxLabs/wayland#547 (engine-native email channel instance; do not auto-close — release closes).

## Root cause

The dispatch kernel already has a loop guard — `classify()` silently drops any inbound with `is_self`/`is_bot` — but the email channel never set `is_self` (`imap.rs` parse punted: "not determinable without knowing our own address here"). So an agent whose sent mail lands back in its own monitored inbox (self-send, forwarding rule, shared inbox) replied to itself once per poll cycle, unbounded.

## Fix — two inbound detectors, either marks `is_self`

1. **Echoed Message-ID (precise).** `build_message` now stamps an explicit `Message-ID: <wl-{nanos}-{seq}@{from-domain}>` (previously the relay assigned one we never learned — lettre only generates when asked). `send_message` records the bare id in a new bounded FIFO index (`sent_index.rs`, cap 512) **before** the wire send, so the IMAP poll task can never race ahead of the recording. Only ever matches mail this process sent — a human mailing the bot from the shared account is never flagged.
2. **Own-address From (backstop).** Normalized sender matches the channel's own address set (configured `from_address` + address-shaped IMAP account). Covers Message-ID-rewriting relays and agent mail sent before the current process started. Tradeoff: also flags a human's mail sent from the bot's own account — consistent with how every other channel treats own-account messages.

The drop decision stays in the kernel's existing guard — the same path Discord/Slack use; the channel only marks.

## Scope notes

- The wayland#547 *observed* repro loops through the desktop's ChannelMessageService (sends were host-delegated per wayland#543); that half is being handed back to the desktop lane with this design as the reference. This PR closes the engine-native instance, which has the identical unbounded loop via `channel_send_transport` → IMAP echo → `InboundSubscriber`.
- A per-conversation reply rate limit (guards two-agent ping-pong, which dedup cannot) is deliberately out of scope — noted on the issue as a follow-up.

## Verification

- Hetzner gate green: fmt, clippy `--all-targets -D warnings`, nextest 71/71 (`-p wcore-channel-email`).
- 12 new tests: Message-ID stamping + extraction + uniqueness + domain fallback; sent-index FIFO eviction bounds; `mark_self_inbound` by echoed id (incl. foreign-From rewrite case), by own address, negative cases (unrelated mail, empty-sender vs empty-own-address); end-to-end `send_message` records the stamped id and the echo is marked `is_self`.
