### PR TITLE
feat(agent): honest capability availability — boot advisory + channel-media notices (#660)

### DIFF
--- a/crates/wcore-agent/src/bootstrap.rs
+++ b/crates/wcore-agent/src/bootstrap.rs
@@ -1628,6 +1628,14 @@ impl AgentBootstrap {
         if let Some(block) = user_ctx_block {
             system_prompt.push_str(&block);
         }
+        // #660 — honest capability availability. Env-gated tools (vision, image
+        // generation, transcription, …) hide themselves from the schema when
+        // unconfigured; without this advisory the model fabricates a cause
+        // instead of naming the missing key. Read from `registry` (fully
+        // populated above) so the reasons match what was actually hidden.
+        if let Some(block) = crate::capability_advisory::render_capability_advisory(&registry) {
+            system_prompt.push_str(&block);
+        }
         self.config.system_prompt = Some(system_prompt);
 
         // W6 — opt the catalog into cross-project skill resolution. The
@@ -2545,22 +2553,23 @@ impl AgentBootstrap {
                 // is built. Bytes are fetched through the originating connector
                 // (auth-aware: the connector uses its own token), then the
                 // host-wired vision/transcription backend derives the text.
-                // Inert (and skipped) when neither backend has an API key.
+                //
+                // #660: installed even when NO backend is configured. With a
+                // backend absent the enricher no longer sits idle — it writes an
+                // honest degraded notice ("no vision backend; cannot see this
+                // image; set a key") into the attachment so the model never
+                // answers an unseen image blind from a bare URL.
                 let media_enricher = {
                     let vision = crate::tool_backends::build_vision_backend();
                     let transcription = crate::tool_backends::build_transcription_backend();
-                    if vision.is_none() && transcription.is_none() {
-                        None
-                    } else {
-                        let source = Arc::new(crate::channel_media::ManagerMediaSource::new(
-                            std::sync::Arc::clone(&lifted),
-                        ));
-                        Some(Arc::new(crate::channel_media::ChannelMediaEnricher::new(
-                            vision,
-                            transcription,
-                            source,
-                        )))
-                    }
+                    let source = Arc::new(crate::channel_media::ManagerMediaSource::new(
+                        std::sync::Arc::clone(&lifted),
+                    ));
+                    Some(Arc::new(crate::channel_media::ChannelMediaEnricher::new(
+                        vision,
+                        transcription,
+                        source,
+                    )))
                 };
 
                 let dispatcher: Arc<dyn crate::channel_inbound::TurnDispatcher> =

--- a/crates/wcore-agent/src/bootstrap.rs
+++ b/crates/wcore-agent/src/bootstrap.rs
@@ -1631,9 +1631,23 @@ impl AgentBootstrap {
         // #660 — honest capability availability. Env-gated tools (vision, image
         // generation, transcription, …) hide themselves from the schema when
         // unconfigured; without this advisory the model fabricates a cause
-        // instead of naming the missing key. Read from `registry` (fully
-        // populated above) so the reasons match what was actually hidden.
-        if let Some(block) = crate::capability_advisory::render_capability_advisory(&registry) {
+        // instead of naming the missing key. `registry` is the final tool set
+        // here for local (posture `None`) and `Full`-posture engines, so its
+        // absences are accurate.
+        //
+        // Skipped for a restrictive channel posture (Conversational/Workspace):
+        // there the capability tools are stripped by `apply_posture` further
+        // below — governed by posture, not API keys — so a key-naming advisory
+        // read from the still-full registry would be both stale and misleading.
+        // Inbound-media blindness on those channel engines is instead surfaced
+        // honestly by the channel-media degraded notices.
+        let restrictive_channel_posture = self
+            .channel_tool_posture
+            .as_ref()
+            .is_some_and(|s| s.posture != wcore_channels::ChannelToolPosture::Full);
+        if !restrictive_channel_posture
+            && let Some(block) = crate::capability_advisory::render_capability_advisory(&registry)
+        {
             system_prompt.push_str(&block);
         }
         self.config.system_prompt = Some(system_prompt);

--- a/crates/wcore-agent/src/capability_advisory.rs
+++ b/crates/wcore-agent/src/capability_advisory.rs
@@ -37,7 +37,7 @@ const OPTIONAL_CAPABILITIES: &[Capability] = &[
     Capability {
         label: "Image generation",
         tool: "image_generate",
-        hint: "set OPENAI_API_KEY, FAL_API_KEY, or GEMINI_API_KEY",
+        hint: "set OPENAI_API_KEY, FAL_API_KEY, GEMINI_API_KEY, or HF_API_KEY",
     },
     Capability {
         label: "Image understanding (vision)",
@@ -129,7 +129,7 @@ mod tests {
         );
         // Missing ones are named with their fix.
         assert!(advisory.contains("Image generation"));
-        assert!(advisory.contains("set OPENAI_API_KEY, FAL_API_KEY, or GEMINI_API_KEY"));
+        assert!(advisory.contains("set OPENAI_API_KEY, FAL_API_KEY, GEMINI_API_KEY, or HF_API_KEY"));
         assert!(advisory.contains("Text-to-speech"));
         assert!(advisory.contains("set DISCORD_BOT_TOKEN"));
     }
@@ -139,5 +139,91 @@ mod tests {
         // The advisory must instruct the model to name the fix, not fabricate.
         let advisory = render_from_names(&[]).expect("advisory when nothing registered");
         assert!(advisory.contains("do NOT claim the ability does not exist"));
+    }
+
+    /// Pull the argument of each `read_env_key("NAME")` call out of resolver
+    /// source, in source order (the order the resolver probes providers).
+    fn read_env_keys_in(src: &str) -> Vec<String> {
+        let mut keys = Vec::new();
+        let marker = "read_env_key(\"";
+        let mut rest = src;
+        while let Some(i) = rest.find(marker) {
+            rest = &rest[i + marker.len()..];
+            if let Some(end) = rest.find('"') {
+                keys.push(rest[..end].to_string());
+                rest = &rest[end + 1..];
+            } else {
+                break;
+            }
+        }
+        keys
+    }
+
+    /// Extract the `*_API_KEY` / `*_TOKEN` env-var names named in a hint string.
+    fn env_vars_in(hint: &str) -> Vec<String> {
+        hint.split(|c: char| !(c.is_ascii_uppercase() || c.is_ascii_digit() || c == '_'))
+            .filter(|t| t.ends_with("_API_KEY") || t.ends_with("_TOKEN"))
+            .map(|t| t.to_string())
+            .collect()
+    }
+
+    /// Anti-drift: the env-var hints in `OPTIONAL_CAPABILITIES` must stay in
+    /// sync with the resolvers in `crate::tool_backends`. This test is the guard
+    /// that stops the hint list from silently drifting from the resolvers again
+    /// (the image-gen hint has already omitted `HF_API_KEY` once).
+    #[test]
+    fn advisory_hints_stay_in_sync_with_resolvers() {
+        use std::fs;
+        use std::path::Path;
+
+        let backends = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/tool_backends");
+
+        // Guard 1: the image_generate hint must name exactly the provider keys
+        // that `build_image_gen_backend` probes, in the same order.
+        let image_gen_src = fs::read_to_string(backends.join("image_gen.rs"))
+            .expect("read image_gen resolver source");
+        let resolver_keys = read_env_keys_in(&image_gen_src);
+        assert_eq!(
+            resolver_keys,
+            vec!["OPENAI_API_KEY", "FAL_API_KEY", "GEMINI_API_KEY", "HF_API_KEY"],
+            "image_gen resolver probe order changed — update the image_generate hint to match"
+        );
+        let image_hint = OPTIONAL_CAPABILITIES
+            .iter()
+            .find(|c| c.tool == "image_generate")
+            .map(|c| c.hint)
+            .expect("image_generate capability present");
+        assert_eq!(
+            env_vars_in(image_hint),
+            resolver_keys,
+            "image_generate hint env vars must match the resolver's probe order exactly: {image_hint}"
+        );
+
+        // Guard 2: every env var named in ANY hint must actually be read by some
+        // resolver in tool_backends — no hint may promise a key that configures
+        // nothing (catches typos and renamed keys across all capabilities).
+        let mut all_src = String::new();
+        for entry in fs::read_dir(&backends).expect("read tool_backends dir") {
+            let path = entry.expect("dir entry").path();
+            if path.extension().and_then(|e| e.to_str()) == Some("rs") {
+                all_src.push_str(&fs::read_to_string(&path).expect("read backend source"));
+            }
+        }
+        for cap in OPTIONAL_CAPABILITIES {
+            let vars = env_vars_in(cap.hint);
+            assert!(
+                !vars.is_empty(),
+                "{} hint names no env var — expected at least one: {}",
+                cap.label,
+                cap.hint
+            );
+            for key in vars {
+                assert!(
+                    all_src.contains(&format!("\"{key}\"")),
+                    "{} hint names {key}, but no tool_backends resolver reads it",
+                    cap.label
+                );
+            }
+        }
     }
 }

--- a/crates/wcore-agent/src/capability_advisory.rs
+++ b/crates/wcore-agent/src/capability_advisory.rs
@@ -129,7 +129,9 @@ mod tests {
         );
         // Missing ones are named with their fix.
         assert!(advisory.contains("Image generation"));
-        assert!(advisory.contains("set OPENAI_API_KEY, FAL_API_KEY, GEMINI_API_KEY, or HF_API_KEY"));
+        assert!(
+            advisory.contains("set OPENAI_API_KEY, FAL_API_KEY, GEMINI_API_KEY, or HF_API_KEY")
+        );
         assert!(advisory.contains("Text-to-speech"));
         assert!(advisory.contains("set DISCORD_BOT_TOKEN"));
     }
@@ -185,7 +187,12 @@ mod tests {
         let resolver_keys = read_env_keys_in(&image_gen_src);
         assert_eq!(
             resolver_keys,
-            vec!["OPENAI_API_KEY", "FAL_API_KEY", "GEMINI_API_KEY", "HF_API_KEY"],
+            vec![
+                "OPENAI_API_KEY",
+                "FAL_API_KEY",
+                "GEMINI_API_KEY",
+                "HF_API_KEY"
+            ],
             "image_gen resolver probe order changed — update the image_generate hint to match"
         );
         let image_hint = OPTIONAL_CAPABILITIES

--- a/crates/wcore-agent/src/capability_advisory.rs
+++ b/crates/wcore-agent/src/capability_advisory.rs
@@ -1,0 +1,143 @@
+//! Boot-time "unavailable capabilities and why" advisory (#660).
+//!
+//! Optional capability tools (vision, image generation, transcription, TTS,
+//! video, Discord, …) hide themselves from the call schema when their backend
+//! is unconfigured — `Tool::is_available() == false` at registration, so the
+//! model never sees the tool. The drop is silent: asked to generate an image
+//! with no key set, the model fabricates a cause ("I don't have image
+//! generation") instead of the honest, actionable reason ("set OPENAI_API_KEY").
+//!
+//! This module surfaces the truth into the system prompt. Availability is read
+//! straight from the populated [`ToolRegistry`] (the single source of truth —
+//! the backend resolver already decided), and each absent capability contributes
+//! a static, human-readable hint naming the env var(s) that would enable it.
+//! When every capability is available the advisory is `None`, so a fully
+//! configured session's prompt is byte-identical to before.
+
+use wcore_tools::registry::ToolRegistry;
+
+/// One optional capability: the tool `name()` that exposes it and the honest
+/// hint naming the configuration that would enable it.
+struct Capability {
+    /// Human-facing capability label used in the advisory line.
+    label: &'static str,
+    /// The tool's `name()` — present in the registry iff the capability is
+    /// available this session.
+    tool: &'static str,
+    /// What the user must configure to enable it. Env-var names verified
+    /// against each backend resolver.
+    hint: &'static str,
+}
+
+/// The env-gated capabilities whose absence is otherwise invisible to the model.
+/// Env-var names mirror the resolvers in `crate::tool_backends` (`image_gen`,
+/// `tts`, `video_analyze`, `discord`, and `build_vision_backend` /
+/// `build_transcription_backend` in `tool_backends/mod.rs`).
+const OPTIONAL_CAPABILITIES: &[Capability] = &[
+    Capability {
+        label: "Image generation",
+        tool: "image_generate",
+        hint: "set OPENAI_API_KEY, FAL_API_KEY, or GEMINI_API_KEY",
+    },
+    Capability {
+        label: "Image understanding (vision)",
+        tool: "vision_analyze",
+        hint: "set ANTHROPIC_API_KEY, OPENAI_API_KEY, or GEMINI_API_KEY",
+    },
+    Capability {
+        label: "Audio transcription",
+        tool: "transcribe_audio",
+        hint: "set GROQ_API_KEY or OPENAI_API_KEY",
+    },
+    Capability {
+        label: "Text-to-speech",
+        tool: "text_to_speech",
+        hint: "set OPENAI_API_KEY or ELEVENLABS_API_KEY",
+    },
+    Capability {
+        label: "Video analysis",
+        tool: "video_analyze",
+        hint: "set ANTHROPIC_API_KEY, OPENAI_API_KEY, or GEMINI_API_KEY (and install ffmpeg)",
+    },
+    Capability {
+        label: "Discord",
+        tool: "discord_server",
+        hint: "set DISCORD_BOT_TOKEN",
+    },
+];
+
+/// Render the "unavailable capabilities" advisory for appending to the system
+/// prompt, given the fully-populated tool registry.
+///
+/// Returns `None` when every optional capability is available, keeping the
+/// prompt unchanged for fully-configured sessions.
+pub fn render_capability_advisory(registry: &ToolRegistry) -> Option<String> {
+    render_from_names(&registry.tool_names())
+}
+
+/// Testable core: build the advisory from a set of registered tool names.
+fn render_from_names(registered: &[String]) -> Option<String> {
+    let missing: Vec<&Capability> = OPTIONAL_CAPABILITIES
+        .iter()
+        .filter(|c| !registered.iter().any(|n| n == c.tool))
+        .collect();
+    if missing.is_empty() {
+        return None;
+    }
+    let mut out = String::new();
+    out.push_str("\n\n# Unavailable capabilities\n");
+    out.push_str(
+        "The capabilities below are NOT available in this session because their backend \
+         is not configured. If the user asks for one, do NOT claim the ability does not \
+         exist or invent another reason — tell them exactly what to configure:\n",
+    );
+    for c in missing {
+        out.push_str(&format!("- {} — unavailable: {}\n", c.label, c.hint));
+    }
+    Some(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn all_capability_tools() -> Vec<String> {
+        OPTIONAL_CAPABILITIES
+            .iter()
+            .map(|c| c.tool.to_string())
+            .collect()
+    }
+
+    #[test]
+    fn none_when_every_capability_available() {
+        // A fully-configured session (all capability tools registered) must
+        // produce no advisory, keeping the prompt byte-identical to before.
+        assert!(render_from_names(&all_capability_tools()).is_none());
+    }
+
+    #[test]
+    fn lists_only_the_missing_capabilities_with_hints() {
+        // Only vision is configured; every other capability must be named as
+        // unavailable, each with its honest env-var hint.
+        let registered = vec!["vision_analyze".to_string(), "read".to_string()];
+        let advisory = render_from_names(&registered).expect("advisory when capabilities missing");
+        assert!(advisory.contains("# Unavailable capabilities"));
+        // Vision is present → must NOT be listed as unavailable.
+        assert!(
+            !advisory.contains("Image understanding"),
+            "configured capability must not appear: {advisory}"
+        );
+        // Missing ones are named with their fix.
+        assert!(advisory.contains("Image generation"));
+        assert!(advisory.contains("set OPENAI_API_KEY, FAL_API_KEY, or GEMINI_API_KEY"));
+        assert!(advisory.contains("Text-to-speech"));
+        assert!(advisory.contains("set DISCORD_BOT_TOKEN"));
+    }
+
+    #[test]
+    fn honest_instruction_forbids_fabricating_a_cause() {
+        // The advisory must instruct the model to name the fix, not fabricate.
+        let advisory = render_from_names(&[]).expect("advisory when nothing registered");
+        assert!(advisory.contains("do NOT claim the ability does not exist"));
+    }
+}

--- a/crates/wcore-agent/src/channel_media.rs
+++ b/crates/wcore-agent/src/channel_media.rs
@@ -27,8 +27,10 @@
 //!
 //! Every step is best-effort: a connector that can't fetch (default
 //! `Rejected`), a fetch error/timeout, an oversize payload, an unsupported
-//! format, or a backend error all log and leave the attachment as a bare-URL
-//! summary. A media problem never fails the turn. Both the fetch and the
+//! format, a missing backend, or a backend error all log and write an honest
+//! degraded notice into [`Attachment::transcribed`] (#660) — the model is told
+//! it cannot see/hear the content and why, never left to answer blind from a
+//! bare URL. A media problem never fails the turn. Both the fetch and the
 //! analyze step are wall-clock bounded.
 
 use std::sync::Arc;
@@ -57,6 +59,22 @@ const ANALYZE_TIMEOUT: Duration = Duration::from_secs(45);
 /// Vision prompt for eager image enrichment — terse on purpose.
 const IMAGE_DESCRIBE_PROMPT: &str =
     "Concisely describe this image for a chat assistant, and quote any visible text verbatim.";
+
+// Honest degraded-mode notices (#660). When inbound media cannot be turned into
+// text, the model must be told WHY — otherwise the prompt carries only a bare
+// URL it cannot fetch and it answers blind (confidently describing an image it
+// never saw). These strings are written into `Attachment::transcribed`, which
+// `build_turn_prompt` surfaces into the turn.
+const IMAGE_NO_VISION_NOTICE: &str = "[Inbound image received but NOT analyzed: no vision backend is configured, so the \
+     assistant cannot see this image. Do not guess its contents. To enable image \
+     understanding, set ANTHROPIC_API_KEY, OPENAI_API_KEY, or GEMINI_API_KEY.]";
+const AUDIO_NO_TRANSCRIPTION_NOTICE: &str = "[Inbound audio received but NOT transcribed: no transcription backend is configured, so \
+     the assistant cannot hear this audio. To enable transcription, set GROQ_API_KEY or \
+     OPENAI_API_KEY.]";
+const IMAGE_ANALYSIS_FAILED_NOTICE: &str = "[Inbound image could not be analyzed (it may be too large, an unsupported format, or the \
+     vision backend errored/timed out). The assistant has NOT seen its contents; do not guess.]";
+const AUDIO_ANALYSIS_FAILED_NOTICE: &str = "[Inbound audio could not be transcribed (it may be too large, an unsupported format, or the \
+     transcription backend errored/timed out). The assistant has NOT heard its contents.]";
 
 /// Source of inbound media bytes, fetched WITH the originating connector's
 /// own credentials. Abstracts [`ChannelManager`] so the enricher is unit
@@ -96,8 +114,9 @@ impl MediaByteSource for ManagerMediaSource {
 /// and a [`MediaByteSource`] for the auth-aware download.
 ///
 /// Construct via [`ChannelMediaEnricher::new`]. When neither backend is
-/// configured the enricher is *inert* ([`Self::is_inert`]) and the caller
-/// should skip installing it.
+/// configured the enricher is *inert* ([`Self::is_inert`]) for deriving text,
+/// but is still installed so it can emit honest "cannot see/hear this" degraded
+/// notices (#660) rather than letting inbound media be answered blind.
 pub struct ChannelMediaEnricher {
     vision: Option<Arc<dyn VisionBackend>>,
     transcription: Option<Arc<dyn TranscriptionBackend>>,
@@ -123,22 +142,37 @@ impl ChannelMediaEnricher {
         }
     }
 
-    /// `true` when no backend is wired — the enricher would do nothing.
+    /// `true` when no backend is wired — the enricher derives no text and only
+    /// emits honest degraded notices for inbound media (#660).
     pub fn is_inert(&self) -> bool {
         self.vision.is_none() && self.transcription.is_none()
     }
 
     /// Enrich each attachment in place. Best-effort and fail-soft.
+    ///
+    /// When an image/audio attachment cannot be turned into text — no backend
+    /// configured, or fetch/analysis failed — an honest degraded notice is
+    /// written to [`Attachment::transcribed`] instead of silently leaving a
+    /// bare URL (#660). Non-media kinds are left untouched.
     pub async fn enrich(&self, attachments: &mut [Attachment], channel: &str) {
         for att in attachments.iter_mut() {
             // Never overwrite a connector-supplied transcript.
             if att.transcribed.is_some() {
                 continue;
             }
-            // Only kinds we actually have a backend for proceed.
+            // No backend for this media kind → record why, don't drop it blind.
             match att.kind {
-                MediaKind::Image if self.vision.is_some() => {}
-                MediaKind::Audio if self.transcription.is_some() => {}
+                MediaKind::Image if self.vision.is_none() => {
+                    att.transcribed = Some(IMAGE_NO_VISION_NOTICE.to_string());
+                    continue;
+                }
+                MediaKind::Audio if self.transcription.is_none() => {
+                    att.transcribed = Some(AUDIO_NO_TRANSCRIPTION_NOTICE.to_string());
+                    continue;
+                }
+                // A matching backend is configured — proceed to fetch+analyze.
+                MediaKind::Image | MediaKind::Audio => {}
+                // Non-media kind (file, …) — nothing to derive, leave as-is.
                 _ => continue,
             }
 
@@ -151,7 +185,7 @@ impl ChannelMediaEnricher {
             )
             .await
             {
-                Ok(Ok(b)) => b,
+                Ok(Ok(b)) => Some(b),
                 Ok(Err(e)) => {
                     tracing::debug!(
                         target: "wcore_agent::channel_media",
@@ -160,7 +194,7 @@ impl ChannelMediaEnricher {
                         error = %e,
                         "inbound media fetch failed"
                     );
-                    continue;
+                    None
                 }
                 Err(_) => {
                     tracing::warn!(
@@ -170,26 +204,39 @@ impl ChannelMediaEnricher {
                         timeout_secs = self.fetch_timeout.as_secs(),
                         "inbound media fetch timed out"
                     );
-                    continue;
+                    None
                 }
             };
 
-            let derived = match att.kind {
-                MediaKind::Image => self.describe_image(&bytes, channel).await,
-                MediaKind::Audio => self.transcribe_audio(&bytes, channel).await,
+            let derived = match (att.kind, bytes.as_deref()) {
+                (MediaKind::Image, Some(b)) => self.describe_image(b, channel).await,
+                (MediaKind::Audio, Some(b)) => self.transcribe_audio(b, channel).await,
                 _ => None,
             };
-            if let Some(text) = derived {
-                let (text, truncated) = truncate(text, MAX_DERIVED_CHARS);
-                tracing::info!(
-                    target: "wcore_agent::channel_media",
-                    channel,
-                    kind = ?att.kind,
-                    chars = text.len(),
-                    truncated,
-                    "inbound media enriched"
-                );
-                att.transcribed = Some(text);
+            match derived {
+                Some(text) => {
+                    let (text, truncated) = truncate(text, MAX_DERIVED_CHARS);
+                    tracing::info!(
+                        target: "wcore_agent::channel_media",
+                        channel,
+                        kind = ?att.kind,
+                        chars = text.len(),
+                        truncated,
+                        "inbound media enriched"
+                    );
+                    att.transcribed = Some(text);
+                }
+                // Backend WAS configured but fetch/analysis produced nothing —
+                // an honest "could not analyze" notice, never a silent drop.
+                None => {
+                    att.transcribed = Some(
+                        match att.kind {
+                            MediaKind::Image => IMAGE_ANALYSIS_FAILED_NOTICE,
+                            _ => AUDIO_ANALYSIS_FAILED_NOTICE,
+                        }
+                        .to_string(),
+                    );
+                }
             }
         }
     }
@@ -353,11 +400,16 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn fetch_error_leaves_attachment_untouched() {
+    async fn fetch_error_yields_analysis_failed_notice() {
+        // #660: a fetch failure (backend present) must surface an honest notice,
+        // not silently drop the image to a bare URL the model answers blind.
         let enricher = vision_enricher("never", StaticSource(Err("401 unauthorized".into())));
         let mut atts = vec![image_att()];
         enricher.enrich(&mut atts, "slack").await;
-        assert!(atts[0].transcribed.is_none());
+        assert_eq!(
+            atts[0].transcribed.as_deref(),
+            Some(IMAGE_ANALYSIS_FAILED_NOTICE)
+        );
     }
 
     #[tokio::test]
@@ -387,31 +439,52 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn image_skipped_when_only_transcription_wired() {
+    async fn image_without_vision_backend_yields_notice() {
+        // #660: an image with no vision backend must get an honest "cannot see,
+        // set a key" notice instead of being silently dropped.
         let enricher = audio_enricher("audio only", StaticSource(Ok(png_bytes())));
         let mut atts = vec![image_att()];
         enricher.enrich(&mut atts, "slack").await;
-        assert!(atts[0].transcribed.is_none());
+        assert_eq!(atts[0].transcribed.as_deref(), Some(IMAGE_NO_VISION_NOTICE));
     }
 
     #[tokio::test]
-    async fn non_media_bytes_are_rejected_by_mime_sniff() {
-        // Source returns an HTML error page; the mime sniff fails → skip.
+    async fn audio_without_transcription_backend_yields_notice() {
+        // #660: audio with no transcription backend gets the honest notice.
+        let enricher = vision_enricher("vision only", StaticSource(Ok(ogg_bytes())));
+        let mut atts = vec![audio_att()];
+        enricher.enrich(&mut atts, "whatsapp").await;
+        assert_eq!(
+            atts[0].transcribed.as_deref(),
+            Some(AUDIO_NO_TRANSCRIPTION_NOTICE)
+        );
+    }
+
+    #[tokio::test]
+    async fn non_media_bytes_yield_analysis_failed_notice() {
+        // Source returns an HTML error page; the mime sniff fails. Backend was
+        // present, so #660 surfaces an honest "could not analyze" notice.
         let html = b"<!DOCTYPE html><html>nope</html>".to_vec();
         let enricher = vision_enricher("never", StaticSource(Ok(html)));
         let mut atts = vec![image_att()];
         enricher.enrich(&mut atts, "slack").await;
-        assert!(atts[0].transcribed.is_none());
+        assert_eq!(
+            atts[0].transcribed.as_deref(),
+            Some(IMAGE_ANALYSIS_FAILED_NOTICE)
+        );
     }
 
     #[tokio::test]
-    async fn oversize_payload_is_skipped() {
+    async fn oversize_payload_yields_analysis_failed_notice() {
         let mut huge = b"\x89PNG\r\n\x1a\n".to_vec();
         huge.resize(VISION_MAX_BYTES + 1024, 0u8);
         let enricher = vision_enricher("never", StaticSource(Ok(huge)));
         let mut atts = vec![image_att()];
         enricher.enrich(&mut atts, "slack").await;
-        assert!(atts[0].transcribed.is_none());
+        assert_eq!(
+            atts[0].transcribed.as_deref(),
+            Some(IMAGE_ANALYSIS_FAILED_NOTICE)
+        );
     }
 
     #[tokio::test]
@@ -425,13 +498,16 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn inert_enricher_is_a_noop() {
+    async fn inert_enricher_emits_degraded_notice_not_noop() {
+        // #660: even with NO backend wired the enricher must not silently drop
+        // inbound media — it emits the honest no-vision notice so the model
+        // never answers an unseen image blind.
         let enricher =
             ChannelMediaEnricher::new(None, None, Arc::new(StaticSource(Ok(png_bytes()))));
         assert!(enricher.is_inert());
         let mut atts = vec![image_att()];
         enricher.enrich(&mut atts, "slack").await;
-        assert!(atts[0].transcribed.is_none());
+        assert_eq!(atts[0].transcribed.as_deref(), Some(IMAGE_NO_VISION_NOTICE));
     }
 
     #[test]

--- a/crates/wcore-agent/src/lib.rs
+++ b/crates/wcore-agent/src/lib.rs
@@ -33,6 +33,7 @@ pub mod channel_dispatch;
 // derived text (description/transcript) via the host-wired vision /
 // transcription tools before the turn prompt is built. Inert when no
 // backend is configured. Consumed by `channel_dispatch` + `bootstrap`.
+pub mod capability_advisory;
 pub mod channel_media;
 // FleetDispatcher-class fix (audit 2026-05-24): bridges SendMessageTool's
 // `MessageTransport` boundary to the host's `ChannelManager` so the LLM


### PR DESCRIPTION
## #660 — honest capability availability (audit, rolls up to #656)

Anti-pattern: a capability is unavailable and the agent silently drops it or invents a cause instead of honestly reporting why. This PR lands the two P0 fixes the issue calls out first.

### 1. Boot-time capability advisory (finding 1 + the API-key column)

Env-gated tools (vision, image generation, transcription, TTS, video, Discord) hide themselves from the call schema when their backend is unconfigured — `Tool::is_available() == false`, so the model never sees the tool. Asked to generate an image with no key, the model fabricates "I don't have image generation" instead of the honest, actionable "set OPENAI_API_KEY".

New `capability_advisory` module: availability is read straight from the populated `ToolRegistry` (single source of truth — the resolver already decided), and each absent capability contributes a static hint naming the env var(s) that enable it. Env-var names verified against each backend resolver (`tool_backends::image_gen` / `tts` / `video_analyze` / `discord`, and `build_vision_backend` / `build_transcription_backend`). Injected in bootstrap next to the user-context block; returns `None` (prompt byte-identical) when every capability is available.

The Doctor in wcore-cli was NOT reused: wrong dependency direction (wcore-agent cannot depend on wcore-cli), and it only probes external binaries + a few env vars, not tool-capability availability.

### 2. Inbound channel image/audio answered blind (findings 2 + 3)

`channel_media::enrich` silently dropped an image when no vision backend was wired (`_ => continue`) or when fetch/analysis failed (`describe_image` → `None`), leaving the turn prompt a bare URL the model confidently described unseen. `enrich` now writes an honest degraded notice into `Attachment::transcribed` (the channel `build_turn_prompt` already surfaces) for every undescribed image/audio, distinguishing:
- no backend configured → "cannot see this image; set ANTHROPIC_API_KEY/OPENAI_API_KEY/GEMINI_API_KEY"
- backend present but fetch/analysis failed → "could not be analyzed; has NOT seen its contents"

The enricher is now installed even when inert (both backends absent) so the notice fires with no backend at all — previously it was skipped entirely, which was the exact blind path.

### Tests

3 new advisory unit tests (none-when-all-available, lists-only-missing-with-hints, honest-instruction). channel_media tests that encoded the old silent-drop are updated to assert the notices, plus new no-backend image/audio notice tests. Hetzner gate green (fmt 0, clippy 0, nextest: only the two known flakes).

### Deferred to a #660 follow-up (flagged on the issue)

- Finding 4 (P1): provider tool-drop honesty — bedrock/openai silently omit the tools array for tool-incapable models. Separate provider-layer change.
- Finding 5 (P2): ModelInfo capability fields + real `message_requires_vision` (engine.rs) — its vision half overlaps the already-open #648/PR #171 (adds `ContentBlock::Image`); folding it in here would collide. Best done after #648 lands.
