### PR TITLE
fix(security): redact live approval resume_tokens on the ACP and TUI output paths (GHSA-8r7g)

### DIFF
--- a/crates/wcore-cli/src/acp_engine.rs
+++ b/crates/wcore-cli/src/acp_engine.rs
@@ -384,14 +384,39 @@ struct ProtocolToMessageStream {
     /// `(name, input)` by `call_id` so the gate frame projects a faithful
     /// `ToolCall`. The map is bounded by the in-flight tool calls of one turn.
     pending_calls: HashMap<String, (String, serde_json::Value)>,
+    /// wayland#568 (GHSA-8r7g follow-up): scrubs in-flight approval
+    /// resume_tokens from tool-result output before it is projected to the ACP
+    /// host. Empty (default `new`) → no-op; [`Self::with_redactor`] binds the
+    /// session engine's live active-token set.
+    redactor: wcore_agent::output::protocol_sink::ActiveTokenRedactor,
 }
 
 impl ProtocolToMessageStream {
+    /// No-redaction constructor — test-only. Production always binds the live
+    /// active-token set via [`Self::with_redactor`], so a redactor-less
+    /// projection exists purely for tests that don't exercise scrubbing.
+    #[cfg(test)]
     fn new(rx: UnboundedReceiver<ProtocolEvent>) -> Self {
         Self {
             rx,
             done: false,
             pending_calls: HashMap::new(),
+            redactor: wcore_agent::output::protocol_sink::ActiveTokenRedactor::new(),
+        }
+    }
+
+    /// Build a projection whose tool-result output is scrubbed of in-flight
+    /// approval resume_tokens. `redactor` must be bound to the session engine's
+    /// `ApprovalBridge::redactor()` so it observes the live active-token set.
+    fn with_redactor(
+        rx: UnboundedReceiver<ProtocolEvent>,
+        redactor: wcore_agent::output::protocol_sink::ActiveTokenRedactor,
+    ) -> Self {
+        Self {
+            rx,
+            done: false,
+            pending_calls: HashMap::new(),
+            redactor,
         }
     }
 
@@ -420,13 +445,19 @@ impl ProtocolToMessageStream {
                 status,
                 output,
                 ..
-            } => Some(MessageEvent::ToolResult {
-                result: ToolResult {
-                    call_id,
-                    output: serde_json::Value::String(output),
-                    is_error: matches!(status, ToolStatus::Error),
-                },
-            }),
+            } => {
+                // wayland#568: a tool that echoes a live approval resume_token
+                // in its output must not leak it to the ACP host. Scrub the
+                // in-flight token set before projecting (no-op when idle).
+                let output = self.redactor.redact(&output);
+                Some(MessageEvent::ToolResult {
+                    result: ToolResult {
+                        call_id,
+                        output: serde_json::Value::String(output),
+                        is_error: matches!(status, ToolStatus::Error),
+                    },
+                })
+            }
             ProtocolEvent::ToolCancelled {
                 call_id, reason, ..
             } => Some(MessageEvent::ToolResult {
@@ -540,6 +571,11 @@ pub struct EngineSession {
     /// Tool names the engine registered, captured at build time for the A2A
     /// capability catalog.
     tool_names: Vec<String>,
+    /// wayland#568 (GHSA-8r7g follow-up): the engine's shared active-token
+    /// redactor, cloned into each turn's [`ProtocolToMessageStream`] so a tool
+    /// that echoes a live approval resume_token cannot leak it through
+    /// `MessageEvent::ToolResult`.
+    redactor: wcore_agent::output::protocol_sink::ActiveTokenRedactor,
 }
 
 impl EngineSession {
@@ -553,11 +589,16 @@ impl EngineSession {
         relay: RelayHandle,
     ) -> Self {
         let tool_names = engine.tools().tool_names();
+        // wayland#568: capture the engine's active-token redactor so each turn's
+        // projection can scrub in-flight approval resume_tokens from tool-result
+        // output before it reaches the ACP host.
+        let redactor = engine.approval_bridge().redactor();
         Self {
             engine: Arc::new(AsyncMutex::new(engine)),
             approval_manager,
             relay,
             tool_names,
+            redactor,
         }
     }
 
@@ -643,7 +684,10 @@ impl EngineSession {
             }
         });
 
-        Box::pin(ProtocolToMessageStream::new(rx))
+        Box::pin(ProtocolToMessageStream::with_redactor(
+            rx,
+            self.redactor.clone(),
+        ))
     }
 
     /// Drive one turn to completion and collect the streamed `TextDelta`
