### PR TITLE
fix(security): stamp the bridge secret resume_token on the ACP relay

### DIFF
--- a/crates/wcore-cli/src/acp_engine.rs
+++ b/crates/wcore-cli/src/acp_engine.rs
@@ -230,9 +230,18 @@ struct RelayEmitter {
     /// GHSA-8r7g M1 (wayland#497) — the session engine's `ApprovalBridge`.
     /// Threaded into `ChannelEmitter::with_dedupe` so a bridge-backed
     /// approval (Crucible council / egress consent) synthesized on the ACP
-    /// relay stamps the server-generated SECRET `apr-{uuid}` resume_token,
-    /// exactly like the stdin/TUI transports — instead of the legacy
-    /// model-known `call_id`. `None` only in unit tests.
+    /// relay stamps the server-generated SECRET `apr-{uuid}` resume_token
+    /// instead of the legacy model-known `call_id`. `None` only in unit
+    /// tests.
+    ///
+    /// SCOPE (per the #497 cross-audit): this is frame-level parity with the
+    /// stdin/TUI transports only. The ACP PROJECTION drops `resume_token`
+    /// before it reaches the host (`MessageEvent::ApprovalRequired` carries
+    /// no token field) and the resolve endpoint stays call_id-keyed behind
+    /// X-API-Key — so a bridge-backed gate raised during an ACP turn is not
+    /// yet resolvable by the ACP host at all, and manager-gated resolution
+    /// still keys on the model-known call_id. Carrying + accepting the
+    /// secret end-to-end on ACP is tracked as a separate follow-up issue.
     approval_bridge: Option<Arc<wcore_agent::approval::ApprovalBridge>>,
 }
 

