### PR TITLE
fix(cli): a mid-turn Stop must not strand the json-stream session

### DIFF
--- a/crates/wcore-cli/src/main.rs
+++ b/crates/wcore-cli/src/main.rs
@@ -3194,11 +3194,16 @@ async fn run_json_stream_mode(
                                         approval_manager.resolve(&call_id, ToolApprovalResult::Denied { reason });
                                     }
                                     ProtocolCommand::Stop => {
-                                        // Cancelling the turn drops `engine_fut`, but the host's
-                                        // turn-loop still waits for a terminator. Emit `stream_end`
-                                        // (FinishReason::Stop) for this msg_id — same as the /exit
-                                        // path above — so the host doesn't hang forever waiting for
-                                        // a turn end that the bare break would never send.
+                                        // wayland#403 fix-3: Stop CANCELS THE ACTIVE TURN — it must
+                                        // NOT end the session. Dropping `engine_fut` (via the inner
+                                        // `break` below) cancels the turn; we emit `stream_end`
+                                        // (FinishReason::Stop) for this msg_id so the host's turn-loop
+                                        // gets its terminator and doesn't hang. `stopped` then makes
+                                        // the outer loop `continue` (keep reading commands) instead of
+                                        // breaking — the pre-fix `break` stranded the session
+                                        // ("new chat required") after any mid-turn Stop. Only EOF and
+                                        // `/exit` end a json-stream session, matching the TUI (Esc
+                                        // cancels the turn, never closes the session).
                                         output.emit_stream_end(&msg_id, 0, 0, 0, 0, 0, FinishReason::Stop);
                                         stopped = true;
                                         break;
@@ -3335,11 +3340,19 @@ async fn run_json_stream_mode(
                     );
                 }
                 if stopped {
-                    break;
+                    // wayland#403 fix-3: the mid-turn Stop cancelled the turn and
+                    // already emitted its `stream_end`; resume the command loop so
+                    // the next Message streams. Pre-fix this was `break`, which
+                    // ended the whole session.
+                    continue;
                 }
             }
             ProtocolCommand::Stop => {
-                break;
+                // wayland#403 fix-3: a Stop that arrives with no active turn (or
+                // just as one finishes) is a no-op — it must not close the
+                // session. Keep reading commands; EOF / `/exit` are the
+                // terminators.
+                continue;
             }
             ProtocolCommand::ToolApprove {
                 call_id,

--- a/crates/wcore-cli/tests/smoke_p0.rs
+++ b/crates/wcore-cli/tests/smoke_p0.rs
@@ -392,6 +392,133 @@ fn smoke_17_force_posture_auto_approves_mutating_tool_in_engine() {
     );
 }
 
