### PR TITLE
fix(engine): distinct max_turns finish reason so hosts show Continue (#457)

### DIFF
--- a/crates/wcore-agent/src/engine.rs
+++ b/crates/wcore-agent/src/engine.rs
@@ -3731,23 +3731,25 @@ impl AgentEngine {
 
     /// AUDIT A1 / E-C1 / A2 — shared clean-termination path for the
     /// non-natural loop exits (turn cap, budget cap, context ceiling,
-    /// host cancel).
+    /// host cancel, no-progress loop).
     ///
-    /// Every one of these is a *failure verdict*: the model did not
-    /// close the task on its own. They run the identical session-end
-    /// bookkeeping the `MaxTurns` exit already did — `fire_on_session_end`,
-    /// `save_session`, and the two learning observes — then return an
-    /// `AgentResult` with `StopReason::MaxTurns` (the engine's existing
-    /// "ran out of budget" verdict; `observe_*` already maps it to
-    /// `Failure` and `FinishReason::from_stop_reason` maps it to
-    /// `Error`). The distinct, user-visible reason is surfaced via the
-    /// `emit_error` call the caller makes before invoking this — the
-    /// `StopReason` enum lives in `wcore-types` and is not extended
-    /// here.
+    /// Every one of these is a *failure verdict*: the model did not close the
+    /// task on its own. They run the identical session-end bookkeeping —
+    /// `fire_on_session_end`, `save_session`, and the two learning observes —
+    /// then return an `AgentResult` with `StopReason::MaxTurns` (the engine's
+    /// existing "ran out of budget" verdict; `observe_*` maps it to `Failure`).
+    ///
+    /// #457: the host-facing `finish_reason` is passed IN by the caller, not
+    /// derived here, because the exits are NOT interchangeable — the `max_turns`
+    /// cap is `FinishReason::MaxTurns` (host offers "Continue"), while a context
+    /// ceiling / budget cap / loop-break stays `FinishReason::Length` (Continue
+    /// would not help). The distinct human-readable reason is surfaced via the
+    /// `emit_info`/`emit_error` call the caller makes before invoking this.
     async fn finish_run_terminated(
         &mut self,
         user_input: &str,
         turn: usize,
+        finish_reason: FinishReason,
     ) -> Result<AgentResult, AgentError> {
         self.fire_on_session_end(turn).await;
         self.save_session();
@@ -3757,7 +3759,7 @@ impl AgentEngine {
         Ok(AgentResult {
             text: String::new(),
             stop_reason: StopReason::MaxTurns,
-            finish_reason: FinishReason::Length,
+            finish_reason,
             usage: self.total_usage.clone(),
             turns: turn,
             active_window_percent: self.active_window_percent_now(&self.model, 0),
@@ -4191,7 +4193,10 @@ impl AgentEngine {
                 self.output.emit_info(&format!(
                     "Run stopped: reached the configured max_turns limit ({limit})."
                 ));
-                return self.finish_run_terminated(user_input, turn).await;
+                // #457: the turn cap is a "Continue"-able exit, not a failure.
+                return self
+                    .finish_run_terminated(user_input, turn, FinishReason::MaxTurns)
+                    .await;
             }
             // Fire on_turn_start hooks at the top of each iteration so Rust
             // hooks can override the model or inject prompt messages before
@@ -4211,7 +4216,9 @@ impl AgentEngine {
                 if let Some(reason) = self.apply_pre_turn_outcome(outcome) {
                     self.output
                         .emit_info(&format!("Run stopped by on_turn_start hook: {reason}"));
-                    return self.finish_run_terminated(user_input, turn).await;
+                    return self
+                        .finish_run_terminated(user_input, turn, FinishReason::Length)
+                        .await;
                 }
             }
 
@@ -4565,7 +4572,10 @@ impl AgentEngine {
                         ),
                         false,
                     );
-                    return self.finish_run_terminated(user_input, turn).await;
+                    // Context ceiling: a bigger budget is needed, not more turns.
+                    return self
+                        .finish_run_terminated(user_input, turn, FinishReason::Length)
+                        .await;
                 }
             }
 
@@ -5193,7 +5203,9 @@ impl AgentEngine {
                     ),
                     false,
                 );
-                return self.finish_run_terminated(user_input, turn + 1).await;
+                return self
+                    .finish_run_terminated(user_input, turn + 1, FinishReason::Length)
+                    .await;
             }
 
             if tool_calls.is_empty() {
@@ -5726,7 +5738,9 @@ impl AgentEngine {
                     ),
                     false,
                 );
-                return self.finish_run_terminated(user_input, turn + 1).await;
+                return self
+                    .finish_run_terminated(user_input, turn + 1, FinishReason::Length)
+                    .await;
             }
 
             // W1 F9: emit one TurnTrace per turn. Hosts that opt in via

