### PR TITLE
feat(types): add ContentBlock::Image and encode it across all providers (#648)

### DIFF
--- a/crates/wayland-ollama/src/provider.rs
+++ b/crates/wayland-ollama/src/provider.rs
@@ -366,6 +366,14 @@ fn extract_text(m: &Message) -> Result<String, OllamaError> {
                 return Err(OllamaError::ToolUseUnsupported("tool_result"));
             }
             ContentBlock::Thinking { .. } => {}
+            // Ollama's native image channel (message.images) is not wired here;
+            // substitute a text placeholder rather than drop the turn silently.
+            ContentBlock::Image { .. } => {
+                if !out.is_empty() {
+                    out.push('\n');
+                }
+                out.push_str("[image omitted: model not vision-capable]");
+            }
         }
     }
     Ok(out)

--- a/crates/wcore-agent/src/compact/estimate.rs
+++ b/crates/wcore-agent/src/compact/estimate.rs
@@ -5,6 +5,17 @@ const CHARS_PER_TOKEN_TEXT: usize = 4;
 
 const CHARS_PER_TOKEN_JSON: usize = 3;
 
+/// Flat per-image token charge. Images are not char-countable, so decoding
+/// them in this hot estimator is avoided; instead each inline image is charged
+/// a constant at the HIGH end of provider vision-token accounting. Anthropic's
+/// patch-based cost reaches ~4784 tokens for a large image (≈3888 at 2000x1500,
+/// ≈2691 at 1920x1080); OpenAI/Gemini high-detail costs sit below that. The
+/// EMERGENCY compaction watermark must never undercount, so this deliberately
+/// over-estimates: firing compaction early is safe, overflowing the window is
+/// not. A composer-dropped image is typically a full-resolution screenshot, so
+/// the ceiling — not an average — is the correct charge.
+const TOKENS_PER_IMAGE: usize = 4800;
+
 /// Estimate the total token count for a slice of messages.
 ///
 /// Intentionally conservative (slightly over-estimates) to ensure