@@ -1014,6 +1058,65 @@ mod tests {
             args: serde_json::json!({"path": "x"}),
             description: "desc".to_string(),
         }
+    }
+
+    /// wayland#568 (GHSA-8r7g follow-up): a tool that echoes a live approval
+    /// resume_token in its output must not leak it to the ACP host. The
+    /// per-turn projection, bound to the bridge's active-token set, scrubs the
+    /// token from `MessageEvent::ToolResult.output`.
+    #[tokio::test]
+    async fn projection_redacts_live_token_from_tool_result_output() {
+        let bridge = wcore_agent::approval::ApprovalBridge::new();
+        // Spawn a pending approval so the bridge's redactor observes the live
+        // secret resume_token. `request` returns the SECRET `apr-{uuid}` token,
+        // which is exactly the value the redactor scrubs from tool output.
+        let (token, _rx) = bridge
+            .request(wcore_agent::approval::ApprovalRequest {
+                call_id: "c-1".into(),
+                reason: "test".into(),
+                context: "ctx".into(),
+            })
+            .await;
+
+        let (tx, rx) = unbounded_channel::<ProtocolEvent>();
+        tx.send(ProtocolEvent::ToolResult {
+            msg_id: "m".into(),
+            call_id: "c-1".into(),
+            tool_name: "Bash".into(),
+            status: ToolStatus::Success,
+            output: format!("leaked token: {token} — oops!"),
+            output_type: wcore_protocol::events::OutputType::Text,
+            metadata: None,
+        })
+        .unwrap();
+        tx.send(ProtocolEvent::StreamEnd {
+            msg_id: "m".into(),
+            finish_reason: FinishReason::Stop,
+            usage: None,
+            agent_run_id: None,
+        })
+        .unwrap();
+        drop(tx);
+
+        let out: Vec<MessageEvent> = ProtocolToMessageStream::with_redactor(rx, bridge.redactor())
+            .collect()
+            .await;
+        let result = out
+            .iter()
+            .find_map(|e| match e {
+                MessageEvent::ToolResult { result } => Some(result),
+                _ => None,
+            })
+            .expect("a ToolResult frame must be projected");
+        let output_str = result.output.as_str().unwrap_or_default();
+        assert!(
+            !output_str.contains(&token),
+            "the live resume_token must be scrubbed from the projected output: {output_str}"
+        );
+        assert!(
+            output_str.contains("[REDACTED]"),
+            "the scrubbed output must carry the [REDACTED] marker: {output_str}"
+        );
     }
 
     #[tokio::test]

--- a/crates/wcore-cli/src/main.rs
+++ b/crates/wcore-cli/src/main.rs
@@ -1862,7 +1862,16 @@ async fn run_tui_mode(
     // `rx`. The channel is unbounded so an event burst during a turn
     // never back-pressures the engine.
     let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
-    let output: Arc<dyn OutputSink> = Arc::new(tui::ChannelSink::new(tx.clone()));
+    // wayland#568 (GHSA-8r7g follow-up): scrub in-flight approval resume_tokens
+    // from tool output on the TUI path too. The sink is built before the engine
+    // (bootstrap needs it), so create the redactor here and `share_with` the
+    // bridge's set once the engine exists — mirroring the json-stream
+    // `ProtocolSink::share_token_redactor_with` wiring.
+    let tui_token_redactor = wcore_agent::output::protocol_sink::ActiveTokenRedactor::new();
+    let output: Arc<dyn OutputSink> = Arc::new(tui::ChannelSink::with_redactor(
+        tx.clone(),
+        tui_token_redactor.clone(),
+    ));
     let approval_manager = Arc::new(ToolApprovalManager::new());
     // GHSA-8r7g: a protocol peer may escalate to Force only when this local
     // operator opted in at launch (--force or WAYLAND_ALLOW_WIRE_FORCE).
@@ -1965,6 +1974,9 @@ async fn run_tui_mode(
         std::sync::Arc::new(std::sync::Mutex::new(std::collections::HashSet::new())),
         Some(engine.approval_bridge().clone()),
     )));