+/// wayland#403 fix-3 regression: a mid-turn `Stop` must CANCEL THE TURN but
+/// NOT strand the json-stream session — a subsequent Message must still
+/// stream. Pre-fix, the mid-turn Stop broke the outer command loop, so after
+/// any Stop the session was dead ("new chat required") — reproduced here
+/// deterministically: turn 1 issues a Bash tool call which, under the default
+/// approval posture, PAUSES on approval (a deterministic mid-turn state);
+/// while paused we send Stop, then send a second Message. The fix requires
+/// the second Message to reach its `stream_end`.
+#[test]
+fn stop_mid_turn_does_not_strand_json_stream_session() {
+    use std::io::{BufRead, BufReader, Write};
+    use std::sync::{Arc, Mutex};
+    use std::time::{Duration, Instant};
+
+    // Turn 1: a Bash (exec-category) tool call — under the default posture the
+    // engine emits ToolRequest and BLOCKS on approval. Turn 2 (a fresh LLM
+    // call after Stop cancels turn 1): plain text.
+    let (_rt, server) = start_mock(
+        MockLlm::new()
+            .tool_use("Bash", serde_json::json!({ "command": "echo repro-403" }))
+            .text("SESSION-ALIVE"),
+    );
+    // Default posture (NO --force): the Bash call must pause on approval.
+    let home = TempDir::new().expect("tempdir");
+    write_config(
+        home.path(),
+        "anthropic",
+        Some("claude-sonnet-4-20250514"),
+        Some(&server.uri()),
+    );
+
+    let mut cmd = std::process::Command::new(binary());
+    cmd.args(["--json-stream", "--provider", "anthropic"])
+        .current_dir(home.path());
+    harden_child_env(&mut cmd, home.path());
+    let mut child = cmd
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("spawn --json-stream");
+
+    let mut stdin = child.stdin.take().expect("stdin");
+    let stdout = child.stdout.take().expect("stdout");
+
+    // Collect every stdout line so the test can look for specific frames.
+    let frames: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    {
+        let frames = frames.clone();
+        std::thread::spawn(move || {
+            let reader = BufReader::new(stdout);
+            for line in reader.lines().map_while(Result::ok) {
+                frames.lock().unwrap().push(line);
+            }
+        });
+    }
+
+    // Frame predicate: any collected line whose JSON `type` is one of `types`
+    // and (when `msg_id` is Some) matches that msg_id.
+    let seen = |types: &[&str], msg_id: Option<&str>| -> bool {
+        frames.lock().unwrap().iter().any(|ln| {
+            let Ok(j) = serde_json::from_str::<serde_json::Value>(ln) else {
+                return false;
+            };
+            let ty = j.get("type").and_then(|t| t.as_str()).unwrap_or("");
+            let mid_ok =
+                msg_id.is_none_or(|want| j.get("msg_id").and_then(|m| m.as_str()) == Some(want));
+            types.contains(&ty) && mid_ok
+        })
+    };
+    let wait_until = |pred: &dyn Fn() -> bool, secs: u64| -> bool {
+        let deadline = Instant::now() + Duration::from_secs(secs);
+        while Instant::now() < deadline {
+            if pred() {
+                return true;
+            }
+            std::thread::sleep(Duration::from_millis(150));
+        }
+        false
+    };
+
+    // Turn 1 — forces the Bash tool call, which pauses on approval.
+    writeln!(
+        stdin,
+        "{{\"type\":\"message\",\"msg_id\":\"m1\",\"content\":\"run bash\"}}"
+    )
+    .expect("write m1");
+
+    assert!(
+        wait_until(
+            &|| seen(&["tool_request", "approval_required"], Some("m1")),
+            20
+        ),
+        "turn 1 must pause on the Bash approval gate (deterministic mid-turn state); \
+         frames={:?}",
+        frames.lock().unwrap()
+    );
+
+    // Stop mid-turn — cancels turn 1; the session must survive.
+    writeln!(stdin, "{{\"type\":\"stop\"}}").expect("write stop");
+    assert!(
+        wait_until(&|| seen(&["stream_end"], Some("m1")), 10),
+        "the mid-turn Stop must emit a stream_end for m1 so the host isn't left hanging"
+    );
+
+    // Turn 2 — the actual regression check: a new Message must still stream.
+    writeln!(
+        stdin,
+        "{{\"type\":\"message\",\"msg_id\":\"m2\",\"content\":\"say hi\"}}"
+    )
+    .expect("write m2 (broken pipe here would already prove the session died)");
+
+    let m2_streamed = wait_until(&|| seen(&["stream_end"], Some("m2")), 20);
+
+    let _ = writeln!(stdin, "{{\"type\":\"stop\"}}");
+    let _ = child.kill();
+    let _ = child.wait();
+
+    assert!(
+        m2_streamed,
+        "after a mid-turn Stop the session must keep streaming — m2 produced no \
+         stream_end, so Stop stranded the session (the #403 fix-3 regression). \
+         frames={:?}",
+        frames.lock().unwrap()
+    );
+}
+
 /// wayland#241 regression: config `[default] approval_mode = "auto-edit"`
 /// must reach the json-stream session WITHOUT `--force`. Pre-fix
 /// `run_json_stream_mode` only seeded `--force` and ignored the config


### PR DESCRIPTION
Addresses FerroxLabs/wayland#403 (fix-3; do not auto-close — release closes). Overwatch queue item; the deferred third fix from the #403 batch.

## Repro (confirmed on current main `b042e32e`, before this PR)

Driving the real binary + live provider: send Message m1 that triggers a Bash tool call → under the default approval posture the turn **pauses** on approval (deterministic mid-turn state) → send `Stop` → m1 correctly gets its `stream_end` (an earlier partial fix) → send Message m2 → **m2 never streams**. The process stays alive but the session no longer processes commands — the "new chat required" symptom desktop reported.

## Root cause

In `run_json_stream_mode`, a mid-turn `Stop` sets `stopped = true` and `break`s the inner turn `select!`; after the turn block, `if stopped { break }` broke the **outer command loop**, ending the session. The top-level `Stop` arm (a Stop with no active turn) `break`'d too.

## Fix

`Stop` now **cancels the active turn but keeps the session alive**, matching the TUI (where Esc cancels the turn and never closes the session). The mid-turn Stop still emits `stream_end` for the cancelled msg_id (host gets its terminator), then the `stopped` branch `continue`s the command loop instead of breaking; the top-level Stop arm is a no-op `continue`. Only **EOF** (stdin closed) and **`/exit`** end a json-stream session. The pre-message-phase Stop (before any turn) is left as-is (session-close during setup is a distinct, intentional path).

## Verification

- Hetzner gate green: fmt, clippy `-D warnings`, nextest 1731/1731 (`-p wcore-cli`).
- New regression test `stop_mid_turn_does_not_strand_json_stream_session` drives the **real binary** with a mock LLM: turn 1's Bash call pauses on approval, Stop mid-pause, then a second Message must reach its `stream_end` — pre-fix it never did.
- **Live-verified** on the real binary + live provider: the exact repro above flips from BUG CONFIRMED (m2 no stream_end) to SESSION SURVIVED (m2 streams).
