### PR TITLE
feat(channels): per-conversation autonomous-send rate cap — runaway ping-pong backstop (#574)

### DIFF
--- a/crates/wcore-agent/src/channel_inbound.rs
+++ b/crates/wcore-agent/src/channel_inbound.rs
@@ -47,13 +47,14 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::sync::Mutex as StdMutex;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use async_trait::async_trait;
 use tokio::sync::{RwLock, broadcast, mpsc};
 use wcore_channels::{
-    AckMode, ChannelEvent, ChannelManager, DedupeCache, InboundPolicy, IncomingMessage,
-    OutgoingMessage, TurnAdmission, evaluate,
+    AckMode, AutoReplyRateLimiter, ChannelEvent, ChannelManager, DedupeCache, InboundPolicy,
+    IncomingMessage, OutgoingMessage, TurnAdmission, evaluate,
 };
 
 /// Depth of each per-session FIFO. Bounds how far one session may fall
@@ -130,6 +131,14 @@ pub struct InboundSubscriber {
     /// Shared duplicate-suppression cache. Its key already namespaces by
     /// platform / account / message-id, so one cache covers all channels.
     dedupe: DedupeCache,
+    /// Per-conversation rolling-window guard on autonomous auto-replies. Two
+    /// agents wired to the same channel can auto-reply to each other forever
+    /// (wayland#574); this caps how many autonomous sends one conversation may
+    /// emit per window, breaking the ping-pong. Shared (behind a `std::Mutex`)
+    /// because each per-session worker runs its own turn and must consult one
+    /// limiter; the critical section is a bounded map op, never held across an
+    /// `await`.
+    rate_limiter: Arc<StdMutex<AutoReplyRateLimiter>>,
     /// Runtime kill switch. When `false`, inbound events are drained (to
     /// keep the broadcast from lagging) but processed no further.
     enabled: Arc<AtomicBool>,
@@ -151,8 +160,28 @@ impl InboundSubscriber {
             dispatcher,
             policies,
             dedupe: DedupeCache::new(dedupe_ttl_ms, dedupe_max_size),
+            rate_limiter: Arc::new(StdMutex::new(AutoReplyRateLimiter::default())),
             enabled: Arc::new(AtomicBool::new(true)),
         }
+    }
+
+    /// Override the autonomous auto-reply rate limit (default:
+    /// [`wcore_channels::DEFAULT_MAX_AUTO_REPLIES`] per
+    /// [`wcore_channels::DEFAULT_AUTO_REPLY_WINDOW`]). A `window` of
+    /// [`std::time::Duration::ZERO`] disables the guard entirely. Builder-style
+    /// so the default construction path stays unchanged.
+    pub fn with_auto_reply_limit(
+        mut self,
+        max_sends: usize,
+        window: std::time::Duration,
+        conversation_cap: usize,
+    ) -> Self {
+        self.rate_limiter = Arc::new(StdMutex::new(AutoReplyRateLimiter::new(
+            max_sends,
+            window,
+            conversation_cap,
+        )));
+        self
     }
 
     /// Clone of the kill switch so the host can disable the subscriber at
@@ -184,6 +213,9 @@ impl InboundSubscriber {
         let dispatcher = self.dispatcher;
         let policies = self.policies;
         let enabled = self.enabled;
+        // Shared across the per-session workers so every autonomous reply is
+        // counted against one per-conversation budget.
+        let rate_limiter = self.rate_limiter;
         // The loop owns the dedupe cache (mutated per non-short-circuited
         // event).
         let mut dedupe = self.dedupe;
@@ -254,6 +286,7 @@ impl InboundSubscriber {
                                     ev,
                                     &manager,
                                     &dispatcher,
+                                    &rate_limiter,
                                 );
                             }
                             TurnAdmission::ObserveOnly => {
@@ -352,6 +385,7 @@ fn enqueue_to_worker(
     ev: AdmittedEvent,
     manager: &Arc<RwLock<ChannelManager>>,
     dispatcher: &Arc<dyn TurnDispatcher>,
+    rate_limiter: &Arc<StdMutex<AutoReplyRateLimiter>>,
 ) {
     // Fast path: a live worker already exists for this session.
     let ev = match workers.get_mut(&session_key) {
@@ -402,6 +436,7 @@ fn enqueue_to_worker(
         rx,
         Arc::clone(manager),
         Arc::clone(dispatcher),
+        Arc::clone(rate_limiter),
     );
     // The FIFO is fresh and we hold the only sender, so this can be neither
     // Full nor Closed; the event is enqueued unconditionally.
@@ -436,10 +471,11 @@ fn spawn_session_worker(
     mut rx: mpsc::Receiver<AdmittedEvent>,
     manager: Arc<RwLock<ChannelManager>>,
     dispatcher: Arc<dyn TurnDispatcher>,
+    rate_limiter: Arc<StdMutex<AutoReplyRateLimiter>>,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         while let Some(ev) = rx.recv().await {
-            run_turn(&session_key, &ev, &manager, &dispatcher).await;
+            run_turn(&session_key, &ev, &manager, &dispatcher, &rate_limiter).await;
         }
     })
 }
@@ -454,6 +490,7 @@ async fn run_turn(
     ev: &AdmittedEvent,
     manager: &Arc<RwLock<ChannelManager>>,
     dispatcher: &Arc<dyn TurnDispatcher>,
+    rate_limiter: &Arc<StdMutex<AutoReplyRateLimiter>>,
 ) {
     let AdmittedEvent {
         channel_name,
@@ -504,6 +541,28 @@ async fn run_turn(
 
     match dispatch_result {
         Ok(Some(reply)) => {
+            // Per-conversation ping-pong guard (wayland#574): suppress the
+            // autonomous reply once this conversation has emitted its quota of
+            // autonomous sends within the rolling window. The lock is released
+            // before any `.await` (bounded map op only — never held across the
+            // send); a poisoned mutex is recovered rather than panicking, since
+            // the critical section cannot itself panic.
+            let allowed = {
+                let mut limiter = rate_limiter
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner());
+                limiter.check_and_record(session_key, std::time::Instant::now())
+            };
+            if !allowed {
+                // Content-free: log only the session key, never message text.
+                tracing::warn!(
+                    target: "wcore_agent::channel_inbound",
+                    session_key = %session_key,
+                    "autonomous reply suppressed: per-conversation rate limit hit (ping-pong guard)"
+                );
+                return;
+            }
+
             let outgoing = OutgoingMessage {
                 conversation_id: msg.conversation_id.clone(),
                 text: reply,
@@ -1094,5 +1153,173 @@ mod tests {
 
         manager.write().await.stop_all().await.unwrap();
         handle.abort();
+    }
+
+    /// Build a subscriber with an explicit autonomous auto-reply limit, register
+    /// a `CapturingChannel` feeding `inbound`, and spawn it. Mirrors [`harness`]
+    /// but applies [`InboundSubscriber::with_auto_reply_limit`].
+    async fn harness_with_limit(
+        channel_name: &str,
+        inbound: VecDeque<IncomingMessage>,
+        policies: HashMap<String, InboundPolicy>,
+        max_sends: usize,
+        window: Duration,
+    ) -> (
+        Arc<RwLock<ChannelManager>>,
+        OutboundLog,
+        Arc<Mutex<Vec<(String, String)>>>,
+        Arc<AtomicUsize>,
+        tokio::task::JoinHandle<()>,
+    ) {
+        let (ch, outbound) = CapturingChannel::new(channel_name, inbound);
+
+        let mgr = ChannelManager::new().with_poll_interval(Duration::from_millis(5));
+        let manager = Arc::new(RwLock::new(mgr));
+
+        let (dispatcher, calls, count) = MockDispatcher::new();
+        let subscriber = InboundSubscriber::new(
+            Arc::clone(&manager),
+            Arc::new(dispatcher),
+            policies,
+            60_000,
+            1024,
+        )
+        .with_auto_reply_limit(max_sends, window, 1024);
+
+        let handle = subscriber.spawn().await;
+
+        {
+            let mut guard = manager.write().await;
+            guard.register(Box::new(ch)).await;
+            guard.start_all().await.unwrap();
+        }
+
+        (manager, outbound, calls, count, handle)
+    }
+
+    /// wayland#574: once a conversation hits its autonomous-send quota within
+    /// the window, further auto-replies are suppressed even though every inbound
+    /// is distinct (not a self-echo, not a duplicate) — the two-agent ping-pong
+    /// case the self/bot loop guard and the Message-ID echo guard both miss.
+    /// The turns still run; only the outbound SEND is throttled.
+    #[tokio::test]
+    async fn over_limit_autonomous_replies_are_suppressed() {
+        let mut policies = HashMap::new();
+        policies.insert("slack".to_string(), open_dm_policy());
+
+        // Five distinct-id messages, all in the same conversation "c1" -> same
+        // session key. Cap autonomous sends at 2 within a wide window.
+        let mut q = VecDeque::new();
+        for i in 0..5 {
+            q.push_back(dm_conv(&format!("m{i}"), "c1"));
+        }
+
+        let (manager, outbound, calls, count, handle) =
+            harness_with_limit("slack", q, policies, 2, Duration::from_secs(600)).await;
+
+        // All five turns dispatch (dispatch is not gated, only the send is).
+        let dispatched = wait_for_len(&calls, 5, Duration::from_secs(3)).await;
+        assert_eq!(dispatched, 5, "every distinct inbound drives a turn");
+        assert_eq!(count.load(Ordering::SeqCst), 5);
+
+        // Give any (incorrect) extra sends a chance to land, then assert the cap.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        assert_eq!(
+            outbound.lock().await.len(),
+            2,
+            "autonomous sends capped at the per-conversation limit"
+        );
+
+        manager.write().await.stop_all().await.unwrap();
+        handle.abort();
+    }
+
+    /// The rate limit is per-conversation: one conversation exhausting its quota
+    /// must not throttle a different conversation.
+    #[tokio::test]
+    async fn rate_limit_is_per_conversation() {
+        let mut policies = HashMap::new();
+        policies.insert("slack".to_string(), open_dm_policy());
+
+        // Two messages each for conversations "c1" and "c2", cap of 1 per
+        // conversation. Expect exactly one send per conversation = two total.
+        let mut q = VecDeque::new();
+        q.push_back(dm_conv("a0", "c1"));
+        q.push_back(dm_conv("b0", "c2"));
+        q.push_back(dm_conv("a1", "c1"));
+        q.push_back(dm_conv("b1", "c2"));
+
+        let (manager, outbound, calls, count, handle) =
+            harness_with_limit("slack", q, policies, 1, Duration::from_secs(600)).await;
+
+        let dispatched = wait_for_len(&calls, 4, Duration::from_secs(3)).await;
+        assert_eq!(dispatched, 4, "all four turns run");
+        assert_eq!(count.load(Ordering::SeqCst), 4);
+
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        let out = outbound.lock().await;
+        assert_eq!(out.len(), 2, "one allowed send per conversation");
+        let mut convs: Vec<String> = out.iter().map(|m| m.conversation_id.clone()).collect();
+        convs.sort();
+        assert_eq!(convs, vec!["c1".to_string(), "c2".to_string()]);
+
+        drop(out);
+        manager.write().await.stop_all().await.unwrap();
+        handle.abort();
+    }
+
+    /// A disabled guard (`window == 0`) never throttles: all autonomous replies
+    /// for one conversation flow through regardless of count.
+    #[tokio::test]
+    async fn disabled_limit_lets_all_autonomous_replies_through() {
+        let mut policies = HashMap::new();
+        policies.insert("slack".to_string(), open_dm_policy());
+
+        let mut q = VecDeque::new();
+        for i in 0..4 {
+            q.push_back(dm_conv(&format!("m{i}"), "c1"));
+        }
+
+        // Cap of 1 but a ZERO window disables the limiter entirely.
+        let (manager, outbound, calls, _count, handle) =
+            harness_with_limit("slack", q, policies, 1, Duration::ZERO).await;
+
+        let _ = wait_for_len(&calls, 4, Duration::from_secs(3)).await;
+        let replied = wait_for_len(&outbound, 4, Duration::from_secs(3)).await;
+        assert_eq!(replied, 4, "disabled guard sends every reply");
+
+        manager.write().await.stop_all().await.unwrap();
+        handle.abort();
+    }
+
+    /// Human / operator sends go through `ChannelManager::send_to` directly and
+    /// are NEVER gated by the auto-reply limiter — only the inbound-driven
+    /// `run_turn` reply path consults it. This drives more direct sends than any
+    /// auto-reply cap would allow and asserts all are delivered.
+    #[tokio::test]
+    async fn interactive_sends_bypass_the_rate_limit() {
+        let (ch, outbound) = CapturingChannel::new("slack", VecDeque::new());
+        let mgr = ChannelManager::new();
+        let manager = Arc::new(RwLock::new(mgr));
+        {
+            let mut guard = manager.write().await;
+            guard.register(Box::new(ch)).await;
+            guard.start_all().await.unwrap();
+        }
+
+        // Ten operator-initiated sends to the same conversation — far above any
+        // conservative auto-reply cap — all reach the channel.
+        for i in 0..10 {
+            let msg = OutgoingMessage::text("c1", format!("operator-{i}"));
+            manager.read().await.send_to("slack", msg).await.unwrap();
+        }
+
+        assert_eq!(
+            outbound.lock().await.len(),
+            10,
+            "direct operator sends are not rate-limited"
+        );
+
+        manager.write().await.stop_all().await.unwrap();
     }
 }

--- a/crates/wcore-channels/src/dispatch/mod.rs
+++ b/crates/wcore-channels/src/dispatch/mod.rs
@@ -21,6 +21,7 @@
 pub mod access;
 pub mod admission;
 pub mod dedupe;
+pub mod rate_limit;
 pub mod session_key;
 
 pub use access::{
@@ -29,6 +30,10 @@ pub use access::{
 };
 pub use admission::{TurnAdmission, classify};
 pub use dedupe::{DedupeCache, DedupeKey};
+pub use rate_limit::{
+    AutoReplyRateLimiter, DEFAULT_AUTO_REPLY_WINDOW, DEFAULT_CONVERSATION_CAP,
+    DEFAULT_MAX_AUTO_REPLIES,
+};
 pub use session_key::build_session_key;
 
 use crate::event::IncomingMessage;

--- a/crates/wcore-channels/src/dispatch/rate_limit.rs
+++ b/crates/wcore-channels/src/dispatch/rate_limit.rs
@@ -1,0 +1,292 @@
+//! `AutoReplyRateLimiter` — per-conversation rolling-window throttle for
+//! AUTONOMOUS channel sends (the agent's auto-replies to inbound messages).
+//!
+//! Two Wayland agents wired to the same channel (e.g. two email bots) can
+//! auto-reply to each other indefinitely: A replies to B, B replies to A, and
+//! so on forever. Neither existing guard catches it — the self/bot loop guard
+//! ([`crate::dispatch::classify`]) only drops the channel's own / other bots'
+//! messages, and the wayland#547 `Message-ID` echo guard only recognises a
+//! channel's own outbound mail bouncing back. In a two-agent ping-pong every
+//! message is genuinely new: not a self-echo, not a duplicate, and (from the
+//! receiver's side) not flagged as a bot. So both guards pass and the loop runs.
+//!
+//! This limiter breaks that ping-pong by capping how many autonomous replies a
+//! single conversation may emit within a rolling time window. Once a
+//! conversation hits the cap, further autonomous sends are suppressed (and
+//! logged by the caller) until enough of the window has elapsed for older sends
+//! to age out.
+//!
+//! Only autonomous auto-replies are gated. Human/operator-initiated sends (the
+//! `send_message` tool, cron, direct [`crate::ChannelManager::send_to`]) take a
+//! different code path and never reach this limiter.
+//!
+//! Time is caller-supplied (`now: Instant`, monotonic) so the limiter is fully
+//! deterministic under test — it never reads the wall clock. Production callers
+//! pass `std::time::Instant::now()`.
+
+use std::collections::{HashMap, VecDeque};
+use std::time::{Duration, Instant};
+
+/// Default cap on autonomous replies per conversation per window. This is a
+/// runaway-RATE BACKSTOP, not a full loop terminator: a rolling window caps the
+/// send *rate* (a sustained ping-pong is throttled, not stopped), which bounds
+/// the runaway cost/spam explosion — the actual harm — even though a slow loop
+/// can persist at the cap rate. The guard keys on the conversation and cannot
+/// tell a human from a peer agent at the send site (exactly why the #547
+/// self/dedupe guards miss a two-agent ping-pong), so the cap is set well ABOVE
+/// any realistic conversation: a runaway agent-to-agent loop fires as fast as
+/// turns complete (seconds apart → hundreds per window) and is caught, while a
+/// person rapidly messaging their own agent stays under it. On the primary
+/// threat channel (email) a human never approaches this rate. Suppression logs
+/// at WARN (operator-visible); it does not surface a channel-side notice — that
+/// and tool-driven-send coverage are tracked follow-ups.
+pub const DEFAULT_MAX_AUTO_REPLIES: usize = 30;
+
+/// Default rolling window for [`DEFAULT_MAX_AUTO_REPLIES`].
+pub const DEFAULT_AUTO_REPLY_WINDOW: Duration = Duration::from_secs(600);
+
+/// Default upper bound on the number of distinct conversations tracked at once.
+/// Bounds memory under a flood of distinct conversation ids; least-recently
+/// active conversations are evicted first (their history would age out anyway).
+pub const DEFAULT_CONVERSATION_CAP: usize = 4096;
+
+/// Per-conversation rolling-window rate limiter for autonomous sends.
+///
+/// State is a bounded map of `conversation id -> timestamps of recent
+/// autonomous sends`. On each admitted send the conversation's history is
+/// pruned to the window, then the send is allowed (and recorded) only if fewer
+/// than `max_sends` remain. A suppressed send is NOT recorded — otherwise the
+/// window would never drain.
+#[derive(Debug, Clone)]
+pub struct AutoReplyRateLimiter {
+    /// Maximum autonomous sends permitted per conversation within `window`.
+    max_sends: usize,
+    /// Rolling window width. `Duration::ZERO` disables the limiter entirely
+    /// (every send is allowed) — mirrors [`crate::DedupeCache`]'s `ttl == 0`
+    /// "disabled" convention so an operator can turn the guard off.
+    window: Duration,
+    /// Upper bound on tracked conversations. `0` disables capping.
+    cap: usize,
+    /// conversation id -> ascending timestamps of its recent recorded sends.
+    conversations: HashMap<String, VecDeque<Instant>>,
+}
+
+impl AutoReplyRateLimiter {
+    /// Construct a limiter. See [`DEFAULT_MAX_AUTO_REPLIES`],
+    /// [`DEFAULT_AUTO_REPLY_WINDOW`], and [`DEFAULT_CONVERSATION_CAP`] for the
+    /// standard values. A `window` of [`Duration::ZERO`] disables limiting.
+    pub fn new(max_sends: usize, window: Duration, cap: usize) -> Self {
+        Self {
+            max_sends,
+            window,
+            cap,
+            conversations: HashMap::new(),
+        }
+    }
+
+    /// Check whether an autonomous send for `conversation` is permitted at
+    /// `now`, recording it if so.
+    ///
+    /// Returns `true` when the send is allowed (and the timestamp is recorded),
+    /// `false` when the conversation has already emitted `max_sends` autonomous
+    /// sends within the rolling `window` — in which case nothing is recorded and
+    /// the caller must suppress the send. A disabled limiter (`window ==
+    /// Duration::ZERO`) always returns `true`.
+    pub fn check_and_record(&mut self, conversation: &str, now: Instant) -> bool {
+        // Disabled: no window means no limiting.
+        if self.window.is_zero() {
+            return true;
+        }
+
+        let window = self.window;
+        let max_sends = self.max_sends;
+        let history = self
+            .conversations
+            .entry(conversation.to_string())
+            .or_default();
+        Self::prune(history, now, window);
+
+        let allowed = if history.len() >= max_sends {
+            false
+        } else {
+            history.push_back(now);
+            true
+        };
+
+        // Bound the number of tracked conversations, never evicting the one we
+        // just touched. Runs after recording so `conversation` is retained.
+        self.enforce_cap(conversation);
+        allowed
+    }
+
+    /// Drop timestamps at the front older than `window` (history is ascending,
+    /// so once one is in-window every later one is too). Uses
+    /// `saturating_duration_since` so a `now` that is somehow not after the
+    /// stored instant yields zero elapsed rather than panicking.
+    fn prune(history: &mut VecDeque<Instant>, now: Instant, window: Duration) {
+        while let Some(front) = history.front() {
+            if now.saturating_duration_since(*front) >= window {
+                history.pop_front();
+            } else {
+                break;
+            }
+        }
+    }
+
+    /// Enforce [`Self::cap`] on the number of tracked conversations, keeping
+    /// `keep`. First drops conversations whose window has fully drained (empty
+    /// history), then evicts the least-recently-active conversation (oldest most
+    /// recent send) until within the cap. `cap == 0` disables capping.
+    fn enforce_cap(&mut self, keep: &str) {
+        if self.cap == 0 || self.conversations.len() <= self.cap {
+            return;
+        }
+        // Empty histories carry no live rate state — reclaim them first.
+        self.conversations.retain(|k, h| k == keep || !h.is_empty());
+        while self.conversations.len() > self.cap {
+            let victim = self
+                .conversations
+                .iter()
+                .filter(|(k, _)| k.as_str() != keep)
+                .min_by_key(|(_, h)| h.back().copied())
+                .map(|(k, _)| k.clone());
+            match victim {
+                Some(v) => {
+                    self.conversations.remove(&v);
+                }
+                None => break,
+            }
+        }
+    }
+
+    /// Number of conversations currently tracked. For tests / introspection.
+    pub fn tracked_conversations(&self) -> usize {
+        self.conversations.len()
+    }
+}
+
+impl Default for AutoReplyRateLimiter {
+    /// The standard guard: [`DEFAULT_MAX_AUTO_REPLIES`] per
+    /// [`DEFAULT_AUTO_REPLY_WINDOW`], bounded to [`DEFAULT_CONVERSATION_CAP`]
+    /// conversations.
+    fn default() -> Self {
+        Self::new(
+            DEFAULT_MAX_AUTO_REPLIES,
+            DEFAULT_AUTO_REPLY_WINDOW,
+            DEFAULT_CONVERSATION_CAP,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A fixed base instant plus helpers to advance it deterministically —
+    /// no sleeping, no wall clock.
+    fn base() -> Instant {
+        Instant::now()
+    }
+
+    fn after(t: Instant, secs: u64) -> Instant {
+        t.checked_add(Duration::from_secs(secs))
+            .expect("test instant in range")
+    }
+
+    #[test]
+    fn under_limit_passes() {
+        let mut rl = AutoReplyRateLimiter::new(3, Duration::from_secs(600), 1024);
+        let t = base();
+        // Three sends within the window are all allowed.
+        assert!(rl.check_and_record("conv", t));
+        assert!(rl.check_and_record("conv", after(t, 1)));
+        assert!(rl.check_and_record("conv", after(t, 2)));
+    }
+
+    #[test]
+    fn over_limit_is_suppressed() {
+        let mut rl = AutoReplyRateLimiter::new(3, Duration::from_secs(600), 1024);
+        let t = base();
+        assert!(rl.check_and_record("conv", t));
+        assert!(rl.check_and_record("conv", after(t, 1)));
+        assert!(rl.check_and_record("conv", after(t, 2)));
+        // Fourth send within the window is suppressed.
+        assert!(!rl.check_and_record("conv", after(t, 3)));
+        // Still suppressed just before the window rolls over.
+        assert!(!rl.check_and_record("conv", after(t, 599)));
+    }
+
+    #[test]
+    fn window_rollover_reallows() {
+        let mut rl = AutoReplyRateLimiter::new(2, Duration::from_secs(600), 1024);
+        let t = base();
+        assert!(rl.check_and_record("conv", t));
+        assert!(rl.check_and_record("conv", after(t, 1)));
+        // Over the cap while both are in-window.
+        assert!(!rl.check_and_record("conv", after(t, 2)));
+        // At t+600 the first send (at t) has aged out (elapsed == window is
+        // NOT < window -> pruned), freeing one slot.
+        assert!(rl.check_and_record("conv", after(t, 600)));
+        // But the second send (at t+1) is still in-window, so the next is
+        // suppressed again.
+        assert!(!rl.check_and_record("conv", after(t, 600)));
+        // Once the second also ages out, sends flow again.
+        assert!(rl.check_and_record("conv", after(t, 601)));
+    }
+
+    #[test]
+    fn distinct_conversations_are_independent() {
+        let mut rl = AutoReplyRateLimiter::new(1, Duration::from_secs(600), 1024);
+        let t = base();
+        // Each conversation gets its own budget.
+        assert!(rl.check_and_record("a", t));
+        assert!(rl.check_and_record("b", t));
+        // Second send for "a" is suppressed, but "b" is untouched.
+        assert!(!rl.check_and_record("a", after(t, 1)));
+        assert!(!rl.check_and_record("b", after(t, 1)));
+        // A third, fresh conversation still passes.
+        assert!(rl.check_and_record("c", after(t, 1)));
+    }
+
+    #[test]
+    fn zero_window_disables_limiting() {
+        let mut rl = AutoReplyRateLimiter::new(1, Duration::ZERO, 1024);
+        let t = base();
+        // With the guard disabled, an unbounded number of sends pass.
+        for i in 0..100 {
+            assert!(rl.check_and_record("conv", after(t, i)));
+        }
+        // No state is accumulated when disabled.
+        assert_eq!(rl.tracked_conversations(), 0);
+    }
+
+    #[test]
+    fn conversation_map_is_bounded_by_cap() {
+        let mut rl = AutoReplyRateLimiter::new(3, Duration::from_secs(600), 2);
+        let t = base();
+        // Record for many distinct conversations; the map never exceeds the cap.
+        for i in 0..50 {
+            let conv = format!("conv-{i}");
+            assert!(rl.check_and_record(&conv, after(t, i)));
+            assert!(
+                rl.tracked_conversations() <= 2,
+                "tracked conversations must stay within the cap"
+            );
+        }
+    }
+
+    #[test]
+    fn eviction_keeps_the_just_recorded_conversation() {
+        // Cap of 1: each new conversation evicts the previous, but the one being
+        // recorded is always retained (so its send was truly counted).
+        let mut rl = AutoReplyRateLimiter::new(1, Duration::from_secs(600), 1);
+        let t = base();
+        assert!(rl.check_and_record("first", t));
+        assert!(rl.check_and_record("second", after(t, 1)));
+        assert_eq!(rl.tracked_conversations(), 1);
+        // "first" was evicted, so it reads as fresh (allowed) again; recording
+        // it now evicts "second".
+        assert!(rl.check_and_record("first", after(t, 2)));
+        assert_eq!(rl.tracked_conversations(), 1);
+    }
+}

--- a/crates/wcore-channels/src/lib.rs
+++ b/crates/wcore-channels/src/lib.rs
@@ -27,9 +27,10 @@ pub mod webhook;
 pub use chunk::chunk_message;
 pub use config::{ChannelConfig, ChannelConfigLoader};
 pub use dispatch::{
-    AccessDecision, AckMode, ChannelToolPosture, DedupeCache, DedupeKey, DispatchOutcome, DmPolicy,
-    GroupPolicy, InboundPolicy, TurnAdmission, build_session_key, classify, decide_access,
-    evaluate,
+    AccessDecision, AckMode, AutoReplyRateLimiter, ChannelToolPosture, DEFAULT_AUTO_REPLY_WINDOW,
+    DEFAULT_CONVERSATION_CAP, DEFAULT_MAX_AUTO_REPLIES, DedupeCache, DedupeKey, DispatchOutcome,
+    DmPolicy, GroupPolicy, InboundPolicy, TurnAdmission, build_session_key, classify,
+    decide_access, evaluate,
 };
 pub use error::ChannelError;
 pub use event::{


### PR DESCRIPTION
## #574 — two-agent auto-reply ping-pong backstop

Two Wayland agents on a channel (e.g. email) can auto-reply to each other forever. The existing guards miss it: each peer message is genuinely new — not a self-echo (`dispatch::classify`'s self/bot guard passes), not a duplicate (dedupe passes), not flagged bot.

## Fix
`AutoReplyRateLimiter` (`wcore-channels/src/dispatch/rate_limit.rs`) — a deterministic, `Instant`-driven per-conversation rolling-window counter (modelled on `DedupeCache`/`SentMessageIds`; bounded map, caller-supplied clock). Keyed by the session key (conversation/thread identity). Enforced in `channel_inbound.rs::run_turn` on the autonomous-reply send path; human/operator sends (`send_message` tool, cron, direct `ChannelManager::send_to`) bypass it.

## What it is (honest framing, per cross-audit)
A runaway-**rate backstop**, not a full loop terminator. A rolling window caps the send *rate*, so a sustained loop is throttled rather than stopped — but that bounds the runaway cost/spam explosion, which is the actual harm. **Default 30 replies / 10 min**: a runaway agent↔agent loop fires as fast as turns complete (hundreds/window) and is caught; a human never approaches this rate on the primary threat channel (email). Overridable via `with_auto_reply_limit`; `window == 0` disables. Bounded to 4096 conversations.

## Verification
- Hetzner gate: fmt 0 / clippy 0 / all rate-limit tests pass (the one nextest failure is `new_via_slash...`, a pre-existing known flake, unrelated).
- 7 unit + 4 integration tests (window slides + drains + recovers; cap allows exactly N; `window==0` disabled; per-conversation isolation; cap eviction; human/operator sends bypass).
- Independent cross-audit: mechanically correct, no bug.

## Deferred follow-ups (filed, not blocking)
- Channel-side notice on suppression (vs operator-only WARN) + tool-driven-send coverage → tracked follow-up.
- The bridge/manager path and origin-aware true loop termination are noted there too.