@@ -36,6 +47,7 @@ pub fn estimate_tokens_from_messages_with_thinking(
 fn estimate_tokens_from_messages_inner(messages: &[Message], count_thinking: bool) -> u64 {
     let mut total_chars: usize = 0;
     let mut json_chars: usize = 0;
+    let mut image_tokens: usize = 0;
 
     for msg in messages {
         for block in &msg.content {
@@ -55,6 +67,12 @@ fn estimate_tokens_from_messages_inner(messages: &[Message], count_thinking: boo
                 ContentBlock::ToolResult { content, .. } => {
                     total_chars += content.len();
                 }
+                // Charge a flat conservative constant per inline image rather
+                // than counting the base64 payload (which would wildly
+                // over-count against the model's real vision token cost).
+                ContentBlock::Image { .. } => {
+                    image_tokens += TOKENS_PER_IMAGE;
+                }
             }
         }
     }
@@ -62,7 +80,7 @@ fn estimate_tokens_from_messages_inner(messages: &[Message], count_thinking: boo
     let text_tokens = total_chars / CHARS_PER_TOKEN_TEXT;
     let json_tokens = json_chars / CHARS_PER_TOKEN_JSON;
 
-    (text_tokens + json_tokens) as u64
+    (text_tokens + json_tokens + image_tokens) as u64
 }
 
 /// AUDIT A5 — estimate the token count of a FULL request: messages
@@ -104,6 +122,23 @@ mod tests {
         let text = "a".repeat(400);
         let msg = Message::new(Role::User, vec![ContentBlock::Text { text }]);
         assert_eq!(estimate_tokens_from_messages(&[msg]), 100);
+    }
+
+    #[test]
+    fn image_block_charges_flat_constant() {
+        // An inline image is charged the flat per-image constant regardless of
+        // its (tiny) base64 payload length — not counted as text chars.
+        let msg = Message::new(
+            Role::User,
+            vec![ContentBlock::Image {
+                mime: "image/png".into(),
+                data: "QUJD".into(),
+            }],
+        );
+        assert_eq!(
+            estimate_tokens_from_messages(&[msg]),
+            TOKENS_PER_IMAGE as u64
+        );
     }
 
     #[test]

--- a/crates/wcore-agent/src/engine.rs
+++ b/crates/wcore-agent/src/engine.rs
@@ -129,15 +129,18 @@ fn resolve_turn_cost_usd(
 /// Finding #174 — does this turn carry image/vision content that forbids a
 /// tier downgrade?
 ///
-/// The `wcore-types` `ContentBlock` enum has no image variant today, so there
-/// is no real vision content to detect and this returns `false`. It is kept as
-/// the single chokepoint for the vision signal: when a future image
-/// `ContentBlock` lands, only this function must change for the smart-routing
-/// guard (and the router's `requires_vision` shape input) to start respecting
-/// it. The router independently promotes any vision turn to Premium, which
-/// [`select_tier_model`] already refuses to swap; this is belt-and-suspenders.
-fn message_requires_vision(_messages: &[Message]) -> bool {
-    false
+/// Returns `true` when any message carries a `ContentBlock::Image` (#648). This
+/// is the single chokepoint for the vision signal feeding the smart-routing
+/// guard (and the router's `requires_vision` shape input): a vision turn must
+/// never be silently downgraded to a text-only tier model. The router also
+/// independently promotes any vision turn to Premium, which [`select_tier_model`]
+/// refuses to swap; this is belt-and-suspenders.
+fn message_requires_vision(messages: &[Message]) -> bool {
+    messages.iter().any(|m| {
+        m.content
+            .iter()
+            .any(|b| matches!(b, ContentBlock::Image { .. }))
+    })
 }
 
 /// Finding #174 — decide whether to swap to a configured tier model, and to
@@ -4129,6 +4132,7 @@ impl AgentEngine {
                         if *is_error { " error" } else { "" }
                     )),
                     ContentBlock::Thinking { thinking } => Some(format!("thinking: {thinking}")),
+                    ContentBlock::Image { mime, .. } => Some(format!("[image: {mime}]")),
                 };
                 if let Some(line) = line {
                     summary.push_str(role);
@@ -8490,6 +8494,7 @@ mod tier_routing_tests {
     use super::{message_requires_vision, select_tier_model};
     use wcore_config::compat::{ProviderCompat, TierModels};
     use wcore_providers::{RequestShape, RoutingHeuristics, route};
+    use wcore_types::message::{ContentBlock, Message, Role};
 
     /// A shape that classifies to Cheap (simple turn): small context, no tools,
     /// no code, no vision.
@@ -8576,6 +8581,37 @@ mod tier_routing_tests {
     #[test]
     fn vision_helper_is_false_without_image_blocks() {
         assert!(!message_requires_vision(&[]));
+        // A text-only turn is not a vision turn.
+        let text = Message::new(Role::User, vec![ContentBlock::Text { text: "hi".into() }]);
+        assert!(!message_requires_vision(&[text]));
+    }
+
+    #[test]
+    fn vision_helper_is_true_with_image_block() {
+        // #648: an image block makes the turn a vision turn, which
+        // `select_tier_model` must refuse to downgrade to a text-only model.
+        let img = Message::new(
+            Role::User,
+            vec![
+                ContentBlock::Text {
+                    text: "what is this".into(),
+                },
+                ContentBlock::Image {
+                    mime: "image/png".into(),
+                    data: "QUJD".into(),
+                },
+            ],
+        );
+        assert!(message_requires_vision(&[img]));
+
+        // And the guard consequently blocks a downgrade even to a configured
+        // cheap tier model.
+        let decision = route(&cheap_shape(), &RoutingHeuristics::default());
+        assert_eq!(
+            select_tier_model(&decision, true, &compat_with_cheap_model()),
+            None,
+            "a vision turn must never be downgraded to a tier model"
+        );
     }
 }
 

--- a/crates/wcore-cli/src/tui/protocol_bridge.rs
+++ b/crates/wcore-cli/src/tui/protocol_bridge.rs
@@ -1520,6 +1520,10 @@ pub fn hydrate_history(messages: &[Message]) -> (Vec<TurnView>, Vec<ToolCardMode
                             });
                         }
                         ContentBlock::ToolResult { .. } => {}
+                        ContentBlock::Image { mime, .. } => {
+                            turn.elements
+                                .push(TurnElement::Markdown(format!("_[image: {mime}]_")));
+                        }
                     }
                 }
                 if !turn.elements.is_empty() {

--- a/crates/wcore-config/src/compat.rs
+++ b/crates/wcore-config/src/compat.rs
@@ -315,6 +315,21 @@ pub struct ProviderCompat {
     /// without the field or default to a tiny ceiling like 16).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub omit_max_tokens_when_unsized: Option<bool>,
+
+    /// #648 — whether the provider's served model(s) accept inline image
+    /// (vision) input. Consulted by `OpenAIProvider::build_messages`: when
+    /// `false` (or unset) a `ContentBlock::Image` is NOT emitted as an OpenAI
+    /// `image_url` multipart part — text-only endpoints 400 on it — and instead
+    /// the shared `[image omitted: model not vision-capable]` text placeholder
+    /// is appended, matching cohere / bedrock (mistral) / wayland-ollama.
+    ///
+    /// `None`/`Some(false)` (the default) is the SAFE choice: omit the image
+    /// (soft degradation) rather than risk a hard 400 on a non-vision model.
+    /// Presets set `Some(true)` only for providers whose catalog hosts
+    /// vision-capable models (openai, azure-openai, openrouter, together,
+    /// fireworks, nvidia, xai, qwen, groq, flux-router, mistral).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub supports_vision: Option<bool>,
 }
 
 impl ProviderCompat {
@@ -486,6 +501,8 @@ impl ProviderCompat {
             // the `o1*`/`o3*` reasoning families are excluded per-model by
             // `openai_compat::accepts_temperature`.
             supports_temperature: Some(true),
+            // #648: native OpenAI hosts vision models (gpt-4o family).
+            supports_vision: Some(true),
             ..Default::default()
         }
     }
@@ -551,7 +568,11 @@ impl ProviderCompat {
     /// Azure prices match OpenAI list price, but cost attribution must be
     /// labelled `"azure-openai"` and resolve against the catalog.
     pub fn azure_openai_defaults() -> Self {
-        Self::openai_compat_provider("azure-openai")
+        Self {
+            // #648: Azure hosts the OpenAI vision models (gpt-4o family).
+            supports_vision: Some(true),
+            ..Self::openai_compat_provider("azure-openai")
+        }
     }
 
     /// Defaults for "Sign in with ChatGPT" (the Codex backend).
@@ -583,6 +604,8 @@ impl ProviderCompat {
         // native `--provider together` arm does not build `/v1/v1/...` (404).
         Self {
             api_path: Some("/chat/completions".into()),
+            // #648: Together hosts vision models (Llama-Vision, Qwen-VL).
+            supports_vision: Some(true),
             ..Self::openai_compat_provider("together")
         }
     }
@@ -592,6 +615,8 @@ impl ProviderCompat {
         // Base URL ends in `/inference/v1`; pin `api_path` to avoid `/v1/v1`.
         Self {
             api_path: Some("/chat/completions".into()),
+            // #648: Fireworks hosts vision models (Llama-Vision, Qwen-VL, Phi).
+            supports_vision: Some(true),
             ..Self::openai_compat_provider("fireworks")
         }
     }
@@ -601,6 +626,8 @@ impl ProviderCompat {
         // Base URL ends in `/v1`; pin `api_path` to avoid `/v1/v1`.
         Self {
             api_path: Some("/chat/completions".into()),
+            // #648: NVIDIA NIM catalog hosts vision models (Llama-Vision, NeVA).
+            supports_vision: Some(true),
             ..Self::openai_compat_provider("nvidia")
         }
     }
@@ -612,6 +639,8 @@ impl ProviderCompat {
         // not 404.
         Self {
             api_path: Some("/chat/completions".into()),
+            // #648: Perplexity's Sonar chat API is text-only — omit images safely.
+            supports_vision: Some(false),
             ..Self::openai_compat_provider("perplexity")
         }
     }
@@ -621,6 +650,8 @@ impl ProviderCompat {
         // Base URL ends in `/v1`; pin `api_path` to avoid `/v1/v1`.
         Self {
             api_path: Some("/chat/completions".into()),
+            // #648: Cerebras serves text-only Llama models — omit images safely.
+            supports_vision: Some(false),
             ..Self::openai_compat_provider("cerebras")
         }
     }
@@ -632,6 +663,8 @@ impl ProviderCompat {
             // `max_tokens` is absent, so an unknown/aliased model with no
             // explicit user cap may omit the field.
             omit_max_tokens_when_unsized: Some(true),
+            // #648: OpenRouter routes hundreds of vision-capable models.
+            supports_vision: Some(true),
             ..Self::openai_compat_provider("openrouter")
         }
     }
@@ -647,6 +680,8 @@ impl ProviderCompat {
             // omit the field. The sized internal budget still rides the
             // `x-wl-expected-output` header.
             omit_max_tokens_when_unsized: Some(true),
+            // #648: Flux routes to vision-capable models across providers.
+            supports_vision: Some(true),
             ..Self::openai_compat_provider("flux-router")
         }
     }