+    // wayland#568: bind the TUI sink's redactor to the bridge's active-token
+    // set so streaming tool output is scrubbed of in-flight resume_tokens.
+    tui_token_redactor.share_with(&engine.approval_bridge().redactor());
 
     // Snapshot the loaded skills + MCP servers for the `/skills` and `/mcp`
     // listings. Taken here while `engine` and `result.mcp_managers` are still

--- a/crates/wcore-cli/src/tui/engine_bridge.rs
+++ b/crates/wcore-cli/src/tui/engine_bridge.rs
@@ -233,12 +233,36 @@ impl ProtocolEmitter for ChannelEmitter {
 /// `ProtocolWriter` (stdout), not an arbitrary emitter.
 pub struct ChannelSink {
     tx: UnboundedSender<ProtocolEvent>,
+    /// GHSA-8r7g follow-up (wayland#568): scrub in-flight approval
+    /// resume_tokens from tool-derived output before it reaches the TUI
+    /// transcript — parity with the json-stream `ProtocolSink`. Empty
+    /// (default) → no-op fast path when no approval is outstanding.
+    token_redactor: wcore_agent::output::protocol_sink::ActiveTokenRedactor,
 }
 
 impl ChannelSink {
-    /// Build a sink that forwards onto `tx`.
+    /// Build a sink that forwards onto `tx` with no active-token redaction.
+    /// Used by relay/sub-agent sinks that are not bound to an approval bridge;
+    /// the main TUI sink uses [`Self::with_redactor`].
     pub fn new(tx: UnboundedSender<ProtocolEvent>) -> Self {
-        Self { tx }
+        Self {
+            tx,
+            token_redactor: wcore_agent::output::protocol_sink::ActiveTokenRedactor::new(),
+        }
+    }
+
+    /// Build a sink that scrubs in-flight approval resume_tokens from tool
+    /// output. Pair `redactor` with the engine's `ApprovalBridge::redactor()`
+    /// (via `share_with`) so the bridge's refresh pass updates the same set
+    /// this sink reads — mirroring `ProtocolSink::share_token_redactor_with`.
+    pub fn with_redactor(
+        tx: UnboundedSender<ProtocolEvent>,
+        redactor: wcore_agent::output::protocol_sink::ActiveTokenRedactor,
+    ) -> Self {
+        Self {
+            tx,
+            token_redactor: redactor,
+        }
     }
 
     /// Forward one event, dropping the result — a closed channel means
@@ -348,9 +372,12 @@ impl OutputSink for ChannelSink {
     }
 
     fn emit_info(&self, msg: &str) {
+        // wayland#568: some tools log structured info on the result path, so
+        // scrub in-flight approval resume_tokens (no-op when idle).
+        let message = self.token_redactor.redact(msg);
         self.send(ProtocolEvent::Info {
             msg_id: String::new(),
-            message: msg.to_string(),
+            message,
         });
     }
 
@@ -368,11 +395,14 @@ impl OutputSink for ChannelSink {
     }
 
     fn emit_tool_chunk(&self, msg_id: &str, call_id: &str, tool_name: &str, chunk: &str) {
+        // wayland#568: scrub in-flight approval resume_tokens from streaming
+        // tool output before it reaches the transcript (no-op when idle).
+        let chunk = self.token_redactor.redact(chunk);
         self.send(ProtocolEvent::ToolChunk {
             msg_id: msg_id.to_string(),
             call_id: call_id.to_string(),
             tool_name: tool_name.to_string(),
-            chunk: chunk.to_string(),
+            chunk,
         });
     }
 
@@ -3254,6 +3284,58 @@ mod tests {
                 );
             }
             panic!("emit_tool_result must not enqueue any ProtocolEvent: {event:?}");
+        }
+    }
+
+    /// wayland#568 (GHSA-8r7g follow-up): a streaming tool chunk that echoes a
+    /// live approval resume_token must be scrubbed before it reaches the TUI
+    /// transcript, exactly as the json-stream `ProtocolSink` scrubs it. The
+    /// sink's redactor is bound to the bridge's active-token set.
+    #[tokio::test]
+    async fn channel_sink_redacts_live_token_from_tool_output() {
+        let bridge = wcore_agent::approval::ApprovalBridge::new();
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let sink = ChannelSink::with_redactor(tx, bridge.redactor());
+
+        // Spawn a pending approval — the bridge refreshes the shared redactor's
+        // active set as part of the request. `request` returns the SECRET
+        // `apr-{uuid}` resume_token, which is exactly the value the redactor
+        // scrubs from tool output.
+        let (token, _rx) = bridge
+            .request(wcore_agent::approval::ApprovalRequest {
+                call_id: "c-1".into(),
+                reason: "test".into(),
+                context: "ctx".into(),
+            })
+            .await;
+
+        // A tool that echoes the live token on the streaming path must not leak
+        // it — the chunk on the wire is redacted.
+        let chunk = format!("here is a leaked token: {token} — oops!");
+        OutputSink::emit_tool_chunk(&sink, "m", "c-1", "Bash", &chunk);
+        let event = rx.try_recv().expect("a ToolChunk event must be enqueued");
+        match event {
+            ProtocolEvent::ToolChunk { chunk, .. } => {
+                assert!(
+                    !chunk.contains(&token),
+                    "the live resume_token must be scrubbed from the tool chunk: {chunk}"
+                );
+                assert!(
+                    chunk.contains("[REDACTED]"),
+                    "the scrubbed chunk must carry the [REDACTED] marker: {chunk}"
+                );
+            }
+            other => panic!("expected ToolChunk, got {other:?}"),
+        }
+
+        // The same scrubbing applies to tool-derived Info messages.
+        OutputSink::emit_info(&sink, &format!("info with {token} inside"));
+        match rx.try_recv().expect("an Info event must be enqueued") {
+            ProtocolEvent::Info { message, .. } => assert!(
+                !message.contains(&token) && message.contains("[REDACTED]"),
+                "the live resume_token must be scrubbed from Info: {message}"
+            ),
+            other => panic!("expected Info, got {other:?}"),
         }
     }
 }


