### PR TITLE
feat(mcp): per-assistant scoping for config MCP servers (#111)

### DIFF
--- a/crates/wcore-agent/src/bootstrap.rs
+++ b/crates/wcore-agent/src/bootstrap.rs
@@ -180,6 +180,12 @@ pub struct AgentBootstrap {
     /// local shells whose connects are bounded and cheap. Default `false`
     /// keeps TUI/one-shot behavior unchanged.
     defer_config_mcp: bool,
+    /// #111 — the host-supplied active assistant identity for per-assistant MCP
+    /// scoping. `None` (the default, and always the case for a bare CLI/TUI
+    /// session) means no assistant is identified, so any config MCP server
+    /// marked `only_for_assistant` is EXCLUDED (fail-closed). The json-stream
+    /// host (desktop) threads the active assistant here via `--assistant`.
+    active_assistant: Option<String>,
 }
 
 impl AgentBootstrap {
@@ -197,7 +203,18 @@ impl AgentBootstrap {
             enable_inbound_dispatch: false,
             channel_tool_posture: None,
             defer_config_mcp: false,
+            active_assistant: None,
         }
+    }
+
+    /// #111 — set the host-supplied active assistant for per-assistant MCP
+    /// scoping. Config MCP servers marked `only_for_assistant` are injected
+    /// only when this matches their allow-list (fail-closed otherwise). This is
+    /// a DEDICATED identity, distinct from the `--agent` persona (system-prompt
+    /// pack): do not conflate them.
+    pub fn active_assistant(mut self, v: Option<String>) -> Self {
+        self.active_assistant = v;
+        self
     }
 
     /// wayland#551 — defer config-declared MCP connects out of `build()`.
@@ -1025,7 +1042,17 @@ impl AgentBootstrap {
         // wayland#551 — when the caller deferred config MCP, skip the
         // connect entirely; the caller connects in the background after
         // boot so a slow/hung server cannot gate the host's ready frame.
-        let mcp_manager = if !self.config.mcp.servers.is_empty() && !self.defer_config_mcp {
+        // #111 — per-assistant MCP scoping. Filter the config-declared servers
+        // to those visible to the host-supplied active assistant BEFORE any
+        // connect/register, so a server marked `only_for_assistant` is never
+        // injected into a non-matching (or unidentified) session. This is the
+        // NON-deferred choke point; the CLI applies the same filter to the #551
+        // deferred-connect path (both read `config.mcp.servers`).
+        let scoped_servers = self
+            .config
+            .mcp
+            .servers_for_assistant(self.active_assistant.as_deref());
+        let mcp_manager = if !scoped_servers.is_empty() && !self.defer_config_mcp {
             // Slice 3, Piece 2 — resolve any `${cred:KEY}` header references
             // against the credentials store at the connect boundary, on a clone.
             // The long-lived `self.config` keeps the literal `${cred:...}` so the
@@ -1034,10 +1061,10 @@ impl AgentBootstrap {
             // fails its own connect, in isolation).
             let resolved_servers = match self.config.open_credentials_store() {
                 Ok(store) => wcore_config::mcp_cred_refs::resolve_servers_for_connect(
-                    &self.config.mcp.servers,
+                    &scoped_servers,
                     &*store,
                 ),
-                Err(_) => self.config.mcp.servers.clone(),
+                Err(_) => scoped_servers.clone(),
             };
             match McpManager::connect_all(&resolved_servers).await {
                 Ok(mgr) => {

--- a/crates/wcore-agent/src/plugins/mcp_delivery.rs
+++ b/crates/wcore-agent/src/plugins/mcp_delivery.rs
@@ -53,6 +53,7 @@ pub fn translate_mcp_server_spec(spec: &McpServerSpec) -> McpServerConfig {
             headers: None,
             deferred: None,
             allow_local: false,
+            only_for_assistant: None,
         },
         McpTransport::Sse { url } => McpServerConfig {
             transport: TransportType::Sse,
@@ -63,6 +64,7 @@ pub fn translate_mcp_server_spec(spec: &McpServerSpec) -> McpServerConfig {
             headers: None,
             deferred: None,
             allow_local: false,
+            only_for_assistant: None,
         },
         McpTransport::Http { url } => McpServerConfig {
             transport: TransportType::StreamableHttp,
@@ -73,6 +75,7 @@ pub fn translate_mcp_server_spec(spec: &McpServerSpec) -> McpServerConfig {
             headers: None,
             deferred: None,
             allow_local: false,
+            only_for_assistant: None,
         },
     }
 }

--- a/crates/wcore-agent/tests/bootstrap_test.rs
+++ b/crates/wcore-agent/tests/bootstrap_test.rs
@@ -396,6 +396,87 @@ async fn bootstrap_no_mcp_when_no_servers() {
 /// connect entirely: build() returns without dialing (the configured
 /// server here would hang the full 30s per-server budget if dialed —
 /// the exact stall that blew hosts' 30s ready timeout), registers no
+/// #111 — a config MCP server marked `only_for_assistant` must be injected
+/// ONLY for a matching active assistant. Overwatch #613 requires proving a
+/// non-Concierge (or unidentified) session does NOT receive the scoped server
+/// while a Concierge session DOES. The server command exits immediately, so a
+/// DIALED server still yields a manager (connect_all is non-fatal per-server);
+/// a FILTERED server is never dialed, so `has_mcp` stays false.
+#[tokio::test]
+#[serial]
+async fn bootstrap_scopes_marked_mcp_server_to_matching_assistant() {
+    use wcore_config::config::{McpServerConfig, TransportType};
+
+    let (_plugins, _env) = isolated_plugins();
+    let scoped_config = || {
+        let mut config = minimal_config();
+        config.mcp.servers.insert(
+            "diag".into(),
+            McpServerConfig {
+                transport: TransportType::Stdio,
+                command: Some("sleep".into()),
+                args: Some(vec!["0".into()]), // exits immediately → fast connect
+                env: None,
+                url: None,
+                headers: None,
+                deferred: None,
+                allow_local: false,
+                only_for_assistant: Some(vec!["concierge".into()]),
+            },
+        );
+        config
+    };
+    let workdir = tempfile::TempDir::new().expect("workdir");
+
+    // Unidentified session (fail-closed): the marked server is filtered out and
+    // never dialed.
+    let excluded = AgentBootstrap::new(
+        scoped_config(),
+        workdir.path().to_str().unwrap(),
+        null_output(),
+    )
+    .active_assistant(None)
+    .build()
+    .await
+    .unwrap();
+    assert!(
+        !excluded.has_mcp,
+        "a scoped server must NOT reach an unidentified session (fail-closed)"
+    );
+    assert!(excluded.mcp_managers.is_empty());
+
+    // Non-matching assistant: also filtered out.
+    let wrong = AgentBootstrap::new(
+        scoped_config(),
+        workdir.path().to_str().unwrap(),
+        null_output(),
+    )
+    .active_assistant(Some("default".into()))
+    .build()
+    .await
+    .unwrap();
+    assert!(
+        !wrong.has_mcp,
+        "a scoped server must NOT reach a non-matching assistant"
+    );
+
+    // Concierge session: the scoped server IS in the dialed set.
+    let included = AgentBootstrap::new(
+        scoped_config(),
+        workdir.path().to_str().unwrap(),
+        null_output(),
+    )
+    .active_assistant(Some("concierge".into()))
+    .build()
+    .await
+    .unwrap();
+    assert!(
+        included.has_mcp,
+        "the Concierge session MUST receive its scoped server"
+    );
+    assert!(!included.mcp_managers.is_empty());
+}
+
 /// MCP tools, and reports has_mcp=false (the caller advertises MCP
 /// capability itself for declared-but-deferred servers).
 #[tokio::test]
@@ -418,6 +499,7 @@ async fn bootstrap_defer_config_mcp_skips_connect() {
             headers: None,
             deferred: None,
             allow_local: false,
+            only_for_assistant: None,
         },
     );
     let workdir = tempfile::TempDir::new().expect("workdir");

--- a/crates/wcore-cli/src/doctor/mod.rs
+++ b/crates/wcore-cli/src/doctor/mod.rs
@@ -455,6 +455,14 @@ async fn print_mcp_section(probe: bool) {
         println!("Probing config-declared MCP servers (connect-test)...");
         match wcore_config::config::Config::resolve(&wcore_config::config::CliArgs::default()) {
             Ok(cfg) if !cfg.mcp.servers.is_empty() => {
+                // #111 note: this deliberately connect-tests ALL config servers,
+                // INCLUDING any marked `only_for_assistant` — the per-assistant
+                // scoping filter (`servers_for_assistant`) is intentionally NOT
+                // applied here. This is a throwaway diagnostic manager for the
+                // trusted local operator: its tools are never injected into any
+                // agent tool set or exposed to a model, and it is dropped at the
+                // end of this block. If this manager is ever wired into an agent,
+                // it MUST be filtered by the active assistant first.
                 match wcore_mcp::manager::McpManager::connect_all(&cfg.mcp.servers).await {
                     Ok(mgr) => {
                         let mut names: Vec<&String> = mgr.health().keys().collect();

--- a/crates/wcore-cli/src/main.rs
+++ b/crates/wcore-cli/src/main.rs
@@ -225,6 +225,14 @@ struct Cli {
     #[arg(long, value_name = "NAME")]
     agent: Option<String>,
 
+    /// #111 — the host's active assistant identity, for per-assistant MCP
+    /// scoping. A config MCP server marked `only_for_assistant` is injected
+    /// only when this matches its allow-list (fail-closed otherwise). Distinct
+    /// from `--agent` (persona/system-prompt); the desktop host sets this when
+    /// spawning the json-stream engine.
+    #[arg(long, value_name = "NAME", env = "WAYLAND_ASSISTANT")]
+    assistant: Option<String>,
+
     /// List built-in agent personas and exit.
     #[arg(long)]
     list_agents: bool,
@@ -1463,7 +1471,15 @@ async fn run() -> anyhow::Result<ExitCode> {
 
     // Branch to JSON stream mode
     if cli.json_stream {
-        run_json_stream_mode(config, &cwd, resume, cli.session_id, cli.force).await?;
+        run_json_stream_mode(
+            config,
+            &cwd,
+            resume,
+            cli.session_id,
+            cli.force,
+            cli.assistant.clone(),
+        )
+        .await?;
         return Ok(ExitCode::SUCCESS);
     }
 
@@ -2517,6 +2533,7 @@ fn to_mcp_server_config(
         headers,
         deferred: Some(false),
         allow_local: false,
+        only_for_assistant: None,
     })
 }
 
@@ -2659,6 +2676,7 @@ async fn run_json_stream_mode(
     resume: Option<String>,
     session_id: Option<String>,
     force: bool,
+    assistant: Option<String>,
 ) -> anyhow::Result<()> {
     let writer = Arc::new(ProtocolWriter::new());
 
@@ -2720,15 +2738,20 @@ async fn run_json_stream_mode(
     // skip them, and dial them in the background right after ready goes out.
     // Resolution happens here on a clone, mirroring bootstrap's own connect
     // boundary: the long-lived config keeps the literal `${cred:...}`.
-    let deferred_mcp_servers = if config.mcp.servers.is_empty() {
+    // #111 — apply per-assistant MCP scoping to the DEFERRED path too (the
+    // second injection choke point per the #613 completeness guardrail): a
+    // server marked `only_for_assistant` must not be background-connected for a
+    // non-matching assistant. Fail-closed when `assistant` is None.
+    let scoped_config_servers = config.mcp.servers_for_assistant(assistant.as_deref());
+    let deferred_mcp_servers = if scoped_config_servers.is_empty() {
         None
     } else {
         Some(match config.open_credentials_store() {
             Ok(store) => wcore_config::mcp_cred_refs::resolve_servers_for_connect(
-                &config.mcp.servers,
+                &scoped_config_servers,
                 &*store,
             ),
-            Err(_) => config.mcp.servers.clone(),
+            Err(_) => scoped_config_servers,
         })
     };
 
@@ -2739,6 +2762,7 @@ async fn run_json_stream_mode(
     let mut bootstrap = AgentBootstrap::new(config, cwd, output.clone())
         .plugin_provider_router(make_plugin_provider_router())
         .enable_inbound_dispatch(true)
+        .active_assistant(assistant.clone())
         .defer_config_mcp(deferred_mcp_servers.is_some());
 
     if let Some(resume_id) = &resume {

--- a/crates/wcore-cli/src/tui/engine_bridge.rs
+++ b/crates/wcore-cli/src/tui/engine_bridge.rs
@@ -706,6 +706,7 @@ fn mcp_config_from_target(target: &str) -> Result<wcore_config::config::McpServe
             headers: None,
             deferred: Some(false),
             allow_local: false,
+            only_for_assistant: None,
         });
     }
     let mut parts = target.split_whitespace();
@@ -724,6 +725,7 @@ fn mcp_config_from_target(target: &str) -> Result<wcore_config::config::McpServe
         headers: None,
         deferred: Some(false),
         allow_local: false,
+        only_for_assistant: None,
     })
 }
 

--- a/crates/wcore-config/src/config.rs
+++ b/crates/wcore-config/src/config.rs
@@ -125,6 +125,33 @@ pub struct McpServerConfig {
     /// enabled. No effect on stdio transport.
     #[serde(default)]
     pub allow_local: bool,
+    /// #111 — per-assistant scoping allow-list. `None`/empty ⇒ the server is
+    /// GLOBAL, available to every session (today's behavior). `Some([...])` ⇒
+    /// the server is injected ONLY when the host-supplied active assistant
+    /// matches one of these names. Used to gate a read-only Concierge diag MCP
+    /// to the Concierge assistant on the engine leg. FAIL-CLOSED: a marked
+    /// server is excluded when the active assistant is unknown/unset (see
+    /// [`McpServerConfig::is_visible_to_assistant`]).
+    #[serde(default)]
+    pub only_for_assistant: Option<Vec<String>>,
+}
+
+impl McpServerConfig {
+    /// #111 — is this server visible to the given `active` assistant?
+    ///
+    /// - `only_for_assistant` unset or empty ⇒ GLOBAL, always visible.
+    /// - marked ⇒ visible ONLY when `active` is `Some(a)` and `a` is in the
+    ///   allow-list. FAIL-CLOSED: an unknown/unset active assistant (`None`) or
+    ///   a non-matching one does NOT see a marked server — a scoped diag server
+    ///   must never leak to a bare CLI or an unidentified session (Overwatch
+    ///   ruling on FerroxLabs/wayland#613).
+    pub fn is_visible_to_assistant(&self, active: Option<&str>) -> bool {
+        match self.only_for_assistant.as_deref() {
+            // Unset or empty allow-list ⇒ global.
+            None | Some([]) => true,
+            Some(list) => active.is_some_and(|a| list.iter().any(|name| name == a)),
+        }
+    }
 }
 
 /// Collection of MCP server configurations
@@ -138,6 +165,23 @@ pub struct McpConfig {
     /// `wcore_agent::mcp_curator::McpCurator`. Default `TopK(15)`.
     #[serde(default)]
     pub curation: McpCurationPolicy,
+}
+
+impl McpConfig {
+    /// #111 — the subset of configured servers visible to the given `active`
+    /// assistant. Unmarked servers are always kept; a server marked
+    /// `only_for_assistant` is kept only when `active` matches its allow-list
+    /// (fail-closed for `None`/unknown). Callers MUST apply this at EVERY path
+    /// that injects config-declared MCP servers into an agent (the bootstrap
+    /// connect_all/register choke point AND the #551 deferred-connect path) so
+    /// a scoped server cannot slip through an unfiltered path.
+    pub fn servers_for_assistant(&self, active: Option<&str>) -> HashMap<String, McpServerConfig> {
+        self.servers
+            .iter()
+            .filter(|(_, cfg)| cfg.is_visible_to_assistant(active))
+            .map(|(name, cfg)| (name.clone(), cfg.clone()))
+            .collect()
+    }
 }
 
 /// W6 F17 — MCP tool curation policy. Selected at config-load time; consumed
@@ -3791,6 +3835,88 @@ max_sessions = 20                # auto-cleanup oldest
 mod tests {
     use super::*;
     use wcore_types::model_aliases::OPENAI_GPT4O;
+
+    // -------------------------------------------------------------------------
+    // #111 — per-assistant MCP scoping
+    // -------------------------------------------------------------------------
+
+    fn mcp_server(only_for: Option<Vec<String>>) -> McpServerConfig {
+        McpServerConfig {
+            transport: TransportType::Stdio,
+            command: Some("echo".into()),
+            args: None,
+            env: None,
+            url: None,
+            headers: None,
+            deferred: None,
+            allow_local: false,
+            only_for_assistant: only_for,
+        }
+    }
+
+    #[test]
+    fn unmarked_server_is_visible_to_everyone() {
+        let s = mcp_server(None);
+        assert!(s.is_visible_to_assistant(None), "unmarked = global");
+        assert!(s.is_visible_to_assistant(Some("concierge")));
+        // empty allow-list also means global
+        assert!(mcp_server(Some(vec![])).is_visible_to_assistant(None));
+    }
+
+    #[test]
+    fn marked_server_is_fail_closed() {
+        let s = mcp_server(Some(vec!["concierge".into()]));
+        // FAIL-CLOSED: excluded for None/unknown/non-matching (#613 ruling).
+        assert!(
+            !s.is_visible_to_assistant(None),
+            "marked server must NOT leak to an unidentified session"
+        );
+        assert!(
+            !s.is_visible_to_assistant(Some("default")),
+            "marked server must NOT show for a non-matching assistant"
+        );
+        // Visible only for an exact allow-list match.
+        assert!(s.is_visible_to_assistant(Some("concierge")));
+    }
+
+    #[test]
+    fn servers_for_assistant_filters_by_allow_list() {
+        let mut cfg = McpConfig::default();
+        cfg.servers.insert("global".into(), mcp_server(None));
+        cfg.servers
+            .insert("diag".into(), mcp_server(Some(vec!["concierge".into()])));
+
+        // Concierge sees both.
+        let for_concierge = cfg.servers_for_assistant(Some("concierge"));
+        assert!(for_concierge.contains_key("global"));
+        assert!(for_concierge.contains_key("diag"));
+
+        // A non-Concierge assistant sees only the global one.
+        let for_default = cfg.servers_for_assistant(Some("default"));
+        assert!(for_default.contains_key("global"));
+        assert!(
+            !for_default.contains_key("diag"),
+            "scoped server must be filtered out"
+        );
+
+        // A bare session (None) also only sees the global one (fail-closed).
+        let for_none = cfg.servers_for_assistant(None);
+        assert!(for_none.contains_key("global"));
+        assert!(!for_none.contains_key("diag"));
+    }
+
+    #[test]
+    fn only_for_assistant_defaults_to_none_when_absent() {
+        // Back-compat: a config with no `only_for_assistant` key deserializes
+        // to None (global). Uses the TOML shape a user/desktop would write.
+        let toml = r#"
+            transport = "stdio"
+            command = "echo"
+        "#;
+        let s: McpServerConfig = toml::from_str(toml).unwrap();
+        assert!(s.only_for_assistant.is_none());
+        assert!(s.is_visible_to_assistant(None));
+    }
 
     // -------------------------------------------------------------------------
     // parse_builtin_provider tests

--- a/crates/wcore-config/src/mcp_cred_refs.rs
+++ b/crates/wcore-config/src/mcp_cred_refs.rs
@@ -59,6 +59,7 @@ pub fn build_forge_mcp_server_config(url: &str, cred_key: &str) -> McpServerConf
         headers: Some(headers),
         deferred: None,
         allow_local: true,
+        only_for_assistant: None,
     }
 }
 
@@ -193,6 +194,7 @@ mod tests {
             headers: Some(headers),
             deferred: None,
             allow_local: true,
+            only_for_assistant: None,
         }
     }
 

--- a/crates/wcore-mcp/src/manager.rs
+++ b/crates/wcore-mcp/src/manager.rs
@@ -956,6 +956,7 @@ mod tests {
             headers: None,
             deferred: None,
             allow_local: false,
+            only_for_assistant: None,
         };
         let mut configs = HashMap::new();
         configs.insert("hung-server".to_string(), hung);
@@ -994,6 +995,7 @@ mod tests {
             headers: None,
             deferred: None,
             allow_local: false,
+            only_for_assistant: None,
         };
         // A real MCP handshake fixture: answer initialize + tools/list.
         let healthy_script = r#"
@@ -1013,6 +1015,7 @@ mod tests {
             headers: None,
             deferred: None,
             allow_local: false,
+            only_for_assistant: None,
         };
         let mut configs = HashMap::new();
         configs.insert("hung".to_string(), hung);
@@ -1047,6 +1050,7 @@ mod tests {
             headers: None,
             deferred: None,
             allow_local: false,
+            only_for_assistant: None,
         };
         let mut configs = HashMap::new();
         configs.insert("hung".to_string(), hung);
@@ -1081,6 +1085,7 @@ mod tests {
             headers: None,
             deferred: None,
             allow_local: false,
+            only_for_assistant: None,
         };
         let mut configs = HashMap::new();
         configs.insert("broken".to_string(), broken);
@@ -1122,6 +1127,7 @@ mod tests {
             headers: None,
             deferred: None,
             allow_local: false,
+            only_for_assistant: None,
         };
         let hung = McpServerConfig {
             transport: TransportType::Stdio,
@@ -1132,6 +1138,7 @@ mod tests {
             headers: None,
             deferred: None,
             allow_local: false,
+            only_for_assistant: None,
         };
         let mut configs = HashMap::new();
         configs.insert("healthy".to_string(), healthy);

--- a/crates/wcore-mcp/src/tool_proxy.rs
+++ b/crates/wcore-mcp/src/tool_proxy.rs
@@ -334,6 +334,7 @@ mod tests {
             headers: None,
             deferred,
             allow_local: false,
+            only_for_assistant: None,
         }
     }
 

--- a/crates/wcore-mcp/tests/mcp_integration.rs
+++ b/crates/wcore-mcp/tests/mcp_integration.rs
@@ -197,6 +197,7 @@ async fn handshake_success_discovers_tools() {
             headers: None,
             deferred: None,
             allow_local: false,
+            only_for_assistant: None,
         },
     );
 
@@ -247,6 +248,7 @@ async fn handshake_init_transport_error_propagates() {
             headers: None,
             deferred: None,
             allow_local: false,
+            only_for_assistant: None,
         },
     );
 


### PR DESCRIPTION
## #111 — per-assistant MCP scoping (Overwatch-approved, FerroxLabs/wayland#613)

Gate a config-declared MCP server to specific assistants so the read-only Concierge diag server (`wayland_concierge_diag`) is exposed **only** to the Concierge assistant on the WCore engine leg. Today the engine injects every config MCP server into every agent with no per-assistant allow-list.

### Design (approach A, engine-enforced)
- **config:** `McpServerConfig.only_for_assistant: Option<Vec<String>>` (`#[serde(default)]`; `None`/empty = global). `is_visible_to_assistant` is **fail-closed** — a marked server is excluded for a `None`/unknown/non-matching active assistant. `McpConfig::servers_for_assistant` filters the map.
- **engine:** `AgentBootstrap.active_assistant` field + builder; the bootstrap `connect_all`/`register_mcp_tools` choke point injects only the scoped subset.
- **CLI:** a dedicated `--assistant` / `WAYLAND_ASSISTANT` flag (distinct from `--agent`, which is a persona) threaded into `run_json_stream_mode`; the **#551 deferred-connect path is filtered too** (both config-server injection choke points).
- The plugin second-pass injects plugin-supplied servers (a different source), so it's out of scope. Runtime `AddMcpServer` scoping is deferred (follow-up #614).

### Guardrail satisfied (completeness)
Per the ruling, the filter must apply at **every** injection path. An adversarial completeness cross-audit traced all `connect_all`/`register_*` sites and confirmed a `only_for_assistant=[concierge]` server **cannot reach a non-Concierge agent through any path** (bootstrap non-deferred + #551 deferred both filtered; TUI/one-shot fail-closed at `active_assistant=None`; `AddMcpServer`/`/mcp add`/Forge/sub-agent-spawn draw from non-config sources). `wayland doctor --probe-mcp` connects all servers unfiltered — documented in-code as an intentional exemption (throwaway diagnostic, no agent/model exposure).

### Back-compat
Nothing is marked until the host sets `only_for_assistant` + passes `--assistant`, so this is a no-op for existing configs. Desktop confirmed it'll adopt the `--assistant` contract + mark the diag server. Fast-follow, **not** a 0.11.13 blocker.

### Verification
Full-workspace Hetzner gate green (fmt + clippy `-D warnings --all-targets` + nextest, 9675 passed). Config unit tests (fail-closed visibility, `servers_for_assistant` filter, serde default) + a bootstrap integration test proving a non-Concierge/None session does NOT receive a marked server while a Concierge session DOES. Adversarial completeness cross-audit → MERGE-READY.