### PR TITLE
fix(providers): bound the openai chat-path tool-call accumulator Vec (#136)

### DIFF
--- a/crates/wcore-providers/src/openai.rs
+++ b/crates/wcore-providers/src/openai.rs
@@ -1530,6 +1530,16 @@ const MAX_SSE_BUFFER_BYTES: usize = 1024 * 1024;
 /// bounding memory; on exceed the stream errors out rather than growing.
 const MAX_TOOL_ARGS_BYTES: usize = 8 * 1024 * 1024;
 
+/// Maximum number of parallel tool-call accumulator slots on the chat path.
+/// #136: `StreamState::get_or_create_tool(index)` grows `tool_calls` until it
+/// is long enough to index `index`, so a runaway or hostile stream that sends
+/// a huge `tool_calls[].index` (e.g. `4_000_000_000`) would allocate unbounded
+/// slots — an OOM reached BEFORE the per-call [`MAX_TOOL_ARGS_BYTES`] cap can
+/// apply, since no arguments have streamed yet. A real assistant turn emits a
+/// handful of parallel calls; 1024 is far beyond any legitimate use. On exceed
+/// the stream errors out (fail closed) rather than growing.
+const MAX_TOOL_CALLS: usize = 1024;
+
 pub(crate) async fn process_sse_stream(
     response: reqwest::Response,
     tx: &mpsc::Sender<LlmEvent>,
@@ -1868,6 +1878,18 @@ fn parse_sse_chunk(data: &str, state: &mut StreamState) -> Vec<LlmEvent> {
     if let Some(tool_calls) = delta["tool_calls"].as_array() {
         for tc in tool_calls {
             let index = tc["index"].as_u64().unwrap_or(0) as usize;
+            // #136: reject an out-of-range tool-call index BEFORE
+            // `get_or_create_tool` grows the accumulator Vec to `index` slots.
+            // Fail closed by aborting the stream, mirroring the arg-bytes cap
+            // below — a stream claiming an absurd index is buggy or hostile and
+            // no tool should run from it.
+            if index >= MAX_TOOL_CALLS {
+                events.push(LlmEvent::Error(format!(
+                    "tool-call index {index} exceeds {MAX_TOOL_CALLS} — \
+                     aborting stream to bound memory"
+                )));
+                return events;
+            }
             let acc = state.get_or_create_tool(index);
 
             if let Some(id) = tc["id"].as_str() {
@@ -2259,6 +2281,48 @@ mod tests {
 
     fn no_compat() -> ProviderCompat {
         ProviderCompat::default()
+    }
+
+    // --- #136: tool-call accumulator Vec bound ----------------------------
+
+    #[test]
+    fn tool_call_index_over_cap_aborts_without_unbounded_growth() {
+        // A hostile/buggy stream claims an absurd tool-call index. Pre-fix,
+        // `get_or_create_tool` grew `StreamState::tool_calls` to `index + 1`
+        // slots (here ~1029, but a real attack sends billions → OOM). It must
+        // now be rejected with an Error and leave the accumulator Vec empty.
+        let mut state = StreamState::new();
+        let data = format!(
+            r#"{{"choices":[{{"index":0,"delta":{{"tool_calls":[{{"index":{},"id":"call_x","function":{{"name":"f","arguments":"{{}}"}}}}]}}}}]}}"#,
+            MAX_TOOL_CALLS + 5
+        );
+        let events = parse_sse_chunk(&data, &mut state);
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, LlmEvent::Error(m) if m.contains("exceeds"))),
+            "an out-of-range tool-call index must surface an Error, got: {events:?}"
+        );
+        assert!(
+            state.tool_calls.is_empty(),
+            "no accumulator slots may be allocated for an out-of-range index"
+        );
+    }
+
+    #[test]
+    fn tool_call_index_within_cap_accumulates_normally() {
+        // Guard must not be too tight: a legitimate small index still
+        // accumulates. Index 3 creates slots 0..=3 and records the tool.
+        let mut state = StreamState::new();
+        let data = r#"{"choices":[{"index":0,"delta":{"tool_calls":[{"index":3,"id":"call_a","function":{"name":"lookup","arguments":"{\"q\":1}"}}]}}]}"#;
+        let events = parse_sse_chunk(data, &mut state);
+        assert!(
+            !events.iter().any(|e| matches!(e, LlmEvent::Error(_))),
+            "a valid tool-call index must not error, got: {events:?}"
+        );
+        assert_eq!(state.tool_calls.len(), 4, "indices 0..=3 create 4 slots");
+        assert_eq!(state.tool_calls[3].name, "lookup");
+        assert_eq!(state.tool_calls[3].id, "call_a");
     }
 
     // --- is_tools_unsupported_error (#389) --------------------------------


### PR DESCRIPTION
## #136 — bound the OpenAI chat-path tool-call accumulator Vec

`StreamState::get_or_create_tool(index)` grew `tool_calls` to the streamed
`tool_calls[].index` with no cap. A runaway or hostile OpenAI-compatible stream
sending a huge `index` (e.g. `4_000_000_000`) allocates unbounded accumulator
slots — an OOM reached **before** the per-call `MAX_TOOL_ARGS_BYTES` cap can
apply, since no arguments have streamed yet.

**Fix:** reject `index >= MAX_TOOL_CALLS` (1024, far beyond any real parallel-call
count) in `parse_sse_chunk` before the Vec grows — fail closed by aborting the
stream, mirroring the adjacent arguments-bytes cap.

**Tests:** an over-cap index errors and leaves the accumulator empty; a valid
small index still accumulates.

**Verification:** Hetzner gate green (fmt + clippy `-D warnings --all-targets` +
nextest `-p wcore-providers` 876/876). Cross-audited (adversarial) → MERGE-READY:
the 32-bit `as usize` truncation cannot bypass the guard (same post-truncation
integer gates both the check and the growth), and `parse_sse_chunk` is the sole
caller (Responses/Gemini paths use string-keyed maps, no sibling hole).