### PR TITLE
fix(sandbox): skip missing bwrap bind sources instead of fail-spawning

### DIFF
--- a/crates/wcore-providers/src/anthropic_shared.rs
+++ b/crates/wcore-providers/src/anthropic_shared.rs
@@ -356,8 +356,37 @@ pub async fn process_sse_stream(
     Ok(())
 }
 
+/// wayland#552 — env-gated raw SSE capture. When
+/// `WAYLAND_ANTHROPIC_SSE_DUMP` names a file, every SSE event this parser
+/// receives is appended as one `event_type\tdata` line BEFORE parsing, so a
+/// frame shape the parser silently ignores (unknown block/delta types fall
+/// through `_ => {}` arms) is still observable. Diagnostic instrument for
+/// model-family rollouts (first user: the claude-fable-5 empty-bash-loop
+/// capture); zero overhead when the env var is unset (checked once).
+/// SECURITY: the dump contains raw model output — the operator chooses the
+/// path and owns the file; nothing is captured by default.
+fn sse_dump(event_type: &str, data: &str) {
+    use std::io::Write;
+    use std::sync::OnceLock;
+    static DUMP_PATH: OnceLock<Option<String>> = OnceLock::new();
+    let Some(path) = DUMP_PATH
+        .get_or_init(|| std::env::var("WAYLAND_ANTHROPIC_SSE_DUMP").ok())
+        .as_ref()
+    else {
+        return;
+    };
+    if let Ok(mut f) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+    {
+        let _ = writeln!(f, "{event_type}\t{data}");
+    }
+}
+
 /// Parse a single SSE data payload into zero or more LlmEvents
 pub fn parse_sse_data(event_type: &str, data: &str, state: &mut StreamState) -> Vec<LlmEvent> {
+    sse_dump(event_type, data);
     let mut events = Vec::new();
 
     let json: Value = match serde_json::from_str(data) {

--- a/crates/wcore-providers/src/anthropic_shared.rs
+++ b/crates/wcore-providers/src/anthropic_shared.rs
@@ -375,11 +375,16 @@ fn sse_dump(event_type: &str, data: &str) {
     else {
         return;
     };
-    if let Ok(mut f) = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(path)
+    let mut opts = std::fs::OpenOptions::new();
+    opts.create(true).append(true);
+    // The dump holds raw model output (may echo secrets / tool args), so
+    // create it owner-only rather than umask-default 0644.
+    #[cfg(unix)]
     {
+        use std::os::unix::fs::OpenOptionsExt;
+        opts.mode(0o600);
+    }
+    if let Ok(mut f) = opts.open(path) {
         let _ = writeln!(f, "{event_type}\t{data}");
     }
 }

--- a/crates/wcore-sandbox/src/backends/bwrap.rs
+++ b/crates/wcore-sandbox/src/backends/bwrap.rs
@@ -158,16 +158,29 @@ impl SandboxBackend for BubblewrapBackend {
             }
         }
 
-        // Manifest-declared mounts.
+        // Manifest-declared mounts. Use the `--*-bind-try` variants so a
+        // declared source that does not exist on THIS host is silently
+        // skipped instead of aborting the whole spawn (bwrap treats a plain
+        // `--bind` with a missing source as a fatal "Can't find source
+        // path"). wayland#552: `WorkspacePolicy::trusted_local` adds the
+        // user's `~/.cache`/`.cargo`/`.npm`/`.rustup` unconditionally, but on
+        // a fresh HOME (fresh profile, container, CI, a user who has never run
+        // cargo/npm) those dirs are absent — with the plain bind that made
+        // EVERY bash command fail-spawn with empty stdout, which a persistent
+        // agent then loops on. `-try` matches the `Path::exists()` guard on
+        // the system dirs above and the AppContainer backend's absent-cache
+        // skip. A skipped WRITE mount is strictly better than a dead shell:
+        // the command runs, and a build that needs the (still-absent) dir
+        // fails on its own terms.
         for p in &manifest.fs_read_allow {
             let s = p.to_string_lossy().into_owned();
-            bwrap_argv.push("--ro-bind".into());
+            bwrap_argv.push("--ro-bind-try".into());
             bwrap_argv.push(s.clone());
             bwrap_argv.push(s);
         }
         for p in &manifest.fs_write_allow {
             let s = p.to_string_lossy().into_owned();
-            bwrap_argv.push("--bind".into());
+            bwrap_argv.push("--bind-try".into());
             bwrap_argv.push(s.clone());
             bwrap_argv.push(s);
         }
@@ -397,6 +410,55 @@ mod tests {
             .await;
         // Could fail if /bin not bound; this is informational.
         let _ = out;
+    }
+
+    /// wayland#552 regression: a manifest-declared mount whose SOURCE does
+    /// not exist on this host must be SKIPPED, not fatal. Pre-fix (`--bind`)
+    /// bwrap aborted the spawn with "Can't find source path", turning every
+    /// bash command into an empty-output error on a fresh HOME (no
+    /// `~/.cache`/`.cargo`/`.npm`/`.rustup`). With `--bind-try` the command
+    /// runs and the absent mount is quietly dropped.
+    #[tokio::test]
+    #[cfg_attr(not(target_os = "linux"), ignore = "bwrap is Linux-only")]
+    async fn missing_bind_source_is_skipped_not_fatal() {
+        let backend = BubblewrapBackend::new();
+        if !backend.is_available() {
+            eprintln!("bwrap not available; skipping");
+            return;
+        }
+        // A path guaranteed absent — the exact failure shape from #552.
+        let ghost = std::path::PathBuf::from("/tmp/wl552-does-not-exist-ghost-mount");
+        assert!(
+            !ghost.exists(),
+            "test precondition: ghost path must be absent"
+        );
+        let m = SandboxManifest {
+            fs_write_allow: vec![ghost.clone()],
+            fs_read_allow: vec![ghost],
+            ..Default::default()
+        };
+        let out = backend
+            .execute(
+                &m,
+                SandboxCommand {
+                    argv: vec!["/bin/echo".into(), "hello-552".into()],
+                    cwd: None,
+                },
+            )
+            .await
+            .expect("spawn must not fail on a missing bind source");
+        assert_eq!(
+            out.exit_code,
+            0,
+            "command must run despite the absent mount; got exit={} stderr={}",
+            out.exit_code,
+            String::from_utf8_lossy(&out.stderr)
+        );
+        assert!(
+            String::from_utf8_lossy(&out.stdout).contains("hello-552"),
+            "stdout must carry the command output, not a sandbox spawn error; stderr={}",
+            String::from_utf8_lossy(&out.stderr)
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
Addresses FerroxLabs/wayland#552 (do not auto-close — release closes). Overwatch queue #3.

## Root cause — NOT a Fable-5 bug, NOT an SSE-parse bug

Desktop's handoff hypothesized the empty output "originates in the engine's Anthropic-route handling of claude-fable-5." That is disproven. I added an env-gated raw SSE capture instrument (`WAYLAND_ANTHROPIC_SSE_DUMP`), ran a `claude-fable-5` direct-Anthropic bash turn against the real API on the build box, and the SSE stream parses **cleanly** — every frame type handled (thinking/signature/tool_use/text), `stop_reason` always set.

The empty bash output is a **bwrap spawn failure**: `WorkspacePolicy::trusted_local` adds `~/.cache`/`.cargo`/`.npm`/`.rustup` as bind mounts unconditionally, and the bwrap backend used plain `--bind`, which bwrap treats as fatal (`Can't find source path`) when the source is absent. On a fresh HOME (fresh profile, container, CI, a user who never ran cargo/npm) **every** bash command fail-spawned with empty stdout. A persistent agent (Fable-5) loops creating the missing dirs and retrying until the tool circuit opens — the reported "runaway loop."

**Decisive control**: `claude-sonnet-5` on a fresh HOME reproduces the *identical* `Can't find source path /tmp/.../.cache` failure. Model-agnostic. Fable only *looked* different because it persisted where Sonnet gave up after two tries.

## Fix

Use bwrap's `--ro-bind-try`/`--bind-try` for manifest-declared mounts — race-free skip-if-missing, matching the `Path::exists()` guard already on the `SYSTEM_RO_DIRS` binds directly above and the AppContainer backend's absent-cache-dir skip. A skipped write mount is strictly better than a dead shell: the command runs; a build that needs the still-absent dir fails on its own terms.

The env-gated SSE capture instrument is kept — it is how this was diagnosed and is a reusable diagnostic for the next model-family rollout (zero overhead when unset).

## Verification

- Hetzner gate green: fmt, clippy `-D warnings`, nextest 927/927 (`wcore-sandbox` + `wcore-providers`), incl. new `missing_bind_source_is_skipped_not_fatal` (a manifest with a nonexistent write+read mount must still run the command; fails pre-fix with the exact `Can't find source path`).
- **Live-verified on the real binary, fresh HOME**: pre-fix `claude-fable-5` → 6 bash calls (errors/retries/circuit-open); post-fix → **1 clean Bash call** (`hello-552`, exit 0), single tool call, clean `stream_end`, zero bwrap errors.

Note: desktop's original repro was Windows/AppContainer, which already skips absent cache dirs — so if a Windows-specific empty-output path remains it is separate; this fixes the Linux/bwrap instance conclusively and the model-agnostic root class.
