### PR TITLE
fix(engine): shed oversized tool outputs before context-overflow abort (#636)

### DIFF
--- a/crates/wcore-agent/src/compact/degrade.rs
+++ b/crates/wcore-agent/src/compact/degrade.rs
@@ -1,0 +1,301 @@
+//! #636 — graceful context-overflow degradation (rung 1).
+//!
+//! Before the run loop aborts a turn with `FinishReason::Length` (the pre-flight
+//! context-window guard in `engine.rs`), shed the largest tool-result outputs
+//! from history so the assembled request drops back under the model's context
+//! ceiling and the run can CONTINUE instead of dying.
+//!
+//! This is the mechanical rung of the degradation ladder — no LLM call. Full
+//! content is spilled to disk (recoverable via the emitted `<persisted-output>`
+//! path that names the file); only a bounded preview stays in-context.
+//!
+//! ## Why this rung is pairing-safe
+//!
+//! It rewrites `ToolResult` *content* in place and never adds or removes blocks,
+//! so every `tool_use` keeps its matching `tool_result`. There is no orphaned-
+//! `tool_use` 400 risk — the reason the riskier drop-oldest sliding window is
+//! deferred to a later phase.
+//!
+//! ## Idempotent, terminating, no hot-loop
+//!
+//! `maybe_persist_tool_result` skips any block already carrying the
+//! [`PERSISTED_OUTPUT_TAG`], so a spilled block is excluded from every later
+//! pass. Each iteration therefore either drops under the ceiling and returns, or
+//! tags exactly one more block — the sheddable set strictly shrinks, so the loop
+//! always terminates. When every oversized result is already spilled and the
+//! request is *still* over the ceiling (a conversation-heavy context, not
+//! tool-heavy), the pass makes no progress and returns `0`, leaving the caller
+//! to terminate cleanly with a session whose tool outputs are already shed (so a
+//! resume heals rather than re-aborting turn 1).
+
+use wcore_tools::tool_result_storage::{
+    BUDGET_TOOL_NAME, BudgetConfig, PERSISTED_OUTPUT_TAG, StorageDir, maybe_persist_tool_result,
+};
+use wcore_types::message::{ContentBlock, Message};
+
+/// Shed oversized tool-result outputs from `messages`, largest-first, until the
+/// recomputed request size (`estimate`) drops below `ceiling` or no oversized,
+/// not-already-spilled tool result remains.
+///
+/// * `min_shed_chars` — never spill a result smaller than this; spilling a
+///   result already near the preview size reclaims little and only churns the
+///   cached prefix. Callers MUST pass a value larger than the persisted-output
+///   replacement (`preview_size` + a small header), both so every shed is a net
+///   reduction AND so a spill-write failure — which replaces content with a
+///   preview-sized `InlineTruncated` fallback that carries no
+///   [`PERSISTED_OUTPUT_TAG`] — lands below the floor and is never re-selected
+///   on a later pass (the only way an untagged block could be revisited).
+/// * `estimate` — recomputes the FULL request token count (messages + system +
+///   tool schemas) against the shed history after each spill; the loop stops as
+///   soon as it is under `ceiling`. Called on a cold path (only when a turn is
+///   about to abort), so the per-shed recompute is acceptable.
+///
+/// Returns the number of tool results rewritten. `0` means the pass could not
+/// help — nothing oversized was left to shed.
+pub fn shed_tool_outputs_until_under(
+    messages: &mut [Message],
+    storage: &StorageDir,
+    config: &BudgetConfig,
+    min_shed_chars: usize,
+    ceiling: u64,
+    estimate: impl Fn(&[Message]) -> u64,
+) -> usize {
+    if estimate(messages) < ceiling {
+        return 0;
+    }
+    // Snapshot the sheddable tool-result blocks ONCE — oversized and not already
+    // spilled — largest-first. Processing a fixed, finite list (each block at
+    // most once) makes the pass provably terminating regardless of how
+    // `maybe_persist_tool_result` rewrote the content (spill success adds the
+    // tag; a spill-write failure falls back to a preview-sized inline truncation
+    // that no longer meets `min_shed_chars`). Indices stay valid because we only
+    // rewrite content strings in place — never resize any `content` vec or the
+    // `messages` slice. This mirrors `enforce_turn_budget`'s largest-first loop.
+    let mut candidates: Vec<(usize, usize, usize)> = Vec::new(); // (msg_idx, block_idx, chars)
+    for (mi, msg) in messages.iter().enumerate() {
+        for (bi, block) in msg.content.iter().enumerate() {
+            if let ContentBlock::ToolResult { content, .. } = block {
+                let chars = content.chars().count();
+                if chars > min_shed_chars && !content.contains(PERSISTED_OUTPUT_TAG) {
+                    candidates.push((mi, bi, chars));
+                }
+            }
+        }
+    }
+    candidates.sort_by_key(|&(_, _, chars)| std::cmp::Reverse(chars));
+
+    let mut shed = 0usize;
+    for (mi, bi, _) in candidates {
+        // Stop as soon as the recomputed request drops under the ceiling.
+        if estimate(messages) < ceiling {
+            break;
+        }
+        if let ContentBlock::ToolResult {
+            tool_use_id,
+            content,
+            ..
+        } = &mut messages[mi].content[bi]
+        {
+            // `BUDGET_TOOL_NAME` is not pinned, so `Some(0)` forces the spill.
+            let (replacement, _outcome) = maybe_persist_tool_result(
+                content,
+                BUDGET_TOOL_NAME,
+                tool_use_id.as_str(),
+                storage,
+                config,
+                Some(0),
+            );
+            *content = replacement;
+            shed += 1;
+        }
+    }
+    shed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+    use wcore_types::message::{ContentBlock, Message, Role};
+
+    fn tool_result(id: &str, content: &str) -> Message {
+        Message::new(
+            Role::User,
+            vec![ContentBlock::ToolResult {
+                tool_use_id: id.to_string(),
+                content: content.to_string(),
+                is_error: false,
+            }],
+        )
+    }
+
+    fn tool_use(id: &str) -> Message {
+        Message::new(
+            Role::Assistant,
+            vec![ContentBlock::ToolUse {
+                id: id.to_string(),
+                name: "read".to_string(),
+                input: serde_json::json!({}),
+                extra: None,
+            }],
+        )
+    }
+
+    /// Chars-based fake estimator: sum of tool-result content lengths. Lets the
+    /// tests drive the ceiling deterministically without the real tokenizer.
+    fn chars_estimator(messages: &[Message]) -> u64 {
+        let mut total = 0u64;
+        for m in messages {
+            for b in &m.content {
+                if let ContentBlock::ToolResult { content, .. } = b {
+                    total += content.chars().count() as u64;
+                }
+            }
+        }
+        total
+    }
+
+    fn test_storage() -> (TempDir, StorageDir) {
+        let dir = TempDir::new().expect("tempdir");
+        let storage = StorageDir(dir.path().join("results"));
+        (dir, storage)
+    }
+
+    #[test]
+    fn sheds_largest_first_and_stops_once_under_ceiling() {
+        let (_dir, storage) = test_storage();
+        let config = BudgetConfig::default();
+        let mut messages = vec![
+            tool_use("a"),
+            tool_result("a", &"x".repeat(50_000)), // biggest
+            tool_use("b"),
+            tool_result("b", &"y".repeat(30_000)),
+            tool_use("c"),
+            tool_result("c", &"z".repeat(1_000)), // below min_shed, untouched
+        ];
+        // Ceiling below the initial 81k but above what shedding the single
+        // biggest result leaves, so exactly ONE shed should suffice.
+        let ceiling = 40_000u64;
+        let shed = shed_tool_outputs_until_under(
+            &mut messages,
+            &storage,
+            &config,
+            8_000,
+            ceiling,
+            chars_estimator,
+        );
+        assert_eq!(shed, 1, "shedding the single biggest result should suffice");
+        assert!(
+            chars_estimator(&messages) < ceiling,
+            "estimate must be under the ceiling after shedding"
+        );
+        // The biggest result was spilled (now a persisted-output preview)...
+        let a = &messages[1].content[0];
+        let ContentBlock::ToolResult { content, .. } = a else {
+            panic!("expected tool result");
+        };
+        assert!(
+            content.contains(PERSISTED_OUTPUT_TAG),
+            "biggest result should be spilled"
+        );
+        // ...the second-biggest was left alone (one shed was enough).
+        let b = &messages[3].content[0];
+        let ContentBlock::ToolResult { content, .. } = b else {
+            panic!("expected tool result");
+        };
+        assert!(
+            !content.contains(PERSISTED_OUTPUT_TAG),
+            "second result should be untouched once under ceiling"
+        );
+    }
+
+    #[test]
+    fn never_sheds_results_below_min_size() {
+        let (_dir, storage) = test_storage();
+        let config = BudgetConfig::default();
+        let mut messages = vec![
+            tool_use("a"),
+            tool_result("a", &"x".repeat(5_000)),
+            tool_use("b"),
+            tool_result("b", &"y".repeat(5_000)),
+        ];
+        // Ceiling is unreachable by shedding because both results are under the
+        // min_shed floor — the pass must make no progress and return 0.
+        let shed = shed_tool_outputs_until_under(
+            &mut messages,
+            &storage,
+            &config,
+            8_000,
+            1_000,
+            chars_estimator,
+        );
+        assert_eq!(shed, 0, "results below min_shed must never be spilled");
+    }
+
+    #[test]
+    fn idempotent_no_progress_when_all_oversized_already_spilled() {
+        let (_dir, storage) = test_storage();
+        let config = BudgetConfig::default();
+        let mut messages = vec![tool_use("a"), tool_result("a", &"x".repeat(50_000))];
+        // First pass spills the block.
+        let first = shed_tool_outputs_until_under(
+            &mut messages,
+            &storage,
+            &config,
+            8_000,
+            1, // impossibly low ceiling → shed everything sheddable
+            chars_estimator,
+        );
+        assert_eq!(first, 1);
+        // Second pass on the already-spilled block must make no progress (no
+        // hot-loop, no re-spill), even with the same impossible ceiling.
+        let second = shed_tool_outputs_until_under(
+            &mut messages,
+            &storage,
+            &config,
+            8_000,
+            1,
+            chars_estimator,
+        );
+        assert_eq!(second, 0, "already-spilled block must not be re-shed");
+    }
+
+    #[test]
+    fn preserves_tool_use_result_pairing() {
+        let (_dir, storage) = test_storage();
+        let config = BudgetConfig::default();
+        let mut messages = vec![tool_use("a"), tool_result("a", &"x".repeat(50_000))];
+        let before_blocks: usize = messages.iter().map(|m| m.content.len()).sum();
+        shed_tool_outputs_until_under(&mut messages, &storage, &config, 8_000, 1, chars_estimator);
+        let after_blocks: usize = messages.iter().map(|m| m.content.len()).sum();
+        assert_eq!(
+            before_blocks, after_blocks,
+            "shedding must not add or remove blocks (no orphaned tool_use)"
+        );
+        // The tool_use and its id-matched tool_result both still present.
+        assert!(matches!(
+            &messages[0].content[0],
+            ContentBlock::ToolUse { id, .. } if id == "a"
+        ));
+        assert!(matches!(
+            &messages[1].content[0],
+            ContentBlock::ToolResult { tool_use_id, .. } if tool_use_id == "a"
+        ));
+    }
+
+    #[test]
+    fn returns_zero_when_already_under_ceiling() {
+        let (_dir, storage) = test_storage();
+        let config = BudgetConfig::default();
+        let mut messages = vec![tool_use("a"), tool_result("a", &"x".repeat(1_000))];
+        let shed = shed_tool_outputs_until_under(
+            &mut messages,
+            &storage,
+            &config,
+            8_000,
+            10_000,
+            chars_estimator,
+        );
+        assert_eq!(shed, 0, "no work when the request is already under ceiling");
+    }
+}

--- a/crates/wcore-agent/src/compact/mod.rs
+++ b/crates/wcore-agent/src/compact/mod.rs
@@ -6,6 +6,7 @@
 //! - **Emergency**: blocks API calls when near the context window limit
 
 pub mod auto;
+pub mod degrade;
 pub mod emergency;
 pub mod estimate;
 pub mod micro;

--- a/crates/wcore-agent/src/engine.rs
+++ b/crates/wcore-agent/src/engine.rs
@@ -4529,7 +4529,7 @@ impl AgentEngine {
             // estimate undercounts the turn-1 watermark by the system
             // prompt + tool-schema size (tens of k tokens for MCP-heavy
             // configs).
-            let input_token_estimate =
+            let mut input_token_estimate =
                 estimate::estimate_request_tokens(&self.messages, &system, &tools) as usize;
             // AUDIT A1 / #255 — context-token overflow guard MOVED below, to
             // immediately AFTER the smart-routing tier swap (so it measures the
@@ -4757,19 +4757,101 @@ impl AgentEngine {
                     self.compact_config.emergency_buffer as u64,
                 ) && ctx.used_tokens >= ceiling
                 {
-                    self.output.emit_error(
-                        &format!(
-                            "Run stopped: estimated request size ({} tokens) \
-                             reached the context-window ceiling ({ceiling}) for model \
-                             '{}' and compaction could not reduce it further.",
-                            ctx.used_tokens, request.model,
-                        ),
-                        false,
+                    // #636 — graceful degradation (rung 1). Before aborting, shed
+                    // the largest tool-result outputs (spilling full content to
+                    // disk, leaving a bounded `<persisted-output>` preview) so the
+                    // request drops back under the ceiling and the run CONTINUES.
+                    // Shedding rewrites `ToolResult` content in place — it never
+                    // adds or removes blocks — so tool_use/tool_result pairing is
+                    // untouched (no orphaned-tool_use 400; the reason drop-oldest
+                    // sliding-window is deferred to a later phase).
+                    //
+                    // Two message sets are shed:
+                    //   * `request.messages` — the copy actually DISPATCHED (a
+                    //     clone of history plus this turn's transient injections);
+                    //     shedding it is what makes the sent call fit. The
+                    //     continue/abort decision is taken on THIS set.
+                    //   * `self.messages` — the PERSISTED history; shedding it too
+                    //     means a saved/resumed session heals (starts already
+                    //     shrunk) instead of re-entering this guard every turn.
+                    // Both target the same oversized blocks and the spills are
+                    // idempotent (`maybe_persist_tool_result` skips already-spilled
+                    // blocks), so re-runs never re-spill or hot-loop.
+                    let storage = wcore_tools::tool_result_storage::StorageDir::os_default();
+                    let budget = wcore_tools::tool_result_storage::BudgetConfig::default();
+                    // Shed any result whose spill is a NET reduction: the
+                    // `<persisted-output>` replacement is the preview (≤
+                    // `preview_size`) plus a small fixed header, so a block over
+                    // `preview_size` + a header margin always shrinks. Keeping the
+                    // floor this low (not a large multiple) means a context that
+                    // is only marginally over the ceiling still gets reduced
+                    // instead of aborting — only genuinely tiny blocks are skipped.
+                    let min_shed = budget.preview_size + 512;
+                    // Fold the fixed system+tools token overhead into a scalar so
+                    // the shedding closure borrows nothing from `request` (the
+                    // `system`/`tools` locals were moved into `request` above).
+                    // `estimate_request_tokens(m, sys, tools)
+                    //   == estimate_tokens_from_messages(m) + overhead` exactly.
+                    let overhead =
+                        estimate::estimate_request_tokens(&[], &request.system, &request.tools);
+                    // `est` captures only `overhead` (a `u64`), so it is `Copy` —
+                    // pass it by value to both sheds and still call it below.
+                    let est = |m: &[Message]| estimate::estimate_tokens_from_messages(m) + overhead;
+                    let shed = crate::compact::degrade::shed_tool_outputs_until_under(
+                        &mut request.messages,
+                        &storage,
+                        &budget,
+                        min_shed,
+                        ceiling,
+                        est,
                     );
-                    // Context ceiling: a bigger budget is needed, not more turns.
-                    return self
-                        .finish_run_terminated(user_input, turn, FinishReason::Length)
-                        .await;
+                    crate::compact::degrade::shed_tool_outputs_until_under(
+                        &mut self.messages,
+                        &storage,
+                        &budget,
+                        min_shed,
+                        ceiling,
+                        est,
+                    );
+                    // Decide on the DISPATCHED set: the window/ceiling are
+                    // unchanged, so only `used_tokens` moves. Re-stamp every
+                    // downstream consumer of the request size so none sees the
+                    // stale pre-shed estimate — `client_context_tokens` feeds the
+                    // Flux/OpenAI context-routing header (mirrors the compaction-
+                    // retry recount below).
+                    let sent = est(&request.messages);
+                    ctx.used_tokens = sent;
+                    input_token_estimate = sent as usize;
+                    request.client_context_tokens = Some(sent);
+                    if sent >= ceiling {
+                        self.output.emit_error(
+                            &format!(
+                                "Run stopped: estimated request size ({sent} tokens) \
+                                 reached the context-window ceiling ({ceiling}) for model \
+                                 '{}' and compaction could not reduce it further.",
+                                request.model,
+                            ),
+                            false,
+                        );
+                        // Context ceiling: a bigger budget is needed, not more turns.
+                        return self
+                            .finish_run_terminated(user_input, turn, FinishReason::Length)
+                            .await;
+                    }
+                    if shed > 0 {
+                        tracing::info!(
+                            target: "wcore_agent::compact",
+                            shed,
+                            ceiling,
+                            used = input_token_estimate,
+                            model = %request.model,
+                            "context overflow: shed oversized tool outputs, continuing"
+                        );
+                        self.output.emit_info(&format!(
+                            "Context exceeded the model limit; shed {shed} large tool \
+                             output(s) to disk and continued."
+                        ));
+                    }
                 }
             }
 

--- a/crates/wcore-agent/tests/engine_compact_test.rs
+++ b/crates/wcore-agent/tests/engine_compact_test.rs
@@ -21,7 +21,7 @@ use wcore_config::compact::CompactConfig;
 use wcore_providers::{LlmProvider, ProviderError};
 use wcore_tools::registry::ToolRegistry;
 use wcore_types::llm::{LlmEvent, LlmRequest};
-use wcore_types::message::{StopReason, TokenUsage};
+use wcore_types::message::{ContentBlock, Message, Role, StopReason, TokenUsage};
 
 use common::test_config;
 
@@ -960,5 +960,77 @@ async fn tc_2_6_context_overflow_sheds_tool_output_and_continues() {
     );
     assert_eq!(result.text, "Continued after shedding");
     // A clean end-turn — NOT the `finish_run_terminated` MaxTurns/Length verdict.
+    assert_eq!(result.stop_reason, StopReason::EndTurn);
+}
+
+/// #636 resume-heals regression: a session that was terminated with
+/// `FinishReason::Length` — its persisted history still exceeds the model's
+/// context ceiling — must SHED the oversized tool output and CONTINUE when it is
+/// reopened, NOT re-abort on the first resumed turn. This guards the fix's
+/// shedding of `self.messages` (the persisted/heal path), which the live-turn
+/// test above does not exercise: without it, a saved over-ceiling session would
+/// re-hit the ceiling guard on turn 1 of every reopen and be permanently stuck
+/// (the unrecoverable-session death #636 set out to close).
+#[tokio::test]
+async fn tc_2_6_context_overflow_resumed_session_heals_and_continues() {
+    // A single normal assistant reply is all the provider must return: if the
+    // guard heals the resumed history it reaches this one call; if it does NOT,
+    // the run aborts BEFORE any dispatch and call_count stays 0.
+    let turn1 = text_turn("Resumed and continued", 5_000);
+    let provider = Arc::new(CompactMockProvider::new(vec![turn1]));
+
+    let mut config = test_config();
+    config.compact.enabled = false; // isolate the pre-flight ceiling guard
+    config.compact.context_window = 60_000; // unknown model → fallback window
+    config.compact.output_reserve = 10_000;
+    config.compact.emergency_buffer = 10_000; // ceiling = 60k - 20k = 40k tokens
+
+    let registry = ToolRegistry::new();
+    let output = silent_output();
+    let mut engine = AgentEngine::new_with_provider(provider.clone(), config, registry, output);
+
+    // Restore the history of a session that blew the ceiling: an assistant tool
+    // call paired with a ~120k-token tool result (480k chars @ ~4 chars/token,
+    // far over the 40k ceiling) — the exact shape `--resume` reloads from disk.
+    let huge = "x".repeat(480_000);
+    engine.load_conversation(vec![
+        Message::new(
+            Role::User,
+            vec![ContentBlock::Text {
+                text: "earlier question".to_string(),
+            }],
+        ),
+        Message::new(
+            Role::Assistant,
+            vec![ContentBlock::ToolUse {
+                id: "big".to_string(),
+                name: "mock_tool".to_string(),
+                input: serde_json::json!({}),
+                extra: None,
+            }],
+        ),
+        Message::new(
+            Role::Tool,
+            vec![ContentBlock::ToolResult {
+                tool_use_id: "big".to_string(),
+                content: huge,
+                is_error: false,
+            }],
+        ),
+    ]);
+
+    let result = engine
+        .run("continue please", "msg-2")
+        .await
+        .expect("resumed run should succeed, not error");
+
+    // The guard healed the persisted over-ceiling history and continued to the
+    // provider. A re-abort would terminate before dispatch (call_count == 0).
+    assert_eq!(
+        provider.call_count(),
+        1,
+        "resumed over-ceiling session must shed persisted tool output and continue, not re-abort on turn 1"
+    );
+    assert_eq!(result.text, "Resumed and continued");
     assert_eq!(result.stop_reason, StopReason::EndTurn);
 }

--- a/crates/wcore-agent/tests/engine_compact_test.rs
+++ b/crates/wcore-agent/tests/engine_compact_test.rs
@@ -894,3 +894,71 @@ async fn tc_2_6_e2e_03_circuit_breaker_stops_retries() {
 
     assert_eq!(result.text, "Final");
 }
+
+// ── #636: graceful context-overflow degradation ────────────────────────────
+
+/// End-to-end proof of #636 through the REAL pre-flight guard: a turn whose
+/// assembled request exceeds the model's context ceiling used to abort with
+/// `FinishReason::Length`. Now the guard sheds the oversized tool-result output
+/// to disk and the run CONTINUES to a real second turn.
+///
+/// The model id `test-model` is unknown to `wcore_config::limits`, so the
+/// guard's window falls back to `compact.context_window`; auto/micro/emergency
+/// compaction are disabled so the pre-flight ceiling guard is the ONLY thing
+/// that can stop the run. Turn 1's tool returns ~120k tokens of output (far over
+/// the 40k ceiling) as a single `ToolResult`, so shedding that one block fits.
+#[tokio::test]
+async fn tc_2_6_context_overflow_sheds_tool_output_and_continues() {
+    let turn1 = vec![
+        LlmEvent::ToolUse {
+            id: "big".to_string(),
+            name: "mock_tool".to_string(),
+            input: serde_json::json!({}),
+            extra: None,
+        },
+        LlmEvent::Done {
+            stop_reason: StopReason::ToolUse,
+            finish_reason: wcore_types::message::FinishReason::from_stop_reason(
+                StopReason::ToolUse,
+            ),
+            usage: TokenUsage {
+                input_tokens: 5_000, // low reported tokens → emergency can't fire
+                output_tokens: 100,
+                ..Default::default()
+            },
+        },
+    ];
+    let turn2 = text_turn("Continued after shedding", 5_000);
+    let provider = Arc::new(CompactMockProvider::new(vec![turn1, turn2]));
+
+    let mut config = test_config();
+    config.compact.enabled = false; // no auto/micro/emergency — isolate the guard
+    config.compact.context_window = 60_000; // unknown model → fallback window
+    config.compact.output_reserve = 10_000;
+    config.compact.emergency_buffer = 10_000; // ceiling = 60k - 20k = 40k tokens
+
+    let mut registry = ToolRegistry::new();
+    // ~120k tokens (480k chars @ ~4 chars/token) — far over the 40k ceiling, but
+    // ONE oversized ToolResult, so the mechanical shed brings it back under.
+    let huge = "x".repeat(480_000);
+    registry.register(Box::new(common::MockTool::new("mock_tool", &huge, false)));
+    let output = silent_output();
+
+    let mut engine = AgentEngine::new_with_provider(provider.clone(), config, registry, output);
+    let result = engine
+        .run("summarize the file", "msg-1")
+        .await
+        .expect("run should succeed, not error");
+
+    // The guard sheds + CONTINUES: it reaches the 2nd provider call rather than
+    // aborting before it. If shedding had failed, the guard would have
+    // terminated the run at turn 2 (call_count == 1).
+    assert_eq!(
+        provider.call_count(),
+        2,
+        "guard must shed the oversized tool output and continue to turn 2, not abort"
+    );
+    assert_eq!(result.text, "Continued after shedding");
+    // A clean end-turn — NOT the `finish_run_terminated` MaxTurns/Length verdict.
+    assert_eq!(result.stop_reason, StopReason::EndTurn);
+}


### PR DESCRIPTION
## Summary

Closes the context-ceiling hard-death (tracker #636): a turn whose assembled request crossed the model's context-window ceiling used to abort with `FinishReason::Length`, and the over-ceiling history was persisted verbatim — so resuming the session re-aborted on turn 1. "Engine feels broken", unrecoverable even in a fresh chat.

This adds **rung 1 of a graceful-degradation ladder**: before the pre-flight guard aborts, it sheds the largest tool-result outputs from history — spilling full content to disk (recoverable via the emitted `<persisted-output>` path) and leaving a bounded preview — then recomputes. If that drops the request back under the ceiling the run **continues** instead of dying. Only a genuinely irreducible (conversation-heavy) context still terminates.

## How

- New pure module `crates/wcore-agent/src/compact/degrade.rs`: `shed_tool_outputs_until_under` reuses the existing `wcore_tools::tool_result_storage::maybe_persist_tool_result` primitive (already used at tool-exec time). Largest-first over a snapshotted candidate list.
- Wired into the `#255` pre-flight context-window guard in `engine.rs`, before `finish_run_terminated(Length)`.

### Why it is safe (verified by three independent cross-audits)

- **Pairing-safe**: shedding rewrites `ToolResult` *content* only — it never adds or removes blocks — so every `tool_use` keeps its matching `tool_result` (no orphaned-`tool_use` 400). This is why the riskier drop-oldest sliding window is deferred to a later phase.
- **Terminating / no hot-loop**: the candidate list is computed once; `maybe_persist_tool_result` skips already-spilled blocks (idempotent via `PERSISTED_OUTPUT_TAG`), so re-runs never re-spill.
- **Heal on save AND resume**: it sheds both `request.messages` (the dispatched copy — the continue/abort decision is taken on this set) and `self.messages` (persisted history). The guard runs every turn, so a session persisted over-ceiling by an old binary heals on turn 1 of resume instead of re-aborting.
- **Metadata consistency**: after shedding, `request.client_context_tokens` is re-stamped so the Flux/OpenAI context-routing header reflects the shed size (mirrors the existing compaction-retry recount).

## Tests

- Unit tests in `degrade.rs`: largest-first shedding, the min-size floor, idempotency / no-progress when all spilled, tool_use/tool_result pairing preservation, already-under-ceiling no-op.
- Integration test `tc_2_6_context_overflow_sheds_tool_output_and_continues` (`engine_compact_test.rs`) drives a **real turn through the engine guard** (unknown model → ceiling falls back to config window; a ~120k-token single tool output over a 40k ceiling) and asserts the run sheds and continues to a second provider call rather than aborting.

## Cross-audit + verification

- Independent non-author cross-audit by three reviewers (Codex, Gemini, adversarial subagent). Two real findings fixed: stale `client_context_tokens` after shed, and a too-high `min_shed` floor that could refuse a reducible block. The adversarial subagent (repo access) returned MERGE-READY with 0 blockers after verifying termination, pairing, dispatch-correctness, heal-on-resume, borrow safety, and cache-marker safety.
- Full Hetzner gate green: `cargo fmt` + `clippy --all-targets` + `nextest` (2134 tests; only pre-existing known flakes, none related).

## Known follow-up (out of scope, pre-existing)

Spill files are keyed by `tool_use_id` under a shared `$TMPDIR/wayland-results`. Real provider `tool_use_id`s are unique, and this change writes the same id → same content, but a session-scoped spill subdirectory would harden the storage primitive against cross-session collision. Tracked as a follow-up.

Part of the 0.12.23 batch alongside #635 (which removes the premature-ceiling *trigger*); this fixes the give-up *behavior*.
