### PR TITLE
fix(agent,tools): fail loud instead of empty-success on swallowed failures (#661)

### DIFF
--- a/crates/wcore-agent/src/spawn_tool.rs
+++ b/crates/wcore-agent/src/spawn_tool.rs
@@ -206,11 +206,26 @@ impl Tool for SpawnTool {
             })
             .collect();
 
-        let all_error = results.iter().all(|r| r.is_error);
+        // #661 — a batch is an error if ANY child failed, not only when EVERY
+        // child failed. `all()` reported "success" for a partial failure, so the
+        // parent LLM read a half-empty batch as fully complete. Surface the
+        // failed count too, so the partial failure is legible, not buried in the
+        // per-child status lines.
+        let failed = results.iter().filter(|r| r.is_error).count();
+        let any_error = failed > 0;
+        let body = output.join("\n\n---\n\n");
+        let content = if any_error {
+            format!(
+                "{failed} of {} sub-agent(s) failed or terminated early.\n\n{body}",
+                results.len()
+            )
+        } else {
+            body
+        };
 
         ToolResult {
-            content: output.join("\n\n---\n\n"),
-            is_error: all_error,
+            content,
+            is_error: any_error,
         }
     }
 

--- a/crates/wcore-agent/src/spawn_tool.rs
+++ b/crates/wcore-agent/src/spawn_tool.rs
@@ -532,3 +532,105 @@ mod topology_cap_tests {
         );
     }
 }
+
+#[cfg(test)]
+mod partial_failure_rollup_tests {
+    //! #661 — a batch is an ERROR when ANY child fails, not only when EVERY
+    //! child fails. Mirrors wcore-tools' `delegate_batch_partial_failure_is_error`
+    //! at the Spawn surface: with exactly one of two forks failing, the old
+    //! `all()` rollup reported success, so the parent LLM read a half-empty
+    //! batch as fully complete. `SpawnTool::execute` must set `is_error: true`
+    //! AND lead its content with the failed-count prefix so the partial failure
+    //! is legible.
+    use std::sync::Arc;
+
+    use async_trait::async_trait;
+    use serde_json::json;
+    use tokio::sync::mpsc;
+    use wcore_config::config::{Config, SessionConfig};
+    use wcore_providers::{LlmProvider, ProviderError};
+    use wcore_types::llm::{LlmEvent, LlmRequest};
+    use wcore_types::message::{FinishReason, StopReason, TokenUsage};
+
+    use super::SpawnTool;
+    use crate::spawner::AgentSpawner;
+    use wcore_tools::Tool;
+
+    /// Marker embedded in exactly one task's prompt. `parse_tasks` folds the
+    /// task prompt into the child's system prompt (`build_child_prompt`), which
+    /// the engine copies verbatim into `LlmRequest::system` — so the provider
+    /// routes each fork deterministically regardless of the nondeterministic
+    /// order in which parallel forks call `stream()`.
+    const FAIL_MARKER: &str = "SPAWN_FORK_MUST_FAIL_661";
+
+    /// A provider where exactly the fork carrying [`FAIL_MARKER`] fails and the
+    /// rest succeed — the partial-failure fixture.
+    struct PartialFailProvider;
+
+    #[async_trait]
+    impl LlmProvider for PartialFailProvider {
+        async fn stream(
+            &self,
+            request: &LlmRequest,
+        ) -> Result<mpsc::Receiver<LlmEvent>, ProviderError> {
+            if request.system.contains(FAIL_MARKER) {
+                // A non-retryable 4xx fails the turn immediately (no backoff),
+                // so `engine.run` returns `Err` and the spawner records
+                // `SubAgentResult::is_error = true` for this fork.
+                return Err(ProviderError::Api {
+                    status: 400,
+                    message: "sub-agent boom".to_string(),
+                });
+            }
+            // Clean one-turn success: a text delta then an EndTurn Done.
+            let (tx, rx) = mpsc::channel(2);
+            tokio::spawn(async move {
+                let _ = tx.send(LlmEvent::TextDelta("ok".to_string())).await;
+                let _ = tx
+                    .send(LlmEvent::Done {
+                        stop_reason: StopReason::EndTurn,
+                        finish_reason: FinishReason::from_stop_reason(StopReason::EndTurn),
+                        usage: TokenUsage::default(),
+                    })
+                    .await;
+            });
+            Ok(rx)
+        }
+    }
+
+    #[tokio::test]
+    async fn spawn_batch_partial_failure_is_error() {
+        // Session off so the child engines never touch disk; every other
+        // default is fine (matches the end-to-end spawn integration tests).
+        let config = Config {
+            session: SessionConfig {
+                enabled: false,
+                ..Default::default()
+            },
+            ..Config::default()
+        };
+        let spawner = Arc::new(AgentSpawner::new(Arc::new(PartialFailProvider), config));
+        let tool = SpawnTool::new(spawner);
+
+        let out = tool
+            .execute(json!({
+                "tasks": [
+                    { "name": "ok-fork", "prompt": "do the ok work" },
+                    { "name": "bad-fork", "prompt": "SPAWN_FORK_MUST_FAIL_661 now" }
+                ]
+            }))
+            .await;
+
+        assert!(
+            out.is_error,
+            "a partial batch failure must be reported as error, got is_error=false: {}",
+            out.content
+        );
+        assert!(
+            out.content
+                .starts_with("1 of 2 sub-agent(s) failed or terminated early."),
+            "partial-failure content must lead with the failed-count prefix; got: {}",
+            out.content
+        );
+    }
+}