### PR DESCRIPTION
## GHSA-8r7g follow-up (split from #568)

The `ActiveTokenRedactor` scrubs live secret `apr-{uuid}` approval resume_tokens out of tool OUTPUT before it streams to the host (so a tool echoing a live token can't leak it). It was wired **only** on the json-stream `ProtocolSink`. ACP and TUI had no redaction pass — a leak vector.

### Wiring
- **ACP** — redact in the `ProtocolToMessageStream` projection's `ToolResult` arm (the only host-facing tool-output seam on ACP; streaming `ToolChunk`/`Info` project to `None`). The projection binds an `ActiveTokenRedactor` shared from the session engine's `ApprovalBridge::redactor()`, captured in `EngineSession` and cloned into each turn's stream.
- **TUI** — mirror the `ProtocolSink` seams: `ChannelSink` gains a redactor applied in `emit_tool_chunk` + `emit_info`, wired in `run_tui_mode` with the same build-then-`share_with` pattern json-stream uses.

The redactor is the **same instance** the bridge feeds, so both observe live tokens. All existing callers keep a default-empty (no-op) redactor.

### Verification
- Hetzner gate: fmt 0 / clippy 0 / **nextest 1733 passed, 7 skipped**.
- Unit tests: a tool-result output containing a live `apr-` token is redacted on both the ACP projection and the TUI sink.
- Independent cross-audit in flight.

### Residual (pre-existing, out of scope)
The **final aggregated** `ProtocolEvent::ToolResult` on TUI + json-stream flows through the emitter/writer path, which doesn't redact — unchanged by this PR. This brings TUI to parity with json-stream (chunk+info) and makes ACP stricter. Closing the emitter-path ToolResult leak on all three is a separate, larger change.