### PR TITLE
fix(sandbox): drain AppContainer pipes concurrently so any/large command output is captured (#520)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8928,7 +8928,7 @@ dependencies = [
 
 [[package]]
 name = "wayland-browser"
-version = "0.12.16"
+version = "0.12.20"
 dependencies = [
  "async-trait",
  "inventory",
@@ -8945,7 +8945,7 @@ dependencies = [
 
 [[package]]
 name = "wayland-cua"
-version = "0.12.16"
+version = "0.12.20"
 dependencies = [
  "async-trait",
  "inventory",
@@ -8962,7 +8962,7 @@ dependencies = [
 
 [[package]]
 name = "wayland-honcho"
-version = "0.12.16"
+version = "0.12.20"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8983,7 +8983,7 @@ dependencies = [
 
 [[package]]
 name = "wayland-ijfw"
-version = "0.12.16"
+version = "0.12.20"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9002,7 +9002,7 @@ dependencies = [
 
 [[package]]
 name = "wayland-ollama"
-version = "0.12.16"
+version = "0.12.20"
 dependencies = [
  "async-trait",
  "futures",
@@ -9023,7 +9023,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-acp"
-version = "0.12.16"
+version = "0.12.20"
 dependencies = [
  "async-trait",
  "axum",
@@ -9046,7 +9046,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-agent"
-version = "0.12.16"
+version = "0.12.20"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9136,7 +9136,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-agents-pack"
-version = "0.12.16"
+version = "0.12.20"
 dependencies = [
  "dirs",
  "serde",
@@ -9149,7 +9149,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-browser"
-version = "0.12.16"
+version = "0.12.20"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9179,7 +9179,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-budget"
-version = "0.12.16"
+version = "0.12.20"
 dependencies = [
  "chrono",
  "parking_lot",
@@ -9192,7 +9192,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-discord"
-version = "0.12.16"
+version = "0.12.20"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9213,7 +9213,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-email"
-version = "0.12.16"
+version = "0.12.20"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9232,7 +9232,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-imessage"
-version = "0.12.16"
+version = "0.12.20"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9249,7 +9249,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-matrix"
-version = "0.12.16"
+version = "0.12.20"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9268,7 +9268,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-msteams"
-version = "0.12.16"
+version = "0.12.20"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -9289,7 +9289,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-signal"
-version = "0.12.16"
+version = "0.12.20"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9304,7 +9304,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-slack"
-version = "0.12.16"
+version = "0.12.20"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9327,7 +9327,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-sms"
-version = "0.12.16"
+version = "0.12.20"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -9350,7 +9350,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-telegram"
-version = "0.12.16"
+version = "0.12.20"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9369,7 +9369,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-whatsapp"
-version = "0.12.16"
+version = "0.12.20"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9392,7 +9392,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channels"
-version = "0.12.16"
+version = "0.12.20"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9408,7 +9408,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channels-registry"
-version = "0.12.16"
+version = "0.12.20"
 dependencies = [
  "dirs",
  "serde",
@@ -9433,7 +9433,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-cli"
-version = "0.12.16"
+version = "0.12.20"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9516,7 +9516,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-compact"
-version = "0.12.16"
+version = "0.12.20"
 dependencies = [
  "regex",
  "serde",
@@ -9525,7 +9525,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-config"
-version = "0.12.16"
+version = "0.12.20"
 dependencies = [
  "anyhow",
  "argon2",
@@ -9563,7 +9563,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-cron"
-version = "0.12.16"
+version = "0.12.20"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9580,7 +9580,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-cua"
-version = "0.12.16"
+version = "0.12.20"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9616,7 +9616,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-dispatch"
-version = "0.12.16"
+version = "0.12.20"
 dependencies = [
  "rand 0.9.4",
  "rand_distr",
@@ -9629,7 +9629,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-egress"
-version = "0.12.16"
+version = "0.12.20"
 dependencies = [
  "async-trait",
  "http 1.4.1",
@@ -9642,7 +9642,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-eval"
-version = "0.12.16"
+version = "0.12.20"
 dependencies = [
  "rstest",
  "serde",
@@ -9659,7 +9659,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-eval-scenarios"
-version = "0.12.16"
+version = "0.12.20"
 dependencies = [
  "anyhow",
  "clap",
@@ -9679,7 +9679,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-evolve"
-version = "0.12.16"
+version = "0.12.20"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9719,7 +9719,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-honcho-adapter"
-version = "0.12.16"
+version = "0.12.20"
 dependencies = [
  "async-trait",
  "serde",
@@ -9734,7 +9734,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-mcp"
-version = "0.12.16"
+version = "0.12.20"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9761,7 +9761,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-memory"
-version = "0.12.16"
+version = "0.12.20"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9802,7 +9802,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-observability"
-version = "0.12.16"
+version = "0.12.20"
 dependencies = [
  "chrono",
  "opentelemetry",
@@ -9826,7 +9826,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-permissions"
-version = "0.12.16"
+version = "0.12.20"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9843,7 +9843,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-plugin-api"
-version = "0.12.16"
+version = "0.12.20"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9870,7 +9870,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-plugin-subprocess"
-version = "0.12.16"
+version = "0.12.20"
 dependencies = [
  "anyhow",
  "serde",
@@ -9889,7 +9889,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-plugin-wasm"
-version = "0.12.16"
+version = "0.12.20"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9911,7 +9911,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-pluginsrc"
-version = "0.12.16"
+version = "0.12.20"
 dependencies = [
  "serde",
  "serde_json",
@@ -9926,7 +9926,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-pricing"
-version = "0.12.16"
+version = "0.12.20"
 dependencies = [
  "chrono",
  "dirs",
@@ -9945,7 +9945,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-protocol"
-version = "0.12.16"
+version = "0.12.20"
 dependencies = [
  "rstest",
  "serde",
@@ -9957,7 +9957,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-providers"
-version = "0.12.16"
+version = "0.12.20"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9992,7 +9992,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-replay"
-version = "0.12.16"
+version = "0.12.20"
 dependencies = [
  "serde",
  "serde_json",
@@ -10003,7 +10003,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-repomap"
-version = "0.12.16"
+version = "0.12.20"
 dependencies = [
  "ignore",
  "regex",
@@ -10016,7 +10016,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-safety"
-version = "0.12.16"
+version = "0.12.20"
 dependencies = [
  "async-trait",
  "regex",
@@ -10029,7 +10029,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-sandbox"
-version = "0.12.16"
+version = "0.12.20"
 dependencies = [
  "async-trait",
  "bollard",
@@ -10049,7 +10049,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-skills"
-version = "0.12.16"
+version = "0.12.20"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10086,7 +10086,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-swarm"
-version = "0.12.16"
+version = "0.12.20"
 dependencies = [
  "futures",
  "humantime-serde",
@@ -10105,7 +10105,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-tools"
-version = "0.12.16"
+version = "0.12.20"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10152,7 +10152,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-types"
-version = "0.12.16"
+version = "0.12.20"
 dependencies = [
  "async-trait",
  "chrono",
@@ -10162,7 +10162,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-user-model"
-version = "0.12.16"
+version = "0.12.20"
 dependencies = [
  "async-trait",
  "serde",

--- a/crates/wcore-sandbox/src/backends/appcontainer.rs
+++ b/crates/wcore-sandbox/src/backends/appcontainer.rs
@@ -1666,50 +1666,91 @@ mod windows_impl {
                 )));
             }
 
+            // ---- 11a. Drain the pipes CONCURRENTLY with the child (#520). ----
+            // The stdout/stderr pipe buffers are only ~4 KB. Draining them only
+            // after the child exits (the pre-#520 behaviour) deadlocks any
+            // command whose output exceeds that buffer: the child blocks in
+            // WriteFile with a full pipe, never exits, `WaitForSingleObject`
+            // times out, and the post-hoc drain returns only the truncated head.
+            // Users saw this as blank output on small commands and 60s timeouts
+            // on large ones (#453 / #500). Reader threads keep the pipes drained
+            // so the child can always make progress. The `stdout_r` / `stderr_r`
+            // OwnedHandles stay in this scope and outlive the joins below, so the
+            // raw handles the threads hold are valid for the threads' whole life;
+            // EOF (and thus thread exit) is reached once every write-end closes —
+            // guaranteed by the `TerminateJobObject` reap below (#100).
+            let stdout_h = stdout_r.as_raw() as usize;
+            let stderr_h = stderr_r.as_raw() as usize;
+            // `drain_pipe` is unsafe; the call is bare because this whole fn body
+            // is one `unsafe` block and the closures inherit that context.
+            let stdout_reader = std::thread::spawn(move || drain_pipe(stdout_h as _));
+            let stderr_reader = std::thread::spawn(move || drain_pipe(stderr_h as _));
+
             let timeout_ms: u32 = match manifest.timeout {
                 Some(d) => clamp_timeout_ms(d),
                 None => 60_000,
             };
 
             let wait_res = WaitForSingleObject(process.as_raw(), timeout_ms);
-            let mut timed_out = false;
-            if wait_res == WAIT_TIMEOUT {
-                timed_out = true;
-            } else if wait_res != WAIT_OBJECT_0 {
-                return Err(SandboxError::ExecFailed(format!(
-                    "WaitForSingleObject: {:#x} last_err={:#x}",
-                    wait_res,
-                    GetLastError()
-                )));
-            }
+            let timed_out = wait_res == WAIT_TIMEOUT;
+            // A wait result other than OBJECT_0 / TIMEOUT is a hard error, but we
+            // must NOT return before the reap + join below: the detached reader
+            // threads hold raw read-handles owned by this scope's OwnedHandles,
+            // so an early return would leak the threads and drop the handles out
+            // from under them. Capture the failure and surface it after the join.
+            // Snapshot GetLastError() now — TerminateJobObject clobbers it.
+            let wait_err = if !timed_out && wait_res != WAIT_OBJECT_0 {
+                Some((wait_res, GetLastError()))
+            } else {
+                None
+            };
 
             // ---- 12. Exit code + drain ----
             // Capture the child's exit code BEFORE reaping the tree (only
             // meaningful on a clean exit; on timeout it is replaced by the
-            // `Timeout` error below).
+            // `Timeout` error below). As above, defer any error return past the
+            // reap + join.
             let mut exit_code: u32 = 0;
-            if !timed_out && GetExitCodeProcess(process.as_raw(), &mut exit_code) == 0 {
-                return Err(SandboxError::ExecFailed(format!(
-                    "GetExitCodeProcess: {:#x}",
-                    GetLastError()
-                )));
-            }
+            let exitcode_err = if !timed_out
+                && wait_err.is_none()
+                && GetExitCodeProcess(process.as_raw(), &mut exit_code) == 0
+            {
+                Some(GetLastError())
+            } else {
+                None
+            };
 
-            // Reap the ENTIRE job tree before draining (#100). The direct child
-            // can spawn helpers — most notably a console host (`conhost.exe`) —
-            // that outlive it and keep the inherited stdout/stderr write-ends
-            // open. A plain `TerminateProcess(child)` leaves them running, so the
-            // blocking `drain_pipe` below would never reach EOF and the call
-            // would hang far past the timeout (observed as a 120s "command timed
-            // out" with no output on disconnected RDP sessions). Terminating the
-            // job closes every member's handles so the pipes EOF; bytes already
-            // written to the pipe buffers stay readable. The short wait lets the
-            // kernel finish closing the handles before we read.
+            // Reap the ENTIRE job tree before joining the drain threads (#100).
+            // The direct child can spawn helpers — most notably a console host
+            // (`conhost.exe`) — that outlive it and keep the inherited
+            // stdout/stderr write-ends open. A plain `TerminateProcess(child)`
+            // leaves them running, so the reader threads would never reach EOF
+            // and the joins below would hang far past the timeout (observed as a
+            // 120s "command timed out" with no output on disconnected RDP
+            // sessions). Terminating the job closes every member's handles so the
+            // pipes EOF; bytes already written stay readable and the threads have
+            // been draining them all along. The short wait lets the kernel finish
+            // closing the handles before the threads see EOF.
             TerminateJobObject(job.as_raw(), if timed_out { 1 } else { exit_code });
             WaitForSingleObject(process.as_raw(), 2_000);
 
-            let stdout = drain_pipe(stdout_r.as_raw());
-            let mut stderr = drain_pipe(stderr_r.as_raw());
+            // Now that every write-end is closed the reader threads reach EOF;
+            // join them to collect the fully-drained output. This MUST run before
+            // the deferred error returns so the threads never outlive their
+            // handles.
+            let stdout = stdout_reader.join().unwrap_or_default();
+            let mut stderr = stderr_reader.join().unwrap_or_default();
+
+            if let Some((wait_res, last_err)) = wait_err {
+                return Err(SandboxError::ExecFailed(format!(
+                    "WaitForSingleObject: {wait_res:#x} last_err={last_err:#x}"
+                )));
+            }
+            if let Some(last_err) = exitcode_err {
+                return Err(SandboxError::ExecFailed(format!(
+                    "GetExitCodeProcess: {last_err:#x}"
+                )));
+            }
 
             // #324: a child that loads a DLL the Low-IL restricted-token
             // AppContainer cannot map (PowerShell's .NET/GAC, git-bash's
@@ -2557,6 +2598,51 @@ mod windows_impl {
                 ResourceLimitEnforcement::Enforced
             ));
             assert!(String::from_utf8_lossy(&out.stdout).contains("hi"));
+        }
+
+        /// Regression for #520 (dups #453 / #500): a command whose output far
+        /// exceeds the ~4 KB pipe buffer must be captured in full. Before the
+        /// concurrent-drain fix the parent waited for the child to exit before
+        /// reading a byte, so the child blocked in `WriteFile` once the buffer
+        /// filled — the wait timed out and the drain returned truncated/empty
+        /// output. Gated like `echo_runs_live`; CI Windows runners opt in.
+        #[tokio::test]
+        async fn large_output_survives_live() {
+            if std::env::var("WAYLAND_SANDBOX_LIVE_WINDOWS").is_err() {
+                return;
+            }
+            let b = AppContainerBackend::new();
+            if !b.is_available() {
+                eprintln!("skip: AppContainer not available on this host");
+                return;
+            }
+            let m = SandboxManifest {
+                timeout: Some(Duration::from_secs(20)),
+                ..Default::default()
+            };
+            // ~4000 lines * ~32 bytes ≈ 128 KB, far past the 4 KB pipe buffer.
+            // On the pre-fix serial drain this deadlocks the child and times out.
+            let out = b
+                .execute(
+                    &m,
+                    SandboxCommand {
+                        argv: vec![
+                            "cmd.exe".into(),
+                            "/c".into(),
+                            "for /L %i in (1,1,4000) do @echo ABCDEFGHIJKLMNOPQRSTUVWXYZ0123"
+                                .into(),
+                        ],
+                        cwd: None,
+                    },
+                )
+                .await
+                .unwrap();
+            assert_eq!(out.exit_code, 0);
+            assert!(
+                out.stdout.len() > 64 * 1024,
+                "captured only {} bytes — pipe drain truncated (#520 regression)",
+                out.stdout.len()
+            );
         }
 
         // Live integrity-boundary verification lives in


### PR DESCRIPTION
## Problem (#520, dups #453 / #500)

Windows users could not run **any** command through wcore's sandboxed Bash tool: small commands returned blank output, larger ones hung for 60s and produced nothing.

Root cause is in the AppContainer backend (`crates/wcore-sandbox/src/backends/appcontainer.rs`). It drained the stdout/stderr pipes **only after** the child exited and the job was terminated:

```
WaitForSingleObject(child, timeout)   // wait for exit FIRST
TerminateJobObject(job)
drain_pipe(stdout) / drain_pipe(stderr)   // read only now
```

Windows anonymous pipes have a ~4 KB buffer. Once a command's output fills it, the child blocks in `WriteFile` — but nothing is reading, because the parent is still waiting for the child to exit. The child never exits, `WaitForSingleObject` times out, the job is killed, and the drain returns only the truncated head. Small output → blank; large output → timeout.

## Fix

Spawn two reader threads that drain both pipes **concurrently with the child**, so the child can always make progress and can never deadlock on a full pipe. `TerminateJobObject` is retained — it closes every write-end (including a lingering `conhost.exe`, the #100 reap invariant) so the reader threads reach EOF; the threads are then joined to collect the full output.

The read-end `OwnedHandle`s stay owned by the spawn scope and outlive the joins, so the raw handles the threads hold are valid for their whole lifetime.

## Verification

- `cargo fmt` clean.
- **cargo-xwin clippy for `x86_64-pc-windows-msvc` clean** — this is the load-bearing check, since the `#[cfg(windows)]` branch is never compiled on the Linux/macOS dev+gate hosts.
- Hetzner gate (Linux): fmt 0 / clippy 0 / nextest 53 passed, 2 skipped (the Windows-gated live tests).
- New Windows-gated regression test `large_output_survives_live` emits ~128 KB; it deadlocks/truncates on the old serial drain and passes on the fix. **Runs on the CI Windows leg (`CI (Array)`) — the definitive live verification**, as no native-Windows AppContainer host is available to core locally.

## Out of scope — flagged to Overwatch

#520 also reports **command text no longer shown in the UI** ("command info hidden"). That is a desktop+core protocol / host-render concern, not this exec-path bug; flagged separately for Overwatch to schedule the desktop side.