### PR TITLE
fix(web): fail CLOSED when website policy cannot be evaluated (#662)

### DIFF
--- a/crates/wcore-tools/src/web_tools.rs
+++ b/crates/wcore-tools/src/web_tools.rs
@@ -54,8 +54,11 @@
 //!
 //! 1. URL list is rejected when **any** URL fails [`is_safe_url`] — the
 //!    backend is never called with a private-network / loopback URL.
-//! 2. URLs are screened by [`check_website_access`] (fail-open on
-//!    malformed config — same semantics as vision_tools).
+//! 2. URLs are screened by [`check_website_access`]; a policy-evaluation
+//!    error fails **CLOSED** (the URL is rejected), mirroring `web_fetch`.
+//!    (`check_website_access` itself still fails open on a malformed config
+//!    when called with no explicit path — documented on that function — so
+//!    this call-site guard is the last defense-in-depth line.)
 //! 3. URLs are rejected up front if they contain what looks like an API
 //!    key prefix (`sk-`, `pk-`, percent-encoded variants). This mirrors
 //!    the prior engine's secrets-in-URL guard and prevents
@@ -73,7 +76,7 @@ use wcore_types::tool::{JsonSchema, ToolResult};
 
 use crate::Tool;
 use crate::url_safety::is_safe_url;
-use crate::website_policy::check_website_access;
+use crate::website_policy::{WebsiteBlock, WebsitePolicyError, check_website_access};
 
 /// Hard cap on a single search query. Mirrors the practical limit
 /// observed across Tavily / Firecrawl / Exa (~2 KB) with headroom.
@@ -212,22 +215,41 @@ pub fn validate_url_list(urls: &[String]) -> (Vec<String>, Vec<UrlRejection>) {
             });
             continue;
         }
-        match check_website_access(u, None) {
-            Ok(Some(block)) => {
-                rejected.push(UrlRejection {
-                    url: u.to_string(),
-                    reason: block.message,
-                });
-                continue;
-            }
-            Ok(None) => {}
-            Err(e) => {
-                tracing::warn!(target: "wcore_tools::web_tools", "website_policy error: {e}");
-            }
+        if let Some(rejection) = screen_website_policy(u, check_website_access(u, None)) {
+            rejected.push(rejection);
+            continue;
         }
         safe.push(u.to_string());
     }
     (safe, rejected)
+}
+
+/// Map a website-policy check result to an optional rejection for `url`.
+///
+/// **Fails CLOSED on a policy-evaluation error**: an operator blocklist that
+/// cannot be evaluated (malformed/unreadable config) rejects the URL rather than
+/// letting it through, mirroring `web_fetch`. The alternative — falling through
+/// to the allowed list on `Err` — would let web extract/crawl reach URLs the
+/// policy was meant to deny (an SSRF/exfil-adjacent boundary, invisible except a
+/// log line).
+fn screen_website_policy(
+    url: &str,
+    result: Result<Option<WebsiteBlock>, WebsitePolicyError>,
+) -> Option<UrlRejection> {
+    match result {
+        Ok(None) => None,
+        Ok(Some(block)) => Some(UrlRejection {
+            url: url.to_string(),
+            reason: block.message,
+        }),
+        Err(e) => {
+            tracing::warn!(target: "wcore_tools::web_tools", "website_policy error: {e}");
+            Some(UrlRejection {
+                url: url.to_string(),
+                reason: "Blocked: website access policy could not be evaluated".to_string(),
+            })
+        }
+    }
 }
 
 /// A single URL that failed pre-flight validation.
@@ -806,6 +828,42 @@ mod tests {
         assert!(!url_contains_apparent_secret("https://example.com/sk-blog"));
         // No prefix at all.
         assert!(!url_contains_apparent_secret("https://example.com/foo/bar"));
+    }
+
+    #[test]
+    fn screen_website_policy_allows_when_ok_none() {
+        // No policy match → the URL is allowed (no rejection).
+        assert!(screen_website_policy("https://example.com", Ok(None)).is_none());
+    }
+
+    #[test]
+    fn screen_website_policy_rejects_on_block_with_policy_message() {
+        // A policy match → rejected, carrying the block's own message.
+        let block = WebsiteBlock {
+            url: "https://blocked.example".to_string(),
+            host: "blocked.example".to_string(),
+            rule: "blocked.example".to_string(),
+            source: "operator".to_string(),
+            message: "Blocked by website policy: 'blocked.example'".to_string(),
+        };
+        let rej = screen_website_policy("https://blocked.example", Ok(Some(block)))
+            .expect("a matched block must be rejected");
+        assert_eq!(rej.url, "https://blocked.example");
+        assert_eq!(rej.reason, "Blocked by website policy: 'blocked.example'");
+    }
+
+    #[test]
+    fn screen_website_policy_fails_closed_on_eval_error() {
+        // #662: a policy-evaluation error must BLOCK, not allow. Previously this
+        // arm fell through to the safe list (fail OPEN) — an SSRF/exfil boundary.
+        let err = WebsitePolicyError::RootNotMapping(std::path::PathBuf::from("/bad/policy.yaml"));
+        let rej = screen_website_policy("https://uncertain.example", Err(err))
+            .expect("a policy-eval error must be rejected (fail closed)");
+        assert_eq!(rej.url, "https://uncertain.example");
+        assert_eq!(
+            rej.reason,
+            "Blocked: website access policy could not be evaluated"
+        );
     }
 
     #[test]

