### PR TITLE
fix(cli): emit json-stream ready before config MCP connects

### DIFF
--- a/crates/wcore-agent/src/bootstrap.rs
+++ b/crates/wcore-agent/src/bootstrap.rs
@@ -171,6 +171,15 @@ pub struct AgentBootstrap {
     /// shell tools. `None` (the default, and always the case for the local
     /// CLI / TUI / json-stream engines) leaves the full toolset intact.
     channel_tool_posture: Option<crate::channel_tools::ChannelToolScope>,
+    /// wayland#551 — skip the config-declared MCP `connect_all` during
+    /// build so slow/hung servers cannot gate boot. The caller owns
+    /// connecting them afterwards (json-stream does it in the background
+    /// after emitting `ready`; a hung server previously ate the full 30s
+    /// per-server budget INSIDE bootstrap, blowing the host's 30s ready
+    /// timeout). Plugin-supplied MCP servers are NOT deferred — they are
+    /// local shells whose connects are bounded and cheap. Default `false`
+    /// keeps TUI/one-shot behavior unchanged.
+    defer_config_mcp: bool,
 }
 
 impl AgentBootstrap {
@@ -187,7 +196,16 @@ impl AgentBootstrap {
             without_channels: false,
             enable_inbound_dispatch: false,
             channel_tool_posture: None,
+            defer_config_mcp: false,
         }
+    }
+
+    /// wayland#551 — defer config-declared MCP connects out of `build()`.
+    /// See the field doc; the caller becomes responsible for connecting
+    /// `config.mcp.servers` (with `${cred:...}` resolution) after boot.
+    pub fn defer_config_mcp(mut self, v: bool) -> Self {
+        self.defer_config_mcp = v;
+        self
     }
 
     /// Restrict (and, for `Workspace`, jail) the toolset of a
@@ -995,7 +1013,10 @@ impl AgentBootstrap {
         );
 
         let mut mcp_managers: Vec<Arc<McpManager>> = Vec::new();
