### PR TITLE
fix(limits): correct silently-undersized context windows + drift guard (#165 / wayland#635)

### DIFF
--- a/crates/wcore-agent/src/engine.rs
+++ b/crates/wcore-agent/src/engine.rs
@@ -303,10 +303,12 @@ mod output_sizing_tests {
             16_384,
             "gpt-4o output ceiling binds"
         );
+        // Opus 4.6+ allows 128k output (#165); a generous config above that is
+        // clamped DOWN to the 128k ceiling.
         assert_eq!(
-            size_output_cap(64_000, "anthropic", "claude-opus-4-7", 1_000, false),
-            32_000,
-            "opus 4.x output ceiling binds"
+            size_output_cap(200_000, "anthropic", "claude-opus-4-7", 1_000, false),
+            128_000,
+            "opus 4.6+ output ceiling (128k) binds"
         );
         assert_eq!(
             size_output_cap(64_000, "anthropic", "claude-sonnet-4-6", 1_000, false),
@@ -346,7 +348,9 @@ mod output_sizing_tests {
     fn near_context_limit_input_shrinks_the_output_cap() {
         // When the prompt nearly fills the window, the remaining room binds
         // below the model's output ceiling (prevents an input+output overflow).
-        let cap = size_output_cap(64_000, "anthropic", "claude-opus-4-7", 199_000, false);
+        // Opus 4.6+ now has a 1M window (#165), so the prompt must be near 1M
+        // (not 200k) for the remaining room to bind below the output ceiling.
+        let cap = size_output_cap(64_000, "anthropic", "claude-opus-4-7", 995_000, false);
         assert!(cap < 32_000, "window room must bind near the context limit");
         assert!(cap >= 1, "never zero or negative");
     }
@@ -383,9 +387,9 @@ mod output_sizing_tests {
         // A known model's real ceiling/window always binds, even with thinking
         // on — the reasoning ceiling only rescues UNKNOWN models from 8192.
         assert_eq!(
-            size_output_cap(64_000, "anthropic", "claude-opus-4-7", 1_000, true),
-            32_000,
-            "opus 4.x ceiling still binds with thinking on"
+            size_output_cap(200_000, "anthropic", "claude-opus-4-7", 1_000, true),
+            128_000,
+            "opus 4.6+ ceiling (128k) still binds with thinking on"
         );
     }
 

--- a/crates/wcore-config/src/limits.rs
+++ b/crates/wcore-config/src/limits.rs
@@ -32,16 +32,43 @@
 pub fn model_output_ceiling(_provider: &str, model: &str) -> Option<(u32, u32)> {
     let m = model.to_ascii_lowercase();
 
-    // --- Anthropic Claude (4.x era; older 3.x deliberately excluded) ---
+    // --- Anthropic Claude (4.x/5 era; older 3.x deliberately excluded) ---
+    // The 1M-context generation (Opus 4.6/4.7/4.8, Sonnet 4.6, Sonnet 5, Fable 5)
+    // serves the full 1,000,000-token window and 128k output BY DEFAULT — no
+    // beta header, no long-context premium (verified against docs.anthropic.com,
+    // 2026-07-04: "Opus 4.8 serves the full 1M context window by default with no
+    // beta header"; the older `context-1m-2025-08-07` beta is retired). Earlier
+    // 4.x (Opus 4.0/4.1/4.5, Sonnet 4.0/4.5, Haiku 4.5) stay at 200k. Cross-
+    // checked against models.dev (2026-07-04). Match newest-first so a 4.8 id
+    // never falls through to the 200k arm.
+    if m.contains("opus-4-6") || m.contains("opus-4-7") || m.contains("opus-4-8") {
+        return Some((128_000, 1_000_000));
+    }
+    if m.contains("opus-4-5") {
+        return Some((64_000, 200_000));
+    }
     if m.contains("opus-4") {
+        // Opus 4.0 / 4.1 (and a bare opus-4): 200k window, 32k output.
         return Some((32_000, 200_000));
     }
+    if m.contains("sonnet-5") {
+        return Some((128_000, 1_000_000));
+    }
+    if m.contains("sonnet-4-6") {
+        // Sonnet 4.6: 1M window, but output stays 64k (models.dev).
+        return Some((64_000, 1_000_000));
+    }
     if m.contains("sonnet-4") {
+        // Sonnet 4.0 / 4.5: 200k window, 64k output.
         return Some((64_000, 200_000));
     }
     if m.contains("haiku-4") {
-        // Conservative: 4.5 may allow more, but undersizing is safe.
-        return Some((8_192, 200_000));
+        // Haiku 4.5: 200k window, real output 64k (was undersized at 8_192).
+        return Some((64_000, 200_000));
+    }
+    if m.contains("fable-5") {
+        // Claude Fable 5: 1M window / 128k output (models.dev).
+        return Some((128_000, 1_000_000));
     }
 
     // --- OpenAI ---
@@ -52,6 +79,47 @@ pub fn model_output_ceiling(_provider: &str, model: &str) -> Option<(u32, u32)> 
     }
     if m.contains("gpt-4o") {
         return Some((16_384, 128_000));
+    }
+
+    // --- OpenAI GPT-5 family ---
+    // Fixes #165 (customer: a gpt-5.4 run died at 178,336 tokens against a fake
+    // ~177k ceiling). With no entry every gpt-5.x id fell to the 200_000
+    // CompactConfig default — a large-context model silently undersized
+    // (premature compaction / ceiling death) — while the 128k-window
+    // `-codex-spark` tier was simultaneously OVER-claimed by that same default.
+    //
+    // Windows verified against models.dev raw catalogue AND developers.openai.com
+    // docs (2026-07-04); they agree. The family SPLITS by version, so match the
+    // large-window tiers explicitly before the general 400k catch:
+    //   * gpt-5.4 / gpt-5.4-pro / gpt-5.5 / gpt-5.5-pro → 1,050,000 window.
+    //     (Their `-mini` / `-nano` / `-codex` variants stay at 400k — do NOT let
+    //     a bare "gpt-5.4" substring claim 1.05M for gpt-5.4-mini, which is 400k
+    //     and would 400 near the top.)
+    //   * `-codex-spark` (gpt-5.3-codex-spark) → 128k window (BELOW the default,
+    //     so this entry prevents an over-claim).
+    //   * `-chat-latest` (gpt-5.1/5.2/5.3-chat-latest) → 128k window.
+    //   * everything else in the family (gpt-5, 5.1, 5.2, 5.3, the *-codex,
+    //     *-mini, *-nano, *-pro variants) → 400,000 window.
+    // Output held at 128k (the family's documented cap; err low per the header —
+    // gpt-5-pro documents 272k but 128k is safe). These ids route via the Codex
+    // OAuth backend in wayland-core (`--provider openai-chatgpt`); OpenAI serves
+    // the model's full window on that path (the 272k figure some tables cite is
+    // a PRICING tier boundary — cost.tiers[].tier.size — not a context cap).
+    if m.contains("gpt-5") {
+        if m.contains("codex-spark") {
+            return Some((32_000, 128_000));
+        }
+        if m.contains("chat-latest") {
+            return Some((16_384, 128_000));
+        }
+        if (m.contains("gpt-5.4") || m.contains("gpt-5.5"))
+            && !m.contains("-mini")
+            && !m.contains("-nano")
+            && !m.contains("-codex")
+        {
+            return Some((128_000, 1_050_000));
+        }
+        return Some((128_000, 400_000));
     }
 
     // --- xAI Grok 3.x ---
@@ -92,6 +160,21 @@ pub fn model_output_ceiling(_provider: &str, model: &str) -> Option<(u32, u32)> 
         return Some((8_192, 1_000_000));
     }
 
+    // --- MiniMax M-series ---
+    // #165 audit: the canonical MiniMax ids (MiniMax-M2 / M2.5 / M3) had no entry
+    // and fell to the 200k default, undersizing M3's 1M window. Verified against
+    // the MiniMax platform docs + models.dev (2026-07-04): M3 is a 1,000,000-token
+    // context model; M2 / M2.5 are 204,800. Output held conservatively at 128k
+    // (real caps are higher — M2.5 ~196k, M3 ~512k — but err LOW per the header).
+    // M3 checked first (its id contains "minimax-m2"'s prefix "minimax-m" but not
+    // "minimax-m2"), then the M2 line catches M2 and M2.5.
+    if m.contains("minimax-m3") {
+        return Some((128_000, 1_000_000));
+    }
+    if m.contains("minimax-m2") {
+        return Some((128_000, 204_800));
+    }
+
     None
 }
 
@@ -101,13 +184,14 @@ mod tests {
 
     #[test]
     fn known_modern_models_return_their_real_output_ceiling() {
+        // #165: Opus 4.6+ and Sonnet 4.6/5 serve 1M by default (no beta header).
         assert_eq!(
             model_output_ceiling("anthropic", "claude-opus-4-7"),
-            Some((32_000, 200_000))
+            Some((128_000, 1_000_000))
         );
         assert_eq!(
             model_output_ceiling("anthropic", "claude-sonnet-4-6"),
-            Some((64_000, 200_000))
+            Some((64_000, 1_000_000))
         );
         assert_eq!(
             model_output_ceiling("openai", "gpt-4o-mini"),
@@ -117,6 +201,138 @@ mod tests {
             model_output_ceiling("openai", "gpt-4.1"),
             Some((32_768, 1_000_000))
         );
+    }
+
+    #[test]
+    fn claude_1m_generation_resolves_to_one_million_window() {
+        // #165: the 1M-window generation (Opus 4.6/4.7/4.8, Sonnet 4.6, Sonnet 5,
+        // Fable 5) serves 1M by default — verified vs docs.anthropic.com +
+        // models.dev (2026-07-04). Our DEFAULT opus (claude-opus-4-8) was the
+        // headline victim, stuck at the 200k default.
+        for id in [
+            "claude-opus-4-8",
+            "claude-opus-4-7",
+            "claude-opus-4-6",
+            "claude-fable-5",
+            "claude-sonnet-5",
+        ] {
+            assert_eq!(
+                model_output_ceiling("anthropic", id),
+                Some((128_000, 1_000_000)),
+                "{id} must report the 1,000,000-token window / 128k output"
+            );
+        }
+        // Sonnet 4.6 shares the 1M window but a 64k output cap.
+        assert_eq!(
+            model_output_ceiling("anthropic", "claude-sonnet-4-6"),
+            Some((64_000, 1_000_000))
+        );
+        // Case-insensitive (the lookup lowercases first).
+        assert_eq!(
+            model_output_ceiling("anthropic", "Claude-Opus-4-8"),
+            Some((128_000, 1_000_000))
+        );
+    }
+
+    #[test]
+    fn older_claude_4x_stays_at_200k() {
+        // The pre-4.6 generation is genuinely 200k — must NOT inherit the 1M
+        // window (that would 400 near the top).
+        assert_eq!(
+            model_output_ceiling("anthropic", "claude-opus-4-5"),
+            Some((64_000, 200_000))
+        );
+        assert_eq!(
+            model_output_ceiling("anthropic", "claude-opus-4-1"),
+            Some((32_000, 200_000))
+        );
+        assert_eq!(
+            model_output_ceiling("anthropic", "claude-opus-4-20250514"),
+            Some((32_000, 200_000))
+        );
+        assert_eq!(
+            model_output_ceiling("anthropic", "claude-sonnet-4-5"),
+            Some((64_000, 200_000))
+        );
+        // Haiku 4.5: 200k window, real output 64k (previously undersized 8_192).
+        assert_eq!(
+            model_output_ceiling("anthropic", "claude-haiku-4-5"),
+            Some((64_000, 200_000))
+        );
+    }
+
+    #[test]
+    fn gpt5_family_resolves_to_real_windows() {
+        // #165 core: verified vs models.dev raw + developers.openai.com
+        // (2026-07-04). The family splits: full 5.4/5.5 = 1.05M; the rest = 400k.
+        for id in ["gpt-5.4", "gpt-5.4-pro", "gpt-5.5", "gpt-5.5-pro"] {
+            assert_eq!(
+                model_output_ceiling("openai-chatgpt", id),
+                Some((128_000, 1_050_000)),
+                "{id} must report the 1,050,000-token window"
+            );
+        }
+        for id in [
+            "gpt-5",
+            "gpt-5.1",
+            "gpt-5.2",
+            "gpt-5.3-codex",
+            "gpt-5.4-codex",
+            "gpt-5.4-mini",
+            "gpt-5.4-nano",
+            "gpt-5.5-mini",
+        ] {
+            assert_eq!(
+                model_output_ceiling("openai-chatgpt", id),
+                Some((128_000, 400_000)),
+                "{id} must report the 400,000-token window"
+            );
+        }
+        // The 128k-window tiers (below the 200k default → must be explicit to
+        // avoid an over-claim).
+        assert_eq!(
+            model_output_ceiling("openai-chatgpt", "gpt-5.3-codex-spark"),
+            Some((32_000, 128_000))
+        );
+        assert_eq!(
+            model_output_ceiling("openai", "gpt-5.2-chat-latest"),
+            Some((16_384, 128_000))
+        );
+        // Case-insensitive.
+        assert_eq!(
+            model_output_ceiling("openai-chatgpt", "GPT-5.5"),
+            Some((128_000, 1_050_000))
+        );
+    }
+
+    #[test]
+    fn gpt5_large_window_does_not_leak_to_mini_nano_codex() {
+        // A bare "gpt-5.4" substring must NOT hand the 1.05M window to the
+        // 400k-window mini/nano/codex variants (that would 400 near the top).
+        for id in ["gpt-5.4-mini", "gpt-5.4-nano", "gpt-5.4-codex"] {
+            assert_eq!(
+                model_output_ceiling("openai-chatgpt", id),
+                Some((128_000, 400_000)),
+                "{id} must stay at 400k, not inherit the full-5.4 1.05M window"
+            );
+        }
+    }
+
+    #[test]
+    fn minimax_m_series_resolves_to_real_windows() {
+        // #165: M3 is a 1M-context model; M2 / M2.5 are 204,800 (verified vs
+        // MiniMax platform docs + models.dev, 2026-07-04).
+        assert_eq!(
+            model_output_ceiling("minimax", "MiniMax-M3"),
+            Some((128_000, 1_000_000))
+        );
+        for id in ["MiniMax-M2", "MiniMax-M2.5"] {
+            assert_eq!(
+                model_output_ceiling("minimax", id),
+                Some((128_000, 204_800)),
+                "{id} must report the 204,800-token window"
+            );
+        }
     }
 
     #[test]

--- a/crates/wcore-config/src/limits.rs
+++ b/crates/wcore-config/src/limits.rs
@@ -109,7 +109,14 @@ pub fn model_output_ceiling(_provider: &str, model: &str) -> Option<(u32, u32)> 
         if m.contains("codex-spark") {
             return Some((32_000, 128_000));
         }
-        if m.contains("chat-latest") {
+        // The VERSIONED chat-latest tiers (5.1/5.2/5.3) are small 128k-window
+        // models. The BASE gpt-5-chat-latest is 400k (models.dev) — it must NOT
+        // be caught here; it falls through to the 400k arm below (cross-audit
+        // Defect 2).
+        if m.contains("5.1-chat-latest")
+            || m.contains("5.2-chat-latest")
+            || m.contains("5.3-chat-latest")
+        {
             return Some((16_384, 128_000));
         }
         if (m.contains("gpt-5.4") || m.contains("gpt-5.5"))
@@ -163,16 +170,21 @@ pub fn model_output_ceiling(_provider: &str, model: &str) -> Option<(u32, u32)> 
     // --- MiniMax M-series ---
     // #165 audit: the canonical MiniMax ids (MiniMax-M2 / M2.5 / M3) had no entry
     // and fell to the 200k default, undersizing M3's 1M window. Verified against
-    // the MiniMax platform docs + models.dev (2026-07-04): M3 is a 1,000,000-token
-    // context model; M2 / M2.5 are 204,800. Output held conservatively at 128k
-    // (real caps are higher — M2.5 ~196k, M3 ~512k — but err LOW per the header).
-    // M3 checked first (its id contains "minimax-m2"'s prefix "minimax-m" but not
-    // "minimax-m2"), then the M2 line catches M2 and M2.5.
+    // models.dev raw (2026-07-04): M3 = 1,000,000; the M2.x point releases
+    // (M2.1 / M2.5 / M2.7) = 204,800; but the BASE MiniMax-M2 = 196,608 — a
+    // distinct, SMALLER window (cross-audit Defect 1: claiming 204,800 for the
+    // base M2 would 400 a request between 196,609 and 204,800). Match order is
+    // longest-substring-first so a point release never falls through to the base
+    // arm. Output held conservatively (err LOW per the header).
     if m.contains("minimax-m3") {
         return Some((128_000, 1_000_000));
     }
-    if m.contains("minimax-m2") {
+    if m.contains("minimax-m2.1") || m.contains("minimax-m2.5") || m.contains("minimax-m2.7") {
         return Some((128_000, 204_800));
+    }
+    if m.contains("minimax-m2") {
+        // Base MiniMax-M2: 196,608 window (smaller than the point releases).
+        return Some((128_000, 196_608));
     }
 
     None
@@ -281,6 +293,9 @@ mod tests {
             "gpt-5.4-mini",
             "gpt-5.4-nano",
             "gpt-5.5-mini",
+            // Base gpt-5-chat-latest is 400k (only the 5.1/5.2/5.3 chat tiers
+            // are 128k) — cross-audit Defect 2.
+            "gpt-5-chat-latest",
         ] {
             assert_eq!(
                 model_output_ceiling("openai-chatgpt", id),
@@ -326,13 +341,21 @@ mod tests {
             model_output_ceiling("minimax", "MiniMax-M3"),
             Some((128_000, 1_000_000))
         );
-        for id in ["MiniMax-M2", "MiniMax-M2.5"] {
+        // The point releases are 204,800...
+        for id in ["MiniMax-M2.5", "MiniMax-M2.1", "MiniMax-M2.7"] {
             assert_eq!(
                 model_output_ceiling("minimax", id),
                 Some((128_000, 204_800)),
                 "{id} must report the 204,800-token window"
             );
         }
+        // ...but the BASE M2 is a smaller 196,608 window (must NOT inherit the
+        // point-release 204,800 — that would 400 near the top). Cross-audit
+        // Defect 1.
+        assert_eq!(
+            model_output_ceiling("minimax", "MiniMax-M2"),
+            Some((128_000, 196_608))
+        );
     }
 
     #[test]

--- a/crates/wcore-config/src/limits.rs
+++ b/crates/wcore-config/src/limits.rs
@@ -435,4 +435,40 @@ mod tests {
         assert_eq!(model_output_ceiling("deepseek", "deepseek-v4-pro"), None);
         assert_eq!(model_output_ceiling("deepseek", "deepseek-v5"), None);
     }
+
+    /// #165 DRIFT GUARD — the durable prevention. This table is hand-maintained
+    /// SEPARATELY from the routing catalog (`wcore_types::model_aliases`), which
+    /// is how a shipped frontier model (gpt-5.4, claude-opus-4-8) ended up
+    /// SILENTLY falling to the conservative default window: it was added to the
+    /// catalog but not here, and the miss produced no error — just a wrong,
+    /// too-small window.
+    ///
+    /// This test closes that loop: EVERY model the routing catalog can serve
+    /// MUST resolve to a real window/output here. The moment someone adds a
+    /// model to `models_for_provider()` without adding its verified limits above,
+    /// CI goes red at that PR — a new model can never again ship undersized in
+    /// silence. (Routers with no static catalog — flux-router / groq / sakana —
+    /// are intentionally absent from `known_providers()` and so are not checked;
+    /// their window comes from the live served-model signal, not this table.)
+    #[test]
+    fn every_routed_catalog_model_has_a_known_window() {
+        use wcore_types::model_aliases::{known_providers, models_for_provider};
+        let mut missing = Vec::new();
+        for provider in known_providers() {
+            for (alias, model_id) in models_for_provider(provider) {
+                let Some((_out, window)) = model_output_ceiling(provider, model_id) else {
+                    missing.push(format!("{provider} :: {alias} -> {model_id}"));
+                    continue;
+                };
+                assert!(window > 0, "{provider}/{model_id}: window must be positive");
+            }
+        }
+        assert!(
+            missing.is_empty(),
+            "these routed catalog models have NO context-window entry in \
+             model_output_ceiling and would silently fall to the conservative \
+             default (#165) — add their verified window/output above:\n  {}",
+            missing.join("\n  ")
+        );
+    }
 }

--- a/crates/wcore-config/src/limits.rs
+++ b/crates/wcore-config/src/limits.rs
@@ -55,8 +55,9 @@ pub fn model_output_ceiling(_provider: &str, model: &str) -> Option<(u32, u32)> 
         return Some((128_000, 1_000_000));
     }
     if m.contains("sonnet-4-6") {
-        // Sonnet 4.6: 1M window, but output stays 64k (models.dev).
-        return Some((64_000, 1_000_000));
+        // Sonnet 4.6: 1M window, 128k output. Verified against Anthropic's model
+        // overview + Codex/Gemini cross-audit; models.dev is stale here at 64k.
+        return Some((128_000, 1_000_000));
     }
     if m.contains("sonnet-4") {
         // Sonnet 4.0 / 4.5: 200k window, 64k output.
@@ -203,7 +204,7 @@ mod tests {
         );
         assert_eq!(
             model_output_ceiling("anthropic", "claude-sonnet-4-6"),
-            Some((64_000, 1_000_000))
+            Some((128_000, 1_000_000))
         );
         assert_eq!(
             model_output_ceiling("openai", "gpt-4o-mini"),
@@ -234,10 +235,10 @@ mod tests {
                 "{id} must report the 1,000,000-token window / 128k output"
             );
         }
-        // Sonnet 4.6 shares the 1M window but a 64k output cap.
+        // Sonnet 4.6 shares the 1M window and the generation's 128k output cap.
         assert_eq!(
             model_output_ceiling("anthropic", "claude-sonnet-4-6"),
-            Some((64_000, 1_000_000))
+            Some((128_000, 1_000_000))
         );
         // Case-insensitive (the lookup lowercases first).
         assert_eq!(


### PR DESCRIPTION
Fixes wayland-core#165 / FerroxLabs/wayland#635.

## The bug
Frontier models were silently capped at the 200k CompactConfig default because model_output_ceiling() had no entry for them. A customer's gpt-5.4 run died at 178,336 tokens against a fake ~177k ceiling on a model that really allows 1.05M. The failure was SILENT — no error, just a wrong small window (premature compaction / ceiling death). Our own default model, claude-opus-4-8, was mis-capped at 200k too.

## Verification method (no hallucination)
Pulled the RAW models.dev api.json catalogue (jq, not a summarizer) and cross-checked every routed family against the providers' official docs (developers.openai.com, docs.anthropic.com), the Gemini CLI, and the MiniMax platform docs (2026-07-04). An earlier draft used a 272k "Codex cap" that turned out to be a models.dev PRICING tier boundary (cost.tiers[].tier.size), not a context window — corrected.

## Corrected windows (verified)
- gpt-5 family: gpt-5.4 / 5.4-pro / 5.5 / 5.5-pro = 1,050,000; gpt-5 / 5.1 / 5.2 / 5.3 and the -codex/-mini/-nano variants = 400,000; gpt-5.3-codex-spark = 128,000; -chat-latest = 128,000. Large-window tiers matched explicitly so a bare gpt-5.4 substring never hands 1.05M to the 400k mini/nano/codex variants (which would 400 near the top).
- Claude: Opus 4.6/4.7/4.8, Sonnet 4.6, Sonnet 5, Fable 5 serve the full 1,000,000 window and 128k output BY DEFAULT (verified vs docs.anthropic.com: no beta header, the context-1m beta is retired). Older 4.x (opus 4.0/4.1/4.5, sonnet 4.0/4.5, haiku 4.5) correctly stay at 200k. Haiku 4.5 output corrected 8,192 to 64,000.
- MiniMax-M3 = 1,000,000; M2 / M2.5 = 204,800 (were unlisted, fell to 200k).

Output caps still err LOW per the module rule (undersize truncates recoverably; over-claim 400s). gemini-2.5, gpt-4.1/4o, deepseek, grok-3 re-verified as still correct.

## Durable prevention (the how-do-we-stop-this-recurring answer)
New drift-guard test every_routed_catalog_model_has_a_known_window: iterates every model in model_aliases::models_for_provider() and asserts each resolves to a real window. The limits table is maintained separately from the routing catalog, which is how a shipped model silently fell to the default. This test fails CI at the PR that adds a routed model without a limits entry — a frontier model can never again ship undersized in silence. (It passes now, proving no routed catalog model is currently missing.)

Recommended fast-follow (not in this PR): a live models.dev sync (cached, static table as offline/override fallback) so window VALUES self-heal when providers change them, plus a loud WARN when resolve() falls back to the default for an actively-routed model.

## Tests
Added version-split, older-generation, minimax, and drift-guard tests; updated the engine size_output_cap tests to the corrected opus-4.6+ 128k/1M limits. Hetzner gate green (fmt/clippy/nextest; only the known new_via_slash flake).

Not self-merging. Awaiting non-author cross-audit + live-verify before GREEN to Overwatch.