### PR TITLE
fix(compact): rung-2 conversation-heavy overflow degradation (#646)

### DIFF
--- a/crates/wcore-agent/src/compact/degrade.rs
+++ b/crates/wcore-agent/src/compact/degrade.rs
@@ -33,6 +33,13 @@ use wcore_tools::tool_result_storage::{
 };
 use wcore_types::message::{ContentBlock, Message, Role};
 
+/// Stable substring embedded in every [`truncate_head_tail`] marker. Rung 2's
+/// pass 1 skips any block already containing it so a truncated block is never
+/// re-truncated on a later pass — mirroring rung 1's [`PERSISTED_OUTPUT_TAG`]
+/// skip. This keeps rung 2 idempotent: a resumed/re-degraded session re-emits
+/// the identical prefix instead of churning the Anthropic prompt cache.
+const TRUNC_MARKER: &str = "chars truncated";
+
 /// Shed oversized tool-result outputs from `messages`, largest-first, until the
 /// recomputed request size (`estimate`) drops below `ceiling` or no oversized,
 /// not-already-spilled tool result remains.
@@ -147,16 +154,29 @@ pub fn degrade_conversation_overflow(
     // borrow); the ceiling re-check happens after the sweep.
     for msg in messages.iter_mut() {
         for block in msg.content.iter_mut() {
+            // Skip blocks that already carry the truncation marker: a truncated
+            // block sits at ~budget chars and would otherwise re-qualify on every
+            // later pass, re-truncating and churning the cached prefix.
             match block {
-                ContentBlock::Text { text } if text.chars().count() > per_block_budget_chars => {
-                    *text = truncate_head_tail(text, per_block_budget_chars);
-                    changed = true;
+                ContentBlock::Text { text }
+                    if text.chars().count() > per_block_budget_chars
+                        && !text.contains(TRUNC_MARKER) =>
+                {
+                    let truncated = truncate_head_tail(text, per_block_budget_chars);
+                    if truncated.chars().count() < text.chars().count() {
+                        *text = truncated;
+                        changed = true;
+                    }
                 }
                 ContentBlock::Thinking { thinking }
-                    if thinking.chars().count() > per_block_budget_chars =>
+                    if thinking.chars().count() > per_block_budget_chars
+                        && !thinking.contains(TRUNC_MARKER) =>
                 {
-                    *thinking = truncate_head_tail(thinking, per_block_budget_chars);
-                    changed = true;
+                    let truncated = truncate_head_tail(thinking, per_block_budget_chars);
+                    if truncated.chars().count() < thinking.chars().count() {
+                        *thinking = truncated;
+                        changed = true;
+                    }
                 }
                 _ => {}
             }
@@ -170,6 +190,16 @@ pub fn degrade_conversation_overflow(
     // nothing safe is left to drop. Re-scan from the front each iteration so the
     // oldest droppable message goes first; each pass removes exactly one message
     // (finite → terminates).
+    //
+    // Pairing is safe by construction (a `ToolUse` lives on an assistant message
+    // and its `ToolResult` on a separate user message; both are protected by the
+    // `matches!` guard below, so neither half of a pair can be dropped). Dropping
+    // the oldest turns can leave the remaining history assistant-leading; that is
+    // repaired downstream by Anthropic's default-on `ensure_message_alternation`
+    // (anthropic_shared.rs), which prepends a user filler. Residual edge: a
+    // provider configured with `ensure_alternation:false` AND no surviving user
+    // message could send an assistant-leading history — acceptable for v1 since
+    // the last message here is always the current (user-role) turn.
     loop {
         if estimate(messages) < ceiling {
             break;
@@ -200,6 +230,12 @@ pub fn degrade_conversation_overflow(
 
 /// Truncate `s` to a head+tail preview totalling about `budget` chars with a
 /// `[N chars truncated]` marker between. Char-boundary safe.
+///
+/// Guarantees a NET REDUCTION: for a block only marginally over budget, the
+/// head+tail+marker framing can be longer than the original, which would grow
+/// the request instead of shrinking it. When the candidate is not strictly
+/// shorter, return `s` unchanged so the caller's `changed`/`estimate` logic
+/// never registers a phantom shrink.
 fn truncate_head_tail(s: &str, budget: usize) -> String {
     let total = s.chars().count();
     if total <= budget {
@@ -209,7 +245,12 @@ fn truncate_head_tail(s: &str, budget: usize) -> String {
     let head: String = s.chars().take(half).collect();
     let tail: String = s.chars().skip(total - half).collect();
     let dropped = total - 2 * half;
-    format!("{head}\n\n... [{dropped} chars truncated] ...\n\n{tail}")
+    let candidate = format!("{head}\n\n... [{dropped} {TRUNC_MARKER}] ...\n\n{tail}");
+    if candidate.chars().count() < total {
+        candidate
+    } else {
+        s.to_string()
+    }
 }
 
 #[cfg(test)]
@@ -544,5 +585,52 @@ mod tests {
         let changed =
             degrade_conversation_overflow(&mut messages, 10_000, 5_000, all_content_estimator);
         assert!(!changed, "no work when already under the ceiling");
+    }
+
+    #[test]
+    fn truncate_head_tail_never_grows_marginal_block() {
+        // A block only a few chars over budget: head+tail+marker framing would be
+        // LONGER than the input. `truncate_head_tail` must return it unchanged so
+        // truncation is always a net reduction, never a phantom "shrink" that
+        // actually grows the request.
+        let s = "A".repeat(50);
+        let out = truncate_head_tail(&s, 48);
+        assert_eq!(out, s, "a marginally-oversized block must not be grown");
+    }
+
+    #[test]
+    fn truncation_pass_is_idempotent() {
+        // Rung-2 pass 1 must be idempotent: a block that already carries the
+        // truncation marker must NOT be re-truncated even when it is still over
+        // the per-block budget, because a truncated block sits at ~budget chars
+        // and would otherwise re-qualify on every later pass — churning the
+        // Anthropic prompt cache on resume.
+        //
+        // Craft a single already-marked, still-oversized block as the sole
+        // (latest, drop-oldest-protected) message so the call is forced past the
+        // early ceiling guard into pass 1: pass 1 must skip it, and drop-oldest
+        // has no eligible victim, so nothing changes.
+        let marked = format!(
+            "{}\n\n... [50000 {TRUNC_MARKER}] ...\n\n{}",
+            "H".repeat(15_000),
+            "T".repeat(15_000)
+        );
+        let mut messages = vec![text_msg(Role::User, &marked)];
+        let snapshot = marked.clone();
+        let ceiling = 10_000u64; // well under the ~30k marked block
+        let changed = degrade_conversation_overflow(
+            &mut messages,
+            ceiling,
+            20_000, // block (~30k) exceeds budget, but marker must guard it
+            all_content_estimator,
+        );
+        let ContentBlock::Text { text } = &messages[0].content[0] else {
+            panic!("expected text");
+        };
+        assert_eq!(
+            *text, snapshot,
+            "already-marked block must not be re-truncated"
+        );
+        assert!(!changed, "marker-guarded pass must report no change");
     }
 }

--- a/crates/wcore-agent/src/compact/degrade.rs
+++ b/crates/wcore-agent/src/compact/degrade.rs
@@ -31,7 +31,7 @@
 use wcore_tools::tool_result_storage::{
     BUDGET_TOOL_NAME, BudgetConfig, PERSISTED_OUTPUT_TAG, StorageDir, maybe_persist_tool_result,
 };
-use wcore_types::message::{ContentBlock, Message};
+use wcore_types::message::{ContentBlock, Message, Role};
 
 /// Shed oversized tool-result outputs from `messages`, largest-first, until the
 /// recomputed request size (`estimate`) drops below `ceiling` or no oversized,
@@ -110,6 +110,106 @@ pub fn shed_tool_outputs_until_under(
         }
     }
     shed
+}
+
+/// #646 — graceful context-overflow degradation (rung 2): conversation-heavy
+/// overflow that rung 1 cannot touch.
+///
+/// When the tool-output shed ([`shed_tool_outputs_until_under`]) still leaves
+/// the request over the ceiling — because the bulk is in a plain `Text` (a
+/// pasted log/file) or `Thinking` block, not a tool result — degrade the
+/// non-tool content in two passes, mutating `messages` in place so a persisted/
+/// resumed session heals rather than re-aborting turn 1:
+///
+/// 1. **Truncate** every oversized non-tool block (`Text`/`Thinking`) to a
+///    head+tail preview with a `[N chars truncated]` marker. This alone rescues
+///    the dominant real-world case (one big paste).
+/// 2. **Drop-oldest** sliding window: if still over, remove the oldest
+///    non-essential message until under the ceiling. Pairing-safe by
+///    construction — it never removes the system prompt, never removes the most
+///    recent turn (the last message), and never removes a message carrying a
+///    `ToolUse`/`ToolResult`, so no `tool_use` is ever orphaned (no 400).
+///
+/// Returns `true` if anything was truncated or dropped.
+pub fn degrade_conversation_overflow(
+    messages: &mut Vec<Message>,
+    ceiling: u64,
+    per_block_budget_chars: usize,
+    estimate: impl Fn(&[Message]) -> u64,
+) -> bool {
+    if estimate(messages) < ceiling {
+        return false;
+    }
+    let mut changed = false;
+
+    // Pass 1: truncate every oversized non-tool block. Done in one sweep (no
+    // per-block `estimate` recompute, which would conflict with the `iter_mut`
+    // borrow); the ceiling re-check happens after the sweep.
+    for msg in messages.iter_mut() {
+        for block in msg.content.iter_mut() {
+            match block {
+                ContentBlock::Text { text } if text.chars().count() > per_block_budget_chars => {
+                    *text = truncate_head_tail(text, per_block_budget_chars);
+                    changed = true;
+                }
+                ContentBlock::Thinking { thinking }
+                    if thinking.chars().count() > per_block_budget_chars =>
+                {
+                    *thinking = truncate_head_tail(thinking, per_block_budget_chars);
+                    changed = true;
+                }
+                _ => {}
+            }
+        }
+    }
+    if estimate(messages) < ceiling {
+        return changed;
+    }
+
+    // Pass 2: drop the oldest non-essential message until under the ceiling or
+    // nothing safe is left to drop. Re-scan from the front each iteration so the
+    // oldest droppable message goes first; each pass removes exactly one message
+    // (finite → terminates).
+    loop {
+        if estimate(messages) < ceiling {
+            break;
+        }
+        let last = messages.len().saturating_sub(1);
+        let victim = messages.iter().enumerate().position(|(i, m)| {
+            i != last
+                && m.role != Role::System
+                && !m.content.iter().any(|b| {
+                    matches!(
+                        b,
+                        ContentBlock::ToolUse { .. } | ContentBlock::ToolResult { .. }
+                    )
+                })
+        });
+        match victim {
+            Some(idx) => {
+                messages.remove(idx);
+                changed = true;
+            }
+            // Nothing left that is safe to drop — the caller's final ceiling
+            // check will terminate the run cleanly.
+            None => break,
+        }
+    }
+    changed
+}
+
+/// Truncate `s` to a head+tail preview totalling about `budget` chars with a
+/// `[N chars truncated]` marker between. Char-boundary safe.
+fn truncate_head_tail(s: &str, budget: usize) -> String {
+    let total = s.chars().count();
+    if total <= budget {
+        return s.to_string();
+    }
+    let half = budget / 2;
+    let head: String = s.chars().take(half).collect();
+    let tail: String = s.chars().skip(total - half).collect();
+    let dropped = total - 2 * half;
+    format!("{head}\n\n... [{dropped} chars truncated] ...\n\n{tail}")
 }
 
 #[cfg(test)]
@@ -297,5 +397,152 @@ mod tests {
             chars_estimator,
         );
         assert_eq!(shed, 0, "no work when the request is already under ceiling");
+    }
+
+    // ── #646 rung 2: conversation-heavy (non-tool) overflow ─────────────────
+
+    fn text_msg(role: Role, content: &str) -> Message {
+        Message::new(
+            role,
+            vec![ContentBlock::Text {
+                text: content.to_string(),
+            }],
+        )
+    }
+
+    /// Chars-based estimator counting Text + Thinking + ToolResult content, so
+    /// the rung-2 tests can drive the ceiling with plain-text bulk.
+    fn all_content_estimator(messages: &[Message]) -> u64 {
+        let mut total = 0u64;
+        for m in messages {
+            for b in &m.content {
+                match b {
+                    ContentBlock::Text { text } => total += text.chars().count() as u64,
+                    ContentBlock::Thinking { thinking } => total += thinking.chars().count() as u64,
+                    ContentBlock::ToolResult { content, .. } => {
+                        total += content.chars().count() as u64
+                    }
+                    _ => {}
+                }
+            }
+        }
+        total
+    }
+
+    #[test]
+    fn truncate_head_tail_keeps_head_and_tail() {
+        let s = format!(
+            "{}{}{}",
+            "H".repeat(100),
+            "M".repeat(1_000),
+            "T".repeat(100)
+        );
+        let out = truncate_head_tail(&s, 40);
+        assert!(out.starts_with("HHHH"), "keeps head: {out}");
+        assert!(out.ends_with("TTTT"), "keeps tail: {out}");
+        assert!(out.contains("chars truncated"), "has marker: {out}");
+        assert!(
+            out.chars().count() < s.chars().count(),
+            "shorter than input"
+        );
+    }
+
+    #[test]
+    fn truncates_oversized_text_block_and_continues() {
+        // Rung-2 test 1/2: the overflow bulk is a single big Text block (a paste),
+        // not a tool result — truncation must bring it under the ceiling.
+        let mut messages = vec![
+            text_msg(Role::User, &"P".repeat(100_000)), // the big paste
+            text_msg(Role::Assistant, "ok"),
+        ];
+        let ceiling = 40_000u64;
+        // Per-block budget below the ceiling so the truncated block plus the
+        // other content lands under it (this fake estimator counts chars 1:1;
+        // the real engine's estimator is tokens = chars/4, so it passes the
+        // ceiling itself as the char budget).
+        let changed = degrade_conversation_overflow(
+            &mut messages,
+            ceiling,
+            20_000, // per-block budget < ceiling
+            all_content_estimator,
+        );
+        assert!(changed, "an oversized text block must be degraded");
+        assert!(
+            all_content_estimator(&messages) < ceiling,
+            "truncation must bring the request under the ceiling"
+        );
+        // The block was truncated with a marker, not dropped.
+        assert_eq!(messages.len(), 2, "truncation must not drop the message");
+        let ContentBlock::Text { text } = &messages[0].content[0] else {
+            panic!("expected text");
+        };
+        assert!(text.contains("chars truncated"), "head+tail marker: {text}");
+    }
+
+    #[test]
+    fn drops_oldest_nonessential_and_preserves_system_and_latest() {
+        // Many small text messages, none individually oversized — pass 1 can't
+        // help, so drop-oldest must remove the oldest non-essential messages
+        // while preserving the system prompt and the most recent turn.
+        let mut messages = vec![
+            text_msg(Role::System, &"S".repeat(1_000)),
+            text_msg(Role::User, &"1".repeat(20_000)), // oldest droppable
+            text_msg(Role::Assistant, &"2".repeat(20_000)),
+            text_msg(Role::User, &"3".repeat(20_000)), // latest — preserved
+        ];
+        let ceiling = 35_000u64;
+        let changed =
+            degrade_conversation_overflow(&mut messages, ceiling, 100_000, all_content_estimator);
+        assert!(changed, "drop-oldest must fire");
+        assert!(all_content_estimator(&messages) < ceiling, "under ceiling");
+        // System prompt survives.
+        assert_eq!(messages[0].role, Role::System, "system preserved");
+        // The most recent turn (the "3..." block) survives.
+        let last = messages.last().unwrap();
+        let ContentBlock::Text { text } = &last.content[0] else {
+            panic!("expected text");
+        };
+        assert!(
+            text.starts_with("333"),
+            "latest turn preserved: got {}",
+            &text[..3]
+        );
+    }
+
+    #[test]
+    fn dropoldest_never_orphans_tool_pairs() {
+        // A tool_use/tool_result pair must never be split by drop-oldest, even
+        // when it is the oldest content. Only the pure-text message is dropped.
+        let mut messages = vec![
+            tool_use("a"),
+            tool_result("a", "small"),
+            text_msg(Role::User, &"B".repeat(60_000)), // droppable bulk
+            text_msg(Role::Assistant, "latest"),
+        ];
+        // Force the estimator to count everything; ceiling below the text bulk.
+        let ceiling = 20_000u64;
+        degrade_conversation_overflow(&mut messages, ceiling, 100_000, all_content_estimator);
+        // The tool_use and its result both survive (pairing intact).
+        assert!(
+            messages
+                .iter()
+                .any(|m| matches!(&m.content[0], ContentBlock::ToolUse { id, .. } if id == "a")),
+            "tool_use must survive drop-oldest"
+        );
+        assert!(
+            messages.iter().any(|m| matches!(
+                &m.content[0],
+                ContentBlock::ToolResult { tool_use_id, .. } if tool_use_id == "a"
+            )),
+            "paired tool_result must survive drop-oldest"
+        );
+    }
+
+    #[test]
+    fn returns_false_when_already_under_ceiling() {
+        let mut messages = vec![text_msg(Role::User, "hi")];
+        let changed =
+            degrade_conversation_overflow(&mut messages, 10_000, 5_000, all_content_estimator);
+        assert!(!changed, "no work when already under the ceiling");
     }
 }

--- a/crates/wcore-agent/src/engine.rs
+++ b/crates/wcore-agent/src/engine.rs
@@ -4817,6 +4817,35 @@ impl AgentEngine {
                         ceiling,
                         est,
                     );
+                    // #646 — graceful degradation (rung 2). If tool-output
+                    // shedding did not bring the DISPATCHED request under the
+                    // ceiling, the overflow is conversation-heavy: a big pasted
+                    // `Text`/`Thinking` block or many non-tool messages, which
+                    // rung 1 cannot touch. Degrade the non-tool content too —
+                    // truncate an oversized non-tool block head+tail, then drop
+                    // the oldest non-essential (pairing-safe: never a
+                    // tool_use/tool_result, the system prompt, or the latest
+                    // turn) message until under the ceiling. Applied to both the
+                    // dispatched request and persisted history so a resume heals.
+                    if est(&request.messages) >= ceiling {
+                        // Cap any single non-tool block at ~`ceiling` chars
+                        // (≈ a quarter of the ceiling in tokens), so one huge
+                        // paste truncates well under the window and the
+                        // drop-oldest pass mops up any residual.
+                        let per_block_budget = ceiling as usize;
+                        crate::compact::degrade::degrade_conversation_overflow(
+                            &mut request.messages,
+                            ceiling,
+                            per_block_budget,
+                            est,
+                        );
+                        crate::compact::degrade::degrade_conversation_overflow(
+                            &mut self.messages,
+                            ceiling,
+                            per_block_budget,
+                            est,
+                        );
+                    }
                     // Decide on the DISPATCHED set: the window/ceiling are
                     // unchanged, so only `used_tokens` moves. Re-stamp every
                     // downstream consumer of the request size so none sees the

--- a/crates/wcore-agent/src/engine.rs
+++ b/crates/wcore-agent/src/engine.rs
@@ -4827,13 +4827,18 @@ impl AgentEngine {
                     // tool_use/tool_result, the system prompt, or the latest
                     // turn) message until under the ceiling. Applied to both the
                     // dispatched request and persisted history so a resume heals.
+                    let mut rung2_fired = false;
                     if est(&request.messages) >= ceiling {
                         // Cap any single non-tool block at ~`ceiling` chars
                         // (≈ a quarter of the ceiling in tokens), so one huge
                         // paste truncates well under the window and the
                         // drop-oldest pass mops up any residual.
                         let per_block_budget = ceiling as usize;
-                        crate::compact::degrade::degrade_conversation_overflow(
+                        // The dispatched-set result drives the user notification:
+                        // rung 2 is LOSSY (truncates pasted content, drops oldest
+                        // turns) and irreversible, unlike rung 1's disk-spill — so
+                        // it must never fire silently.
+                        rung2_fired = crate::compact::degrade::degrade_conversation_overflow(
                             &mut request.messages,
                             ceiling,
                             per_block_budget,
@@ -4871,18 +4876,34 @@ impl AgentEngine {
                             .finish_run_terminated(user_input, turn, FinishReason::Length)
                             .await;
                     }
-                    if shed > 0 {
+                    if shed > 0 || rung2_fired {
                         tracing::info!(
                             target: "wcore_agent::compact",
                             shed,
+                            rung2_fired,
                             ceiling,
                             used = input_token_estimate,
                             model = %request.model,
-                            "context overflow: shed oversized tool outputs, continuing"
+                            "context overflow: degraded history to continue"
                         );
+                        // Two distinct degradations may have fired: rung 1 spills
+                        // large tool outputs to disk (recoverable); rung 2 truncates
+                        // pasted content and/or drops the oldest turns (lossy). Name
+                        // whichever ran so the user knows what changed.
+                        let mut parts: Vec<String> = Vec::new();
+                        if shed > 0 {
+                            parts.push(format!("shed {shed} large tool output(s) to disk"));
+                        }
+                        if rung2_fired {
+                            parts.push(
+                                "truncated oversized message content and/or dropped the \
+                                 oldest turns"
+                                    .to_string(),
+                            );
+                        }
                         self.output.emit_info(&format!(
-                            "Context exceeded the model limit; shed {shed} large tool \
-                             output(s) to disk and continued."
+                            "Context exceeded the model limit; {} to continue.",
+                            parts.join(" and "),
                         ));
                     }
                 }

--- a/crates/wcore-agent/tests/engine_compact_test.rs
+++ b/crates/wcore-agent/tests/engine_compact_test.rs
@@ -1034,3 +1034,85 @@ async fn tc_2_6_context_overflow_resumed_session_heals_and_continues() {
     assert_eq!(result.text, "Resumed and continued");
     assert_eq!(result.stop_reason, StopReason::EndTurn);
 }
+
+/// #646 rung 2 — a turn whose overflow is a big pasted TEXT block (no tool
+/// call) must degrade (truncate the block) and CONTINUE, not hard-abort. Rung 1
+/// finds zero sheddable tool results here; rung 2 truncates the non-tool block.
+#[tokio::test]
+async fn tc_2_6_context_overflow_text_paste_truncates_and_continues() {
+    let turn1 = text_turn("Handled the big paste", 5_000);
+    let provider = Arc::new(CompactMockProvider::new(vec![turn1]));
+
+    let mut config = test_config();
+    config.compact.enabled = false; // isolate the pre-flight ceiling guard
+    config.compact.context_window = 60_000; // unknown model → fallback window
+    config.compact.output_reserve = 10_000;
+    config.compact.emergency_buffer = 10_000; // ceiling = 40k tokens
+
+    let registry = ToolRegistry::new();
+    let output = silent_output();
+    let mut engine = AgentEngine::new_with_provider(provider.clone(), config, registry, output);
+
+    // A huge pasted user message (~120k tokens of plain text, no tool call).
+    let huge_paste = "x".repeat(480_000);
+    let result = engine
+        .run(&huge_paste, "msg-1")
+        .await
+        .expect("run should succeed, not error");
+
+    // rung 2 truncates the oversized text block and continues to the provider;
+    // an abort would leave call_count == 0.
+    assert_eq!(
+        provider.call_count(),
+        1,
+        "rung 2 must truncate the paste and continue, not abort"
+    );
+    assert_eq!(result.text, "Handled the big paste");
+    assert_eq!(result.stop_reason, StopReason::EndTurn);
+}
+
+/// #646 rung 2 resume-heals — a session terminated on the conversation-heavy
+/// path (a huge non-tool Text block in persisted history) must heal on resume:
+/// rung 2 truncates the block so the first resumed turn continues instead of
+/// re-aborting. This is the non-tool counterpart to the rung-1 resume test.
+#[tokio::test]
+async fn tc_2_6_context_overflow_resumed_text_session_heals() {
+    let turn1 = text_turn("Resumed past the paste", 5_000);
+    let provider = Arc::new(CompactMockProvider::new(vec![turn1]));
+
+    let mut config = test_config();
+    config.compact.enabled = false;
+    config.compact.context_window = 60_000;
+    config.compact.output_reserve = 10_000;
+    config.compact.emergency_buffer = 10_000; // ceiling = 40k tokens
+
+    let registry = ToolRegistry::new();
+    let output = silent_output();
+    let mut engine = AgentEngine::new_with_provider(provider.clone(), config, registry, output);
+
+    // Restore a session whose history holds a huge non-tool Text block (the
+    // shape a big paste leaves), far over the 40k ceiling.
+    let huge = "x".repeat(480_000);
+    engine.load_conversation(vec![
+        Message::new(Role::User, vec![ContentBlock::Text { text: huge }]),
+        Message::new(
+            Role::Assistant,
+            vec![ContentBlock::Text {
+                text: "prior reply".to_string(),
+            }],
+        ),
+    ]);
+
+    let result = engine
+        .run("continue please", "msg-2")
+        .await
+        .expect("resumed run should succeed, not error");
+
+    assert_eq!(
+        provider.call_count(),
+        1,
+        "resumed conversation-heavy session must truncate persisted text and continue, not re-abort"
+    );
+    assert_eq!(result.text, "Resumed past the paste");
+    assert_eq!(result.stop_reason, StopReason::EndTurn);
+}

--- a/crates/wcore-agent/tests/engine_compact_test.rs
+++ b/crates/wcore-agent/tests/engine_compact_test.rs
@@ -1116,3 +1116,60 @@ async fn tc_2_6_context_overflow_resumed_text_session_heals() {
     assert_eq!(result.text, "Resumed past the paste");
     assert_eq!(result.stop_reason, StopReason::EndTurn);
 }
+
+/// #646 rung 2 drop-oldest — engine level. When the overflow is spread across
+/// MANY non-tool messages that are each individually UNDER the per-block budget
+/// (so pass-1 truncation cannot help), the drop-oldest sliding window (pass 2)
+/// must remove the oldest non-essential turns until the request fits, and the
+/// run must continue to the provider instead of aborting. The two existing
+/// rung-2 integration tests both use one huge block, so pass 1 rescues them and
+/// this end-to-end drop-oldest path would otherwise be untested.
+#[tokio::test]
+async fn tc_2_6_context_overflow_many_small_turns_drop_oldest_and_continue() {
+    let turn1 = text_turn("Continued after dropping old turns", 5_000);
+    let provider = Arc::new(CompactMockProvider::new(vec![turn1]));
+
+    let mut config = test_config();
+    config.compact.enabled = false; // isolate the pre-flight ceiling guard
+    config.compact.context_window = 60_000; // unknown model → fallback window
+    config.compact.output_reserve = 10_000;
+    config.compact.emergency_buffer = 10_000; // ceiling = 40k tokens
+
+    let registry = ToolRegistry::new();
+    let output = silent_output();
+    let mut engine = AgentEngine::new_with_provider(provider.clone(), config, registry, output);
+
+    // 24 plain-text turns of 20k chars each (~5k tokens apiece → ~120k tokens
+    // total, far over the 40k ceiling). Each block is well under the per-block
+    // budget (ceiling = 40k chars), so pass-1 truncation is a no-op and only
+    // drop-oldest can bring the request under the ceiling.
+    let history: Vec<Message> = (0..24)
+        .map(|i| {
+            let role = if i % 2 == 0 {
+                Role::User
+            } else {
+                Role::Assistant
+            };
+            Message::new(
+                role,
+                vec![ContentBlock::Text {
+                    text: "y".repeat(20_000),
+                }],
+            )
+        })
+        .collect();
+    engine.load_conversation(history);
+
+    let result = engine
+        .run("what's next", "msg-3")
+        .await
+        .expect("run should succeed, not error");
+
+    assert_eq!(
+        provider.call_count(),
+        1,
+        "rung 2 drop-oldest must shrink the many-turn history and continue, not abort"
+    );
+    assert_eq!(result.text, "Continued after dropping old turns");
+    assert_eq!(result.stop_reason, StopReason::EndTurn);
+}


### PR DESCRIPTION
## #646 — compaction rung 2 (conversation-heavy overflow)

Second rung of the graceful context-overflow degradation ladder. Rung 1 (#636/PR #169, merged) sheds oversized tool-result outputs to disk before the pre-flight ceiling guard aborts a turn. Rung 2 handles the case rung 1 cannot touch: the overflow bulk is in plain non-tool content — one big pasted Text/Thinking block, or many accumulated conversation turns.

When the tool-output shed still leaves the dispatched request over the ceiling, rung 2 degrades non-tool content in two passes, mutating both the dispatched request and the persisted history so a saved/resumed session heals instead of re-aborting turn 1:

1. Truncate every oversized non-tool block (Text/Thinking) to a head+tail preview with a marker. Rescues the dominant real-world case (one big paste).
2. Drop-oldest sliding window if still over: remove the oldest non-essential message until under the ceiling. Pairing-safe by construction — never the system prompt, never the latest turn, never a message carrying a tool_use/tool_result.

## 3-way cross-audit hardening

Cross-audited (Codex + Gemini + adversarial subagent with repo access). The subagent refuted two Codex/Gemini findings (Thinking has no signature field and providers drop it on replay, so truncating it is inert-to-harmless; drop-oldest is pairing-safe and assistant-leading is repaired by Anthropic's default-on ensure_message_alternation). Both passes are kept. The audit's real findings are fixed here:

- Net reduction: truncate_head_tail returns the block unchanged when the head+tail+marker framing would be longer than the input (a marginally-oversized block), so truncation can never grow the request.
- Idempotency: pass-1 skips blocks already carrying the truncation marker, mirroring rung 1's persisted-output-tag skip, so a resumed/re-degraded session re-emits the identical prefix instead of churning the Anthropic prompt cache.
- Lossy-degrade notification: rung 2 is lossy and irreversible (unlike rung 1's recoverable disk spill) but previously fired silently — the emit was gated on rung-1's shed count. The rung-2 changed flag is now captured and a distinct user-visible notification fires whenever it runs.

Residual noted in-code: a provider configured with ensure_alternation:false AND no surviving user message could send an assistant-leading history — acceptable for v1 since the last message at this guard is always the current user turn.

## Tests

- Unit (degrade.rs): net-reduction (marginal block not grown), pass-1 idempotency (marker-guarded block not re-truncated), plus the existing truncate/drop-oldest/pairing coverage.
- Integration (engine_compact_test.rs): engine-level drop-oldest — many small non-tool turns that pass-1 cannot rescue must drop oldest and continue, not abort. Closes the end-to-end gap where the two prior rung-2 integration tests were both rescued by pass-1.

Hetzner gate green (fmt 0, clippy 0, nextest: only the two known flakes).