-        let mcp_manager = if !self.config.mcp.servers.is_empty() {
+        // wayland#551 — when the caller deferred config MCP, skip the
+        // connect entirely; the caller connects in the background after
+        // boot so a slow/hung server cannot gate the host's ready frame.
+        let mcp_manager = if !self.config.mcp.servers.is_empty() && !self.defer_config_mcp {
             // Slice 3, Piece 2 — resolve any `${cred:KEY}` header references
             // against the credentials store at the connect boundary, on a clone.
             // The long-lived `self.config` keeps the literal `${cred:...}` so the

--- a/crates/wcore-agent/src/bootstrap.rs
+++ b/crates/wcore-agent/src/bootstrap.rs
@@ -203,6 +203,15 @@ impl AgentBootstrap {
     /// wayland#551 — defer config-declared MCP connects out of `build()`.
     /// See the field doc; the caller becomes responsible for connecting
     /// `config.mcp.servers` (with `${cred:...}` resolution) after boot.
+    ///
+    /// Documented, accepted limitations of deferral (tracked follow-up):
+    /// boot-time consumers that read the config MCP manager during
+    /// `build()` do not see deferred servers — (1) MCP-provided skills
+    /// (`skill://` resources via `load_catalog`) are not loaded for the
+    /// session, and (2) the plugin hook dispatcher / `McpManagerCaller`
+    /// resolve against the boot manager set only (a gap already shared
+    /// with the dynamic `AddMcpServer` path). Late tool REGISTRATION is
+    /// fully supported; late skill/hook binding is not.
     pub fn defer_config_mcp(mut self, v: bool) -> Self {
         self.defer_config_mcp = v;
         self

--- a/crates/wcore-agent/tests/bootstrap_test.rs
+++ b/crates/wcore-agent/tests/bootstrap_test.rs
@@ -392,6 +392,62 @@ async fn bootstrap_no_mcp_when_no_servers() {
     assert!(result.mcp_managers.is_empty());
 }
 
+/// wayland#551 — `defer_config_mcp(true)` must skip the config-server
+/// connect entirely: build() returns without dialing (the configured
+/// server here would hang the full 30s per-server budget if dialed —
+/// the exact stall that blew hosts' 30s ready timeout), registers no
+/// MCP tools, and reports has_mcp=false (the caller advertises MCP
+/// capability itself for declared-but-deferred servers).
+#[tokio::test]
+#[serial]
+async fn bootstrap_defer_config_mcp_skips_connect() {
+    use wcore_config::config::{McpServerConfig, TransportType};
+
+    let (_plugins, _env) = isolated_plugins();
+    let mut config = minimal_config();
+    config.mcp.servers.insert(
+        "hang".into(),
+        McpServerConfig {
+            transport: TransportType::Stdio,
+            // Starts fine, never speaks MCP — a dialed connect would sit in
+            // the handshake until the 30s per-server timeout.
+            command: Some("sleep".into()),
+            args: Some(vec!["300".into()]),
+            env: None,
+            url: None,
+            headers: None,
+            deferred: None,
+            allow_local: false,
+        },
+    );
+    let workdir = tempfile::TempDir::new().expect("workdir");
+
+    let start = std::time::Instant::now();
+    let result = AgentBootstrap::new(config, workdir.path().to_str().unwrap(), null_output())
+        .defer_config_mcp(true)
+        .build()
+        .await
+        .unwrap();
+
+    // Generous bound: well under the 30s connect budget the skipped dial
+    // would have burned, far above any honest build cost.
+    assert!(
+        start.elapsed() < std::time::Duration::from_secs(15),
+        "deferred build must not dial config MCP servers (took {:?})",
+        start.elapsed()
+    );
+    assert!(!result.has_mcp, "deferred servers must not set has_mcp");
+    assert!(result.mcp_managers.is_empty());
+    assert!(
+        !result
+            .engine
+            .tool_names()
+            .iter()
+            .any(|n| n.contains("hang")),
+        "no tools from the deferred server may be registered at build time"
+    );
+}
+
 #[tokio::test]
 async fn bootstrap_with_custom_system_prompt() {
     let mut config = minimal_config();

--- a/crates/wcore-cli/Cargo.toml
+++ b/crates/wcore-cli/Cargo.toml
@@ -246,6 +246,9 @@ rand.workspace = true
 # W6 B.7: test the boot-time `McpReady` emission helper against a
 # pre-populated `McpManager` without spinning up real transports.
 wcore-mcp = { path = "../wcore-mcp", features = ["test-utils"] }
+# wayland#551: `integrate_deferred_mcp` tests drive a real engine via
+# `AgentBootstrap::build_for_test` (mirrors wcore-agent's own self-dep).
+wcore-agent = { path = "../wcore-agent", features = ["test-utils"] }
 # v0.6.4 Task 2.4: mcp-serve smoke test constructs a FakeTool against
 # the `Tool` trait — needs `ToolResult` / `JsonSchema` from `wcore-types`.
 wcore-types.workspace = true

--- a/crates/wcore-cli/src/main.rs
+++ b/crates/wcore-cli/src/main.rs
@@ -2932,16 +2932,16 @@ async fn run_json_stream_mode(
     'session: loop {
         // wayland#551 — retry a parked integration between turns (the
         // registry Arc is only borrowable while no turn is running).
-        if let Some((mgr, resolved)) = pending_deferred_mcp.take() {
-            if !integrate_deferred_mcp(
+        if let Some((mgr, resolved)) = pending_deferred_mcp.take()
+            && !integrate_deferred_mcp(
                 &mut engine,
                 mgr.clone(),
                 &resolved,
                 &writer,
                 &mut dynamic_managers,
-            ) {
-                pending_deferred_mcp = Some((mgr, resolved));
-            }
+            )
+        {
+            pending_deferred_mcp = Some((mgr, resolved));
         }
 
         let cmd = if let Some(c) = pending_cmd.take() {

--- a/crates/wcore-cli/src/main.rs
+++ b/crates/wcore-cli/src/main.rs
@@ -2391,6 +2391,65 @@ fn mcp_ready_events_for(mgr: &McpManager) -> Vec<ProtocolEvent> {
         .collect()
 }
 
+/// wayland#551 — companion to [`mcp_ready_events_for`]: one `McpFailed`
+/// event per server whose connect failed or timed out, so a host whose
+/// config MCP servers were dialed in the background still learns WHY a
+/// server's tools never appeared (parity with the dynamic `AddMcpServer`
+/// path's failure emit). Pure and name-sorted for deterministic tests.
+fn mcp_failed_events_for(mgr: &McpManager) -> Vec<ProtocolEvent> {
+    use wcore_mcp::manager::McpServerHealth;
+    let mut entries: Vec<(&String, &McpServerHealth)> = mgr.health().iter().collect();
+    entries.sort_by_key(|(name, _)| name.as_str());
+    entries
+        .into_iter()
+        .filter_map(|(name, health)| {
+            let reason = match health {
+                McpServerHealth::Failed { reason } => reason.clone(),
+                McpServerHealth::TimedOut { after } => {
+                    format!("connect timed out after {}s", after.as_secs())
+                }
+                McpServerHealth::Skipped { reason } => reason.clone(),
+                McpServerHealth::Ready { .. } => return None,
+            };
+            Some(ProtocolEvent::McpFailed {
+                name: name.clone(),
+                reason,
+            })
+        })
+        .collect()
+}
+
+/// wayland#551 — integrate a background-connected config-MCP manager into
+/// the LIVE engine. Registers the manager's tools (same collision handling
+/// as boot via [`wcore_mcp::tool_proxy::register_mcp_tools`]), emits one
+/// `McpReady` per connected server and one `McpFailed` per failed server,
+/// and parks the manager in `dynamic_managers` so it stays alive.
+///
+/// Returns `false` when the registry Arc is currently borrowed (a turn is
+/// mid-flight) — the caller parks the manager and retries at the next
+/// between-turns boundary.
+fn integrate_deferred_mcp(
+    engine: &mut wcore_agent::engine::AgentEngine,
+    mgr: Arc<McpManager>,
+    resolved_servers: &HashMap<String, McpServerConfig>,
+    writer: &ProtocolWriter,
+    dynamic_managers: &mut Vec<Arc<McpManager>>,
+) -> bool {
+    let builtin_names = engine.tool_names();
+    let Some(reg) = engine.registry_mut() else {
+        return false;
+    };
+    wcore_mcp::tool_proxy::register_mcp_tools(reg, &mgr, &builtin_names, resolved_servers);
+    for event in mcp_ready_events_for(&mgr) {
+        let _ = writer.emit(&event);
+    }
+    for event in mcp_failed_events_for(&mgr) {
+        let _ = writer.emit(&event);
+    }
+    dynamic_managers.push(mgr);
+    true
+}
+
 fn to_mcp_server_config(
     transport: &str,
     command: Option<String>,
@@ -2609,13 +2668,34 @@ async fn run_json_stream_mode(
 
     let provider_name = config.provider_label.clone();
 
+    // wayland#551 — config-declared MCP connects must NOT gate the `ready`
+    // frame: a slow/hung server eats up to the full 30s per-server connect
+    // budget INSIDE bootstrap, and hosts (the desktop app) time out waiting
+    // for ready at 30s — the chat never opens. Capture + cred-resolve the
+    // servers now (config is moved into bootstrap next), tell bootstrap to
+    // skip them, and dial them in the background right after ready goes out.
+    // Resolution happens here on a clone, mirroring bootstrap's own connect
+    // boundary: the long-lived config keeps the literal `${cred:...}`.
+    let deferred_mcp_servers = if config.mcp.servers.is_empty() {
+        None
+    } else {
+        Some(match config.open_credentials_store() {
+            Ok(store) => wcore_config::mcp_cred_refs::resolve_servers_for_connect(
+                &config.mcp.servers,
+                &*store,
+            ),
+            Err(_) => config.mcp.servers.clone(),
+        })
+    };
+
     // Bootstrap engine with full feature initialization. Phase 1B-2 —
     // json-stream is a primary long-running host session (e.g. the Wayland
     // desktop app), so
     // opt into inbound channel dispatch.
     let mut bootstrap = AgentBootstrap::new(config, cwd, output.clone())
         .plugin_provider_router(make_plugin_provider_router())
-        .enable_inbound_dispatch(true);
+        .enable_inbound_dispatch(true)
+        .defer_config_mcp(deferred_mcp_servers.is_some());
 
     if let Some(resume_id) = &resume {
         let cfg = bootstrap.config();
@@ -2636,7 +2716,9 @@ async fn run_json_stream_mode(
         }
     };
     let mut engine = result.engine;
-    let initial_has_mcp = result.has_mcp;
+    // wayland#551 — declared-but-still-connecting servers count as MCP
+    // capability on the ready frame; their tools register shortly after.
+    let initial_has_mcp = result.has_mcp || deferred_mcp_servers.is_some();
     let initial_has_plugins = result.has_plugins;
     // W8c.3 H.2: snapshot the plugin-derived capability set so the
     // protocol sink advertises `browser_suite` / `computer_use` flags
@@ -2689,6 +2771,22 @@ async fn run_json_stream_mode(
             let _ = writer.emit(&event);
         }
     }
+
+    // wayland#551 — dial the deferred config MCP servers in the background,
+    // AFTER ready is on the wire. The command loop integrates the manager
+    // into the live engine between turns (see the select below) and emits
+    // McpReady / McpFailed per server, exactly like the dynamic
+    // `AddMcpServer` path. A turn that starts before the connects settle
+    // simply runs without the MCP tools — the old behavior was a chat that
+    // never opened at all.
+    let mut deferred_mcp_rx = deferred_mcp_servers.map(|resolved| {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        tokio::spawn(async move {
+            let outcome = McpManager::connect_all(&resolved).await;
+            let _ = tx.send((outcome, resolved));
+        });
+        rx
+    });
 
     engine.set_approval_manager(approval_manager.clone());
     // D012 (P0 security): install the gating writer as the engine's
@@ -2826,13 +2924,66 @@ async fn run_json_stream_mode(
     let has_mcp = initial_has_mcp || !dynamic_managers.is_empty();
     let mut pending_cmd = first_cmd;
 
-    loop {
+    // wayland#551 — a deferred-MCP manager whose integration found the
+    // registry borrowed; retried at the next between-turns boundary.
+    let mut pending_deferred_mcp: Option<(Arc<McpManager>, HashMap<String, McpServerConfig>)> =
+        None;
+
+    'session: loop {
+        // wayland#551 — retry a parked integration between turns (the
+        // registry Arc is only borrowable while no turn is running).
+        if let Some((mgr, resolved)) = pending_deferred_mcp.take() {
+            if !integrate_deferred_mcp(
+                &mut engine,
+                mgr.clone(),
+                &resolved,
+                &writer,
+                &mut dynamic_managers,
+            ) {
+                pending_deferred_mcp = Some((mgr, resolved));
+            }
+        }
+
         let cmd = if let Some(c) = pending_cmd.take() {
             c
         } else {
-            match cmd_rx.recv().await {
-                Some(c) => c,
-                None => break,
+            loop {
+                tokio::select! {
+                    c = cmd_rx.recv() => match c {
+                        Some(c) => break c,
+                        None => break 'session,
+                    },
+                    // wayland#551 — background config-MCP connect settled;
+                    // integrate into the live engine and keep waiting for
+                    // the next command. Guarded so a consumed receiver is
+                    // never polled again.
+                    res = async { deferred_mcp_rx.as_mut().expect("guarded by is_some").await },
+                        if deferred_mcp_rx.is_some() =>
+                    {
+                        deferred_mcp_rx = None;
+                        match res {
+                            Ok((Ok(mgr), resolved)) => {
+                                let mgr = Arc::new(mgr);
+                                if !integrate_deferred_mcp(
+                                    &mut engine,
+                                    mgr.clone(),
+                                    &resolved,
+                                    &writer,
+                                    &mut dynamic_managers,
+                                ) {
+                                    pending_deferred_mcp = Some((mgr, resolved));
+                                }
+                            }
+                            Ok((Err(e), _)) => {
+                                // Mirrors bootstrap's inline-connect wording.
+                                output.emit_error(&format!("MCP initialization error: {e}"), false);
+                            }
+                            // Connect task dropped without sending (panic);
+                            // nothing to integrate.
+                            Err(_) => {}
+                        }
+                    }
+                }
             }
         };
 
@@ -3432,6 +3583,46 @@ mod tests {
                 assert!(tools.is_empty());
             }
             other => panic!("expected McpReady, got {other:?}"),
+        }
+    }
+
+    /// wayland#551: background-connect failure surfacing — one `McpFailed`
+    /// per Failed/TimedOut/Skipped server, none for Ready, name-sorted.
+    /// Pre-fix the deferred path would have reported connect failures
+    /// nowhere (bootstrap's inline emit no longer runs for these servers).
+    #[test]
+    fn test_mcp_failed_events_for_reports_failures_only() {
+        use wcore_mcp::manager::McpServerHealth;
+        let mgr = McpManager::new_for_test_with_health(vec![
+            (
+                "slow",
+                McpServerHealth::TimedOut {
+                    after: std::time::Duration::from_secs(30),
+                },
+            ),
+            ("okay", McpServerHealth::Ready { tool_count: 3 }),
+            (
+                "broken",
+                McpServerHealth::Failed {
+                    reason: "handshake refused".into(),
+                },
+            ),
+        ]);
+        let events = mcp_failed_events_for(&mgr);
+        assert_eq!(events.len(), 2, "Ready servers must not emit McpFailed");
+        match &events[0] {
+            ProtocolEvent::McpFailed { name, reason } => {
+                assert_eq!(name, "broken");
+                assert!(reason.contains("handshake refused"), "reason = {reason}");
+            }
+            other => panic!("expected McpFailed, got {other:?}"),
+        }
+        match &events[1] {
+            ProtocolEvent::McpFailed { name, reason } => {
+                assert_eq!(name, "slow");
+                assert!(reason.contains("30"), "reason = {reason}");
+            }
+            other => panic!("expected McpFailed, got {other:?}"),
         }
     }
 

--- a/crates/wcore-cli/src/main.rs
+++ b/crates/wcore-cli/src/main.rs
@@ -3690,6 +3690,81 @@ mod tests {
         }
     }
 
+    /// wayland#551: deferred-MCP integration must register the manager's
+    /// tools into a LIVE engine (post-boot), emit per-server events, and
+    /// park the manager alive in `dynamic_managers`. Pins the integration
+    /// half of the deferral wiring — removing `register_mcp_tools` from
+    /// `integrate_deferred_mcp` fails this.
+    #[tokio::test]
+    async fn integrate_deferred_mcp_registers_tools_into_live_engine() {
+        let (mut engine, _sink) = wcore_agent::bootstrap::AgentBootstrap::build_for_test(
+            wcore_config::config::Config::default(),
+            vec![],
+        );
+        let before = engine.tool_names().len();
+        let mgr = Arc::new(McpManager::new_for_test_with_tools(vec![(
+            "quick",
+            false,
+            Box::new(NoopTransport) as Box<dyn McpTransport>,
+            vec![tool("quick_echo")],
+        )]));
+        let writer = ProtocolWriter::new();
+        let mut dynamic_managers = Vec::new();
+        assert!(
+            integrate_deferred_mcp(
+                &mut engine,
+                mgr,
+                &HashMap::new(),
+                &writer,
+                &mut dynamic_managers
+            ),
+            "integration must succeed on an idle engine"
+        );
+        assert!(
+            engine.tool_names().len() > before
+                && engine.tool_names().iter().any(|n| n.contains("quick_echo")),
+            "deferred server's tools must be registered; got {:?}",
+            engine.tool_names()
+        );
+        assert_eq!(dynamic_managers.len(), 1, "manager must be kept alive");
+    }
+
+    /// wayland#551: while the registry Arc is borrowed (as during a turn),
+    /// integration must decline — no partial registration — so the caller
+    /// parks the manager and retries at the next between-turns boundary.
+    #[tokio::test]
+    async fn integrate_deferred_mcp_parks_while_registry_is_borrowed() {
+        let (mut engine, _sink) = wcore_agent::bootstrap::AgentBootstrap::build_for_test(
+            wcore_config::config::Config::default(),
+            vec![],
+        );
+        let hold = engine.tools(); // second Arc ref → registry_mut() is None
+        let mgr = Arc::new(McpManager::new_for_test_with_tools(vec![(
+            "quick",
+            false,
+            Box::new(NoopTransport) as Box<dyn McpTransport>,
+            vec![tool("quick_echo")],
+        )]));
+        let writer = ProtocolWriter::new();
+        let mut dynamic_managers = Vec::new();
+        assert!(
+            !integrate_deferred_mcp(
+                &mut engine,
+                mgr,
+                &HashMap::new(),
+                &writer,
+                &mut dynamic_managers
+            ),
+            "integration must decline while the registry is borrowed"
+        );
+        assert!(dynamic_managers.is_empty());
+        assert!(
+            !engine.tool_names().iter().any(|n| n.contains("quick_echo")),
+            "no tools may be registered on a declined integration"
+        );
+        drop(hold);
+    }
+
     /// Rank 47 regression: `--no-memory` must parse and flip
     /// `config.memory.enabled` to `false`, giving users an accessible way to
     /// run a stateless session. Pre-fix the flag did not exist (only a TODO

--- a/crates/wcore-cli/src/main.rs
+++ b/crates/wcore-cli/src/main.rs
@@ -2858,7 +2858,39 @@ async fn run_json_stream_mode(
     let mut dynamic_managers: Vec<Arc<McpManager>> = Vec::new();
     let mut first_cmd: Option<ProtocolCommand> = None;
 
-    while let Some(cmd) = cmd_rx.recv().await {
+    // wayland#551 — a deferred-MCP manager whose integration found the
+    // registry borrowed; retried at the next between-turns boundary.
+    let mut pending_deferred_mcp: Option<(Arc<McpManager>, HashMap<String, McpServerConfig>)> =
+        None;
+
+    loop {
+        // wayland#551 — the pre-message phase can park in recv() forever on
+        // a quiet host, so the background connect result must be settled
+        // here too, or McpReady/McpFailed health would wait on host
+        // activity (live-verify caught exactly that).
+        let cmd = tokio::select! {
+            c = cmd_rx.recv() => match c {
+                Some(c) => c,
+                None => break,
+            },
+            res = async { deferred_mcp_rx.as_mut().expect("guarded by is_some").await },
+                if deferred_mcp_rx.is_some() =>
+            {
+                deferred_mcp_rx = None;
+                // Err = connect task dropped without sending (panic).
+                if let Ok((outcome, resolved)) = res {
+                    pending_deferred_mcp = note_deferred_mcp_connect(
+                        outcome,
+                        resolved,
+                        &mut engine,
+                        &writer,
+                        &output,
+                        &mut dynamic_managers,
+                    );
+                }
+                continue;
+            }
+        };
         match cmd {
             ProtocolCommand::AddMcpServer {
                 name,
@@ -2952,11 +2984,6 @@ async fn run_json_stream_mode(
 
     let has_mcp = initial_has_mcp || !dynamic_managers.is_empty();
     let mut pending_cmd = first_cmd;
-
-    // wayland#551 — a deferred-MCP manager whose integration found the
-    // registry borrowed; retried at the next between-turns boundary.
-    let mut pending_deferred_mcp: Option<(Arc<McpManager>, HashMap<String, McpServerConfig>)> =
-        None;
 
     'session: loop {
         // wayland#551 — settle deferred MCP at every between-turns boundary,

--- a/crates/wcore-cli/src/main.rs
+++ b/crates/wcore-cli/src/main.rs
@@ -2425,6 +2425,35 @@ fn mcp_failed_events_for(mgr: &McpManager) -> Vec<ProtocolEvent> {
 /// `McpReady` per connected server and one `McpFailed` per failed server,
 /// and parks the manager in `dynamic_managers` so it stays alive.
 ///
+/// wayland#551 — absorb a settled background config-MCP connect: on
+/// success, integrate into the live engine (returning the parked pair when
+/// the registry is momentarily borrowed so the caller can retry between
+/// turns); on failure, surface the error with bootstrap's inline-connect
+/// wording. Shared by the loop-top non-blocking poll and the select arm.
+fn note_deferred_mcp_connect(
+    outcome: Result<McpManager, wcore_mcp::transport::McpError>,
+    resolved: HashMap<String, McpServerConfig>,
+    engine: &mut wcore_agent::engine::AgentEngine,
+    writer: &ProtocolWriter,
+    output: &Arc<dyn OutputSink>,
+    dynamic_managers: &mut Vec<Arc<McpManager>>,
+) -> Option<(Arc<McpManager>, HashMap<String, McpServerConfig>)> {
+    match outcome {
+        Ok(mgr) => {
+            let mgr = Arc::new(mgr);
+            if integrate_deferred_mcp(engine, mgr.clone(), &resolved, writer, dynamic_managers) {
+                None
+            } else {
+                Some((mgr, resolved))
+            }
+        }
+        Err(e) => {
+            output.emit_error(&format!("MCP initialization error: {e}"), false);
+            None
+        }
+    }
+}
+
 /// Returns `false` when the registry Arc is currently borrowed (a turn is
 /// mid-flight) — the caller parks the manager and retries at the next
 /// between-turns boundary.
@@ -2930,8 +2959,25 @@ async fn run_json_stream_mode(
         None;
 
     'session: loop {
-        // wayland#551 — retry a parked integration between turns (the
-        // registry Arc is only borrowable while no turn is running).
+        // wayland#551 — settle deferred MCP at every between-turns boundary,
+        // BEFORE the next command is processed, so a message that arrives
+        // after the connects finished runs WITH the MCP tools. Two sources:
+        // a non-blocking poll of the connect task (the blocking wait lives
+        // in the select below) and a parked integration whose earlier
+        // attempt found the registry borrowed.
+        if let Some(rx) = deferred_mcp_rx.as_mut()
+            && let Ok((outcome, resolved)) = rx.try_recv()
+        {
+            deferred_mcp_rx = None;
+            pending_deferred_mcp = note_deferred_mcp_connect(
+                outcome,
+                resolved,
+                &mut engine,
+                &writer,
+                &output,
+                &mut dynamic_managers,
+            );
+        }
         if let Some((mgr, resolved)) = pending_deferred_mcp.take()
             && !integrate_deferred_mcp(
                 &mut engine,
@@ -2961,26 +3007,17 @@ async fn run_json_stream_mode(
                         if deferred_mcp_rx.is_some() =>
                     {
                         deferred_mcp_rx = None;
-                        match res {
-                            Ok((Ok(mgr), resolved)) => {
-                                let mgr = Arc::new(mgr);
-                                if !integrate_deferred_mcp(
-                                    &mut engine,
-                                    mgr.clone(),
-                                    &resolved,
-                                    &writer,
-                                    &mut dynamic_managers,
-                                ) {
-                                    pending_deferred_mcp = Some((mgr, resolved));
-                                }
-                            }
-                            Ok((Err(e), _)) => {
-                                // Mirrors bootstrap's inline-connect wording.
-                                output.emit_error(&format!("MCP initialization error: {e}"), false);
-                            }
-                            // Connect task dropped without sending (panic);
-                            // nothing to integrate.
-                            Err(_) => {}
+                        // Err = connect task dropped without sending (panic);
+                        // nothing to integrate.
+                        if let Ok((outcome, resolved)) = res {
+                            pending_deferred_mcp = note_deferred_mcp_connect(
+                                outcome,
+                                resolved,
+                                &mut engine,
+                                &writer,
+                                &output,
+                                &mut dynamic_managers,
+                            );
                         }
                     }
                 }

--- a/crates/wcore-mcp/src/manager.rs
+++ b/crates/wcore-mcp/src/manager.rs
@@ -501,6 +501,22 @@ impl McpManager {
         }
     }
 
+    /// Test-only constructor: build a manager with an explicit health map
+    /// and no live servers. wayland#551 — lets `mcp_failed_events_for`-style
+    /// consumers be tested against `Failed` / `TimedOut` entries, which the
+    /// other test constructors can't produce (they mark everything Ready).
+    #[cfg(any(test, feature = "test-utils"))]
+    pub fn new_for_test_with_health(health: Vec<(&str, McpServerHealth)>) -> Self {
+        Self {
+            servers: HashMap::new(),
+            health: health
+                .into_iter()
+                .map(|(name, h)| (name.to_string(), h))
+                .collect(),
+            next_id: AtomicU64::new(10),
+        }
+    }
+
     /// Test-only constructor: build a manager from pre-configured servers.
     #[cfg(any(test, feature = "test-utils"))]
     pub fn new_for_test(


### PR DESCRIPTION
Addresses FerroxLabs/wayland#551 (do not auto-close — release closes). Overwatch-allocated P1.

## Root cause

`bootstrap.build()` awaits `McpManager::connect_all` for config-declared MCP servers before `run_json_stream_mode` can emit `{type:ready}`. Connects run concurrently, but each server has a **30s** connect budget — one slow or hung server (heavy npx-launched stdio servers on Intel macOS: MS-365, Apple-Ecosystem, GitHub) stalls boot right past the desktop host's 30s ready timeout. The chat never opens; a clean profile "fixes" it because there is nothing to stall on.

## Fix

- **`AgentBootstrap::defer_config_mcp(v)`** — `build()` skips the config-server connect block. Default `false`: TUI and one-shot paths are byte-identical (a one-shot turn genuinely needs its tools before running).
- **json-stream boot**: cred-resolves the declared servers up front (config is moved into bootstrap; same connect-boundary clone semantics), defers them, emits `ready` immediately — declared servers count toward the `has_mcp` capability — then dials `connect_all` on a background task.
- **Integration into the live engine**: the command loop settles the connect result at every between-turns boundary — a non-blocking poll at the top of both the pre-message phase and the session loop (so a message arriving after connects finish runs WITH the tools, and a quiet host still gets health events the moment connects settle), plus a blocking select arm while idle. Same `register_mcp_tools` collision handling as boot; if the registry Arc is momentarily borrowed the manager parks and retries at the next boundary.
- **Failure surfacing**: new `mcp_failed_events_for` emits one `McpFailed` per failed/timed-out server (parity with the dynamic `AddMcpServer` path) — previously bootstrap's inline error emit covered this; the deferred path now reports through protocol events.

Accepted tradeoff (was the point of the ruling): a turn that starts before the connects settle runs without the MCP tools; previously the session never became usable at all. Known gap shared with the dynamic `AddMcpServer` path: deferred managers aren't wired into the bootstrap-time hooks `McpManagerCaller`.

## Verification

- Hetzner gate green ×3: fmt, clippy `--all-targets -D warnings`, nextest **3969/3969** (`wcore-mcp` + `wcore-agent` + `wcore-cli`).
- New tests: `bootstrap_defer_config_mcp_skips_connect` (drives the REAL `build()` with a hanging stdio server; fails in 30s if the gate is removed), `test_mcp_failed_events_for_reports_failures_only` (+ a health-injecting test constructor in wcore-mcp).
- **Live-verified on the box** (real binary, real config, hanging `sleep 300` stdio server + real minimal MCP server):
  - hung server configured: `ready` at **0.07s** (pre-fix: blocked ~30s, past the host timeout);
  - silent host: `mcp_ready{quick}` + `mcp_failed{hang, "connect timed out after 30s"}` at **30.08s** — the moment connects settle, no host activity needed (an earlier build parked these on host activity; caught live, fixed);
  - healthy-server path: `mcp_ready` **20ms** after ready.