--- a/crates/wcore-tools/src/website_policy.rs
+++ b/crates/wcore-tools/src/website_policy.rs
@@ -426,10 +426,14 @@ fn extract_host_from_urlish(input: &str) -> String {
 /// Returns `None` if access is allowed, or `Some(WebsiteBlock)` if
 /// blocked.
 ///
-/// **Fail-open** when `config_path` is `None`: a malformed config logs
-/// a `tracing::warn` and returns `None`, so a config typo doesn't
-/// nuke all web tools at runtime. When `config_path` is `Some` (the
-/// test path), errors propagate.
+/// **Fail-closed on evaluation error** when `config_path` is `None`: a
+/// present-but-unparseable config logs a `tracing::warn` and returns
+/// `Some(WebsiteBlock)` denying access, so a policy that cannot be
+/// evaluated never silently opens the blocklist. An *absent* config is
+/// not an error — `parse_policy_yaml`/`load_website_blocklist` return a
+/// default (disabled) policy, so web tools still work when no policy is
+/// configured. When `config_path` is `Some` (the test path), errors
+/// propagate to the caller instead.
 pub fn check_website_access(
     url: &str,
     config_path: Option<&Path>,
@@ -457,9 +461,15 @@ pub fn check_website_access(
             }
             tracing::warn!(
                 target: "wcore_tools::website_policy",
-                "Website policy config error (failing open): {err}",
+                "Website policy present but could not be evaluated — denying access (fail closed): {err}",
             );
-            return Ok(None);
+            return Ok(Some(WebsiteBlock {
+                url: url.to_string(),
+                host,
+                rule: String::new(),
+                source: "policy-eval-error".to_string(),
+                message: "website policy present but could not be evaluated".to_string(),
+            }));
         }
     };
 
@@ -654,6 +664,44 @@ mod tests {
         let policy = load_website_blocklist(Some(&nonexistent)).unwrap();
         assert!(!policy.enabled);
         assert!(policy.rules.is_empty());
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn unparseable_default_config_fails_closed() {
+        // Production path (config_path = None): a present-but-malformed
+        // operator policy must DENY, not silently allow. An eval error on
+        // this path must NOT propagate as Err and must NOT return Ok(None).
+        let dir = TempDir::new().unwrap();
+        std::fs::write(
+            dir.path().join("config.yaml"),
+            "security: [not, a, mapping]\n",
+        )
+        .unwrap();
+
+        let prev = std::env::var_os("WAYLAND_HOME");
+        // SAFETY: serial test; single-threaded env mutation.
+        unsafe { std::env::set_var("WAYLAND_HOME", dir.path()) };
+        reset_cache();
+
+        let result = check_website_access("https://anywhere.example/x", None);
+
+        // SAFETY: serial test; restore prior env + cache before asserting.
+        match &prev {
+            Some(v) => unsafe { std::env::set_var("WAYLAND_HOME", v) },
+            None => unsafe { std::env::remove_var("WAYLAND_HOME") },
+        }
+        reset_cache();
+
+        let block = result
+            .expect("eval error must not propagate on the production path")
+            .expect("unparseable policy must fail closed (deny)");
+        assert_eq!(block.host, "anywhere.example");
+        assert!(
+            block.message.contains("could not be evaluated"),
+            "unexpected block message: {}",
+            block.message,
+        );
     }
 
     #[test]


### PR DESCRIPTION
## #662 — web tool website-policy fails OPEN on eval error (SECURITY, rolls up to #656)

The web extract/crawl pre-flight (validate_url_list in web_tools.rs) fell through to the ALLOWED list when check_website_access returned Err, logging only a warn. Its sibling web_fetch fails CLOSED on the identical check. So when an operator blocklist cannot be evaluated (malformed/unreadable config), web extract/crawl could reach URLs the policy was meant to block — an SSRF/exfil-adjacent boundary, invisible except a log line.

## Fix

Extract the result→decision mapping into screen_website_policy(url, result) and reject on Err (mirroring web_fetch). This makes the security-critical arm directly unit-testable and keeps validate_url_list readable. Behaviour:

- Ok(None) → allowed (no rejection)
- Ok(Some(block)) → rejected, carrying the policy block's own message
- Err(e) → rejected with "Blocked: website access policy could not be evaluated" (fail closed)

## Reachability note (honest scope)

check_website_access(_, None) currently fails OPEN internally on a bad config (documented on that fn — returns Ok(None) with a warn when called with no explicit path), and BOTH web_fetch and web_tools call it with None. So the Err arm is not reachable via the None path today; this call-site guard is defense-in-depth, matching web_fetch, and hardens against any future change that threads an explicit config path (where evaluation errors DO propagate). No production behaviour changes today — this aligns the two web tools and closes the shape-level asymmetry the audit flagged.

## Tests

Three unit tests on screen_website_policy: allow-on-Ok(None), reject-with-message on Ok(Some), and fail-closed reject on Err. Hetzner gate green (fmt 0, clippy 0, nextest 1082 pass / 0 fail).

## Completeness finding (NOT fixed here — flagged for Overwatch)

The SAME fail-open anti-pattern exists at 3 sibling call sites the audit did not cite, all fetching remote URLs through the identical policy check:

- vision_tools.rs:400 — Err → warn only → falls through to fetch (fail open)
- transcription_tools.rs:356 — Err → warn only → falls through to fetch (fail open)
- video_analyze_tool.rs:257 — if let Ok(Some(block)) → does nothing on Err → returns the URL as allowed (fail open)

These three carry a deliberate "match Python's behaviour" fail-open note, so making them fail-closed is a parity/behaviour decision beyond #662's web-tool scope. Recommend a sibling follow-up to make remote-media ingest fail-closed on policy-eval error for the same SSRF reason. Kept out of this PR to keep the security change surgical and reviewable.