--- a/crates/wcore-agent/tests/engine_test.rs
+++ b/crates/wcore-agent/tests/engine_test.rs
@@ -354,6 +354,15 @@ async fn test_engine_max_turns_returns_ok() {
 
     assert_eq!(result.stop_reason, StopReason::MaxTurns);
     assert_eq!(result.turns, 1);
+    // #457: the max_turns exit must surface finish_reason=max_turns (NOT length)
+    // so the host offers "Continue" instead of the "use a bigger model" UX. This
+    // exercises the real production path (finish_run_terminated), guarding against
+    // the emit site regressing back to a hardcoded FinishReason.
+    assert_eq!(
+        result.finish_reason,
+        wcore_types::message::FinishReason::MaxTurns,
+        "max_turns run must emit finish_reason=max_turns"
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/wcore-cli/src/acp_engine.rs
+++ b/crates/wcore-cli/src/acp_engine.rs
@@ -327,12 +327,15 @@ impl Drop for TerminalGuard {
 // ─────────────────────────────────────────────────────────────────────────
 
 /// Map a protocol [`FinishReason`] onto an ACP StopReason string. `cancelled`
-/// / `max_turn_requests` are produced by other paths, not by `FinishReason`.
+/// is produced by other paths, not by `FinishReason`.
 fn stop_reason_str(reason: FinishReason) -> &'static str {
     match reason {
         FinishReason::Stop => "end_turn",
         FinishReason::Length => "max_tokens",
         FinishReason::Error => "refusal",
+        // #457: the engine's per-turn cap maps to the ACP `max_turn_requests`
+        // stop reason so an ACP client can offer Continue, not a refusal.
+        FinishReason::MaxTurns => "max_turn_requests",
     }
 }
 

--- a/crates/wcore-protocol/src/events.rs
+++ b/crates/wcore-protocol/src/events.rs
@@ -933,6 +933,8 @@ mod tests {
             (FinishReason::Stop, "stop"),
             (FinishReason::Length, "length"),
             (FinishReason::Error, "error"),
+            // #457: the engine turn-cap is a distinct, host-visible value.
+            (FinishReason::MaxTurns, "max_turns"),
         ] {
             let event = ProtocolEvent::StreamEnd {
                 msg_id: "m1".to_string(),

--- a/crates/wcore-types/src/llm.rs
+++ b/crates/wcore-types/src/llm.rs
@@ -266,9 +266,11 @@ mod tests {
             FinishReason::from_stop_reason(StopReason::MaxTokens),
             FinishReason::Length
         );
+        // #457: the per-turn cap now maps to its own FinishReason::MaxTurns
+        // (was Error) so hosts can offer Continue instead of a model-failure UX.
         assert_eq!(
             FinishReason::from_stop_reason(StopReason::MaxTurns),
-            FinishReason::Error
+            FinishReason::MaxTurns
         );
     }
 

--- a/crates/wcore-types/src/message.rs
+++ b/crates/wcore-types/src/message.rs
@@ -123,11 +123,13 @@ pub enum StopReason {
 ///
 /// Distinct from `StopReason` (internal): `FinishReason` is the contract
 /// the JSON stream protocol exposes to host integrations (e.g. the Wayland
-/// app). It coalesces every provider's native stop signal into three
-/// values so the host can render UX consistently (e.g. show "Response was
-/// truncated" on `Length`).
+/// app). It coalesces stop signals into a small set of values so the host can
+/// render UX consistently (e.g. show "Response was truncated" on `Length`).
 ///
-/// Unmapped provider values map to `Error` rather than silently degrading.
+/// Provider-native signals coalesce to `Stop` / `Length` / `Error`; unmapped
+/// provider values map to `Error` rather than silently degrading. `MaxTurns`
+/// is an ENGINE-level stop (never emitted by a provider) that the host must be
+/// able to tell apart from a provider `Error` — see the variant docs.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum FinishReason {
@@ -139,6 +141,12 @@ pub enum FinishReason {
     /// Provider returned an unrecognized stop signal, refused, or the
     /// engine never received a Done event (e.g. mid-stream error).
     Error,
+    /// #457: the ENGINE stopped the run because it hit the per-turn `max_turns`
+    /// cap — the model did NOT fail. Serialized as `"max_turns"`. Hosts should
+    /// offer a "Continue" affordance (resume the run) rather than the provider-
+    /// error UX ("use a bigger model"). Previously coalesced into `Error`, which
+    /// made "out of turns" indistinguishable from a real model failure.
+    MaxTurns,
 }
 
 impl FinishReason {
@@ -147,7 +155,9 @@ impl FinishReason {
         match sr {
             StopReason::EndTurn | StopReason::ToolUse => FinishReason::Stop,
             StopReason::MaxTokens => FinishReason::Length,
-            StopReason::MaxTurns => FinishReason::Error,
+            // #457: keep the turn-cap distinct from a provider Error so the host
+            // can surface Continue instead of a generic model-failure message.
+            StopReason::MaxTurns => FinishReason::MaxTurns,
         }
     }
 }
@@ -345,6 +355,42 @@ mod tests {
     fn test_stop_reason_max_tokens_variant() {
         let reason = StopReason::MaxTokens;
         assert_eq!(reason, StopReason::MaxTokens);
+    }
+
+    // --- FinishReason::from_stop_reason (#457) ---
+
+    #[test]
+    fn finish_reason_maps_each_stop_reason() {
+        assert_eq!(
+            FinishReason::from_stop_reason(StopReason::EndTurn),
+            FinishReason::Stop
+        );
+        assert_eq!(
+            FinishReason::from_stop_reason(StopReason::ToolUse),
+            FinishReason::Stop
+        );
+        assert_eq!(
+            FinishReason::from_stop_reason(StopReason::MaxTokens),
+            FinishReason::Length
+        );
+        // #457: the turn cap must NOT coalesce into Error — it is its own value
+        // so the host can offer Continue instead of a model-failure message.
+        assert_eq!(
+            FinishReason::from_stop_reason(StopReason::MaxTurns),
+            FinishReason::MaxTurns
+        );
+        assert_ne!(
+            FinishReason::from_stop_reason(StopReason::MaxTurns),
+            FinishReason::Error,
+            "regression guard: max_turns must never map back to Error"
+        );
+    }
+
+    #[test]
+    fn finish_reason_max_turns_serializes_snake_case() {
+        // The host contract: the new variant is exposed as "max_turns".
+        let json = serde_json::to_value(FinishReason::MaxTurns).unwrap();
+        assert_eq!(json, json!("max_turns"));
     }
 
     // --- TokenUsage default ---

--- a/docs/json-stream-protocol.md
+++ b/docs/json-stream-protocol.md
@@ -241,7 +241,7 @@ Current response turn finished.
 | Field | Type | Description |
 |-------|------|-------------|
 | `msg_id` | string | Message ID this turn belongs to |
-| `finish_reason` | `"stop" \| "length" \| "error"` | Why the turn ended. `stop`: model finished normally. `length`: hit max_tokens. `error`: provider/runtime error. |
+| `finish_reason` | `"stop" \| "length" \| "error" \| "max_turns"` | Why the turn ended. `stop`: model finished normally. `length`: hit max_tokens. `error`: provider/runtime error. `max_turns`: the engine hit the per-turn `max_turns` cap (the model did **not** fail) — offer a "Continue" affordance to resume the run rather than a model-error message. Hosts should treat `finish_reason` as an open string and tolerate future values. |
 | `usage` | object? | Token counts (optional; omitted when provider does not report usage) |
 
 ### 1.10 `error`


### PR DESCRIPTION
## #457 (engine half) — True-Continue

The per-turn `max_turns` cap exits via `finish_run_terminated`, which **hardcoded** `finish_reason = Length` for **all five** of its terminal callers (turn cap, hook stop, context ceiling, budget cap, no-progress loop). So a run that ran out of turns emitted `finish_reason: "length"` and the desktop showed the max_tokens UX ("use a bigger model") instead of offering **Continue**. (The `from_stop_reason` mapping the issue pointed at was never on this path — the emit site bypassed it.)

### Change
- **types:** add a distinct `FinishReason::MaxTurns` (serialized `"max_turns"`); map `StopReason::MaxTurns -> MaxTurns` in `from_stop_reason`.
- **engine:** `finish_run_terminated` now takes `finish_reason` from the caller, so **only** the max_turns exit emits `MaxTurns`; context-ceiling / budget-cap / loop-break keep `Length` (Continue would not help those — a naive one-liner would have mislabeled them).
- **acp:** `FinishReason::MaxTurns -> "max_turn_requests"` (in the ACP allowed set).
- **docs:** document `"max_turns"` in `json-stream-protocol.md`; hosts treat `finish_reason` as an open string.

The **desktop lane** owns the Continue affordance (tracked on #457). Engine issue: FerroxLabs/wayland#606.

### Verification
Full-workspace Hetzner gate green (fmt + clippy `-D warnings --all-targets` + nextest, 9654 passed; only the known `new_via_slash` flake fails). The `test_engine_max_turns_returns_ok` integration test now drives the **real production path** and asserts `finish_reason == MaxTurns`, guarding against the emit site regressing to a hardcoded value. Adversarially cross-audited — the audit caught that v1 was dead code (emit site bypassed the mapping); v2 fixes the actual emit site and locks reachability with the integration test.