@@ -669,6 +704,8 @@ impl ProviderCompat {
             // carries `reasoning_content` once any turn produced thinking, so we
             // must replay prior-turn thinking here (finding #174 exception).
             replays_thinking_in_history: Some(true),
+            // #648: DeepSeek chat/reasoner are text-only — omit images safely.
+            supports_vision: Some(false),
             ..Self::openai_compat_provider("deepseek")
         }
     }
@@ -682,13 +719,19 @@ impl ProviderCompat {
             // the engine otherwise attaches as a client-side output
             // optimization — suppress it so Grok models actually run.
             supports_stop_param: Some(false),
+            // #648: xAI Grok hosts vision models (grok-2-vision, grok-4).
+            supports_vision: Some(true),
             ..Self::openai_compat_provider("xai")
         }
     }
 
     /// v0.8.1 U10b — Defaults for Groq (fast LPU inference, OpenAI-compatible).
     pub fn groq_defaults() -> Self {
-        Self::openai_compat_provider("groq")
+        Self {
+            // #648: Groq hosts multimodal Llama-4 (scout/maverick) vision models.
+            supports_vision: Some(true),
+            ..Self::openai_compat_provider("groq")
+        }
     }
 
     /// Defaults for Moonshot (Kimi). v0.8.1 U10e.