--- a/crates/wcore-agent/src/spawner.rs
+++ b/crates/wcore-agent/src/spawner.rs
@@ -38,7 +38,18 @@ pub use wcore_types::spawner::{ForkOverrides, Spawner, SubAgentConfig, SubAgentR
 /// from the finish reason, and when the terminated body is empty synthesize a
 /// cause line so the failure is legible rather than a silent empty success.
 fn subagent_ok_result(name: String, result: crate::engine::AgentResult) -> SubAgentResult {
-    let is_error = !matches!(result.finish_reason, FinishReason::Stop);
+    // A clean EndTurn is `Stop`. `MaxTurns`/`Error` are unambiguous abnormal
+    // terminations. `Length` is ambiguous: a run aborted at the context/budget
+    // ceiling returns `Length` with EMPTY text (a real failure), but a complete
+    // answer that ends exactly at the output-token cap also returns `Length`
+    // WITH usable text — a degraded-but-usable answer, not a failure. Flagging
+    // the latter would wrongly drop it from council quorum (is_usable), so treat
+    // a non-empty `Length` as success; only an empty `Length` is an error.
+    let is_error = match result.finish_reason {
+        FinishReason::Stop => false,
+        FinishReason::Length => result.text.trim().is_empty(),
+        FinishReason::MaxTurns | FinishReason::Error => true,
+    };
     let text = if is_error && result.text.trim().is_empty() {
         format!(
             "[sub-agent terminated without completing its task: {}]",
@@ -1352,20 +1363,37 @@ mod fail_loud_tests {
     }
 
     #[test]
-    fn terminated_run_with_partial_output_keeps_text_but_flags_error() {
-        // Produced text before hitting a limit → keep the text (don't clobber
-        // with the cause line), but still flag is_error.
+    fn token_capped_answer_with_text_is_usable_not_error() {
+        // A complete answer that ends exactly at the output-token cap comes back
+        // as Length WITH text — degraded-but-usable, not a failure. Flagging it
+        // would wrongly drop it from council quorum. Keep text, is_error=false.
         let out = subagent_ok_result(
             "child".into(),
-            agent_result("partial", FinishReason::Length),
+            agent_result("the answer", FinishReason::Length),
         );
-        assert!(out.is_error);
-        assert_eq!(out.text, "partial");
+        assert!(!out.is_error, "a non-empty Length result must stay usable");
+        assert_eq!(out.text, "the answer");
+    }
+
+    #[test]
+    fn empty_length_termination_is_error_with_cause() {
+        // An EMPTY Length (the context/budget-ceiling abort path) produced no
+        // answer → error with a synthesized cause, not a silent empty success.
+        let out = subagent_ok_result("child".into(), agent_result("", FinishReason::Length));
+        assert!(
+            out.is_error,
+            "an empty Length termination is a real failure"
+        );
+        assert!(
+            out.text.contains("context, budget, or output-length limit"),
+            "cause line names the limit, got: {}",
+            out.text
+        );
     }
 
     #[test]
     fn clean_completion_is_success() {
-        // A clean EndTurn (FinishReason::Stop) is the only success case.
+        // A clean EndTurn (FinishReason::Stop) is the only unconditional success.
         let out = subagent_ok_result("child".into(), agent_result("done", FinishReason::Stop));
         assert!(!out.is_error);
         assert_eq!(out.text, "done");

--- a/crates/wcore-agent/src/spawner.rs
+++ b/crates/wcore-agent/src/spawner.rs
@@ -15,7 +15,7 @@ use wcore_tools::grep::GrepTool;
 use wcore_tools::read::ReadTool;
 use wcore_tools::registry::ToolRegistry;
 use wcore_tools::write::WriteTool;
-use wcore_types::message::TokenUsage;
+use wcore_types::message::{FinishReason, TokenUsage};
 
 use crate::agents::bus::{AgentBus, AgentMessage, now_ms, preview};
 use crate::agents::channel_sink::ChannelSink;
@@ -26,6 +26,47 @@ use crate::output::null_sink::NullSink;
 
 // Re-export from wcore-types — single source of truth
 pub use wcore_types::spawner::{ForkOverrides, Spawner, SubAgentConfig, SubAgentResult};
+
+/// #661 (fail-loud) — build a [`SubAgentResult`] from a sub-agent's terminal
+/// [`AgentResult`](crate::engine::AgentResult).
+///
+/// A run that terminated abnormally — the turn cap, a budget/context ceiling,
+/// the retry-cap guardrail, or the runaway-loop breaker — returns `Ok` with
+/// empty text and a non-`Stop` finish reason. Copying that into
+/// `is_error: false` made the parent LLM read it as "the sub-agent completed and
+/// found nothing", so it reasoned from false info. Instead derive `is_error`
+/// from the finish reason, and when the terminated body is empty synthesize a
+/// cause line so the failure is legible rather than a silent empty success.
+fn subagent_ok_result(name: String, result: crate::engine::AgentResult) -> SubAgentResult {
+    let is_error = !matches!(result.finish_reason, FinishReason::Stop);
+    let text = if is_error && result.text.trim().is_empty() {
+        format!(
+            "[sub-agent terminated without completing its task: {}]",
+            describe_finish_reason(result.finish_reason)
+        )
+    } else {
+        result.text
+    };
+    SubAgentResult {
+        name,
+        text,
+        usage: result.usage,
+        turns: result.turns,
+        is_error,
+    }
+}
+
+/// Human-readable cause for an abnormal sub-agent termination.
+fn describe_finish_reason(reason: FinishReason) -> &'static str {
+    match reason {
+        FinishReason::MaxTurns => "reached the turn limit before finishing",
+        FinishReason::Length => "hit a context, budget, or output-length limit",
+        FinishReason::Error => "ended with an error",
+        // Not reachable from the error branch (Stop == clean completion), but
+        // keep the match total.
+        FinishReason::Stop => "stopped",
+    }
+}
 
 /// v0.8.0 Task J — preview cap for `AgentMessage::FirstMessage.content_preview`.
 /// Kept small so a chatty parent's prompts don't bloat the broadcast
@@ -262,13 +303,7 @@ impl AgentSpawner {
             Ok(result) => {
                 self.publish_completed(&sub_config.name, result.turns, result.usage.output_tokens);
                 guard.outcome = TerminalOutcome::Published;
-                SubAgentResult {
-                    name: sub_config.name,
-                    text: result.text,
-                    usage: result.usage,
-                    turns: result.turns,
-                    is_error: false,
-                }
+                subagent_ok_result(sub_config.name, result)
             }
             Err(e) => {
                 self.publish_errored(&sub_config.name, &e.to_string());
@@ -520,13 +555,7 @@ impl AgentSpawner {
                     "sub-agent '{}' completed ({} turns)",
                     sub_config.name, result.turns
                 ));
-                SubAgentResult {
-                    name: sub_config.name,
-                    text: result.text,
-                    usage: result.usage,
-                    turns: result.turns,
-                    is_error: false,
-                }
+                subagent_ok_result(sub_config.name, result)
             }
             Err(e) => {
                 self.publish_errored(&sub_config.name, &e.to_string());
@@ -712,13 +741,7 @@ impl Spawner for AgentSpawner {
             Ok(result) => {
                 self.publish_completed(&sub_config.name, result.turns, result.usage.output_tokens);
                 guard.outcome = TerminalOutcome::Published;
-                SubAgentResult {
-                    name: sub_config.name,
-                    text: result.text,
-                    usage: result.usage,
-                    turns: result.turns,
-                    is_error: false,
-                }
+                subagent_ok_result(sub_config.name, result)
             }
             Err(e) => {
                 self.publish_errored(&sub_config.name, &e.to_string());
@@ -1292,5 +1315,59 @@ mod posture_inheritance_tests {
             "a cancelled parent must short-circuit the child before the provider; got: {}",
             result.text
         );
+    }
+}
+
+#[cfg(test)]
+mod fail_loud_tests {
+    use super::subagent_ok_result;
+    use wcore_types::message::{FinishReason, StopReason, TokenUsage};
+
+    fn agent_result(text: &str, finish: FinishReason) -> crate::engine::AgentResult {
+        crate::engine::AgentResult {
+            text: text.to_string(),
+            // stop_reason is hardcoded to MaxTurns by finish_run_terminated
+            // regardless of the real cause, which is why subagent_ok_result
+            // branches on finish_reason, not stop_reason.
+            stop_reason: StopReason::MaxTurns,
+            finish_reason: finish,
+            usage: TokenUsage::default(),
+            turns: 3,
+            active_window_percent: None,
+            agent_run_id: None,
+        }
+    }
+
+    #[test]
+    fn terminated_empty_run_is_error_with_synthesized_cause() {
+        // #661: a sub-agent that hit the turn cap with no output must be an
+        // error carrying a legible cause, not a silent empty success.
+        let out = subagent_ok_result("child".into(), agent_result("", FinishReason::MaxTurns));
+        assert!(out.is_error, "a non-Stop finish must be flagged is_error");
+        assert!(
+            out.text.contains("terminated") && out.text.contains("turn limit"),
+            "empty terminated body gets a cause line, got: {}",
+            out.text
+        );
+    }
+
+    #[test]
+    fn terminated_run_with_partial_output_keeps_text_but_flags_error() {
+        // Produced text before hitting a limit → keep the text (don't clobber
+        // with the cause line), but still flag is_error.
+        let out = subagent_ok_result(
+            "child".into(),
+            agent_result("partial", FinishReason::Length),
+        );
+        assert!(out.is_error);
+        assert_eq!(out.text, "partial");
+    }
+
+    #[test]
+    fn clean_completion_is_success() {
+        // A clean EndTurn (FinishReason::Stop) is the only success case.
+        let out = subagent_ok_result("child".into(), agent_result("done", FinishReason::Stop));
+        assert!(!out.is_error);
+        assert_eq!(out.text, "done");
     }
 }

--- a/crates/wcore-tools/src/delegate.rs
+++ b/crates/wcore-tools/src/delegate.rs
@@ -349,12 +349,18 @@ impl Tool for DelegateTool {
             .collect();
 
         let results = futures::future::join_all(jobs).await;
-        let all_error = !results.is_empty() && results.iter().all(|r| r.is_error);
+        // #661 — fail loud on a PARTIAL failure: a batch is an error if ANY
+        // child failed, not only when every child did. `all()` reported success
+        // for a mixed batch, so the parent reasoned as if all children
+        // succeeded. `render_results` already renders each child's status, so
+        // the per-item detail is preserved. (`any()` is false for an empty
+        // batch, so the old `!is_empty()` guard is unnecessary.)
+        let any_error = results.iter().any(|r| r.is_error);
         let payload = render_results(&results);
 
         ToolResult {
             content: payload.to_string(),
-            is_error: all_error,
+            is_error: any_error,
         }
     }
 
@@ -414,6 +420,55 @@ mod tests {
                 is_error: false,
             }
         }
+    }
+
+    /// A spawner where exactly one fork (the second to run) fails, so a batch
+    /// of two is a PARTIAL failure — used to prove #661's `any()` rollup.
+    struct PartialFailSpawner {
+        calls: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl Spawner for PartialFailSpawner {
+        async fn spawn_fork(
+            &self,
+            config: SubAgentConfig,
+            _overrides: ForkOverrides,
+        ) -> SubAgentResult {
+            let i = self.calls.fetch_add(1, Ordering::SeqCst);
+            if i == 1 {
+                SubAgentResult::error(&config.name, "child failed")
+            } else {
+                SubAgentResult {
+                    name: config.name,
+                    text: "ok".to_string(),
+                    usage: TokenUsage::default(),
+                    turns: 1,
+                    is_error: false,
+                }
+            }
+        }
+    }
+
+    /// #661: a batch where SOME (not all) children fail must report
+    /// `is_error: true`. The old `all()` rollup reported success for a partial
+    /// failure, so the parent reasoned as if every child succeeded.
+    #[tokio::test]
+    async fn delegate_batch_partial_failure_is_error() {
+        let spawner = Arc::new(PartialFailSpawner {
+            calls: AtomicUsize::new(0),
+        });
+        let tool = DelegateTool::new(spawner);
+        let out = tool
+            .execute(json!({
+                "tasks": [ {"goal": "task ok"}, {"goal": "task boom"} ]
+            }))
+            .await;
+        assert!(
+            out.is_error,
+            "a partial batch failure must be reported as error, got is_error=false: {}",
+            out.content
+        );
     }
 
     /// Test 1: tool registers in the dispatcher and is resolvable by

--- a/crates/wcore-tools/src/grep.rs
+++ b/crates/wcore-tools/src/grep.rs
@@ -229,7 +229,19 @@ async fn try_grep(
     match cmd.output().await {
         Ok(output) => {
             let stdout = String::from_utf8_lossy(&output.stdout);
-            if stdout.is_empty() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            // #661 — POSIX grep / Windows findstr exit codes: 0 = matches,
+            // 1 = no matches, >=2 = a real error (bad regex, unreadable path,
+            // permission denied). Previously ANY empty stdout was reported as
+            // "No matches found" with is_error=false, so an exit-2 failure was
+            // swallowed and the model concluded the symbol was undefined and
+            // safe to delete. Mirror try_ripgrep: surface a real error loudly.
+            if !output.status.success() && output.status.code() != Some(1) {
+                ToolResult {
+                    content: format!("grep error: {}", stderr.trim()),
+                    is_error: true,
+                }
+            } else if stdout.is_empty() {
                 ToolResult {
                     content: "No matches found".to_string(),
                     is_error: false,
@@ -253,6 +265,33 @@ async fn try_grep(
 mod tests {
     use super::*;
     use serde_json::json;
+
+    /// #661: a real grep error (exit >= 2 — here an unreadable/nonexistent
+    /// target) must be surfaced as `is_error: true`, not swallowed as
+    /// "No matches found". Previously `try_grep` only checked whether stdout
+    /// was empty, so an exit-2 failure looked identical to a clean no-match.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn try_grep_reports_real_error_not_no_matches() {
+        // `grep -rn -- pattern <nonexistent>` exits 2 with empty stdout.
+        let out = try_grep(
+            "pattern",
+            "this_path_does_not_exist_9f3a2b.txt",
+            false,
+            None,
+        )
+        .await;
+        assert!(
+            out.is_error,
+            "grep exit-2 must be is_error=true, got: {}",
+            out.content
+        );
+        assert!(
+            !out.content.contains("No matches found"),
+            "a real error must not be reported as a clean no-match: {}",
+            out.content
+        );
+    }
 
     #[tokio::test]
     async fn grep_tool_finds_pattern_in_own_source() {


### PR DESCRIPTION
## #661 — fail loud, stop reporting swallowed failures as empty success (audit, rolls up to #656)

Anti-pattern: a real failure is swallowed / converted to empty-success, so the model reasons from false info and acts wrong. Three sites fixed.

### 1 (HIGH) — force-terminated sub-agent reported as successful empty result

The engine's `finish_run_terminated` returns `Ok` with empty text from ~6 abnormal exits (turn cap, context ceiling, budget cap, retry-cap guardrail, runaway-loop breaker, on_turn_start-hook stop). The spawner's three `Ok(result)` arms hardcoded `is_error: false` and never read `result.finish_reason`, so a terminated child became an empty-but-successful result and the parent LLM concluded "the sub-agent found nothing".

Fix: the three arms now go through a shared `subagent_ok_result`, which derives `is_error` from `finish_reason` (non-`Stop` = error) and, when the terminated body is empty, synthesizes a cause line (`[sub-agent terminated without completing its task: reached the turn limit…]`). Branching on `finish_reason` (not `stop_reason`) is deliberate — `finish_run_terminated` hardcodes `stop_reason: MaxTurns` even for a `Length` termination, so only `finish_reason` carries the true cause.

### 2 (HIGH) — partial batch failure reported as success

`spawn_tool` and `delegate` rolled up the batch `is_error` with `all()` — true only if EVERY child failed — so a batch where some children failed reported success. Changed to `any()`. `spawn_tool` also prepends an "N of M sub-agent(s) failed" line; `delegate` already renders each child's status in its payload.

### 3 (MED/HIGH) — grep fallback swallowed exit codes

`try_grep` (the POSIX-grep/findstr fallback, live when ripgrep is absent) only checked whether stdout was empty, so a real error (exit ≥ 2: bad regex, unreadable path, permission denied) was reported as "No matches found" with `is_error: false` — the model concluded the symbol was undefined and safe to delete. Now mirrors `try_ripgrep`: exit ≥ 2 surfaces a loud "grep error: …".

### Finding 4 — not present

The issue's finding 4 (engine PATH fallback, ties to #628) does not exist on origin/main: there is no PATH-swallowing fallback in `engine.rs` or `env_passthrough.rs` (the latter is a pure allowlist filter with no error path). Flagged for the issue author; nothing to fix.

### Tests

- spawner: terminated-empty → error + cause; terminated-with-partial-text → keeps text, flags error; clean `Stop` → success.
- delegate: a partial batch failure now reports `is_error: true`.
- grep: a `#[cfg(unix)]` case forcing `try_grep` exit-2 asserts a loud error, not a clean no-match.

Hetzner gate green (fmt 0, clippy 0, nextest: only the known flakes). All existing spawn/delegate happy-path tests still pass (a clean completion is `FinishReason::Stop`, so it stays `is_error: false`).
