### PR TITLE
fix(acp): carry + accept the secret resume_token end-to-end on ACP (#568)

### DIFF
--- a/crates/wcore-acp/src/protocol.rs
+++ b/crates/wcore-acp/src/protocol.rs
@@ -192,6 +192,14 @@ pub enum MessageEvent {
         /// Human-readable explanation of why approval is required (e.g. the
         /// tool category). No em-dashes; surfaced verbatim to hosts.
         reason: String,
+        /// GHSA-8r7g M2 (wayland#568) — the server-generated SECRET
+        /// `resume_token` (`apr-{uuid}`) the host MUST present on the matching
+        /// `POST .../resolve` to answer a BRIDGE-backed gate (Crucible council
+        /// / egress consent). Empty for a manager-gated tool (ordinary
+        /// approve/deny), which has no secret and resolves by the call `id`.
+        /// `skip_serializing_if` keeps the frame clean when there is no secret.
+        #[serde(default, skip_serializing_if = "String::is_empty")]
+        resume_token: String,
     },
     ToolResult {
         result: ToolResult,

--- a/crates/wcore-acp/src/transport/rest.rs
+++ b/crates/wcore-acp/src/transport/rest.rs
@@ -100,6 +100,14 @@ pub struct ApprovalResolveRequest {
     /// through the approval channel.
     #[serde(default)]
     pub answer: Option<String>,
+    /// GHSA-8r7g M2 (wayland#568) — the SECRET `resume_token` copied from the
+    /// matching `ApprovalRequired` frame. REQUIRED to resolve a BRIDGE-backed
+    /// gate (Crucible council / egress consent); OMIT for a manager-gated tool
+    /// (ordinary approve/deny, resolved by the path `call_id`). A stale or
+    /// unknown token falls through to the manager path, then 404s if that also
+    /// misses — the endpoint stays idempotent.
+    #[serde(default)]
+    pub resume_token: Option<String>,
 }
 
 /// Wire spelling of the approval scope. Flat string enum so the OpenAPI
@@ -491,6 +499,7 @@ async fn resolve_approval<H: HttpHandler>(
         approved: body.approved,
         scope,
         answer: body.answer,
+        resume_token: body.resume_token,
     };
     // Idempotency + 404: an unknown session or unknown/already-resolved/
     // expired call_id surfaces as `AcpError::Session("... not found ...")`,

--- a/crates/wcore-acp/src/turn.rs
+++ b/crates/wcore-acp/src/turn.rs
@@ -46,6 +46,10 @@ pub struct ApprovalDecision {
     /// Optional answer payload (AskUserQuestion choice). `None` for a plain
     /// approve/deny.
     pub answer: Option<String>,
+    /// GHSA-8r7g M2 (wayland#568) — the SECRET `resume_token` for a
+    /// bridge-backed gate. `None`/empty resolves via the approval manager by
+    /// `call_id` (the legacy manager-gated path).
+    pub resume_token: Option<String>,
 }
 
 /// Per-turn parameters handed to the engine bridge. A struct (not a long

--- a/crates/wcore-acp/tests/approval_gate.rs
+++ b/crates/wcore-acp/tests/approval_gate.rs
@@ -74,6 +74,8 @@ async fn mutating_tool_emits_approval_required_before_result() {
             MessageEvent::ApprovalRequired {
                 call: write_call(),
                 reason: "mutating tool Write requires approval".to_string(),
+                // Manager-gated Write carries no bridge secret (#568).
+                resume_token: String::new(),
             },
             MessageEvent::ToolResult {
                 result: ToolResult {
@@ -111,12 +113,23 @@ async fn mutating_tool_emits_approval_required_before_result() {
 
     // The gate carries the call so a host can correlate the decision.
     match &frames[approval_idx] {
-        MessageEvent::ApprovalRequired { call, reason } => {
+        MessageEvent::ApprovalRequired {
+            call,
+            reason,
+            resume_token,
+        } => {
             assert_eq!(call.id, "c1");
             assert_eq!(call.name, "Write");
             assert!(
                 !reason.is_empty(),
                 "gate must carry a human-readable reason"
+            );
+            // #568 (B): a MANAGER-gated tool (plain Write) carries no bridge
+            // secret, so its resume_token is empty and the host resolves by
+            // call_id. Bridge-backed gates (Crucible/egress) carry a real token.
+            assert!(
+                resume_token.is_empty(),
+                "a manager-gated tool must not carry a bridge secret; got {resume_token:?}"
             );
         }
         other => panic!("expected ApprovalRequired, got {other:?}"),

--- a/crates/wcore-cli/src/acp_engine.rs
+++ b/crates/wcore-cli/src/acp_engine.rs
@@ -475,12 +475,19 @@ impl ProtocolToMessageStream {
             // was not seen, e.g. an engine site that emits `ApprovalRequired`
             // without a preceding `ToolRequest`).
             ProtocolEvent::ApprovalRequired {
-                call_id, reason, ..
+                call_id,
+                reason,
+                resume_token,
+                ..
             } => {
                 let (name, input) = self
                     .pending_calls
                     .remove(&call_id)
                     .unwrap_or_else(|| (String::new(), serde_json::Value::Null));
+                // #568 (B): carry the SECRET resume_token to the host instead of
+                // dropping it. Bridge-backed gates stamp a real `apr-` token
+                // (via the RelayEmitter's ApprovalBridge); manager-gated tools
+                // carry an empty token and are resolved by `call_id`.
                 Some(MessageEvent::ApprovalRequired {
                     call: ToolCall {
                         id: call_id,
@@ -488,6 +495,7 @@ impl ProtocolToMessageStream {
                         input,
                     },
                     reason,
+                    resume_token,
                 })
             }
             // StreamStart / ToolRunning / ToolChunk / Suspend / ApprovalResume /
@@ -534,6 +542,10 @@ impl Stream for ProtocolToMessageStream {
 pub struct EngineSession {
     engine: Arc<AsyncMutex<AgentEngine>>,
     approval_manager: Arc<ToolApprovalManager>,
+    /// GHSA-8r7g M2 (#568) — the engine's `ApprovalBridge`, captured at build
+    /// time so `resolve_approval` can answer a bridge-backed gate by SECRET
+    /// resume_token WITHOUT locking the engine mutex (a live turn holds it).
+    approval_bridge: Arc<wcore_agent::approval::ApprovalBridge>,
     /// The relay handle the engine's `RelaySink`/`RelayEmitter` forward on.
     /// `run_turn` installs this turn's channel into it.
     relay: RelayHandle,
@@ -553,9 +565,11 @@ impl EngineSession {
         relay: RelayHandle,
     ) -> Self {
         let tool_names = engine.tools().tool_names();
+        let approval_bridge = engine.approval_bridge().clone();
         Self {
             engine: Arc::new(AsyncMutex::new(engine)),
             approval_manager,
+            approval_bridge,
             relay,
             tool_names,
         }
@@ -859,6 +873,24 @@ impl TurnEngine for EngineTurnEngine {
             }
         };
 
+        // #568 (C): secret-preferred resolution. A BRIDGE-backed gate (Crucible
+        // council / egress consent) minted a SECRET `apr-` resume_token and is
+        // resolvable ONLY through the bridge; a manager-gated tool carries no
+        // secret and resolves by `call_id`. When the host presents a non-empty
+        // token, try the bridge first; fall through to the manager path if it
+        // is not a live bridge token (stale, or actually a manager gate). The
+        // ACP resolve carries no `modifications` payload (its `answer` threads
+        // to the manager path), so bridge consent is a plain approve/deny.
+        if let Some(token) = decision.resume_token.as_deref().filter(|t| !t.is_empty()) {
+            let outcome = wcore_agent::approval::ApprovalOutcome {
+                approved: decision.approved,
+                modifications: None,
+            };
+            if session.approval_bridge.resolve(token, outcome).await {
+                return Ok(());
+            }
+        }
+
         let resolved = session.approval_manager().resolve_host(
             call_id,
             decision.approved,
@@ -1113,13 +1145,23 @@ mod tests {
             other => panic!("expected ToolCall, got {other:?}"),
         }
         match &out[1] {
-            MessageEvent::ApprovalRequired { call, reason } => {
+            MessageEvent::ApprovalRequired {
+                call,
+                reason,
+                resume_token,
+            } => {
                 assert_eq!(call.id, "c9", "gate frame correlates to the call");
                 assert_eq!(
                     call.name, "Write",
                     "gate frame carries the gated tool name from the ToolRequest"
                 );
                 assert_eq!(reason, "edit");
+                // #568 (B): the SECRET resume_token on the protocol event is
+                // carried through to the host, not dropped by the projection.
+                assert_eq!(
+                    resume_token, "c9",
+                    "the projection must carry resume_token end-to-end (#568)"
+                );
             }
             other => panic!("expected ApprovalRequired, got {other:?}"),
         }
@@ -1444,13 +1486,90 @@ mod tests {
         Arc::new(EngineSession::new(engine, approval_manager, relay))
     }
 
-    /// A plain "approve once" decision.
+    /// A plain "approve once" decision (manager path — no bridge secret).
     fn approve_once() -> ApprovalDecision {
         ApprovalDecision {
             approved: true,
             scope: ApprovalScopeWire::Once,
             answer: None,
+            resume_token: None,
         }
+    }
+
+    /// (#568 C) A BRIDGE-backed gate (Crucible council / egress consent) is
+    /// resolvable through the ACP resolve path via its SECRET resume_token — the
+    /// ingress that was previously missing, so such gates hung to TTL on ACP.
+    /// Proves the endpoint routes a non-empty token to `ApprovalBridge::resolve`.
+    #[tokio::test]
+    async fn resolve_bridge_gate_by_secret_resume_token() {
+        let turn = EngineTurnEngine::new(placeholder_config(), ".".to_string());
+        let session = live_session();
+        turn.sessions
+            .lock()
+            .await
+            .insert("s1".to_string(), session.clone());
+
+        // Stage a bridge-backed gate the way Crucible/egress would, capturing
+        // the server-minted SECRET token and the pending waiter.
+        let (secret, mut rx) = session
+            .approval_bridge
+            .request_with_id(
+                "corr-1".to_string(),
+                wcore_agent::approval::ApprovalRequest {
+                    call_id: "corr-1".to_string(),
+                    reason: "council".to_string(),
+                    context: String::new(),
+                },
+            )
+            .await;
+        assert!(
+            matches!(rx.try_recv(), Err(TryRecvError::Empty)),
+            "gate is pending before resolve"
+        );
+
+        // Resolve through the ACP endpoint path WITH the secret token.
+        let decision = ApprovalDecision {
+            approved: true,
+            scope: ApprovalScopeWire::Once,
+            answer: None,
+            resume_token: Some(secret),
+        };
+        turn.resolve_approval("s1", "corr-1", decision)
+            .await
+            .expect("bridge gate resolves via secret resume_token");
+
+        let outcome = rx
+            .try_recv()
+            .expect("approved outcome delivered to the bridge waiter");
+        assert!(outcome.approved, "the bridge waiter sees the approval");
+    }
+
+    /// (#568 C) A stale/unknown resume_token does NOT resolve via the bridge and
+    /// falls through to the manager path; with no manager gate staged either the
+    /// endpoint 404s (`Session` error) — idempotent, never a phantom 200.
+    #[tokio::test]
+    async fn resolve_with_stale_token_falls_through_then_404s() {
+        let turn = EngineTurnEngine::new(placeholder_config(), ".".to_string());
+        let session = live_session();
+        turn.sessions
+            .lock()
+            .await
+            .insert("s2".to_string(), session.clone());
+
+        let decision = ApprovalDecision {
+            approved: true,
+            scope: ApprovalScopeWire::Once,
+            answer: None,
+            resume_token: Some("apr-does-not-exist".to_string()),
+        };
+        let err = turn
+            .resolve_approval("s2", "no-such-call", decision)
+            .await
+            .expect_err("stale token + no manager gate must not resolve");
+        assert!(
+            matches!(err, AcpError::Session(_)),
+            "stale token falls through to the manager path and 404s, got {err:?}"
+        );
     }
 
     /// (a) Resolving for an UNKNOWN session id returns a `Session` error and


### PR DESCRIPTION
## GHSA-8r7g M2 (#568)

#497 already wired the `ApprovalBridge` into the ACP `RelayEmitter`, so bridge-backed gate frames **stamp** the secret `apr-` resume_token at synthesis. But it was dead on arrival: the projection dropped it and the resolve endpoint was `call_id`-only, so a bridge-backed gate (Crucible council / egress consent) raised during an ACP turn was **unresolvable by the host and hung to its TTL** (24h Crucible / 5m egress).

### B — carry
Add `resume_token` to `MessageEvent::ApprovalRequired` and stop dropping it in `ProtocolToMessageStream::project`. The ACP host now receives the secret. Manager-gated tools carry an empty token (`skip_serializing_if`) and still resolve by `call_id`.

### C — accept
Add `resume_token` to the `/resolve` request body (and `turn::ApprovalDecision`), and route a non-empty token to `ApprovalBridge::resolve`, falling through to the manager's `resolve_host(call_id)` otherwise — **secret-preferred, staged**, mirroring the json-stream `ApprovalResume` arm. This unblocks bridge-backed ACP gates and closes the self-approval class for them. `EngineSession` captures the bridge at build so `resolve` never locks the engine mutex a live turn holds.

### Scope / boundaries
- Manager-gated tools (plain Bash/edit) stay `call_id`-keyed under the F-017 X-API-Key + loopback binding — out of scope (documented).
- ACP/TUI output redaction (`ActiveTokenRedactor` only on json-stream today) is a **separate follow-up** being built in parallel.

### Verification
- Hetzner gate: fmt 0 / clippy 0 / **nextest 1805 passed, 7 skipped**.
- New tests: projection carries the token; manager-gated gate carries empty; **bridge gate resolves by secret**; **stale token falls through to a 404** (idempotent).
- Independent cross-audit in flight.