@@ -715,6 +758,8 @@ impl ProviderCompat {
         // Base URL ends in `/compatible-mode/v1`; pin `api_path` to avoid `/v1/v1`.
         Self {
             api_path: Some("/chat/completions".into()),
+            // #648: DashScope hosts the Qwen-VL vision family (qwen-vl-max).
+            supports_vision: Some(true),
             ..Self::openai_compat_provider("qwen")
         }
     }
@@ -725,6 +770,8 @@ impl ProviderCompat {
         // Base URL ends in `/v1`; pin `api_path` to avoid `/v1/v1`.
         Self {
             api_path: Some("/chat/completions".into()),
+            // #648: Mistral hosts the Pixtral vision family (pixtral-large).
+            supports_vision: Some(true),
             ..Self::openai_compat_provider("mistral")
         }
     }
@@ -823,6 +870,7 @@ impl ProviderCompat {
             omit_max_tokens_when_unsized: user
                 .omit_max_tokens_when_unsized
                 .or(defaults.omit_max_tokens_when_unsized),
+            supports_vision: user.supports_vision.or(defaults.supports_vision),
         }
     }
 
@@ -891,6 +939,15 @@ impl ProviderCompat {
     /// presets set `true`.
     pub fn omit_max_tokens_when_unsized(&self) -> bool {
         self.omit_max_tokens_when_unsized.unwrap_or(false)
+    }
+
+    /// #648: whether to send inline images as OpenAI `image_url` multipart
+    /// parts. Defaults to `false` — a `ContentBlock::Image` is replaced with the
+    /// shared text placeholder for text-only providers rather than risking a
+    /// 400. Vision-capable presets (openai, azure-openai, openrouter, together,
+    /// fireworks, nvidia, xai, qwen, groq, flux-router, mistral) set `true`.
+    pub fn supports_vision(&self) -> bool {
+        self.supports_vision.unwrap_or(false)
     }
 
     /// Whether to replay historical assistant `reasoning_content` on the Chat

--- a/crates/wcore-providers/src/anthropic_shared.rs
+++ b/crates/wcore-providers/src/anthropic_shared.rs
@@ -67,6 +67,16 @@ pub fn build_messages(messages: &[Message], compat: &ProviderCompat) -> Vec<Valu
                 // whole conversation as unrecoverable. Omitting thinking on
                 // replay is always accepted, so drop it.
                 ContentBlock::Thinking { .. } => None,
+                // Inline image on a user turn. Anthropic native shape:
+                // `{type:image, source:{type:base64, media_type, data}}`.
+                ContentBlock::Image { mime, data } => Some(json!({
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": mime,
+                        "data": data
+                    }
+                })),
             })
             .collect();
 
@@ -609,6 +619,32 @@ mod tests {
         assert_eq!(content.len(), 1);
         assert_eq!(content[0]["type"], "text");
         assert_eq!(content[0]["text"], "Hello");
+    }
+
+    #[test]
+    fn test_build_messages_with_image() {
+        let messages = vec![Message::new(
+            Role::User,
+            vec![
+                ContentBlock::Text {
+                    text: "what is this?".to_string(),
+                },
+                ContentBlock::Image {
+                    mime: "image/png".to_string(),
+                    data: "QUJD".to_string(),
+                },
+            ],
+        )];
+        let result = build_messages(&messages, &default_compat());
+        assert_eq!(result.len(), 1);
+        let content = result[0]["content"].as_array().unwrap();
+        assert_eq!(content.len(), 2);
+        assert_eq!(content[0]["type"], "text");
+        // Anthropic native image shape.
+        assert_eq!(content[1]["type"], "image");
+        assert_eq!(content[1]["source"]["type"], "base64");
+        assert_eq!(content[1]["source"]["media_type"], "image/png");
+        assert_eq!(content[1]["source"]["data"], "QUJD");
     }
 
     #[test]

--- a/crates/wcore-providers/src/bedrock.rs
+++ b/crates/wcore-providers/src/bedrock.rs
@@ -1172,6 +1172,12 @@ pub mod mistral {
                 ContentBlock::ToolUse { name, input, .. } => {
                     out.push_str(&format!("[tool_use: {name} {input}]"));
                 }
+                // Mistral-on-Bedrock is a text-completion family with no native
+                // image support; substitute a placeholder so the turn is not
+                // silently emptied.
+                ContentBlock::Image { .. } => {
+                    out.push_str("[image omitted: model not vision-capable]");
+                }
             }
         }
         out
@@ -1301,6 +1307,10 @@ pub mod cohere {
             match block {
                 ContentBlock::Text { text } => out.push_str(text),
                 ContentBlock::ToolResult { content, .. } => out.push_str(content),
+                // Text-only wire; no native image support.
+                ContentBlock::Image { .. } => {
+                    out.push_str("[image omitted: model not vision-capable]")
+                }
                 _ => {}
             }
         }

