### PR TITLE
fix(engine): retry-cap for consecutive tool failures + MCP isError propagation (#475)

### DIFF
--- a/crates/wcore-agent/src/engine.rs
+++ b/crates/wcore-agent/src/engine.rs
@@ -1104,6 +1104,145 @@ fn loop_call_signature(
     h.finish()
 }
 
+/// #475 — the *failure*-loop backstop that complements [`LoopGuard`].
+///
+/// `LoopGuard` keys on the full `(tool, args, result)` signature, so it only
+/// trips when a call repeats IDENTICALLY. A model that keeps calling the same
+/// tool with DIFFERENT (still-wrong) arguments — e.g. retrying a required-field
+/// validation error with a new guess each time — produces a fresh signature on
+/// every call and slips past `LoopGuard`, burning the turn's budget mid-thought
+/// (the #475 `start_google_auth(service_name)` case).
+///
+/// `FailureGuard` keys on the tool NAME alone and counts CONSECUTIVE error
+/// results (`is_error == true`) for the same tool, regardless of arguments. Any
+/// success — or a switch to a different tool — resets the streak, so productive
+/// work (which mixes in successes or moves between tools) is never cut. The
+/// threshold is read once per run from `WAYLAND_MAX_CONSECUTIVE_TOOL_FAILURES`
+/// (default 10); `0` disables the breaker.
+///
+/// Precedence (deterministic, NOT timing-dependent): the run loop checks the
+/// failure-break BEFORE the identical-signature loop-break, so `FailureGuard`
+/// OWNS failing loops — a failing loop always exits Continue-able
+/// (`finish_reason=max_turns`, #457). `LoopGuard` then handles only the
+/// identical-SUCCESS no-progress case (`FailureGuard` ignores successes).
+///
+/// Scope: the shell tool (`Bash`) is EXCLUDED at the observe site — its
+/// `is_error` is just a non-zero exit, so a legitimate coding burst (build,
+/// clippy, test all failing) must not be read as a stuck loop. Identical Bash
+/// retries are still caught by `LoopGuard`.
+struct FailureGuard {
+    last_failing_tool: Option<String>,
+    count: u32,
+    threshold: u32,
+}
+
+impl FailureGuard {
+    fn from_env() -> Self {
+        let threshold = std::env::var("WAYLAND_MAX_CONSECUTIVE_TOOL_FAILURES")
+            .ok()
+            .and_then(|v| v.trim().parse::<u32>().ok())
+            .unwrap_or(10);
+        Self {
+            last_failing_tool: None,
+            count: 0,
+            threshold,
+        }
+    }
+
+    /// Record one tool outcome. Returns `Some(count)` once the SAME tool has
+    /// returned an error `>= threshold` times in a row. A success — or a
+    /// different tool (whether it succeeds or fails) — resets the streak.
+    fn observe(&mut self, tool_name: &str, is_error: bool) -> Option<u32> {
+        if self.threshold == 0 {
+            return None;
+        }
+        if !is_error {
+            self.last_failing_tool = None;
+            self.count = 0;
+            return None;
+        }
+        if self.last_failing_tool.as_deref() == Some(tool_name) {
+            self.count = self.count.saturating_add(1);
+        } else {
+            self.last_failing_tool = Some(tool_name.to_string());
+            self.count = 1;
+        }
+        (self.count >= self.threshold).then_some(self.count)
+    }
+}
+
+#[cfg(test)]
+mod failure_guard_tests {
+    use super::FailureGuard;
+
+    fn guard(threshold: u32) -> FailureGuard {
+        FailureGuard {
+            last_failing_tool: None,
+            count: 0,
+            threshold,
+        }
+    }
+
+    #[test]
+    fn trips_on_consecutive_same_tool_failures() {
+        let mut g = guard(3);
+        assert_eq!(g.observe("start_google_auth", true), None, "1st");
+        assert_eq!(g.observe("start_google_auth", true), None, "2nd");
+        assert_eq!(
+            g.observe("start_google_auth", true),
+            Some(3),
+            "3rd consecutive failure of the same tool must trip"
+        );
+    }
+
+    #[test]
+    fn varied_args_still_accumulate() {
+        // #475: the model retries with different (still-wrong) args each time.
+        // FailureGuard ignores args, so the streak accumulates and trips where
+        // the signature-based LoopGuard never would.
+        let mut g = guard(3);
+        g.observe("start_google_auth", true);
+        g.observe("start_google_auth", true);
+        assert_eq!(g.observe("start_google_auth", true), Some(3));
+    }
+
+    #[test]
+    fn a_success_resets_the_streak() {
+        let mut g = guard(3);
+        g.observe("t", true);
+        g.observe("t", true);
+        assert_eq!(g.observe("t", false), None, "success resets");
+        assert_eq!(g.observe("t", true), None, "streak restarts at 1");
+        assert_eq!(g.observe("t", true), None);
+        assert_eq!(g.observe("t", true), Some(3));
+    }
+
+    #[test]
+    fn a_different_tool_resets_the_streak() {
+        let mut g = guard(3);
+        g.observe("a", true);
+        g.observe("a", true);
+        assert_eq!(g.observe("b", true), None, "different failing tool resets");
+        assert_eq!(g.observe("a", true), None, "back to a restarts at 1");
+    }
+
+    #[test]
+    fn threshold_zero_disables() {
+        let mut g = guard(0);
+        for _ in 0..100 {
+            assert_eq!(g.observe("t", true), None, "0 disables the breaker");
+        }
+    }
+
+    #[test]
+    fn successes_never_trip() {
+        let mut g = guard(2);
+        for _ in 0..100 {
+            assert_eq!(g.observe("t", false), None);
+        }
+    }
+}
+
 #[cfg(test)]
 mod loop_guard_tests {
     use super::{LoopGuard, loop_call_signature};
@@ -3763,11 +3902,13 @@ impl AgentEngine {
     /// existing "ran out of budget" verdict; `observe_*` maps it to `Failure`).
     ///
     /// #457: the host-facing `finish_reason` is passed IN by the caller, not
-    /// derived here, because the exits are NOT interchangeable — the `max_turns`
-    /// cap is `FinishReason::MaxTurns` (host offers "Continue"), while a context
-    /// ceiling / budget cap / loop-break stays `FinishReason::Length` (Continue
-    /// would not help). The distinct human-readable reason is surfaced via the
-    /// `emit_info`/`emit_error` call the caller makes before invoking this.
+    /// derived here, because the exits are NOT interchangeable — the budget
+    /// guardrails where "Continue" (resume with fresh headroom) is the right
+    /// affordance pass `FinishReason::MaxTurns`: the `max_turns` cap (#457) and
+    /// the per-tool failure cap (#475). A context ceiling / budget cap /
+    /// loop-break stays `FinishReason::Length` (Continue would not help). The
+    /// distinct human-readable reason is surfaced via the `emit_info`/
+    /// `emit_error` call the caller makes before invoking this.
     async fn finish_run_terminated(
         &mut self,
         user_input: &str,
@@ -4189,6 +4330,10 @@ impl AgentEngine {
         // no-progress loops that `max_turns = None` leaves unguarded. Terminates
         // the run if the same tool call keeps producing the same result.
         let mut loop_guard = LoopGuard::from_env();
+        // #475: complementary failure-loop breaker — trips when the SAME tool
+        // keeps failing with DIFFERENT (still-wrong) args, which LoopGuard's
+        // signature keying misses (a validation-error retry loop).
+        let mut failure_guard = FailureGuard::from_env();
         let mut turn: usize = 0;
         loop {
             // AUDIT A2 — cooperative cancellation check between turns.
@@ -5619,6 +5764,9 @@ impl AgentEngine {
             // Runaway-loop breaker: set to the offending (tool, repeat-count) the
             // first time a call+outcome signature trips the window threshold.
             let mut loop_break: Option<(String, u32)> = None;
+            // #475 failure-loop breaker: set to the offending (tool, failure-count)
+            // the first time a tool's consecutive-error streak trips the threshold.
+            let mut failure_break: Option<(String, u32)> = None;
             // Display tool results AND populate the matching ToolCallTrace.
             for result in &outcome.results {
                 if let ContentBlock::ToolResult {
@@ -5658,6 +5806,28 @@ impl AgentEngine {
                         if let Some(count) = loop_guard.observe(sig) {
                             loop_break = Some((tool_name.to_string(), count));
                         }
+                    }
+
+                    // #475: consecutive-failure breaker — keyed on tool name and
+                    // `is_error` only (args ignored), so a validation-error retry
+                    // loop that varies its arguments still accumulates. First trip
+                    // wins.
+                    //
+                    // Scope guard: the cap targets structured-tool retry loops
+                    // (e.g. an MCP tool the model keeps calling with wrong args).
+                    // It deliberately EXCLUDES the shell tool — `Bash` sets
+                    // is_error on any non-zero exit, so a legitimate coding burst
+                    // (build fail, clippy fail, test fail, grep no-match) is a
+                    // stream of same-tool failures that is NOT a stuck loop and
+                    // must not abort the run. Identical Bash retries are still
+                    // caught by LoopGuard above. Unresolved names ("unknown") are
+                    // skipped so two distinct tools can't merge into one streak.
+                    if failure_break.is_none()
+                        && tool_name != "Bash"
+                        && tool_name != "unknown"
+                        && let Some(count) = failure_guard.observe(tool_name, *is_error)
+                    {
+                        failure_break = Some((tool_name.to_string(), count));
                     }
 
                     self.output.emit_tool_result(tool_name, *is_error, content);
@@ -5743,12 +5913,46 @@ impl AgentEngine {
                 }
             }
 
+            // #475 failure-loop breaker tripped: the SAME tool has failed
+            // `count` times in a row (args ignored, so a validation-error retry
+            // loop that varies its arguments still accumulates). Checked BEFORE
+            // the identical-signature loop-break below so the failing-loop case
+            // is deterministically owned by the failure cap (independent of
+            // circuit-breaker timing): a failing loop always exits Continue-able
+            // (finish_reason=max_turns), while the loop-break handles only the
+            // identical-SUCCESS no-progress case. Mirrors the loop-break path
+            // (repair the now-unanswered tool_use blocks, emit a user-visible
+            // error, finish; tool results for this turn are not committed yet,
+            // hence `turn + 1`).
+            if let Some((failing_tool, count)) = failure_break {
+                self.repair_orphaned_tool_use();
+                self.output.emit_error(
+                    &format!(
+                        "Run stopped: the `{failing_tool}` tool failed {count} times in a \
+                         row. Retrying it with new guesses is burning the turn — check the \
+                         tool's required arguments (or its error message) and fix the call, \
+                         or try a different approach. (Tune or disable via \
+                         WAYLAND_MAX_CONSECUTIVE_TOOL_FAILURES.)"
+                    ),
+                    false,
+                );
+                // #475 + #457: the retry-cap is a budget guardrail, not a hard
+                // failure — surface finish_reason=max_turns so the host offers
+                // "Continue" (resume with fresh headroom) rather than a
+                // model-failure UX.
+                return self
+                    .finish_run_terminated(user_input, turn + 1, FinishReason::MaxTurns)
+                    .await;
+            }
+
             // Runaway-loop breaker tripped: the agent is repeating the same tool
-            // call to no effect. Stop the run cleanly with guidance instead of
-            // looping and burning tokens. Mirrors the budget-cap termination
-            // path: repair the assistant's now-unanswered tool_use blocks, emit a
-            // user-visible error, and finish (tool results for this turn were not
-            // committed to history yet, hence `turn + 1`).
+            // call to no effect (an identical (tool, args, result) signature —
+            // for failing loops the failure cap above fires first). Stop the run
+            // cleanly with guidance instead of looping and burning tokens.
+            // Mirrors the budget-cap termination path: repair the assistant's
+            // now-unanswered tool_use blocks, emit a user-visible error, and
+            // finish (tool results for this turn were not committed to history
+            // yet, hence `turn + 1`).
             if let Some((looping_tool, count)) = loop_break {
                 self.repair_orphaned_tool_use();
                 self.output.emit_error(

--- a/crates/wcore-agent/src/hooks/mcp_dispatcher.rs
+++ b/crates/wcore-agent/src/hooks/mcp_dispatcher.rs
@@ -196,7 +196,9 @@ impl McpToolCaller for McpManagerCaller {
         manager
             .call_tool(server, tool, serde_json::json!({}))
             .await
-            .map(cap_hook_response)
+            // Hooks consume the text only; the #475 is_error flag is not
+            // relevant to the hook-dispatch path.
+            .map(|outcome| cap_hook_response(outcome.text))
             .map_err(|e| e.to_string())
     }
 }

--- a/crates/wcore-agent/tests/runaway_loop_test.rs
+++ b/crates/wcore-agent/tests/runaway_loop_test.rs
@@ -44,9 +44,64 @@ fn loop_turn(i: usize) -> Vec<LlmEvent> {
 }
 
 #[tokio::test]
-async fn repeated_identical_tool_call_converges_via_breaker() {
-    // 30 identical tool-call turns queued; max_turns raised to 30 so the breaker
-    // (default threshold 10) is what stops the loop, not the turn cap.
+async fn repeated_identical_successful_tool_call_converges_via_loopguard() {
+    // Identical-SUCCESS no-progress loop: the model calls the same tool with the
+    // same args, getting the same NON-error result every turn. This is
+    // LoopGuard's domain — it keys on the full (tool, args, is_error, content)
+    // signature, so an identical successful call accumulates and trips at the
+    // threshold. (#475: the failing-loop case is now owned by FailureGuard —
+    // see `failing_tool_loop_converges_via_failure_cap_with_maxturns` below.)
+    // max_turns raised to 30 so the breaker (default 10), not the turn cap, is
+    // what stops it.
+    let turns: Vec<Vec<LlmEvent>> = (0..30).map(loop_turn).collect();
+    let provider = Arc::new(MockLlmProvider::with_turns(turns));
+
+    let mut registry = ToolRegistry::new();
+    registry.register(Box::new(MockTool::new(
+        "loop_tool",
+        "same result every time",
+        false, // identical SUCCESSFUL outcome — FailureGuard ignores successes
+    )));
+
+    let sink = Arc::new(TestSink::new());
+    let handle = sink.handle();
+    let output: Arc<dyn OutputSink> = sink;
+    let mut config = test_config();
+    config.max_turns = Some(30);
+
+    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output);
+    let result = engine
+        .run("do the thing", "")
+        .await
+        .expect("run completes (terminated cleanly, not Err)");
+
+    // LoopGuard (threshold 10) must stop the loop well before max_turns(30).
+    assert!(
+        result.turns < 30,
+        "LoopGuard must converge the identical-success loop before max_turns; turns = {}",
+        result.turns
+    );
+
+    // …and surface the no-progress-loop error (LoopGuard's message).
+    let events = handle.snapshot();
+    let saw_loop_error = events
+        .iter()
+        .any(|e| e["type"].as_str() == Some("error") && e.to_string().contains("no-progress loop"));
+    assert!(
+        saw_loop_error,
+        "expected a visible no-progress-loop error event; got {events:?}"
+    );
+}
+
+#[tokio::test]
+async fn failing_tool_loop_converges_via_failure_cap_with_maxturns() {
+    // #475: the model retries a tool that keeps FAILING (here identically, but
+    // FailureGuard is content-agnostic so varied-args validation-error loops
+    // converge the same way). FailureGuard supersedes LoopGuard here — it is
+    // immune to the tool-registry circuit breaker changing the error text after
+    // ~3 failures (which resets LoopGuard's content-keyed streak). It converges
+    // the loop before max_turns and, per #457, exits with finish_reason=max_turns
+    // so the host can offer "Continue" rather than a model-failure UX.
     let turns: Vec<Vec<LlmEvent>> = (0..30).map(loop_turn).collect();
     let provider = Arc::new(MockLlmProvider::with_turns(turns));
 
@@ -54,7 +109,7 @@ async fn repeated_identical_tool_call_converges_via_breaker() {
     registry.register(Box::new(MockTool::new(
         "loop_tool",
         "network is unreachable in this sandbox",
-        true, // identical failing outcome every call
+        true, // failing outcome every call
     )));
 
     let sink = Arc::new(TestSink::new());
@@ -69,22 +124,123 @@ async fn repeated_identical_tool_call_converges_via_breaker() {
         .await
         .expect("run completes (terminated cleanly, not Err)");
 
-    // The breaker (default threshold 10) must stop the loop well before
-    // max_turns(30) — proving it converged, not just hit the turn cap.
     assert!(
         result.turns < 30,
-        "runaway breaker must converge the loop before max_turns; turns = {}",
+        "the failure-cap must converge the failing loop before max_turns; turns = {}",
         result.turns
     );
 
-    // …and surface a clear, user-visible no-progress-loop error.
+    // #457 wiring: a retry-cap stop is Continue-able, not a hard failure.
+    assert_eq!(
+        result.finish_reason,
+        FinishReason::MaxTurns,
+        "the failure-cap exit must surface finish_reason=max_turns (Continue-able)"
+    );
+
+    // …and surface the failure-cap guidance (FailureGuard's message).
     let events = handle.snapshot();
-    let saw_loop_error = events
-        .iter()
-        .any(|e| e["type"].as_str() == Some("error") && e.to_string().contains("no-progress loop"));
+    let saw_failure_cap = events.iter().any(|e| {
+        e["type"].as_str() == Some("error") && e.to_string().contains("failed") && {
+            e.to_string().contains("times in a row")
+        }
+    });
     assert!(
-        saw_loop_error,
-        "expected a visible no-progress-loop error event; got {events:?}"
+        saw_failure_cap,
+        "expected a visible failure-cap error event; got {events:?}"
+    );
+}
+
+#[tokio::test]
+async fn varied_content_failing_loop_converges_via_failure_cap_only() {
+    // Isolation proof (audit follow-up): a tool that FAILS with DIFFERENT
+    // content every call. LoopGuard keys on (tool, args, content), so its
+    // signature changes every turn and it NEVER accumulates — the ONLY breaker
+    // that can converge this loop is FailureGuard (content-agnostic). Proves
+    // FailureGuard owns the failing loop DETERMINISTICALLY, independent of the
+    // circuit breaker or LoopGuard, and exits Continue-able (#457).
+    let turns: Vec<Vec<LlmEvent>> = (0..30).map(loop_turn).collect();
+    let provider = Arc::new(MockLlmProvider::with_turns(turns));
+
+    let mut registry = ToolRegistry::new();
+    registry.register(Box::new(FailingChangingTool::default()));
+
+    let sink = Arc::new(TestSink::new());
+    let handle = sink.handle();
+    let output: Arc<dyn OutputSink> = sink;
+    let mut config = test_config();
+    config.max_turns = Some(30);
+
+    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output);
+    let result = engine.run("keep trying", "").await.expect("run completes");
+
+    assert!(
+        result.turns < 30,
+        "FailureGuard must converge the varied-content failing loop; turns = {}",
+        result.turns
+    );
+    assert_eq!(
+        result.finish_reason,
+        FinishReason::MaxTurns,
+        "the failure-cap exit must be Continue-able (max_turns), not a hard error"
+    );
+    let events = handle.snapshot();
+    assert!(
+        events.iter().any(
+            |e| e["type"].as_str() == Some("error") && e.to_string().contains("times in a row")
+        ),
+        "expected the failure-cap message; got {events:?}"
+    );
+    // LoopGuard must NOT have fired (content varied every call).
+    assert!(
+        !events
+            .iter()
+            .any(|e| e.to_string().contains("no-progress loop")),
+        "LoopGuard must not fire when content varies; got {events:?}"
+    );
+}
+
+/// #475 no-regression: a tool that fails FEWER than the threshold (default 10)
+/// consecutive times must NOT trip the failure-cap — each error result still
+/// reaches the model and the run proceeds normally. Here 6 failing calls under
+/// max_turns=6 stop at the TURN CAP, not the failure-cap, proving a recoverable
+/// isError flow is not aborted mid-stream.
+#[tokio::test]
+async fn sub_threshold_failures_do_not_trip_failure_cap() {
+    let turns: Vec<Vec<LlmEvent>> = (0..6).map(loop_turn).collect();
+    let provider = Arc::new(MockLlmProvider::with_turns(turns));
+
+    let mut registry = ToolRegistry::new();
+    registry.register(Box::new(MockTool::new(
+        "loop_tool",
+        "transient error, retry",
+        true, // failing, but only 6 times — below the default cap of 10
+    )));
+
+    let sink = Arc::new(TestSink::new());
+    let handle = sink.handle();
+    let output: Arc<dyn OutputSink> = sink;
+    let mut config = test_config();
+    config.max_turns = Some(6);
+
+    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output);
+    let result = engine.run("try it", "").await.expect("run completes");
+
+    assert_eq!(
+        result.turns, 6,
+        "run must reach the turn cap, not be cut early"
+    );
+    let events = handle.snapshot();
+    // The stop is the max_turns cap, NOT the failure-cap.
+    assert!(
+        events.iter().any(|e| e["type"].as_str() == Some("info")
+            && e.to_string().contains("reached the configured max_turns")),
+        "expected the max_turns stop, got {events:?}"
+    );
+    assert!(
+        !events
+            .iter()
+            .any(|e| e.to_string().contains("times in a row")),
+        "the failure-cap must NOT fire below its threshold; got {events:?}"
     );
 }
 
@@ -152,6 +308,40 @@ impl wcore_tools::Tool for ChangingTool {
         wcore_types::tool::ToolResult {
             content: format!("progress step {n}"),
             is_error: false,
+        }
+    }
+}
+
+/// A tool that FAILS with a different result on each call — isolates
+/// FailureGuard, since LoopGuard's content-keyed signature never accumulates.
+#[derive(Default)]
+struct FailingChangingTool {
+    calls: std::sync::Mutex<u32>,
+}
+
+#[async_trait::async_trait]
+impl wcore_tools::Tool for FailingChangingTool {
+    fn name(&self) -> &str {
+        "loop_tool"
+    }
+    fn description(&self) -> &str {
+        "Fails with a different message each call"
+    }
+    fn input_schema(&self) -> serde_json::Value {
+        json!({ "type": "object" })
+    }
+    fn category(&self) -> wcore_protocol::events::ToolCategory {
+        wcore_protocol::events::ToolCategory::Info
+    }
+    fn is_concurrency_safe(&self, _input: &serde_json::Value) -> bool {
+        true
+    }
+    async fn execute(&self, _input: serde_json::Value) -> wcore_types::tool::ToolResult {
+        let mut n = self.calls.lock().unwrap();
+        *n += 1;
+        wcore_types::tool::ToolResult {
+            content: format!("distinct failure {n}"),
+            is_error: true,
         }
     }
 }

--- a/crates/wcore-mcp/src/manager.rs
+++ b/crates/wcore-mcp/src/manager.rs
@@ -69,6 +69,20 @@ enum ConnectOutcome {
     TimedOut(Duration),
 }
 
+/// Outcome of a transport-successful MCP tool call ([`McpManager::call_tool`]).
+///
+/// `text` is the concatenated content; `is_error` carries the MCP `isError`
+/// flag. A tool-level failure (argument validation, an API error the tool
+/// surfaces) is a SUCCESSFUL call with `is_error == true`, distinct from a
+/// transport `Err`. Callers must inspect `is_error`, not just `Ok`/`Err`, so an
+/// MCP tool failure is not mistaken for success (#475). The `text` still carries
+/// the tool's error message so the model can read it and recover.
+#[derive(Debug, Clone)]
+pub struct McpCallOutcome {
+    pub text: String,
+    pub is_error: bool,
+}
+
 /// Manages connections to multiple MCP servers
 pub struct McpManager {
     servers: HashMap<String, McpServer>,
@@ -348,13 +362,19 @@ impl McpManager {
             .unwrap_or(false)
     }
 
-    /// Execute a tool on a specific server
+    /// Execute a tool on a specific server.
+    ///
+    /// Returns [`McpCallOutcome`] on a transport-successful call: `text` is the
+    /// concatenated content, `is_error` is the MCP `isError` flag. A tool-level
+    /// failure (e.g. argument validation) is a SUCCESSFUL call with
+    /// `is_error == true` — NOT a transport `Err` — so callers must inspect the
+    /// flag, not just the `Ok`/`Err` split (#475).
     pub async fn call_tool(
         &self,
         server_name: &str,
         tool_name: &str,
         arguments: serde_json::Value,
-    ) -> Result<String, McpError> {
+    ) -> Result<McpCallOutcome, McpError> {
         let server = self
             .servers
             .get(server_name)
@@ -401,7 +421,10 @@ impl McpManager {
             }
         }
 
-        Ok(text_parts.join("\n"))
+        Ok(McpCallOutcome {
+            text: text_parts.join("\n"),
+            is_error: tool_result.is_error,
+        })
     }
 
     /// Get names of all connected servers.

--- a/crates/wcore-mcp/src/protocol.rs
+++ b/crates/wcore-mcp/src/protocol.rs
@@ -63,6 +63,14 @@ pub struct McpToolDef {
 #[derive(Debug, Deserialize)]
 pub struct McpToolResult {
     pub content: Vec<McpContent>,
+    /// MCP `isError` flag (spec: optional; absent = false). Per the MCP spec a
+    /// tool that FAILS — including argument-validation failures the tool itself
+    /// performs — reports it as a result with `isError: true`, NOT a JSON-RPC
+    /// error. Dropping it made every MCP tool failure look like success to the
+    /// agent (the retry-cap guard, the UI error badge, the model's error
+    /// signal) — see #475.
+    #[serde(default, rename = "isError")]
+    pub is_error: bool,
 }
 
 /// Content types returned by MCP tool calls
@@ -239,6 +247,24 @@ mod tests {
             McpContent::Text { text } => assert_eq!(text, "hello world"),
             other => panic!("expected McpContent::Text, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn mcp_tool_result_carries_is_error_flag() {
+        // #475: per the MCP spec a tool-level failure is a SUCCESSFUL call whose
+        // result carries `isError: true` (not a JSON-RPC error). We must not
+        // drop it — that made every MCP tool failure look like success.
+        let failed: McpToolResult = serde_json::from_str(
+            r#"{"content":[{"type":"text","text":"missing required arg: service_name"}],"isError":true}"#,
+        )
+        .unwrap();
+        assert!(failed.is_error, "isError:true must deserialize to is_error");
+        assert_eq!(failed.content.len(), 1, "content must still be captured");
+
+        // Absent `isError` defaults to false — a normal successful result.
+        let ok: McpToolResult =
+            serde_json::from_str(r#"{"content":[{"type":"text","text":"ok"}]}"#).unwrap();
+        assert!(!ok.is_error, "absent isError must default to false");
     }
 
     #[test]

--- a/crates/wcore-mcp/src/tool_proxy.rs
+++ b/crates/wcore-mcp/src/tool_proxy.rs
@@ -79,9 +79,15 @@ impl Tool for McpToolProxy {
             .call_tool(&self.server_name, &self.tool_name, input)
             .await
         {
-            Ok(content) => ToolResult {
-                content,
-                is_error: false,
+            // #475: a transport-successful call may still be a tool-level
+            // failure (MCP `isError: true`). Surface that as `is_error` so the
+            // agent (retry-cap guard, UI badge, model error signal) sees it —
+            // the `content` still carries the tool's error text so the model can
+            // read it and recover. A single failure never aborts; it is just a
+            // normal error result.
+            Ok(outcome) => ToolResult {
+                content: outcome.text,
+                is_error: outcome.is_error,
             },
             Err(e) => ToolResult {
                 content: format!("MCP tool error: {}", e),

--- a/crates/wcore-mcp/tests/mcp_html_content_e2e.rs
+++ b/crates/wcore-mcp/tests/mcp_html_content_e2e.rs
@@ -113,11 +113,11 @@ async fn mcp_tool_html_content_flows_back_through_call_tool() {
 
     // HTML content flows back through McpManager unchanged.
     assert!(
-        result.contains("Example Domain"),
+        result.text.contains("Example Domain"),
         "HTML title must be present in result; got: {result:?}"
     );
     assert!(
-        result.contains("illustrative examples"),
+        result.text.contains("illustrative examples"),
         "HTML body must be present in result; got: {result:?}"
     );
 }

--- a/crates/wcore-mcp/tests/mcp_integration.rs
+++ b/crates/wcore-mcp/tests/mcp_integration.rs
@@ -281,7 +281,11 @@ async fn call_tool_round_trip_returns_text_content() {
         .await
         .unwrap();
 
-    assert_eq!(result, "hello from mock");
+    assert_eq!(result.text, "hello from mock");
+    assert!(
+        !result.is_error,
+        "a normal result must not be flagged is_error"
+    );
 }
 
 #[tokio::test]
@@ -299,7 +303,7 @@ async fn call_tool_image_content_produces_bracketed_label() {
     let manager = McpManager::new_for_test_with_tools(entries);
 
     let result = manager.call_tool("srv", "snap", json!({})).await.unwrap();
-    assert_eq!(result, "[image: image/png]");
+    assert_eq!(result.text, "[image: image/png]");
 }
 
 #[tokio::test]
@@ -320,7 +324,7 @@ async fn call_tool_mixed_content_joins_with_newline() {
     let manager = McpManager::new_for_test_with_tools(entries);
 
     let result = manager.call_tool("srv", "multi", json!({})).await.unwrap();
-    assert_eq!(result, "line1\nline2");
+    assert_eq!(result.text, "line1\nline2");
 }
 
 // ---------------------------------------------------------------------------
@@ -361,8 +365,8 @@ async fn concurrent_calls_to_different_servers_return_correct_results() {
         tokio::spawn(async move { m2.call_tool("slow", "t", json!({})).await }),
     );
 
-    assert_eq!(r1.unwrap().unwrap(), "fast-result");
-    assert_eq!(r2.unwrap().unwrap(), "slow-result");
+    assert_eq!(r1.unwrap().unwrap().text, "fast-result");
+    assert_eq!(r2.unwrap().unwrap().text, "slow-result");
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## #475 — retry-cap so a bad tool call can't exhaust the turn (Overwatch-approved)

A model that keeps calling a tool that keeps FAILING with different wrong args (e.g. `start_google_auth` without its required `service_name`) produces a fresh signature every call, slips past the signature-based LoopGuard, and burns the turn's budget mid-thought.

### Two parts
1. **MCP `isError` propagation (the enabling fix).** `McpToolResult` never deserialized the MCP `isError` flag; `call_tool` returned `Ok(text)` for any JSON-RPC-success; `tool_proxy` hardcoded `is_error=false` — so **every** MCP tool-level failure looked like success to the agent, the UI error badge, and the model's error signal. Now: `McpToolResult` carries `is_error`; `call_tool` returns `McpCallOutcome{text,is_error}`; `tool_proxy` surfaces it (content still carries the error text so the model recovers). A JSON-RPC error still maps to `is_error=true` too.
2. **FailureGuard:** a per-run breaker keyed on tool-name + `is_error` (args ignored), counting CONSECUTIVE same-tool failures, stopping with guidance at the threshold. `WAYLAND_MAX_CONSECUTIVE_TOOL_FAILURES` (default 10); 0 disables.

### Guardrails (per Overwatch ruling)
- A single/recoverable `isError` **never** aborts — it reaches the model as a normal error result; the guard trips only at the consecutive threshold.
- The failure-break is checked **before** the loop-break, so a failing loop is **deterministically** owned by the cap and exits **Continue-able** (`finish_reason=max_turns`, #457) — not dependent on circuit-breaker timing. LoopGuard owns only identical-**success** no-progress loops.
- The shell tool (**Bash**) is **excluded**: its `is_error` is just a non-zero exit, so a legit coding burst (build/clippy/test failing) is not read as a stuck loop. Identical Bash retries are still caught by LoopGuard.

### Verification (green CI was explicitly not sufficient)
- Full-workspace Hetzner gate green (fmt + clippy `-D warnings --all-targets` + nextest, 9668 passed).
- **Adversarial full-MCP-path cross-audit** → found + fixed 2 defects (Bash false-abort; timing-dependent supersede) now covered by an isolated deterministic test.
- **Live E2E on Hetzner** against a real stdio MCP server + live model: `isError:true` → `ToolResult.is_error=true` over real JSON-RPC, error text reached the model; and with a low threshold the cap tripped with `finish_reason=max_turns` — both confirmed live.

Tests: FailureGuard state machine; MCP `isError` deserialization; failing-loop → cap + max_turns; varied-content failing loop converges via FailureGuard **alone** (no breaker coupling); identical-success → LoopGuard; sub-threshold → no trip (no regression).