--- a/crates/wcore-cli/src/acp_engine.rs
+++ b/crates/wcore-cli/src/acp_engine.rs
@@ -227,13 +227,24 @@ struct RelayEmitter {
     /// `ApprovalRequired` (the live-workflow gate emits its own) is suppressed,
     /// preventing a malformed second gate frame on the ACP projection.
     synthesized: crate::tui::DedupeSet,
+    /// GHSA-8r7g M1 (wayland#497) — the session engine's `ApprovalBridge`.
+    /// Threaded into `ChannelEmitter::with_dedupe` so a bridge-backed
+    /// approval (Crucible council / egress consent) synthesized on the ACP
+    /// relay stamps the server-generated SECRET `apr-{uuid}` resume_token,
+    /// exactly like the stdin/TUI transports — instead of the legacy
+    /// model-known `call_id`. `None` only in unit tests.
+    approval_bridge: Option<Arc<wcore_agent::approval::ApprovalBridge>>,
 }
 
 impl RelayEmitter {
-    fn new(handle: RelayHandle) -> Self {
+    fn new(
+        handle: RelayHandle,
+        approval_bridge: Option<Arc<wcore_agent::approval::ApprovalBridge>>,
+    ) -> Self {
         Self {
             handle,
             synthesized: Arc::new(Mutex::new(std::collections::HashSet::new())),
+            approval_bridge,
         }
     }
 }
@@ -242,10 +253,8 @@ impl ProtocolEmitter for RelayEmitter {
     fn emit(&self, event: &ProtocolEvent) -> std::io::Result<()> {
         let tx = self.handle.lock().unwrap().clone();
         if let Some(tx) = tx {
-            // GHSA-8r7g: `None` bridge → legacy resume_token emit on the ACP
-            // relay (its crucible/egress call_ids are already uuids; the ACP
-            // endpoint's secret-token hardening is a separate follow-up).
-            ChannelEmitter::with_dedupe(tx, self.synthesized.clone(), None).emit(event)?;
+            ChannelEmitter::with_dedupe(tx, self.synthesized.clone(), self.approval_bridge.clone())
+                .emit(event)?;
         }
         Ok(())
     }
@@ -773,7 +782,11 @@ impl EngineTurnEngine {
         engine.rebind_memory_session().await;
         engine.run_session_start_hooks().await;
         engine.set_approval_manager(approval_manager.clone());
-        engine.set_protocol_writer(Arc::new(RelayEmitter::new(relay.clone())));
+        // GHSA-8r7g M1 (wayland#497): bind the engine's ApprovalBridge so
+        // bridge-backed gate frames on the ACP relay carry the secret
+        // resume_token (parity with the stdin/TUI transports).
+        let bridge = engine.approval_bridge().clone();
+        engine.set_protocol_writer(Arc::new(RelayEmitter::new(relay.clone(), Some(bridge))));
 
         let session = Arc::new(EngineSession::new(engine, approval_manager, relay));
 
@@ -1120,7 +1133,7 @@ mod tests {
         // The relay's emitter forwards onto the per-turn channel and owns the
         // persistent dedupe set (mirrors `EngineSession`'s wiring).
         let relay: RelayHandle = Arc::new(Mutex::new(Some(tx)));
-        let emitter = RelayEmitter::new(relay);
+        let emitter = RelayEmitter::new(relay, None);
 
         // Reproduce the live-workflow gate's emit sequence (engine.rs):
         // (1) ToolRequest for the gated "Workflow" call, then
@@ -1180,6 +1193,102 @@ mod tests {
                 assert_eq!(
                     call.name, "Workflow",
                     "the surviving gate frame must carry the gated tool name, not an empty phantom"
+                );
+            }
+            other => panic!("expected ApprovalRequired, got {other:?}"),
+        }
+    }
+
+    /// GHSA-8r7g M1 (wayland#497): a bridge-backed approval synthesized on
+    /// the ACP relay must stamp the bridge's SECRET `apr-{uuid}`
+    /// resume_token — not the model-known `call_id` (the pre-fix legacy
+    /// behavior this transport had) and not an empty token. Asserted at the
+    /// raw `ProtocolEvent` boundary, where the wire value is decided.
+    #[tokio::test]
+    async fn relay_emitter_stamps_bridge_secret_resume_token() {
+        let bridge = Arc::new(wcore_agent::approval::ApprovalBridge::new());
+        let (secret, _outcome_rx) = bridge
+            .request_with_id(
+                "crucible-call-9".to_string(),
+                wcore_agent::approval::ApprovalRequest {
+                    call_id: "crucible-call-9".into(),
+                    reason: "council".into(),
+                    context: "ctx".into(),
+                },
+            )
+            .await;
+
+        let (tx, mut rx) = unbounded_channel::<ProtocolEvent>();
+        let relay: RelayHandle = Arc::new(Mutex::new(Some(tx)));
+        let emitter = RelayEmitter::new(relay, Some(bridge));
+
+        emitter
+            .emit(&ProtocolEvent::ToolRequest {
+                msg_id: "m".into(),
+                call_id: "crucible-call-9".into(),
+                tool: wcore_protocol::events::ToolInfo {
+                    name: "CrucibleCouncil".into(),
+                    category: wcore_protocol::events::ToolCategory::Exec,
+                    args: serde_json::json!({}),
+                    description: "council approval".into(),
+                },
+            })
+            .unwrap();
+
+        // First frame is the forwarded ToolRequest; second is the
+        // synthesized gate whose resume_token is under test.
+        let first = rx.recv().await.expect("forwarded ToolRequest");
+        assert!(matches!(first, ProtocolEvent::ToolRequest { .. }));
+        match rx.recv().await.expect("synthesized ApprovalRequired") {
+            ProtocolEvent::ApprovalRequired {
+                call_id,
+                resume_token,
+                ..
+            } => {
+                assert_eq!(call_id, "crucible-call-9");
+                assert_eq!(
+                    resume_token, secret,
+                    "ACP relay must stamp the bridge's secret resume_token"
+                );
+                assert!(resume_token.starts_with("apr-"), "got {resume_token:?}");
+                assert_ne!(
+                    resume_token, call_id,
+                    "the model-known call_id must never be the resume handle"
+                );
+            }
+            other => panic!("expected ApprovalRequired, got {other:?}"),
+        }
+    }
+
+    /// Companion negative: with the bridge bound but NO bridge entry for the
+    /// call (a regular tool gated by the ToolApprovalManager), the
+    /// synthesized token must be EMPTY — never a fallback to the call_id.
+    #[tokio::test]
+    async fn relay_emitter_emits_empty_token_for_non_bridge_call() {
+        let bridge = Arc::new(wcore_agent::approval::ApprovalBridge::new());
+        let (tx, mut rx) = unbounded_channel::<ProtocolEvent>();
+        let relay: RelayHandle = Arc::new(Mutex::new(Some(tx)));
+        let emitter = RelayEmitter::new(relay, Some(bridge));
+
+        emitter
+            .emit(&ProtocolEvent::ToolRequest {
+                msg_id: "m".into(),
+                call_id: "bash-1".into(),
+                tool: wcore_protocol::events::ToolInfo {
+                    name: "Bash".into(),
+                    category: wcore_protocol::events::ToolCategory::Exec,
+                    args: serde_json::json!({"command": "ls"}),
+                    description: "run".into(),
+                },
+            })
+            .unwrap();
+
+        let _tool_req = rx.recv().await.expect("forwarded ToolRequest");
+        match rx.recv().await.expect("synthesized ApprovalRequired") {
+            ProtocolEvent::ApprovalRequired { resume_token, .. } => {
+                assert!(
+                    resume_token.is_empty(),
+                    "non-bridge call must get an EMPTY token (resolved via ToolApprove), got {resume_token:?}"
                 );
             }
             other => panic!("expected ApprovalRequired, got {other:?}"),

--- a/crates/wcore-cli/src/acp_engine.rs
+++ b/crates/wcore-cli/src/acp_engine.rs
@@ -241,7 +241,7 @@ struct RelayEmitter {
     /// X-API-Key — so a bridge-backed gate raised during an ACP turn is not
     /// yet resolvable by the ACP host at all, and manager-gated resolution
     /// still keys on the model-known call_id. Carrying + accepting the
-    /// secret end-to-end on ACP is tracked as a separate follow-up issue.
+    /// secret end-to-end on ACP is tracked as FerroxLabs/wayland#568.
     approval_bridge: Option<Arc<wcore_agent::approval::ApprovalBridge>>,
 }
 

--- a/crates/wcore-cli/src/tui/engine_bridge.rs
+++ b/crates/wcore-cli/src/tui/engine_bridge.rs
@@ -69,9 +69,12 @@ pub struct ChannelEmitter {
     /// GHSA-8r7g: sync correlation→secret lookup so a synthesized gate frame
     /// carries the unguessable `resume_token` for a bridge-backed approval
     /// (crucible/egress), and EMPTY for a regular tool (no bridge entry —
-    /// resolved via `ToolApprove`). `None` (ACP relay + unit tests) keeps the
-    /// legacy behavior of emitting the `call_id` as the resume handle; the ACP
-    /// projection's endpoint hardening is a separate follow-up.
+    /// resolved via `ToolApprove`). All production transports (TUI and, since
+    /// wayland#497, the ACP relay) pass `Some`; `None` (unit tests only)
+    /// falls back to the legacy call_id-as-token emit. NOTE: the ACP
+    /// PROJECTION still drops `resume_token` and its resolve endpoint stays
+    /// call_id-keyed — carrying/accepting the secret end-to-end on ACP is
+    /// tracked separately (see the RelayEmitter field doc).
     approval_bridge: Option<Arc<wcore_agent::approval::ApprovalBridge>>,
 }
 
@@ -99,7 +102,8 @@ impl ChannelEmitter {
     /// TUI/ACP emitters where the engine may also emit its own gate frame.
     /// GHSA-8r7g: `approval_bridge` supplies the sync correlation→secret lookup
     /// used to stamp the unguessable `resume_token` onto a bridge-backed gate
-    /// frame (`Some` for the TUI; `None` for the ACP relay keeps legacy emit).
+    /// frame (`Some` for the TUI and, since wayland#497, the ACP relay;
+    /// `None` only in unit tests).
     pub fn with_dedupe(
         tx: UnboundedSender<ProtocolEvent>,
         synthesized: DedupeSet,


### PR DESCRIPTION
Addresses FerroxLabs/wayland#497 (do not auto-close — release closes). GHSA-8r7g M1, #2 in Overwatch's allocated core queue.

## What

The ACP `RelayEmitter` built its `ChannelEmitter` with no `ApprovalBridge`, so bridge-backed approvals (Crucible council / egress consent) synthesized on the ACP transport emitted the **model-known `call_id`** as the resume handle — the exact legacy pattern GHSA-8r7g part-a removed from the stdin/TUI transports. Per the issue: not exploitable today (ACP/REST is mandatorily X-API-Key gated per F-017 and loopback-bound) — this is defense-in-depth parity, closing the last transport on the part-a pattern.

`RelayEmitter` now carries the session engine's `ApprovalBridge` (grabbed at `EngineSession` construction from `engine.approval_bridge()`) and threads it into `ChannelEmitter::with_dedupe`, so ACP gate frames stamp the server-generated secret `apr-{uuid}` exactly like the other transports. The stale "separate follow-up" deferral comment is gone.

## Verification

- Hetzner gate green first pass: fmt, clippy `--all-targets -D warnings`, nextest 1725/1725 (`-p wcore-cli`).
- New tests at the raw `ProtocolEvent` boundary (where the wire value is decided): bridge-backed call → `resume_token == bridge secret`, `apr-` prefixed, `!= call_id`; non-bridge call → **empty** token (never a call_id fallback); existing workflow double-gate dedupe test unchanged (passes `None`, pinning the legacy-emitters-only fallback).