--- a/crates/wcore-providers/src/cohere.rs
+++ b/crates/wcore-providers/src/cohere.rs
@@ -299,6 +299,13 @@ fn flatten_message_text(m: &Message) -> String {
             ContentBlock::ToolUse { .. } | ContentBlock::Thinking { .. } => {
                 // Skipped — surfaced through dedicated channels by the caller.
             }
+            ContentBlock::Image { .. } => {
+                // Cohere chat is text-only here; no native image support.
+                if !out.is_empty() {
+                    out.push('\n');
+                }
+                out.push_str("[image omitted: model not vision-capable]");
+            }
         }
     }
     out

--- a/crates/wcore-providers/src/gemini.rs
+++ b/crates/wcore-providers/src/gemini.rs
@@ -425,6 +425,15 @@ pub(crate) fn build_contents(
                         "thought": true,
                     }));
                 }
+                ContentBlock::Image { mime, data } => {
+                    // Gemini native shape: `parts:[{inlineData:{mimeType,data}}]`.
+                    parts.push(json!({
+                        "inlineData": {
+                            "mimeType": mime,
+                            "data": data,
+                        }
+                    }));
+                }
             }
         }
 
@@ -1051,6 +1060,26 @@ mod tests {
         assert_eq!(contents[0]["role"], "user");
         let parts = contents[0]["parts"].as_array().unwrap();
         assert_eq!(parts[0]["text"], "Hi");
+    }
+
+    #[test]
+    fn build_contents_user_image_becomes_inline_data() {
+        let messages = vec![Message::new(
+            Role::User,
+            vec![
+                ContentBlock::Text { text: "Hi".into() },
+                ContentBlock::Image {
+                    mime: "image/png".into(),
+                    data: "QUJD".into(),
+                },
+            ],
+        )];
+        let (_sys, contents) = build_contents(&messages, &compat());
+        let parts = contents[0]["parts"].as_array().unwrap();
+        assert_eq!(parts[0]["text"], "Hi");
+        // Gemini native inline image shape.
+        assert_eq!(parts[1]["inlineData"]["mimeType"], "image/png");
+        assert_eq!(parts[1]["inlineData"]["data"], "QUJD");
     }
 
     #[test]

