### PR TITLE
fix(mcp): make /mcp add idempotent — skip the duplicate connect for a live server (#135)

### DIFF
--- a/crates/wcore-agent/src/engine.rs
+++ b/crates/wcore-agent/src/engine.rs
@@ -2135,6 +2135,29 @@ impl AgentEngine {
         self.tools.clone()
     }
 
+    /// #135 (pure, no `self`): does any tool def carry real provenance for the
+    /// MCP server `name`? Extracted so the engine accessor and its unit test
+    /// share one definition. Matches on `ToolDef::server` (real provenance,
+    /// #86), never the `mcp__` name prefix — a bare-named MCP tool still counts.
+    pub fn mcp_server_has_tools(defs: &[wcore_types::tool::ToolDef], name: &str) -> bool {
+        defs.iter().any(|t| t.server.as_deref() == Some(name))
+    }
+
+    /// #135: idempotency probe for the `/mcp add` entry points. Returns true
+    /// when server `name` already has ≥1 tool registered on the live registry,
+    /// so a caller can skip a duplicate connect (and, for stdio transports, a
+    /// duplicate child process). Deferred tools are registered eagerly as
+    /// name-only stubs, so a just-added deferred server is detected too.
+    ///
+    /// LIMITATION: keys on tool provenance only. A server that exposes ONLY
+    /// resources or prompts (zero tools) leaves no tool defs, so it is not
+    /// detected and a re-add still reconnects. That is the SAME behavior as
+    /// before this fix (no regression) — closing it needs a live
+    /// connected-server registry keyed by name, tracked as a follow-up.
+    pub fn mcp_server_connected(&self, name: &str) -> bool {
+        Self::mcp_server_has_tools(&self.tools().to_tool_defs(), name)
+    }
+
     /// Initialize a new session for this engine run
     pub fn init_session(
         &mut self,
@@ -9023,6 +9046,42 @@ mod set_config_tests {
             capped.len(),
             5,
             "all server:None tools kept (correctness > strict limit for built-ins)"
+        );
+    }
+
+    /// #135 — the `/mcp add` idempotency probe keys on real provenance
+    /// (`ToolDef::server`), NOT the tool-name shape. A connected server is
+    /// detected via its bare-named OR `mcp__`-prefixed tools; a not-connected
+    /// name (or a same-named built-in with `server: None`) must NOT match, so
+    /// re-adding a live server no-ops instead of spawning a duplicate process.
+    #[test]
+    fn mcp_server_connected_probe_keys_on_provenance() {
+        // bare_mcp_tool → server: Some("db"); cap_mcp_tool → server: Some("srv").
+        let defs = vec![
+            builtin_tool("execute_sql"), // server: None — name shape only
+            bare_mcp_tool("execute_sql"),
+            cap_mcp_tool("mcp__srv__query"),
+        ];
+
+        assert!(
+            super::AgentEngine::mcp_server_has_tools(&defs, "db"),
+            "server with a bare-named tool must be detected as connected"
+        );
+        assert!(
+            super::AgentEngine::mcp_server_has_tools(&defs, "srv"),
+            "server with a mcp__-prefixed tool must be detected as connected"
+        );
+        assert!(
+            !super::AgentEngine::mcp_server_has_tools(&defs, "notconnected"),
+            "an unconnected server name must not match"
+        );
+        assert!(
+            !super::AgentEngine::mcp_server_has_tools(&defs, "execute_sql"),
+            "a built-in name (server: None) must never be read as a connected server"
+        );
+        assert!(
+            !super::AgentEngine::mcp_server_has_tools(&[], "db"),
+            "empty registry → nothing connected"
         );
     }
 

--- a/crates/wcore-cli/src/main.rs
+++ b/crates/wcore-cli/src/main.rs
@@ -2919,6 +2919,30 @@ async fn run_json_stream_mode(
                 eprintln!(
                     "[mcp] AddMcpServer received: name={name}, transport={transport}, command={command:?}"
                 );
+                // #135: idempotency — re-adding an already-connected server (boot
+                // set or a prior dynamic add) does not spawn a duplicate. Re-emit
+                // the existing tools so the host's view stays consistent, then skip
+                // the reconnect. NOTE: a re-add with changed config is ignored (the
+                // existing connection is kept) — remove then add to reconfigure.
+                if engine.mcp_server_connected(&name) {
+                    let existing: Vec<String> = engine
+                        .tools()
+                        .to_tool_defs()
+                        .iter()
+                        .filter(|t| t.server.as_deref() == Some(name.as_str()))
+                        .map(|t| t.name.clone())
+                        .collect();
+                    eprintln!(
+                        "[mcp] '{name}' already connected ({} tools); keeping existing \
+                         connection, ignoring re-add (remove then add to change config)",
+                        existing.len()
+                    );
+                    let _ = writer.emit(&ProtocolEvent::McpReady {
+                        name,
+                        tools: existing,
+                    });
+                    continue;
+                }
                 let config =
                     match to_mcp_server_config(&transport, command, args, env, url, headers) {
                         Ok(c) => c,

--- a/crates/wcore-cli/src/tui/engine_bridge.rs
+++ b/crates/wcore-cli/src/tui/engine_bridge.rs
@@ -1887,6 +1887,24 @@ impl TuiEngine {
         name: String,
         mut config: wcore_config::config::McpServerConfig,
     ) {
+        // #135: idempotency. If a server with this name is already connected,
+        // re-adding it must NOT spawn a duplicate connection (a second stdio
+        // child process for stdio transports). Check the live registry BEFORE
+        // any connect, report the no-op, and return. Covers the plain `/mcp add`
+        // path and the Forge grant path (both funnel through here).
+        let already_connected = engine.lock().await.mcp_server_connected(&name);
+        if already_connected {
+            let _ = tx.send(ProtocolEvent::Info {
+                msg_id: String::new(),
+                message: format!(
+                    "MCP server '{name}' is already connected — keeping the existing \
+                     connection (no duplicate started). To change its settings, remove \
+                     it first, then add it again."
+                ),
+            });
+            return;
+        }
+
         // Resolve `${cred:KEY}` header references just before connecting. This
         // is the single-server live-add path: per the `mcp_cred_refs` contract,
         // a resolution failure (missing key / store error / malformed ref) is a

--- a/crates/wcore-mcp/src/tool_proxy.rs
+++ b/crates/wcore-mcp/src/tool_proxy.rs
@@ -283,6 +283,35 @@ mod tests {
         assert!(proxy.is_deferred());
     }
 
+    /// #135 linchpin — a DEFERRED MCP tool still registers EAGERLY and still
+    /// carries real provenance (`ToolDef::server`) in `to_tool_defs()`. The
+    /// `/mcp add` idempotency probe (`AgentEngine::mcp_server_connected`) keys
+    /// purely on that provenance, so this is the load-bearing property: if a
+    /// future refactor made deferred registration lazy or dropped the server
+    /// tag, the probe would silently stop detecting a just-added deferred
+    /// server and a re-add would spawn a duplicate process. Lock it here.
+    #[test]
+    fn deferred_mcp_tool_registers_eagerly_with_provenance() {
+        let mut registry = wcore_tools::registry::ToolRegistry::new();
+        registry.register(Box::new(make_proxy(true)));
+
+        let defs = registry.to_tool_defs();
+        assert_eq!(
+            defs.len(),
+            1,
+            "the deferred tool must be registered eagerly"
+        );
+        assert!(
+            defs[0].deferred,
+            "the tool is deferred (name-only schema stub)"
+        );
+        assert_eq!(
+            defs[0].server.as_deref(),
+            Some("test_server"),
+            "deferred registration must still carry real provenance for the probe"
+        );
+    }
+
     #[test]
     fn proxy_deferred_false_returns_false() {
         let proxy = make_proxy(false);


### PR DESCRIPTION
## #135 — `/mcp add` idempotency

Re-adding an already-connected MCP server (via `/mcp add`, the json-stream
`AddMcpServer` command, or a Forge grant) reconnected it — and for stdio
transports spawned a **duplicate child process**. Every entry point now guards
on a new idempotency probe, `AgentEngine::mcp_server_connected`, which keys on
real tool provenance (`ToolDef::server`, #86). Deferred servers are detected too
because their name-only stubs register eagerly.

- **engine:** `mcp_server_connected` + a pure, unit-tested `mcp_server_has_tools` helper.
- **TUI** (`connect_and_register_mcp`): report the no-op and return before any connect; this also covers the Forge grant path, which funnels through here.
- **json-stream** (`AddMcpServer`): re-emit the existing tools as an idempotent `McpReady`, then skip the reconnect.
- **test:** locks the load-bearing property that a *deferred* server still registers eagerly **with provenance** (`tool_proxy.rs`), so a future lazy-registration refactor can't silently break the probe.

### Scope / limitations (tracked as follow-ups)
- Probe keys on **tools** only; a server exposing **only resources/prompts** (zero tools) is not detected and a re-add still reconnects — **same as before this fix (no regression)**. Closing it needs a live connected-server registry keyed by name.
- Closes the **sequential** re-add window; two **concurrent** `/mcp add` for the same name (before either registers) can still both connect.
- A re-add with **changed config** is a no-op (existing connection kept), not a reconfigure — messages now tell the user to remove-then-add.

### Verification
Hetzner gate green (fmt + clippy `-D warnings --all-targets` + nextest `-p wcore-agent -p wcore-cli -p wcore-mcp`; only failure is the known `new_via_slash` flake). Adversarially cross-audited; the core provenance mechanism (incl. deferred-eager registration and deadlock-free lock scoping) was confirmed sound, and the audit's substantive findings are addressed above.