--- a/crates/wcore-providers/src/openai.rs
+++ b/crates/wcore-providers/src/openai.rs
@@ -310,10 +310,43 @@ impl OpenAIProvider {
                             .collect::<Vec<_>>()
                             .join("\n");
                         let text = strip_patterns_from_text(&text, compat);
-                        result.push(json!({
-                            "role": "user",
-                            "content": text
-                        }));
+
+                        // If the turn carries inline images, OpenAI Chat requires
+                        // the multi-part array content shape. Native image part:
+                        // `{type:image_url, image_url:{url:"data:<mime>;base64,<b64>"}}`.
+                        let images: Vec<Value> = msg
+                            .content
+                            .iter()
+                            .filter_map(|b| {
+                                if let ContentBlock::Image { mime, data } = b {
+                                    Some(json!({
+                                        "type": "image_url",
+                                        "image_url": {
+                                            "url": format!("data:{mime};base64,{data}")
+                                        }
+                                    }))
+                                } else {
+                                    None
+                                }
+                            })
+                            .collect();
+
+                        if images.is_empty() {
+                            result.push(json!({
+                                "role": "user",
+                                "content": text
+                            }));
+                        } else {
+                            let mut parts: Vec<Value> = Vec::new();
+                            if !text.is_empty() {
+                                parts.push(json!({ "type": "text", "text": text }));
+                            }
+                            parts.extend(images);
+                            result.push(json!({
+                                "role": "user",
+                                "content": parts
+                            }));
+                        }
                     }
                 }
                 Role::Assistant => {
@@ -3853,6 +3886,43 @@ mod tests {
         let result = OpenAIProvider::build_messages(&messages, "", &no_compat());
         let assistant_msgs: Vec<_> = result.iter().filter(|m| m["role"] == "assistant").collect();
         assert_eq!(assistant_msgs.len(), 2);
+    }
+
+    #[test]
+    fn test_build_messages_user_image_becomes_multipart() {
+        // A user turn with an inline image lowers to the OpenAI Chat multi-part
+        // array shape: a text part + an image_url data-URI part.
+        let messages = vec![Message::new(
+            Role::User,
+            vec![
+                ContentBlock::Text {
+                    text: "describe".into(),
+                },
+                ContentBlock::Image {
+                    mime: "image/png".into(),
+                    data: "QUJD".into(),
+                },
+            ],
+        )];
+        let result = OpenAIProvider::build_messages(&messages, "", &openai_compat());
+        let user = result.iter().find(|m| m["role"] == "user").unwrap();
+        let parts = user["content"].as_array().expect("content must be array");
+        assert_eq!(parts[0]["type"], "text");
+        assert_eq!(parts[0]["text"], "describe");
+        assert_eq!(parts[1]["type"], "image_url");
+        assert_eq!(parts[1]["image_url"]["url"], "data:image/png;base64,QUJD");
+    }
+
+    #[test]
+    fn test_build_messages_user_without_image_stays_string() {
+        // Backwards-compat: no image → plain string content (unchanged wire shape).
+        let messages = vec![Message::new(
+            Role::User,
+            vec![ContentBlock::Text { text: "hi".into() }],
+        )];
+        let result = OpenAIProvider::build_messages(&messages, "", &openai_compat());
+        let user = result.iter().find(|m| m["role"] == "user").unwrap();
+        assert_eq!(user["content"], "hi");
     }
 
     // --- replays_thinking_in_history (finding #174) ---

--- a/crates/wcore-providers/src/openai.rs
+++ b/crates/wcore-providers/src/openai.rs
@@ -3972,7 +3972,10 @@ mod tests {
             user["content"]
         );
         let content = user["content"].as_str().unwrap();
-        assert_eq!(content, "describe\n[image omitted: model not vision-capable]");
+        assert_eq!(
+            content,
+            "describe\n[image omitted: model not vision-capable]"
+        );
 
         // Belt-and-suspenders: the serialized message must carry no image_url.
         assert!(

--- a/crates/wcore-providers/src/openai.rs
+++ b/crates/wcore-providers/src/openai.rs
@@ -309,27 +309,45 @@ impl OpenAIProvider {
                             })
                             .collect::<Vec<_>>()
                             .join("\n");
-                        let text = strip_patterns_from_text(&text, compat);
+                        let mut text = strip_patterns_from_text(&text, compat);
 
-                        // If the turn carries inline images, OpenAI Chat requires
-                        // the multi-part array content shape. Native image part:
-                        // `{type:image_url, image_url:{url:"data:<mime>;base64,<b64>"}}`.
-                        let images: Vec<Value> = msg
-                            .content
-                            .iter()
-                            .filter_map(|b| {
-                                if let ContentBlock::Image { mime, data } = b {
-                                    Some(json!({
-                                        "type": "image_url",
-                                        "image_url": {
-                                            "url": format!("data:{mime};base64,{data}")
-                                        }
-                                    }))
-                                } else {
-                                    None
+                        // #648: vision capability gate. If the turn carries inline
+                        // images, OpenAI Chat requires the multi-part array shape
+                        // with `image_url` parts. But text-only endpoints (deepseek,
+                        // cerebras, perplexity, …) 400 on an `image_url` part, so
+                        // only emit it when `compat.supports_vision()`. Otherwise
+                        // drop the image and append the shared placeholder text —
+                        // the same soft degradation cohere / bedrock (mistral) /
+                        // wayland-ollama already do.
+                        let images: Vec<Value> = if compat.supports_vision() {
+                            msg.content
+                                .iter()
+                                .filter_map(|b| {
+                                    if let ContentBlock::Image { mime, data } = b {
+                                        Some(json!({
+                                            "type": "image_url",
+                                            "image_url": {
+                                                "url": format!("data:{mime};base64,{data}")
+                                            }
+                                        }))
+                                    } else {
+                                        None
+                                    }
+                                })
+                                .collect()
+                        } else {
+                            if msg
+                                .content
+                                .iter()
+                                .any(|b| matches!(b, ContentBlock::Image { .. }))
+                            {
+                                if !text.is_empty() {
+                                    text.push('\n');
                                 }
-                            })
-                            .collect();
+                                text.push_str("[image omitted: model not vision-capable]");
+                            }
+                            Vec::new()
+                        };
 
                         if images.is_empty() {
                             result.push(json!({
@@ -3923,6 +3941,44 @@ mod tests {
         let result = OpenAIProvider::build_messages(&messages, "", &openai_compat());
         let user = result.iter().find(|m| m["role"] == "user").unwrap();
         assert_eq!(user["content"], "hi");
+    }
+
+    #[test]
+    fn test_build_messages_non_vision_omits_image_and_emits_placeholder() {
+        // #648: a text-only (non-vision) compat model MUST NOT emit an
+        // `image_url` multipart part — text-only endpoints 400 on it. Instead
+        // the image is dropped and the shared placeholder text is appended, so
+        // the content stays a plain string (soft degradation, no hard reject).
+        let messages = vec![Message::new(
+            Role::User,
+            vec![
+                ContentBlock::Text {
+                    text: "describe".into(),
+                },
+                ContentBlock::Image {
+                    mime: "image/png".into(),
+                    data: "QUJD".into(),
+                },
+            ],
+        )];
+        // `no_compat()` is `ProviderCompat::default()` → `supports_vision()` false.
+        let result = OpenAIProvider::build_messages(&messages, "", &no_compat());
+        let user = result.iter().find(|m| m["role"] == "user").unwrap();
+
+        // Content is the plain-string form, NOT a multipart array.
+        assert!(
+            user["content"].is_string(),
+            "non-vision content must stay a plain string, got: {}",
+            user["content"]
+        );
+        let content = user["content"].as_str().unwrap();
+        assert_eq!(content, "describe\n[image omitted: model not vision-capable]");
+
+        // Belt-and-suspenders: the serialized message must carry no image_url.
+        assert!(
+            !user.to_string().contains("image_url"),
+            "non-vision message must not serialize an image_url part"
+        );
     }
 
     // --- replays_thinking_in_history (finding #174) ---

--- a/crates/wcore-providers/src/openai_responses.rs
+++ b/crates/wcore-providers/src/openai_responses.rs
@@ -199,14 +199,28 @@ fn push_user_items(input: &mut Vec<Value>, msg: &Message) {
         return;
     }
 
+    // Inline images become `input_image` parts alongside any `input_text`.
+    // Native Responses shape: `{type:input_image, image_url:"data:<mime>;base64,<b64>"}`.
+    let mut content: Vec<Value> = Vec::new();
     let text: String = collect_text(msg);
-    if text.is_empty() {
+    if !text.is_empty() {
+        content.push(json!({ "type": "input_text", "text": text }));
+    }
+    for block in &msg.content {
+        if let ContentBlock::Image { mime, data } = block {
+            content.push(json!({
+                "type": "input_image",
+                "image_url": format!("data:{mime};base64,{data}"),
+            }));
+        }
+    }
+    if content.is_empty() {
         return;
     }
     input.push(json!({
         "type": "message",
         "role": "user",
-        "content": [{ "type": "input_text", "text": text }],
+        "content": content,
     }));
 }
 
@@ -891,6 +905,47 @@ mod tests {
         assert_eq!(input[0]["role"], json!("user"));
         assert_eq!(input[0]["content"][0]["type"], json!("input_text"));
         assert_eq!(input[0]["content"][0]["text"], json!("Hello"));
+    }
+
+    #[test]
+    fn build_input_user_image_becomes_input_image() {
+        let msg = Message::new(
+            Role::User,
+            vec![
+                ContentBlock::Text {
+                    text: "what is this".into(),
+                },
+                ContentBlock::Image {
+                    mime: "image/png".into(),
+                    data: "QUJD".into(),
+                },
+            ],
+        );
+        let input = build_input(&[msg]);
+        assert_eq!(input.len(), 1);
+        let content = input[0]["content"].as_array().unwrap();
+        assert_eq!(content[0]["type"], "input_text");
+        assert_eq!(content[0]["text"], "what is this");
+        // Responses native image-input shape.
+        assert_eq!(content[1]["type"], "input_image");
+        assert_eq!(content[1]["image_url"], "data:image/png;base64,QUJD");
+    }
+
+    #[test]
+    fn build_input_image_only_user_turn_is_not_dropped() {
+        // A turn that is only an image (no text) must still produce an input item.
+        let msg = Message::new(
+            Role::User,
+            vec![ContentBlock::Image {
+                mime: "image/jpeg".into(),
+                data: "QUJD".into(),
+            }],
+        );
+        let input = build_input(&[msg]);
+        assert_eq!(input.len(), 1);
+        let content = input[0]["content"].as_array().unwrap();
+        assert_eq!(content.len(), 1);
+        assert_eq!(content[0]["type"], "input_image");
     }
 
     /// #112: when the engine flags `omit_max_tokens` AND the provider's own

--- a/crates/wcore-types/src/message.rs
+++ b/crates/wcore-types/src/message.rs
@@ -37,6 +37,22 @@ pub enum ContentBlock {
     /// and as `reasoning_content` for OpenAI-compatible providers.
     #[serde(rename = "thinking")]
     Thinking { thinking: String },
+
+    /// An inline image on a user turn (e.g. a composer-dropped local image).
+    /// `data` is standard base64 (no data-URI prefix); `mime` is a sniffed
+    /// image MIME such as `image/png`. The engine resolves any local path to
+    /// bytes at the protocol boundary, so providers never touch the filesystem
+    /// — each provider's `build_messages()` re-encodes this into its native
+    /// image content shape (Anthropic `image.source.base64`, OpenAI
+    /// `image_url` data URI, Gemini `inline_data`). The dedicated text-only
+    /// families (Cohere, Mistral/Bedrock, Ollama) drop it and substitute a
+    /// short text placeholder. The OpenAI-compatible builder always emits the
+    /// image part, so a text-only OpenAI-compatible endpoint would reject it;
+    /// a `ProviderCompat` vision-capability gate is a follow-up, tracked with
+    /// the ingest wiring. Vision turns are kept off text-only tier models by
+    /// the engine's vision-routing guard (`message_requires_vision`).
+    #[serde(rename = "image")]
+    Image { mime: String, data: String },
 }
 
 /// Cache-control hint placed on a `Message` by the prompt-cache discipline
@@ -253,6 +269,30 @@ mod tests {
         // assert
         assert_eq!(value["type"], "text");
         assert_eq!(value["text"], "hello world");
+    }
+
+    #[test]
+    fn test_content_block_image_serialization_roundtrip() {
+        // arrange
+        let block = ContentBlock::Image {
+            mime: "image/png".to_string(),
+            data: "QUJD".to_string(),
+        };
+        // act
+        let value = serde_json::to_value(&block).unwrap();
+        // assert wire tag + fields
+        assert_eq!(value["type"], "image");
+        assert_eq!(value["mime"], "image/png");
+        assert_eq!(value["data"], "QUJD");
+        // round-trips back to the same variant
+        let back: ContentBlock = serde_json::from_value(value).unwrap();
+        match back {
+            ContentBlock::Image { mime, data } => {
+                assert_eq!(mime, "image/png");
+                assert_eq!(data, "QUJD");
+            }
+            other => panic!("expected Image, got {other:?}"),
+        }
     }
 
     // --- ContentBlock::ToolUse ---


### PR DESCRIPTION
## Summary

Foundational engine half of the composer-dropped-image feature (tracker #648, from #637). A locally dropped image could not reach a vision-capable model in the main agent turn because `ContentBlock` had no image variant — an image simply could not ride the conversation. This adds `ContentBlock::Image { mime, data }` (base64, serde tag `image`) and teaches every provider path to encode or gracefully degrade it.

## What this delivers

- **`wcore-types`**: new `ContentBlock::Image { mime: String, data: String }`. `data` is standard base64 (no data-URI prefix); `mime` is a sniffed image MIME. Serde round-trip locked by test.
- **Native encoding (vision providers):**
  - Anthropic / Bedrock-anthropic / Vertex — `{type:image, source:{type:base64, media_type, data}}`
  - OpenAI Chat — multi-part `content` array with `{type:image_url, image_url:{url:"data:<mime>;base64,<b64>"}}`. String content is preserved unchanged when no image is present (wire-compatible).
  - OpenAI Responses / ChatGPT / Codex — `{type:input_image, image_url:"data:…"}`; an image-only user turn is no longer dropped.
  - Gemini — `{inlineData:{mimeType, data}}` (camelCase, matching this path's existing `functionCall`/`functionResponse` convention).
- **Text-only families** (Mistral-on-Bedrock, Bedrock-Cohere, Cohere, Ollama) substitute a short `[image omitted: model not vision-capable]` placeholder instead of silently emptying the turn.
- **Token estimator** (`compact/estimate.rs`) charges a flat conservative per-image constant (~1600 tokens, near Anthropic's per-image ceiling) rather than counting the base64 payload — over-estimating is safe, it makes the compaction watermarks fire sooner rather than undercount and overflow.
- **TUI** render arm + engine conversation-summary arm for exhaustiveness.

## Design

The engine resolves any local path to bytes at the protocol boundary, so **providers never touch the filesystem** — each just re-encodes the base64 into its native image shape, mirroring the existing `tool_backends/*_vision.rs` encoders.

Every exhaustive `match` on `ContentBlock` across the workspace (10 sites in 6 crates) now carries an `Image` arm — verified so a new variant cannot compile-break silently.

## Scope boundary

This PR is the representation + transmission half. The **json-stream `files[]` ingest** (read a dropped image path → bytes → `ContentBlock::Image`) is a small follow-up that reuses the hardened local reader from #637/PR #170 (validate_user_path + UNC reject + TOCTOU open-once + is_file) to avoid duplicating that logic. #648 stays open until that lands. Desktop keeps sending the dropped image path in the Message `files` vector (already done) — no protocol change.

## Tests

`cargo test` (workspace) — new unit tests: serde tag round-trip (wcore-types); native-shape assertions for Anthropic, OpenAI Chat (multi-part + string-preserved-without-image), OpenAI Responses (image part + image-only-turn-not-dropped), Gemini inlineData; estimator flat-constant charge.

## Verification

- Full Hetzner gate: `cargo fmt --all --check` + `cargo clippy --workspace --all-targets -D warnings` + `cargo nextest run --workspace`.

## Cross-audit (3-way, non-author)

Codex + Gemini + an adversarial subagent reviewed the diff.
- **Wire shapes** all verified correct against each provider's real API (Codex web-searched the docs): Anthropic `image.source.base64`, OpenAI Chat `image_url:{url}`, OpenAI Responses bare-string `image_url`, Gemini `inlineData`. Two Gemini findings (Responses shape, cache_control placement) were refuted by Codex as false positives.
- **Real blocker found + fixed** (adversarial subagent): the codebase reserved `message_requires_vision()` as the single vision chokepoint ("only this function must change when an image ContentBlock lands"). This PR now updates it to detect `ContentBlock::Image`, so smart-routing (`tier_models`) never downgrades a vision turn to a text-only model. Test added (`vision_helper_is_true_with_image_block`).
- **Token estimate** raised to a conservative 4800/image (was 1600) to cover Anthropic's documented high-res per-image ceiling (~4784) so the emergency compaction watermark never undercounts.
- **Follow-up filed** (#652): a `ProviderCompat` vision-capability gate so an image sent to a text-only OpenAI-compatible endpoint degrades to a placeholder instead of a 400. Not reachable until the `files[]` ingest lands (also a follow-up, depends on #170).
