### PR TITLE
feat(token-efficiency): prompt_cache_key stamping, per-run usage_delta, flux-* catalog entries, length-wedge + clean-retry gates

### DIFF
--- a/crates/wcore-agent/src/agents/channel_sink.rs
+++ b/crates/wcore-agent/src/agents/channel_sink.rs
@@ -191,6 +191,7 @@ impl OutputSink for ChannelSink {
             msg_id: msg_id.to_string(),
             finish_reason,
             usage: None,
+            usage_delta: None,
             agent_run_id: None,
         });
     }

--- a/crates/wcore-agent/src/compact/micro.rs
+++ b/crates/wcore-agent/src/compact/micro.rs
@@ -268,7 +268,8 @@ fn prune_superseded_reads(messages: &mut [Message], config: &CompactConfig) -> (
 /// request forever. This pass replaces such payloads with a small valid-JSON
 /// stub once the call is older than the last `keep_recent_turns` assistant
 /// turns (the model may still reference recent args; older ones are dead
-/// weight — the outcome is in the tool result and, for file writes, on disk).
+/// weight — the outcome is in the tool result and, for file writes, on disk)
+/// AND the epoch boundary below has ticked past it.
 ///
 /// Modeled on hermes-agent's `_truncate_tool_call_args_json`
 /// (context_compressor.py:1130-1150), but run CONTINUOUSLY on every
@@ -283,6 +284,22 @@ fn prune_superseded_reads(messages: &mut [Message], config: &CompactConfig) -> (
 ///   pass skips it forever after, so a message compacts exactly once and its
 ///   bytes never change again. Growth of history only moves the protected
 ///   tail forward — it can newly compact a message, never un-compact one.
+/// - **Epoch-quantized boundary** (cache economics, GLM byte-walk audit):
+///   monotonicity alone is not enough. If the stub boundary advanced every
+///   turn, exactly one message would flip verbatim→stub INSIDE the
+///   previously-cached prefix each turn; provider prefix-matching is
+///   contiguous, so the byte-identical protected tail AFTER the flip would
+///   re-bill at full price EVERY turn (steady-state cache miss ≈ 2x the
+///   no-compaction baseline; break-even only past ~11 turns). Instead the
+///   boundary advances only in steps of `epoch_turns` (default 4): the count
+///   of eligible assistant turns is `floor((A - keep) / E) * E` where `A` is
+///   the total number of assistant messages. Between ticks the boundary is
+///   FROZEN — zero mid-prefix byte changes, full prefix reuse; at a tick one
+///   batch of `E` turns flips at the deepest possible point, one prefix
+///   rewrite per `E` turns instead of per turn. The formula is a pure
+///   function of the message list (no persisted state), so it is stable
+///   across retries, restarts and session rehydration, and monotone because
+///   `A` only grows. `epoch_turns = 1` degenerates to the per-turn boundary.
 ///
 /// The stub keeps the block's `id`/`name`/`extra` untouched (provider
 /// round-trip metadata such as thought signatures survives) and preserves a
@@ -304,33 +321,36 @@ pub fn compact_tool_call_args(
         };
     }
 
-    // Index of the Nth-most-recent assistant message: everything BEFORE it is
-    // older than the last N assistant turns and eligible for compaction.
+    // Epoch-quantized boundary (see the doc comment): stub the oldest
+    // `floor((A - keep) / E) * E` assistant turns. Always ≤ A - keep, so
+    // nothing newer than the last `keep` assistant turns is ever touched;
+    // between epoch ticks the count is constant, so the pass changes zero
+    // bytes and the provider's contiguous prefix cache holds end-to-end.
     let keep = tca.keep_recent_turns.max(1);
-    let mut seen = 0usize;
-    let mut cutoff = None;
-    for (i, m) in messages.iter().enumerate().rev() {
-        if m.role == Role::Assistant {
-            seen += 1;
-            if seen == keep {
-                cutoff = Some(i);
-                break;
-            }
-        }
-    }
-    let Some(cutoff) = cutoff else {
+    let epoch = tca.epoch_turns.max(1);
+    let total_assistant = messages
+        .iter()
+        .filter(|m| m.role == Role::Assistant)
+        .count();
+    let eligible = (total_assistant.saturating_sub(keep) / epoch) * epoch;
+    if eligible == 0 {
         return MicrocompactResult {
             cleared_count: 0,
             estimated_tokens_freed: 0,
         };
-    };
+    }
 
     let mut cleared_count = 0usize;
     let mut tokens_freed = 0usize;
-    for msg in &mut messages[..cutoff] {
+    let mut ordinal = 0usize;
+    for msg in messages.iter_mut() {
         if msg.role != Role::Assistant {
             continue;
         }
+        if ordinal >= eligible {
+            break;
+        }
+        ordinal += 1;
         for block in &mut msg.content {
             let ContentBlock::ToolUse { name, input, .. } = block else {
                 continue;
@@ -1021,12 +1041,24 @@ mod tests {
         }
     }
 
+    /// Boundary-semantics test config: `epoch_turns = 1` (no quantization) so
+    /// the keep/threshold/stub behavior is exercised at every turn. Epoch
+    /// quantization has its own dedicated tests below.
     fn tca_cfg(keep_recent_turns: usize, min_args_bytes: usize) -> CompactConfig {
+        tca_cfg_epoch(keep_recent_turns, min_args_bytes, 1)
+    }
+
+    fn tca_cfg_epoch(
+        keep_recent_turns: usize,
+        min_args_bytes: usize,
+        epoch_turns: usize,
+    ) -> CompactConfig {
         CompactConfig {
             tool_call_args: ToolCallArgsConfig {
                 enabled: true,
                 keep_recent_turns,
                 min_args_bytes,
+                epoch_turns,
             },
             ..default_config()
         }
@@ -1239,6 +1271,79 @@ mod tests {
         }
     }
 
+    // ── epoch quantization (cache-economics fix, GLM byte-walk audit) ───
+
+    #[test]
+    fn epoch_boundary_frozen_between_ticks() {
+        // keep=2, epoch=4. Eligible count = floor((A - 2) / 4) * 4:
+        // frozen between ticks (zero mid-prefix byte changes = the provider's
+        // contiguous prefix cache holds), one batch flip per epoch tick.
+        let body = "e".repeat(2000);
+        let cfg = tca_cfg_epoch(2, 768, 4);
+        let mut msgs = Vec::new();
+        for i in 0..5 {
+            write_turn(&mut msgs, &format!("w{i}"), &format!("f{i}.rs"), &body);
+        }
+
+        // A=5 → floor(3/4)*4 = 0: below the first tick, nothing stubbed even
+        // though w0..w2 are older than the last 2 assistant turns.
+        let r = compact_tool_call_args(&mut msgs, &cfg);
+        assert_eq!(r.cleared_count, 0, "pre-tick: boundary has not advanced");
+
+        // A=6 → floor(4/4)*4 = 4: first tick stubs w0..w3 in ONE batch.
+        write_turn(&mut msgs, "w5", "f5.rs", &body);
+        let r = compact_tool_call_args(&mut msgs, &cfg);
+        assert_eq!(r.cleared_count, 4, "epoch tick stubs a batch of 4");
+        for idx in [8, 10] {
+            // w4, w5 verbatim (protected tail is >= keep at the tick).
+            assert!(tool_use_input(&msgs[idx]).get(COMPACTED_ARGS_KEY).is_none());
+        }
+        let frozen = serde_json::to_string(&msgs).unwrap();
+        let first_batch = serde_json::to_string(&msgs[..8]).unwrap();
+
+        // A=7,8,9 → still 4 eligible: the pass changes ZERO bytes of the
+        // existing messages — the whole previous request stays a cache hit.
+        let pre_len = msgs.len();
+        for i in 6..9 {
+            write_turn(&mut msgs, &format!("w{i}"), &format!("f{i}.rs"), &body);
+            let r = compact_tool_call_args(&mut msgs, &cfg);
+            assert_eq!(r.cleared_count, 0, "between ticks the boundary is frozen");
+        }
+        let existing = serde_json::to_string(&msgs[..pre_len]).unwrap();
+        assert_eq!(
+            frozen, existing,
+            "between ticks, previously-sent messages must be byte-identical"
+        );
+
+        // A=10 → floor(8/4)*4 = 8: second tick stubs w4..w7 (next batch of 4)
+        // and the first batch's bytes still never move.
+        write_turn(&mut msgs, "w9", "f9.rs", &body);
+        let r = compact_tool_call_args(&mut msgs, &cfg);
+        assert_eq!(r.cleared_count, 4, "second tick stubs the next batch of 4");
+        assert_eq!(
+            first_batch,
+            serde_json::to_string(&msgs[..8]).unwrap(),
+            "first-batch stubs are byte-stable across ticks"
+        );
+    }
+
+    #[test]
+    fn epoch_never_reaches_the_keep_window() {
+        // floor((A - keep) / E) * E <= A - keep for all A: even exactly at a
+        // tick, the last `keep` assistant turns stay verbatim.
+        let body = "k".repeat(2000);
+        let cfg = tca_cfg_epoch(2, 768, 4);
+        let mut msgs = Vec::new();
+        for i in 0..6 {
+            write_turn(&mut msgs, &format!("w{i}"), &format!("g{i}.rs"), &body);
+        }
+        compact_tool_call_args(&mut msgs, &cfg); // tick: A=6, eligible=4
+        for idx in [8, 10] {
+            let input = tool_use_input(&msgs[idx]);
+            assert_eq!(input["content"].as_str().unwrap(), body);
+        }
+    }
+
     #[test]
     fn synthetic_19_turn_capture_shape_byte_reduction() {
         // Mimics the reference capture: 9 user prompts, Write bodies from
@@ -1275,7 +1380,10 @@ mod tests {
         }
 
         let before = serde_json::to_string(&msgs).unwrap().len();
-        let cfg = tca_cfg(2, 768);
+        // Ship defaults: keep=2, min=768, epoch=4. A=23 assistant messages →
+        // eligible = floor(21/4)*4 = 20; all 7 Writes (ordinals ≤ 12) are past
+        // the epoch boundary at the final request.
+        let cfg = tca_cfg_epoch(2, 768, 4);
         let result = compact_tool_call_args(&mut msgs, &cfg);
         let after = serde_json::to_string(&msgs).unwrap().len();
 

--- a/crates/wcore-agent/src/compact/micro.rs
+++ b/crates/wcore-agent/src/compact/micro.rs
@@ -22,6 +22,13 @@ pub const SUPERSEDED_TOOL_RESULT_PREFIX: &str = "[Stale read superseded by a lat
 /// Tools whose result mutates a file, invalidating earlier full reads of it.
 const MUTATION_TOOLS: &[&str] = &["Edit", "Write", "MultiEdit", "NotebookEdit"];
 
+/// Marker key stamped into a `ToolUse.input` object whose arguments were
+/// compacted by [`compact_tool_call_args`] (parity gap 2). Presence of this
+/// key means "already compacted — never re-mutate", which is what makes the
+/// pass monotonic: once a call's arguments are stubbed at turn K, the block
+/// serializes byte-identically at every later turn (prompt-cache safety).
+pub const COMPACTED_ARGS_KEY: &str = "_args_cleared";
+
 /// Statistics returned after a microcompact pass.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MicrocompactResult {
@@ -249,6 +256,143 @@ fn prune_superseded_reads(messages: &mut [Message], config: &CompactConfig) -> (
         }
     }
     (count, tokens)
+}
+
+// ── Tool-call-argument compaction (parity gap 2) ────────────────────────────
+
+/// Compact HISTORICAL assistant tool-call ARGUMENTS in place.
+///
+/// The mirror image of the tool-RESULT clearing above: on real workloads the
+/// biggest resent-history slice is the assistant's own `tool_calls` argument
+/// payloads (Write file bodies up to ~19 KB each) riding in every subsequent
+/// request forever. This pass replaces such payloads with a small valid-JSON
+/// stub once the call is older than the last `keep_recent_turns` assistant
+/// turns (the model may still reference recent args; older ones are dead
+/// weight — the outcome is in the tool result and, for file writes, on disk).
+///
+/// Modeled on hermes-agent's `_truncate_tool_call_args_json`
+/// (context_compressor.py:1130-1150), but run CONTINUOUSLY on every
+/// compaction pipeline pass rather than at a compression threshold.
+///
+/// CACHE-SAFETY invariants (prompt-cache prefix stability):
+/// - **Deterministic**: the stub is a pure function of the original
+///   arguments (serialized size, sorted top-level keys, `file_path`), built
+///   as a `serde_json` object — BTreeMap-backed, so keys serialize in sorted
+///   order every time.
+/// - **Monotonic**: a compacted input carries [`COMPACTED_ARGS_KEY`]; the
+///   pass skips it forever after, so a message compacts exactly once and its
+///   bytes never change again. Growth of history only moves the protected
+///   tail forward — it can newly compact a message, never un-compact one.
+///
+/// The stub keeps the block's `id`/`name`/`extra` untouched (provider
+/// round-trip metadata such as thought signatures survives) and preserves a
+/// top-level `file_path` key when present — the supersession pre-pass above
+/// keys its mutation map off `input.file_path`, and the model keeps the
+/// recovery handle (it can Read the file if it needs the content).
+///
+/// Returns a [`MicrocompactResult`] with the number of argument payloads
+/// stubbed and a rough token estimate freed.
+pub fn compact_tool_call_args(
+    messages: &mut [Message],
+    config: &CompactConfig,
+) -> MicrocompactResult {
+    let tca = &config.tool_call_args;
+    if !config.enabled || !tca.enabled {
+        return MicrocompactResult {
+            cleared_count: 0,
+            estimated_tokens_freed: 0,
+        };
+    }
+
+    // Index of the Nth-most-recent assistant message: everything BEFORE it is
+    // older than the last N assistant turns and eligible for compaction.
+    let keep = tca.keep_recent_turns.max(1);
+    let mut seen = 0usize;
+    let mut cutoff = None;
+    for (i, m) in messages.iter().enumerate().rev() {
+        if m.role == Role::Assistant {
+            seen += 1;
+            if seen == keep {
+                cutoff = Some(i);
+                break;
+            }
+        }
+    }
+    let Some(cutoff) = cutoff else {
+        return MicrocompactResult {
+            cleared_count: 0,
+            estimated_tokens_freed: 0,
+        };
+    };
+
+    let mut cleared_count = 0usize;
+    let mut tokens_freed = 0usize;
+    for msg in &mut messages[..cutoff] {
+        if msg.role != Role::Assistant {
+            continue;
+        }
+        for block in &mut msg.content {
+            let ContentBlock::ToolUse { name, input, .. } = block else {
+                continue;
+            };
+            // Monotonicity: never re-mutate an already-compacted input.
+            if input.get(COMPACTED_ARGS_KEY).is_some() {
+                continue;
+            }
+            let serialized_len = serde_json::to_string(&*input).map(|s| s.len()).unwrap_or(0);
+            if serialized_len < tca.min_args_bytes {
+                continue;
+            }
+            let stub = args_stub(name, input, serialized_len);
+            let stub_len = serde_json::to_string(&stub).map(|s| s.len()).unwrap_or(0);
+            tokens_freed += serialized_len.saturating_sub(stub_len) / 4;
+            *input = stub;
+            cleared_count += 1;
+        }
+    }
+
+    MicrocompactResult {
+        cleared_count,
+        estimated_tokens_freed: tokens_freed,
+    }
+}
+
+/// Build the deterministic replacement `input` for a compacted tool call.
+///
+/// Shape (keys serialize sorted — serde_json maps are BTreeMap-backed):
+/// - `file_path` (when the original args carried one, e.g. Write/Edit):
+///   preserved verbatim as the recovery handle;
+/// - [`COMPACTED_ARGS_KEY`]: a one-line summary — original byte count plus,
+///   generically, the sorted top-level argument keys — telling the model how
+///   to recover (Read the file / the outcome is in the tool result).
+fn args_stub(name: &str, input: &serde_json::Value, original_bytes: usize) -> serde_json::Value {
+    let mut obj = serde_json::Map::new();
+    let summary = if let Some(path) = input.get("file_path").and_then(|v| v.as_str()) {
+        obj.insert(
+            "file_path".to_string(),
+            serde_json::Value::String(path.to_string()),
+        );
+        format!(
+            "[Old tool arguments cleared: {name} {path} ({original_bytes} bytes) — \
+             the content is on disk; Read the file if you need it.]"
+        )
+    } else {
+        let mut keys: Vec<&str> = input
+            .as_object()
+            .map(|o| o.keys().map(String::as_str).collect())
+            .unwrap_or_default();
+        keys.sort_unstable();
+        format!(
+            "[Old tool arguments cleared: {name} keys [{}] ({original_bytes} bytes) — \
+             the outcome is in the tool result; re-run the tool if you need them.]",
+            keys.join(", ")
+        )
+    };
+    obj.insert(
+        COMPACTED_ARGS_KEY.to_string(),
+        serde_json::Value::String(summary),
+    );
+    serde_json::Value::Object(obj)
 }
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
@@ -853,6 +997,300 @@ mod tests {
         ];
         let (count, _) = prune_superseded_reads(&mut msgs, &read_only_cfg());
         assert_eq!(count, 0, "supersession requires an intervening edit");
+    }
+
+    // ── parity gap 2: tool-call-argument compaction ─────────────────────
+
+    use wcore_config::compact::ToolCallArgsConfig;
+
+    fn write_use(id: &str, path: &str, body: &str) -> ContentBlock {
+        ContentBlock::ToolUse {
+            id: id.to_string(),
+            name: "Write".to_string(),
+            input: json!({ "file_path": path, "content": body }),
+            extra: None,
+        }
+    }
+
+    fn bash_use(id: &str, command: &str) -> ContentBlock {
+        ContentBlock::ToolUse {
+            id: id.to_string(),
+            name: "Bash".to_string(),
+            input: json!({ "command": command, "description": "run" }),
+            extra: None,
+        }
+    }
+
+    fn tca_cfg(keep_recent_turns: usize, min_args_bytes: usize) -> CompactConfig {
+        CompactConfig {
+            tool_call_args: ToolCallArgsConfig {
+                enabled: true,
+                keep_recent_turns,
+                min_args_bytes,
+            },
+            ..default_config()
+        }
+    }
+
+    /// A Write turn (assistant tool call + tool result) followed by nothing.
+    fn write_turn(msgs: &mut Vec<Message>, id: &str, path: &str, body: &str) {
+        msgs.push(assistant_msg(vec![write_use(id, path, body)]));
+        msgs.push(user_msg(vec![tool_result_block(id, "File written")]));
+    }
+
+    fn tool_use_input(msg: &Message) -> &serde_json::Value {
+        match &msg.content[0] {
+            ContentBlock::ToolUse { input, .. } => input,
+            _ => panic!("expected ToolUse"),
+        }
+    }
+
+    #[test]
+    fn old_write_args_stubbed_recent_verbatim() {
+        let body = "x".repeat(4000);
+        let mut msgs = Vec::new();
+        write_turn(&mut msgs, "w1", "src/old.rs", &body); // oldest assistant turn
+        write_turn(&mut msgs, "w2", "src/mid.rs", &body); // 2nd-from-last: protected
+        write_turn(&mut msgs, "w3", "src/new.rs", &body); // last: protected
+        let cfg = tca_cfg(2, 768);
+
+        let result = compact_tool_call_args(&mut msgs, &cfg);
+        assert_eq!(result.cleared_count, 1, "only the pre-tail Write compacts");
+        assert!(result.estimated_tokens_freed > 500);
+
+        // w1 (index 0): stubbed — marker present, file_path + byte count kept,
+        // recovery text tells the model to Read the file.
+        let stubbed = tool_use_input(&msgs[0]);
+        let summary = stubbed[COMPACTED_ARGS_KEY].as_str().unwrap();
+        assert_eq!(stubbed["file_path"], "src/old.rs");
+        assert!(summary.contains("src/old.rs"));
+        assert!(summary.contains("bytes"));
+        assert!(summary.contains("Read the file"));
+        assert!(stubbed.get("content").is_none(), "the body must be gone");
+
+        // w2 + w3: verbatim.
+        for idx in [2, 4] {
+            let input = tool_use_input(&msgs[idx]);
+            assert_eq!(input["content"].as_str().unwrap(), body);
+            assert!(input.get(COMPACTED_ARGS_KEY).is_none());
+        }
+    }
+
+    #[test]
+    fn generic_args_stub_lists_top_level_keys() {
+        let long_cmd = "echo ".to_string() + &"y".repeat(2000);
+        let mut msgs = vec![
+            assistant_msg(vec![bash_use("b1", &long_cmd)]),
+            user_msg(vec![tool_result_block("b1", "ok")]),
+        ];
+        write_turn(&mut msgs, "w1", "a.rs", "small");
+        write_turn(&mut msgs, "w2", "b.rs", "small");
+        let cfg = tca_cfg(2, 768);
+
+        let result = compact_tool_call_args(&mut msgs, &cfg);
+        assert_eq!(result.cleared_count, 1);
+        let stubbed = tool_use_input(&msgs[0]);
+        let summary = stubbed[COMPACTED_ARGS_KEY].as_str().unwrap();
+        assert!(
+            summary.contains("[command, description]"),
+            "sorted top-level keys must be listed: {summary}"
+        );
+        assert!(summary.contains("bytes"));
+    }
+
+    #[test]
+    fn determinism_same_history_serializes_byte_identically() {
+        let body = "d".repeat(3000);
+        let mut msgs = Vec::new();
+        for (i, p) in ["one.rs", "two.rs", "three.rs", "four.rs"]
+            .iter()
+            .enumerate()
+        {
+            write_turn(&mut msgs, &format!("w{i}"), p, &body);
+        }
+        let cfg = tca_cfg(2, 768);
+
+        compact_tool_call_args(&mut msgs, &cfg);
+        let first = serde_json::to_string(&msgs).unwrap();
+        // A second pass over the same history (e.g. a retry rebuilding the
+        // same turn) must be a byte-level no-op.
+        let again = compact_tool_call_args(&mut msgs, &cfg);
+        assert_eq!(again.cleared_count, 0);
+        assert_eq!(again.estimated_tokens_freed, 0);
+        let second = serde_json::to_string(&msgs).unwrap();
+        assert_eq!(first, second, "serialization must be byte-identical");
+    }
+
+    #[test]
+    fn monotonic_adding_turns_never_changes_stubbed_bytes() {
+        let body = "m".repeat(3000);
+        let mut msgs = Vec::new();
+        write_turn(&mut msgs, "w0", "zero.rs", &body);
+        write_turn(&mut msgs, "w1", "one.rs", &body);
+        write_turn(&mut msgs, "w2", "two.rs", &body);
+        let cfg = tca_cfg(2, 768);
+
+        compact_tool_call_args(&mut msgs, &cfg);
+        let stub_at_k = serde_json::to_string(&msgs[0]).unwrap();
+
+        // Two more turns land; w1 crosses the boundary and newly compacts,
+        // but w0's already-compacted bytes must not move.
+        write_turn(&mut msgs, "w3", "three.rs", &body);
+        write_turn(&mut msgs, "w4", "four.rs", &body);
+        let result = compact_tool_call_args(&mut msgs, &cfg);
+        assert!(result.cleared_count >= 1, "w1/w2 newly cross the boundary");
+        let stub_later = serde_json::to_string(&msgs[0]).unwrap();
+        assert_eq!(
+            stub_at_k, stub_later,
+            "a compacted message must serialize byte-identically at every later turn"
+        );
+    }
+
+    #[test]
+    fn below_threshold_args_untouched() {
+        let mut msgs = Vec::new();
+        write_turn(&mut msgs, "w0", "tiny.rs", "short body"); // well under 768 B
+        write_turn(&mut msgs, "w1", "a.rs", "x");
+        write_turn(&mut msgs, "w2", "b.rs", "x");
+        let cfg = tca_cfg(2, 768);
+
+        let result = compact_tool_call_args(&mut msgs, &cfg);
+        assert_eq!(result.cleared_count, 0);
+        let input = tool_use_input(&msgs[0]);
+        assert_eq!(input["content"], "short body");
+        assert!(input.get(COMPACTED_ARGS_KEY).is_none());
+    }
+
+    #[test]
+    fn config_off_is_byte_identical_to_today() {
+        let body = "o".repeat(5000);
+        let mut msgs = Vec::new();
+        for i in 0..4 {
+            write_turn(&mut msgs, &format!("w{i}"), &format!("f{i}.rs"), &body);
+        }
+        let before = serde_json::to_string(&msgs).unwrap();
+
+        // Feature gate off.
+        let mut off = tca_cfg(2, 768);
+        off.tool_call_args.enabled = false;
+        let result = compact_tool_call_args(&mut msgs, &off);
+        assert_eq!(result.cleared_count, 0);
+        assert_eq!(before, serde_json::to_string(&msgs).unwrap());
+
+        // Master compaction gate off.
+        let mut master_off = tca_cfg(2, 768);
+        master_off.enabled = false;
+        let result = compact_tool_call_args(&mut msgs, &master_off);
+        assert_eq!(result.cleared_count, 0);
+        assert_eq!(before, serde_json::to_string(&msgs).unwrap());
+    }
+
+    #[test]
+    fn keep_recent_turns_floored_at_one() {
+        let body = "f".repeat(2000);
+        let mut msgs = Vec::new();
+        write_turn(&mut msgs, "w0", "a.rs", &body);
+        write_turn(&mut msgs, "w1", "b.rs", &body);
+        let cfg = tca_cfg(0, 768); // 0 → floored to 1
+
+        let result = compact_tool_call_args(&mut msgs, &cfg);
+        assert_eq!(
+            result.cleared_count, 1,
+            "only w0; the last turn is protected"
+        );
+        let last = tool_use_input(&msgs[2]);
+        assert_eq!(last["content"].as_str().unwrap(), body);
+    }
+
+    #[test]
+    fn file_path_survives_for_supersession_matching() {
+        // The supersession pre-pass keys latest_mutation off Write/Edit
+        // `input.file_path`. A compacted old Write must still register as a
+        // mutation of its path so even-older reads keep getting pruned.
+        let body = "s".repeat(3000);
+        let mut msgs = vec![
+            assistant_msg(vec![read_use("r1", "src/x.rs")]),
+            user_msg(vec![tool_result_block("r1", &"old v1 ".repeat(50))]),
+        ];
+        write_turn(&mut msgs, "w1", "src/x.rs", &body);
+        msgs.push(assistant_msg(vec![read_use("r2", "src/x.rs")]));
+        msgs.push(user_msg(vec![tool_result_block(
+            "r2",
+            &"new v2 ".repeat(50),
+        )]));
+        write_turn(&mut msgs, "w2", "other.rs", &body);
+        write_turn(&mut msgs, "w3", "other2.rs", &body);
+
+        let mut cfg = tca_cfg(2, 768);
+        cfg.compactable_tools = vec!["Read".into()];
+        compact_tool_call_args(&mut msgs, &cfg);
+        // w1's args are now stubbed but its file_path survives...
+        let w1 = tool_use_input(&msgs[2]);
+        assert!(w1.get(COMPACTED_ARGS_KEY).is_some());
+        assert_eq!(w1["file_path"], "src/x.rs");
+        // ...so supersession still prunes the pre-write read of src/x.rs.
+        let (count, _) = prune_superseded_reads(&mut msgs, &cfg);
+        assert_eq!(count, 1, "stale pre-write read must still be superseded");
+        match &msgs[1].content[0] {
+            ContentBlock::ToolResult { content, .. } => {
+                assert!(content.starts_with(SUPERSEDED_TOOL_RESULT_PREFIX));
+            }
+            _ => panic!("expected ToolResult"),
+        }
+    }
+
+    #[test]
+    fn synthetic_19_turn_capture_shape_byte_reduction() {
+        // Mimics the reference capture: 9 user prompts, Write bodies from
+        // ~2 KB to ~19 KB (45 KB of args in the biggest turn), a serial-Bash
+        // tail — then measures serialized history bytes before/after as seen
+        // by the final (19th) request.
+        let mut msgs = Vec::new();
+        let mut w = 0usize;
+        let mut write_sizes = vec![18_895usize, 9_200, 6_400, 4_100, 2_300, 15_700, 11_280];
+        for stage in 0..9 {
+            msgs.push(user_msg(vec![text_block(&format!(
+                "Stage {stage}: build the next piece. {}",
+                "prompt prose ".repeat(120)
+            ))]));
+            if let Some(size) = write_sizes.pop() {
+                let body = "fn main() { /* generated */ }\n".repeat(size / 30);
+                write_turn(
+                    &mut msgs,
+                    &format!("w{w}"),
+                    &format!("src/gen{w}.rs"),
+                    &body,
+                );
+                w += 1;
+            }
+            msgs.push(assistant_msg(vec![text_block("Done with this stage.")]));
+        }
+        // 7-round serial Bash deploy/verify tail (small args, stays verbatim).
+        for i in 0..7 {
+            msgs.push(assistant_msg(vec![bash_use(
+                &format!("b{i}"),
+                "npm run verify && git status",
+            )]));
+            msgs.push(user_msg(vec![tool_result_block(&format!("b{i}"), "ok")]));
+        }
+
+        let before = serde_json::to_string(&msgs).unwrap().len();
+        let cfg = tca_cfg(2, 768);
+        let result = compact_tool_call_args(&mut msgs, &cfg);
+        let after = serde_json::to_string(&msgs).unwrap().len();
+
+        assert_eq!(result.cleared_count, 7, "all 7 Write bodies are historical");
+        let freed = before - after;
+        println!(
+            "synthetic 19-turn history: {before} B -> {after} B \
+             (freed {freed} B, {:.1}% of history; ~{} tokens)",
+            100.0 * freed as f64 / before as f64,
+            freed / 4
+        );
+        assert!(
+            freed > 60_000,
+            "expected >60 KB freed from the Write bodies, got {freed}"
+        );
     }
 
     #[test]

--- a/crates/wcore-agent/src/context.rs
+++ b/crates/wcore-agent/src/context.rs
@@ -112,6 +112,8 @@ allows the user to better understand and review your work:
  - You can call multiple tools in a single response. If there are no \
 dependencies between them, make all independent calls in parallel. \
 However, if one call depends on a previous result, run them sequentially.
+ - Batch independent shell commands into a single Bash call (joined with \
+&& or ;) when safe — each extra round-trip re-sends the whole conversation.
  - Prefer Edit over Write for modifying existing files — Edit sends only \
 the diff, which is easier to review.
  - Always Read a file before editing it.

--- a/crates/wcore-agent/src/engine.rs
+++ b/crates/wcore-agent/src/engine.rs
@@ -15846,11 +15846,17 @@ mod audit_2026_05_22_tests {
             "the second round-trip must never be dispatched"
         );
         let (total, delta) = engine.usage_snapshot();
-        assert_eq!(delta.input_tokens, 100, "delta carries the dead run's usage");
+        assert_eq!(
+            delta.input_tokens, 100,
+            "delta carries the dead run's usage"
+        );
         assert_eq!(delta.output_tokens, 10);
         assert_eq!(delta.cache_creation_tokens, 7);
         assert_eq!(delta.cache_read_tokens, 3);
-        assert_eq!(total.input_tokens, 100, "cumulative grew with the same usage");
+        assert_eq!(
+            total.input_tokens, 100,
+            "cumulative grew with the same usage"
+        );
 
         // And the terminal stream_end built from that snapshot (the CLI's
         // error-path emitter) carries the delta on the wire event.

--- a/crates/wcore-agent/src/engine.rs
+++ b/crates/wcore-agent/src/engine.rs
@@ -1398,6 +1398,14 @@ pub struct AgentEngine {
     /// guards on `is_flux_tier_alias`).
     web_search: bool,
     total_usage: TokenUsage,
+    /// CORE-2: run-scoped usage delta. Reset at the start of each `run()`
+    /// (user turn) and accumulated from the same per-provider-request
+    /// `turn_usage` values as `total_usage`, so it sums every provider
+    /// round-trip of THIS run only (a run can span multiple round-trips in
+    /// the tool loop). Surfaced via `AgentResult::usage_delta` and the
+    /// `stream_end` protocol event's `usage_delta` sibling field; never
+    /// persisted (a resumed session starts with a fresh zero delta).
+    run_usage: TokenUsage,
     thinking: Option<wcore_types::llm::ThinkingConfig>,
     /// Resolved provider compat settings (for capability validation)
     compat: wcore_config::compat::ProviderCompat,
@@ -1942,6 +1950,7 @@ impl AgentEngine {
             temperature: config.temperature,
             max_turns: config.max_turns,
             total_usage: TokenUsage::default(),
+            run_usage: TokenUsage::default(),
             thinking: config.thinking,
             compat: config.compat.clone(),
             confirmer: Arc::new(Mutex::new(confirmer)),
@@ -2122,6 +2131,9 @@ impl AgentEngine {
             temperature: config.temperature,
             max_turns: config.max_turns,
             total_usage: session.total_usage.clone(),
+            // CORE-2: cumulative usage carries over from the persisted
+            // session; the per-run delta always starts fresh.
+            run_usage: TokenUsage::default(),
             thinking: config.thinking,
             compat: config.compat.clone(),
             confirmer: Arc::new(Mutex::new(confirmer)),
@@ -3958,6 +3970,7 @@ impl AgentEngine {
             stop_reason: StopReason::MaxTurns,
             finish_reason,
             usage: self.total_usage.clone(),
+            usage_delta: self.run_usage.clone(),
             turns: turn,
             active_window_percent: self.active_window_percent_now(&self.model, 0),
             agent_run_id: self.current_agent_run_id.clone(),
@@ -4245,6 +4258,10 @@ impl AgentEngine {
             }
         }
         self.current_msg_id = msg_id.to_string();
+        // CORE-2: reset the run-scoped usage delta at the start of each
+        // user turn; the tool loop below re-accumulates it per provider
+        // round-trip alongside the session-cumulative `total_usage`.
+        self.run_usage = TokenUsage::default();
         // #403: clear tool circuit breakers at the start of each user turn.
         // A transient burst of `web`/`WebFetch` failures in one turn opened the
         // breaker and, with no per-turn reset, left every web tool short-circuited
@@ -5304,6 +5321,12 @@ impl AgentEngine {
             self.total_usage.cache_creation_tokens += turn_usage.cache_creation_tokens;
             self.total_usage.cache_read_tokens += turn_usage.cache_read_tokens;
 
+            // CORE-2: mirror into the run-scoped delta (reset per run()).
+            self.run_usage.input_tokens += turn_usage.input_tokens;
+            self.run_usage.output_tokens += turn_usage.output_tokens;
+            self.run_usage.cache_creation_tokens += turn_usage.cache_creation_tokens;
+            self.run_usage.cache_read_tokens += turn_usage.cache_read_tokens;
+
             // B7 writer-side wiring: mirror this turn's token usage into the
             // live introspection state so `wayland_status` /
             // `wayland_telemetry_query` report non-zero token counters.
@@ -5629,6 +5652,7 @@ impl AgentEngine {
                     stop_reason,
                     finish_reason,
                     usage: self.total_usage.clone(),
+                    usage_delta: self.run_usage.clone(),
                     turns: turn + 1,
                     active_window_percent: self
                         .active_window_percent_now(&effective_model, input_token_estimate as u64),
@@ -6770,6 +6794,7 @@ impl AgentEngine {
             stop_reason: StopReason::EndTurn,
             finish_reason: FinishReason::from_stop_reason(StopReason::EndTurn),
             usage: self.total_usage.clone(),
+            usage_delta: self.run_usage.clone(),
             turns: 1,
             active_window_percent: self.active_window_percent_now(&self.model, 0),
             agent_run_id: self.current_agent_run_id.clone(),
@@ -6835,6 +6860,7 @@ impl AgentEngine {
             stop_reason: StopReason::EndTurn,
             finish_reason: FinishReason::from_stop_reason(StopReason::EndTurn),
             usage: self.total_usage.clone(),
+            usage_delta: self.run_usage.clone(),
             turns: turn + 1,
             active_window_percent: self.active_window_percent_now(&self.model, 0),
             agent_run_id: self.current_agent_run_id.clone(),
@@ -9107,6 +9133,7 @@ mod set_config_tests {
             max_tokens_explicit: false,
             max_turns: Some(10),
             total_usage: Default::default(),
+            run_usage: Default::default(),
             thinking: None,
             compat: wcore_config::compat::ProviderCompat::anthropic_defaults(),
             confirmer: Arc::new(Mutex::new(ToolConfirmer::new(true, vec![]))),
@@ -10279,6 +10306,7 @@ mod phase6_tests {
             max_tokens_explicit: false,
             max_turns: Some(10),
             total_usage: Default::default(),
+            run_usage: Default::default(),
             thinking: None,
             compat: wcore_config::compat::ProviderCompat::anthropic_defaults(),
             confirmer: Arc::new(Mutex::new(ToolConfirmer::new(true, allow_list.clone()))),
@@ -10574,6 +10602,7 @@ mod compact_tests {
             max_tokens_explicit: false,
             max_turns: Some(10),
             total_usage: Default::default(),
+            run_usage: Default::default(),
             thinking: None,
             compat: wcore_config::compat::ProviderCompat::anthropic_defaults(),
             confirmer: Arc::new(Mutex::new(ToolConfirmer::new(true, vec![]))),
@@ -11899,6 +11928,7 @@ mod plan_mode_tests {
             max_tokens_explicit: false,
             max_turns: Some(10),
             total_usage: Default::default(),
+            run_usage: Default::default(),
             thinking: None,
             compat: wcore_config::compat::ProviderCompat::anthropic_defaults(),
             confirmer: Arc::new(Mutex::new(ToolConfirmer::new(true, allow_list.clone()))),
@@ -12327,6 +12357,7 @@ mod hook_integration_tests {
             max_tokens_explicit: false,
             max_turns: Some(10),
             total_usage: Default::default(),
+            run_usage: Default::default(),
             thinking: None,
             compat: wcore_config::compat::ProviderCompat::anthropic_defaults(),
             confirmer: Arc::new(Mutex::new(ToolConfirmer::new(true, vec![]))),
@@ -12973,6 +13004,10 @@ pub struct AgentResult {
     /// can advertise the same value the underlying API returned.
     pub finish_reason: FinishReason,
     pub usage: TokenUsage,
+    /// CORE-2: per-run usage delta — the tokens consumed by THIS run only
+    /// (summing every provider round-trip of the run's tool loop), while
+    /// `usage` stays session-cumulative for back-compat.
+    pub usage_delta: TokenUsage,
     pub turns: usize,
     /// #279(a): active-window fill (0..=100) from ContextWindow::percent()
     /// on the post-swap effective model. None when the window is unknown.
@@ -13161,6 +13196,7 @@ mod approval_bridge_engine_tests {
             max_tokens_explicit: false,
             max_turns: Some(10),
             total_usage: Default::default(),
+            run_usage: Default::default(),
             thinking: None,
             compat: wcore_config::compat::ProviderCompat::anthropic_defaults(),
             confirmer: Arc::new(Mutex::new(ToolConfirmer::new(true, vec![]))),
@@ -14163,6 +14199,7 @@ mod user_model_writeback_tests {
             max_tokens_explicit: false,
             max_turns: Some(10),
             total_usage: Default::default(),
+            run_usage: Default::default(),
             thinking: None,
             compat: wcore_config::compat::ProviderCompat::anthropic_defaults(),
             confirmer: Arc::new(Mutex::new(ToolConfirmer::new(true, vec![]))),
@@ -15193,6 +15230,151 @@ mod audit_2026_05_22_tests {
         let mut engine = engine_with(provider);
         let result = engine.run("task", "m-1").await.expect("clean run");
         assert_eq!(result.stop_reason, StopReason::EndTurn);
+    }
+
+    // --- CORE-2: per-run usage delta --------------------------------------
+
+    fn done_endturn_with(usage: TokenUsage) -> LlmEvent {
+        LlmEvent::Done {
+            stop_reason: StopReason::EndTurn,
+            finish_reason: FinishReason::Stop,
+            usage,
+        }
+    }
+
+    fn usage(input: u64, output: u64) -> TokenUsage {
+        TokenUsage {
+            input_tokens: input,
+            output_tokens: output,
+            cache_creation_tokens: 0,
+            cache_read_tokens: 0,
+        }
+    }
+
+    #[tokio::test]
+    async fn usage_delta_resets_per_run_while_usage_accumulates() {
+        // CORE-2 (a) — two consecutive runs: each result's usage_delta
+        // carries THAT run's provider usage only, while the cumulative
+        // `usage` keeps growing across runs (back-compat).
+        let provider = Arc::new(ScriptedProvider::new(vec![
+            vec![
+                LlmEvent::TextDelta("one".into()),
+                done_endturn_with(usage(100, 10)),
+            ],
+            vec![
+                LlmEvent::TextDelta("two".into()),
+                done_endturn_with(usage(200, 20)),
+            ],
+        ]));
+        let mut engine = engine_with(provider);
+
+        let first = engine.run("first", "m-1").await.expect("clean run");
+        assert_eq!(first.usage_delta.input_tokens, 100);
+        assert_eq!(first.usage_delta.output_tokens, 10);
+        assert_eq!(first.usage.input_tokens, 100);
+        assert_eq!(first.usage.output_tokens, 10);
+
+        let second = engine.run("second", "m-2").await.expect("clean run");
+        assert_eq!(
+            second.usage_delta.input_tokens, 200,
+            "the second run's delta must cover the second run ONLY"
+        );
+        assert_eq!(second.usage_delta.output_tokens, 20);
+        assert_eq!(
+            second.usage.input_tokens, 300,
+            "cumulative usage keeps summing across runs (back-compat)"
+        );
+        assert_eq!(second.usage.output_tokens, 30);
+    }
+
+    #[tokio::test]
+    async fn usage_delta_sums_all_round_trips_of_one_run() {
+        // CORE-2 (b) — a run that spans multiple provider round-trips in
+        // the tool loop (a ToolUse turn + the final EndTurn turn) folds
+        // ALL of them into one delta.
+        let provider = Arc::new(ScriptedProvider::new(vec![
+            vec![
+                LlmEvent::ToolUse {
+                    id: "t1".into(),
+                    name: "Nope".into(),
+                    input: json!({}),
+                    extra: None,
+                },
+                LlmEvent::Done {
+                    stop_reason: StopReason::ToolUse,
+                    finish_reason: FinishReason::Stop,
+                    usage: TokenUsage {
+                        input_tokens: 100,
+                        output_tokens: 10,
+                        cache_creation_tokens: 7,
+                        cache_read_tokens: 3,
+                    },
+                },
+            ],
+            vec![
+                LlmEvent::TextDelta("done".into()),
+                done_endturn_with(usage(40, 4)),
+            ],
+        ]));
+        let counter = provider.call_counter();
+        let mut engine = engine_with(provider);
+        let result = engine.run("task", "m-1").await.expect("clean run");
+        assert_eq!(
+            counter.load(std::sync::atomic::Ordering::SeqCst),
+            2,
+            "the scripted tool turn must drive a second provider round-trip"
+        );
+        assert_eq!(result.usage_delta.input_tokens, 140);
+        assert_eq!(result.usage_delta.output_tokens, 14);
+        assert_eq!(result.usage_delta.cache_creation_tokens, 7);
+        assert_eq!(result.usage_delta.cache_read_tokens, 3);
+        // On a fresh engine the first run's cumulative equals its delta.
+        assert_eq!(result.usage.input_tokens, 140);
+    }
+
+    #[tokio::test]
+    async fn resumed_session_carries_cumulative_usage_but_fresh_delta() {
+        // CORE-2 (c) — an engine resumed from a persisted session inherits
+        // the cumulative total_usage, but the per-run delta starts at zero:
+        // the first post-resume run reports ONLY its own tokens as delta.
+        let session = crate::session::Session {
+            schema_version: 1,
+            id: "sess-core2".into(),
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+            provider: "test".into(),
+            model: "test-model".into(),
+            cwd: String::new(),
+            total_usage: usage(1_000, 500),
+            messages: Vec::new(),
+            extra: serde_json::Map::new(),
+        };
+        let provider = Arc::new(ScriptedProvider::new(vec![vec![
+            LlmEvent::TextDelta("resumed".into()),
+            done_endturn_with(usage(50, 5)),
+        ]]));
+        let mut config = wcore_config::config::Config::default();
+        // Keep the test hermetic: no on-disk session manager.
+        config.session.enabled = false;
+        let mut engine = super::AgentEngine::resume_with_provider(
+            provider,
+            config,
+            ToolRegistry::new(),
+            Arc::new(NullOutput),
+            session,
+        );
+        engine.max_turns = Some(20);
+        let result = engine.run("hello again", "m-1").await.expect("clean run");
+        assert_eq!(
+            result.usage.input_tokens, 1_050,
+            "cumulative usage must carry the persisted total across resume"
+        );
+        assert_eq!(result.usage.output_tokens, 505);
+        assert_eq!(
+            result.usage_delta.input_tokens, 50,
+            "the post-resume delta must be THIS run only, not the carried total"
+        );
+        assert_eq!(result.usage_delta.output_tokens, 5);
     }
 
     // --- B1 / B8: tool-dispatch timeout ----------------------------------

--- a/crates/wcore-agent/src/engine.rs
+++ b/crates/wcore-agent/src/engine.rs
@@ -3036,6 +3036,10 @@ impl AgentEngine {
     /// Returns the [`MicrocompactResult`]; `cleared_count == 0` means there was
     /// nothing eligible to compact yet.
     pub fn compact_now(&mut self) -> micro::MicrocompactResult {
+        // Tool-call-args hygiene first (parity gap 2), mirroring
+        // `run_compaction` step 0. No file-cache bump for this pass: it never
+        // touches tool-RESULT bodies (where diff-resend bases live).
+        let args_result = micro::compact_tool_call_args(&mut self.messages, &self.compact_config);
         let result = micro::microcompact(&mut self.messages, &self.compact_config);
         if result.cleared_count > 0 {
             // Token-opt (diff-resend): clearing a tool-result body can remove
@@ -3044,7 +3048,11 @@ impl AgentEngine {
             // mirrors `run_compaction`'s microcompact branch.
             self.bump_file_cache_generation();
         }
-        result
+        micro::MicrocompactResult {
+            cleared_count: result.cleared_count + args_result.cleared_count,
+            estimated_tokens_freed: result.estimated_tokens_freed
+                + args_result.estimated_tokens_freed,
+        }
     }
 
     /// M3.2 — number of background decay-scheduler tasks owned by the
@@ -7371,10 +7379,26 @@ impl AgentEngine {
 
     /// Run the multi-level compaction pipeline before each API call.
     ///
-    /// Execution order: microcompact → autocompact → emergency check.
-    /// After a successful autocompact the emergency check is skipped
-    /// because the context has been significantly reduced.
+    /// Execution order: tool-call-args hygiene → microcompact → autocompact →
+    /// emergency check. After a successful autocompact the emergency check is
+    /// skipped because the context has been significantly reduced.
     async fn run_compaction(&mut self) -> Result<(), AgentError> {
+        // 0. Tool-call-argument hygiene (parity gap 2) — CONTINUOUS: no LLM
+        // call and no trigger gate, so an old Write body stops riding in
+        // resent history on the very pass it leaves the protected tail.
+        // Deterministic + monotonic (see compact/micro.rs), so the prompt-
+        // cache prefix stays byte-stable: a message compacts exactly once and
+        // never changes bytes again. No file-cache generation bump needed:
+        // diff-resend bases require `Provenance::ReadResult` (tool RESULT
+        // bodies), which this pass never touches.
+        let args_result = micro::compact_tool_call_args(&mut self.messages, &self.compact_config);
+        if args_result.cleared_count > 0 {
+            self.output.emit_info(&format!(
+                "Compacted {} old tool-call argument payload(s) (~{} tokens freed)",
+                args_result.cleared_count, args_result.estimated_tokens_freed
+            ));
+        }
+
         // 1. Microcompact (lightweight, no LLM call)
         if micro::should_microcompact(&self.messages, &self.compact_config) {
             let result = micro::microcompact(&mut self.messages, &self.compact_config);

--- a/crates/wcore-agent/src/engine.rs
+++ b/crates/wcore-agent/src/engine.rs
@@ -7385,12 +7385,15 @@ impl AgentEngine {
     async fn run_compaction(&mut self) -> Result<(), AgentError> {
         // 0. Tool-call-argument hygiene (parity gap 2) — CONTINUOUS: no LLM
         // call and no trigger gate, so an old Write body stops riding in
-        // resent history on the very pass it leaves the protected tail.
-        // Deterministic + monotonic (see compact/micro.rs), so the prompt-
-        // cache prefix stays byte-stable: a message compacts exactly once and
-        // never changes bytes again. No file-cache generation bump needed:
-        // diff-resend bases require `Provenance::ReadResult` (tool RESULT
-        // bodies), which this pass never touches.
+        // resent history at the first epoch tick after it leaves the
+        // protected tail. Deterministic + monotonic + epoch-quantized (see
+        // compact/micro.rs): a message compacts exactly once and never
+        // changes bytes again, and the boundary only advances every
+        // `epoch_turns` assistant turns, so between ticks the pass changes
+        // ZERO bytes and the provider's contiguous prefix cache holds
+        // end-to-end. No file-cache generation bump needed: diff-resend
+        // bases require `Provenance::ReadResult` (tool RESULT bodies),
+        // which this pass never touches.
         let args_result = micro::compact_tool_call_args(&mut self.messages, &self.compact_config);
         if args_result.cleared_count > 0 {
             self.output.emit_info(&format!(

--- a/crates/wcore-agent/src/engine.rs
+++ b/crates/wcore-agent/src/engine.rs
@@ -2376,6 +2376,19 @@ impl AgentEngine {
         self.current_session.as_ref().map(|s| s.id.clone())
     }
 
+    /// CORE-2 — snapshot of the engine's usage counters:
+    /// `(total_usage, run_usage)` = (session-cumulative, current/last run's
+    /// delta). `total_usage` and `run_usage` update together after every
+    /// provider round-trip, but a run that errors out (cancellation,
+    /// compaction failure, provider exhaustion) returns `Err` with no
+    /// `AgentResult` — this accessor lets the host's error-path terminal
+    /// `stream_end` still report the tokens that run consumed instead of
+    /// silently dropping them (the cumulative total has already grown and
+    /// is persisted by the next save).
+    pub fn usage_snapshot(&self) -> (TokenUsage, TokenUsage) {
+        (self.total_usage.clone(), self.run_usage.clone())
+    }
+
     /// AUDIT A2 / B1 — clone the engine's session-root cancellation
     /// token.
     ///
@@ -15330,6 +15343,128 @@ mod audit_2026_05_22_tests {
         assert_eq!(result.usage_delta.cache_read_tokens, 3);
         // On a fresh engine the first run's cumulative equals its delta.
         assert_eq!(result.usage.input_tokens, 140);
+    }
+
+    /// A tool that fires the engine's cancel token when executed, so the
+    /// run dies BETWEEN provider round-trips — after the first round-trip's
+    /// usage was accumulated, before the second dispatch.
+    struct CancellingTool {
+        token: tokio_util::sync::CancellationToken,
+    }
+    #[async_trait]
+    impl wcore_tools::Tool for CancellingTool {
+        fn name(&self) -> &str {
+            "CancelNext"
+        }
+        fn description(&self) -> &str {
+            "cancels the run"
+        }
+        fn input_schema(&self) -> serde_json::Value {
+            json!({"type": "object"})
+        }
+        fn is_concurrency_safe(&self, _: &serde_json::Value) -> bool {
+            false
+        }
+        async fn execute(&self, _: serde_json::Value) -> wcore_types::tool::ToolResult {
+            self.token.cancel();
+            wcore_types::tool::ToolResult {
+                content: "cancelled".into(),
+                is_error: false,
+            }
+        }
+        fn category(&self) -> wcore_protocol::events::ToolCategory {
+            wcore_protocol::events::ToolCategory::Info
+        }
+    }
+
+    #[tokio::test]
+    async fn cancelled_run_snapshot_carries_delta_for_terminal_stream_end() {
+        // CORE-2 audit fix — a run that consumed one provider round-trip and
+        // then died (cancellation between turns) returns Err with no
+        // AgentResult, but total_usage/run_usage already grew. The engine's
+        // usage_snapshot() must expose that delta so the host's error-path
+        // terminal stream_end reports it instead of zeros.
+        let token = tokio_util::sync::CancellationToken::new();
+        let mut registry = ToolRegistry::new();
+        registry.register(Box::new(CancellingTool {
+            token: token.clone(),
+        }));
+        let provider = Arc::new(ScriptedProvider::new(vec![
+            vec![
+                LlmEvent::ToolUse {
+                    id: "t1".into(),
+                    name: "CancelNext".into(),
+                    input: json!({}),
+                    extra: None,
+                },
+                LlmEvent::Done {
+                    stop_reason: StopReason::ToolUse,
+                    finish_reason: FinishReason::Stop,
+                    usage: TokenUsage {
+                        input_tokens: 100,
+                        output_tokens: 10,
+                        cache_creation_tokens: 7,
+                        cache_read_tokens: 3,
+                    },
+                },
+            ],
+            // Never reached — the cancel fires before this dispatch.
+            vec![LlmEvent::TextDelta("never".into()), done_endturn()],
+        ]));
+        let counter = provider.call_counter();
+        let mut engine = super::AgentEngine::new_with_provider(
+            provider,
+            wcore_config::config::Config::default(),
+            registry,
+            Arc::new(NullOutput),
+        );
+        engine.max_turns = Some(20);
+        engine.set_cancel_token(token);
+        // Auto-approve so the tool executes without a confirmer prompt.
+        engine.confirmer = Arc::new(Mutex::new(ToolConfirmer::new(true, vec![])));
+
+        let result = engine.run("task", "m-1").await;
+        assert!(
+            matches!(result, Err(super::AgentError::UserAborted)),
+            "the cancel between round-trips must abort the run, got {result:?}"
+        );
+        assert_eq!(
+            counter.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "the second round-trip must never be dispatched"
+        );
+        let (total, delta) = engine.usage_snapshot();
+        assert_eq!(delta.input_tokens, 100, "delta carries the dead run's usage");
+        assert_eq!(delta.output_tokens, 10);
+        assert_eq!(delta.cache_creation_tokens, 7);
+        assert_eq!(delta.cache_read_tokens, 3);
+        assert_eq!(total.input_tokens, 100, "cumulative grew with the same usage");
+
+        // And the terminal stream_end built from that snapshot (the CLI's
+        // error-path emitter) carries the delta on the wire event.
+        let sink = crate::test_utils::TestSink::new();
+        let handle = sink.handle();
+        OutputSink::emit_stream_end_full(
+            &sink,
+            "m-1",
+            0,
+            total.input_tokens,
+            total.output_tokens,
+            total.cache_creation_tokens,
+            total.cache_read_tokens,
+            FinishReason::Error,
+            None,
+            None,
+            Some(&delta),
+        );
+        let events = handle.snapshot();
+        assert_eq!(events.len(), 1, "exactly one stream_end: {events:?}");
+        assert_eq!(events[0]["type"], "stream_end");
+        assert_eq!(events[0]["usage_delta"]["input_tokens"], 100);
+        assert_eq!(events[0]["usage_delta"]["output_tokens"], 10);
+        assert_eq!(events[0]["usage_delta"]["cache_write_tokens"], 7);
+        assert_eq!(events[0]["usage_delta"]["cache_read_tokens"], 3);
+        assert_eq!(events[0]["usage"]["input_tokens"], 100);
     }
 
     #[tokio::test]

--- a/crates/wcore-agent/src/engine.rs
+++ b/crates/wcore-agent/src/engine.rs
@@ -603,31 +603,76 @@ fn is_http_4xx_error(reason: &str) -> bool {
     false
 }
 
-/// LENGTH-WEDGE GATE — deterministic fingerprint of an outbound context: the
-/// dispatched model plus every message's role + content blocks. Timestamps and
-/// cache hints are deliberately EXCLUDED — providers never see them
-/// (`build_messages()` sends role + content only), so two requests that are
-/// byte-identical on the wire fingerprint identically even when their local
-/// `Message.timestamp`s differ (e.g. a host that rebuilds the same wedged
-/// conversation on a retry or a resume).
-fn context_fingerprint(model: &str, messages: &[Message]) -> u64 {
-    use std::hash::{Hash, Hasher};
-    let mut hasher = std::collections::hash_map::DefaultHasher::new();
-    model.hash(&mut hasher);
+/// LENGTH-WEDGE GATE — deterministic fingerprint of an outbound request as
+/// the provider sees it: the dispatched model, the system prompt, every
+/// message's role + content blocks, and the serialized tool surface (the
+/// as-sent, post-curation/post-cap `request.tools`, `deferred` flag
+/// included). All of these are provider-visible bytes — omitting any of them
+/// would falsely refuse a retry that changed only that surface (e.g. the same
+/// messages under a different system prompt or tool set) as an "unchanged"
+/// wedge.
+///
+/// Timestamps and cache hints are deliberately EXCLUDED — providers never see
+/// them (`build_messages()` sends role + content only), so two requests that
+/// are byte-identical on the wire fingerprint identically even when their
+/// local `Message.timestamp`s differ (e.g. a host that rebuilds the same
+/// wedged conversation on a retry or a resume).
+///
+/// Sha256, not a 64-bit `DefaultHasher`: this identity gates whether a
+/// request is ever allowed to be sent again, so it gets a collision-proof
+/// digest. Every field is length-framed so adjacent fields can never alias
+/// (model "a" + system "bc" vs model "ab" + system "c").
+fn request_wire_fingerprint(
+    model: &str,
+    system: &str,
+    messages: &[Message],
+    tools: &[wcore_types::tool::ToolDef],
+) -> [u8; 32] {
+    use sha2::{Digest, Sha256};
+    fn framed(hasher: &mut Sha256, bytes: &[u8]) {
+        hasher.update((bytes.len() as u64).to_le_bytes());
+        hasher.update(bytes);
+    }
+    let mut hasher = Sha256::new();
+    framed(&mut hasher, model.as_bytes());
+    framed(&mut hasher, system.as_bytes());
+    framed(&mut hasher, &(messages.len() as u64).to_le_bytes());
     for msg in messages {
         // `Role` is a small serde enum; its JSON tag is a stable per-variant
         // string. Serialization of these shapes cannot fail in practice; the
         // fallback keeps the fingerprint total rather than skipping content.
-        serde_json::to_string(&msg.role)
-            .unwrap_or_default()
-            .hash(&mut hasher);
-        for block in &msg.content {
-            serde_json::to_string(block)
+        framed(
+            &mut hasher,
+            serde_json::to_string(&msg.role)
                 .unwrap_or_default()
-                .hash(&mut hasher);
+                .as_bytes(),
+        );
+        framed(&mut hasher, &(msg.content.len() as u64).to_le_bytes());
+        for block in &msg.content {
+            framed(
+                &mut hasher,
+                serde_json::to_string(block).unwrap_or_default().as_bytes(),
+            );
         }
     }
-    hasher.finish()
+    framed(&mut hasher, &(tools.len() as u64).to_le_bytes());
+    for tool in tools {
+        // `ToolDef` has no Serialize impl — frame each provider-visible field
+        // (`input_schema` is a `serde_json::Value`). `deferred` changes the
+        // schema actually sent (stub vs full), so it is part of the identity;
+        // `server` provenance disambiguates same-named tools.
+        framed(&mut hasher, tool.name.as_bytes());
+        framed(&mut hasher, tool.description.as_bytes());
+        framed(
+            &mut hasher,
+            serde_json::to_string(&tool.input_schema)
+                .unwrap_or_default()
+                .as_bytes(),
+        );
+        framed(&mut hasher, &[tool.deferred as u8]);
+        framed(&mut hasher, tool.server.as_deref().unwrap_or("").as_bytes());
+    }
+    hasher.finalize().into()
 }
 
 /// Spec v1 Task 5 (clean retry) — the compact stub that replaces a failed
@@ -1895,16 +1940,17 @@ pub struct AgentEngine {
     /// fire, then consumed via `std::mem::take` inside `run_compaction` so the
     /// existing autocompact path runs even though the static threshold is unmet.
     smart_compact_force: bool,
-    /// LENGTH-WEDGE GATE — fingerprint ([`context_fingerprint`]) of the last
-    /// outbound context that came back `finish_reason=length` while at/over
-    /// the resolved input ceiling. Once set, a byte-identical context is
-    /// refused before dispatch: re-sending it can only reproduce the same
-    /// instant `length` truncation (observed in the field as 3 identical
-    /// sub-500ms retries at identical token counts, wedging the conversation
-    /// permanently). `None` until a wedge is observed; an exact-match guard,
-    /// so any context that actually changed (compaction, new user turn)
-    /// passes.
-    length_wedge_fingerprint: Option<u64>,
+    /// LENGTH-WEDGE GATE — fingerprint ([`request_wire_fingerprint`]) of the
+    /// last outbound request that came back `finish_reason=length` while
+    /// at/over the resolved input ceiling. Once set, a wire-identical request
+    /// (model + system + messages + tools) is refused before dispatch:
+    /// re-sending it can only reproduce the same instant `length` truncation
+    /// (observed in the field as 3 identical sub-500ms retries at identical
+    /// token counts, wedging the conversation permanently). `None` until a
+    /// wedge is observed; an exact-match guard, so any request that actually
+    /// changed (compaction, new user turn, different system prompt or tool
+    /// surface) passes.
+    length_wedge_fingerprint: Option<[u8; 32]>,
 }
 
 impl Drop for AgentEngine {
@@ -5223,7 +5269,12 @@ impl AgentEngine {
                 // Hashing only happens once a wedge has been observed — the
                 // common path pays nothing.
                 if let Some(wedge) = self.length_wedge_fingerprint
-                    && context_fingerprint(&request.model, &request.messages) == wedge
+                    && request_wire_fingerprint(
+                        &request.model,
+                        &request.system,
+                        &request.messages,
+                        &request.tools,
+                    ) == wedge
                 {
                     self.output.emit_error(
                         &format!(
@@ -5452,8 +5503,12 @@ impl AgentEngine {
                         if let Some(ceiling) = ceiling
                             && sent_tokens >= ceiling
                         {
-                            let sent_fingerprint =
-                                context_fingerprint(&request.model, &request.messages);
+                            let sent_fingerprint = request_wire_fingerprint(
+                                &request.model,
+                                &request.system,
+                                &request.messages,
+                                &request.tools,
+                            );
                             // Arm the never-resend dispatch guard for this
                             // exact context FIRST, so no path out of here can
                             // be followed by an identical re-send — in this
@@ -5474,8 +5529,12 @@ impl AgentEngine {
                                 // rebuild from `self.messages` drops — which
                                 // would make a no-op compaction look like a
                                 // changed context and defeat the gate.
-                                let history_before =
-                                    context_fingerprint(&request.model, &self.messages);
+                                let history_before = request_wire_fingerprint(
+                                    &request.model,
+                                    &request.system,
+                                    &self.messages,
+                                    &request.tools,
+                                );
                                 // Force the autocompact machinery
                                 // (compact/auto.rs) even though the static
                                 // watermark trigger is unmet — same one-shot
@@ -5486,8 +5545,12 @@ impl AgentEngine {
                                     self.save_session();
                                     return Err(e);
                                 }
-                                let history_after =
-                                    context_fingerprint(&request.model, &self.messages);
+                                let history_after = request_wire_fingerprint(
+                                    &request.model,
+                                    &request.system,
+                                    &self.messages,
+                                    &request.tools,
+                                );
                                 // Rebuild the outbound context from the
                                 // compacted history (mirrors the #282
                                 // ContextOverflow compact-and-retry).
@@ -17390,9 +17453,19 @@ mod retry_wedge_protection_tests {
         let reqs = requests.lock().unwrap();
         assert_eq!(reqs.len(), 3, "wedged turn + compaction call + one retry");
         // The retried context must differ from the wedged one — assert via
-        // the same outbound-context fingerprint the gate uses.
-        let fp_first = super::context_fingerprint(&reqs[0].model, &reqs[0].messages);
-        let fp_retry = super::context_fingerprint(&reqs[2].model, &reqs[2].messages);
+        // the same request-wire fingerprint the gate uses.
+        let fp_first = super::request_wire_fingerprint(
+            &reqs[0].model,
+            &reqs[0].system,
+            &reqs[0].messages,
+            &reqs[0].tools,
+        );
+        let fp_retry = super::request_wire_fingerprint(
+            &reqs[2].model,
+            &reqs[2].system,
+            &reqs[2].messages,
+            &reqs[2].tools,
+        );
         assert_ne!(
             fp_first, fp_retry,
             "the retry must never re-send the identical over-budget context"
@@ -17451,7 +17524,12 @@ mod retry_wedge_protection_tests {
         let wedged_fingerprint = {
             let reqs = control_requests.lock().unwrap();
             assert_eq!(reqs.len(), 1);
-            super::context_fingerprint(&reqs[0].model, &reqs[0].messages)
+            super::request_wire_fingerprint(
+                &reqs[0].model,
+                &reqs[0].system,
+                &reqs[0].messages,
+                &reqs[0].tools,
+            )
         };
 
         let provider = Arc::new(RecordingProvider::new(vec![
@@ -17474,6 +17552,56 @@ mod retry_wedge_protection_tests {
             requests.lock().unwrap().len(),
             0,
             "a byte-identical wedged context must be refused BEFORE dispatch"
+        );
+    }
+
+    #[tokio::test]
+    async fn changed_system_prompt_with_same_messages_is_not_refused() {
+        // Audit finding on the u64 role+content fingerprint: system and
+        // tools[] are provider-visible bytes too. The SAME messages under a
+        // DIFFERENT system prompt are a different wire request — the wedge
+        // guard must let it dispatch, not falsely refuse it as unchanged.
+        let control = Arc::new(RecordingProvider::new(vec![vec![
+            LlmEvent::TextDelta("control".into()),
+            done(StopReason::EndTurn, FinishReason::Stop, 0),
+        ]]));
+        let control_requests = control.recorded();
+        let mut control_engine = wedge_engine(control);
+        control_engine
+            .run("task", "m-sys-a")
+            .await
+            .expect("control run completes");
+        let wedged_fingerprint = {
+            let reqs = control_requests.lock().unwrap();
+            assert_eq!(reqs.len(), 1);
+            super::request_wire_fingerprint(
+                &reqs[0].model,
+                &reqs[0].system,
+                &reqs[0].messages,
+                &reqs[0].tools,
+            )
+        };
+
+        let provider = Arc::new(RecordingProvider::new(vec![vec![
+            LlmEvent::TextDelta("dispatched".into()),
+            done(StopReason::EndTurn, FinishReason::Stop, 0),
+        ]]));
+        let requests = provider.recorded();
+        let mut engine = wedge_engine(provider);
+        // Identical messages ("task" on empty history), different system.
+        engine.system_prompt = format!("{}\n\nCHANGED SURFACE", engine.system_prompt);
+        engine.length_wedge_fingerprint = Some(wedged_fingerprint);
+        let result = engine
+            .run("task", "m-sys-b")
+            .await
+            .expect("a changed-system request must dispatch normally");
+        assert_eq!(result.text, "dispatched");
+        assert_eq!(result.stop_reason, StopReason::EndTurn);
+        assert_eq!(
+            requests.lock().unwrap().len(),
+            1,
+            "same messages under a changed system prompt are a DIFFERENT wire \
+             request and must not be refused as an unchanged wedge"
         );
     }
 
@@ -17656,18 +17784,30 @@ mod retry_wedge_protection_tests {
     }
 
     #[test]
-    fn context_fingerprint_ignores_timestamps_but_not_content() {
+    fn wire_fingerprint_covers_every_provider_visible_surface() {
+        let tools = vec![wcore_types::tool::ToolDef {
+            name: "Read".into(),
+            description: "read a file".into(),
+            input_schema: serde_json::json!({"type": "object"}),
+            deferred: false,
+            server: None,
+        }];
         let a = vec![Message::now(
             Role::User,
             vec![ContentBlock::Text { text: "hi".into() }],
         )];
+        let fp = |model: &str, system: &str, msgs: &[Message], tools: &[_]| {
+            super::request_wire_fingerprint(model, system, msgs, tools)
+        };
+        // Timestamps are NOT sent to the provider — must not change identity.
         let mut b = a.clone();
         b[0].timestamp = Some(chrono::Utc::now() + chrono::Duration::hours(1));
         assert_eq!(
-            super::context_fingerprint("m", &a),
-            super::context_fingerprint("m", &b),
+            fp("m", "sys", &a, &tools),
+            fp("m", "sys", &b, &tools),
             "timestamps are not sent to the provider and must not change the fingerprint"
         );
+        // Every provider-visible surface IS part of the identity.
         let c = vec![Message::now(
             Role::User,
             vec![ContentBlock::Text {
@@ -17675,13 +17815,33 @@ mod retry_wedge_protection_tests {
             }],
         )];
         assert_ne!(
-            super::context_fingerprint("m", &a),
-            super::context_fingerprint("m", &c)
+            fp("m", "sys", &a, &tools),
+            fp("m", "sys", &c, &tools),
+            "message content changes the identity"
         );
         assert_ne!(
-            super::context_fingerprint("model-a", &a),
-            super::context_fingerprint("model-b", &a),
+            fp("model-a", "sys", &a, &tools),
+            fp("model-b", "sys", &a, &tools),
             "the dispatched model is part of the request identity"
+        );
+        assert_ne!(
+            fp("m", "system A", &a, &tools),
+            fp("m", "system B", &a, &tools),
+            "the system prompt is provider-visible and part of the identity"
+        );
+        let mut fewer_tools = tools.clone();
+        fewer_tools.clear();
+        assert_ne!(
+            fp("m", "sys", &a, &tools),
+            fp("m", "sys", &a, &fewer_tools),
+            "the tool surface is provider-visible and part of the identity"
+        );
+        let mut deferred_tools = tools.clone();
+        deferred_tools[0].deferred = true;
+        assert_ne!(
+            fp("m", "sys", &a, &tools),
+            fp("m", "sys", &a, &deferred_tools),
+            "deferral changes the schema actually sent, so it changes the identity"
         );
     }
 }

--- a/crates/wcore-agent/src/engine.rs
+++ b/crates/wcore-agent/src/engine.rs
@@ -603,6 +603,105 @@ fn is_http_4xx_error(reason: &str) -> bool {
     false
 }
 
+/// LENGTH-WEDGE GATE — deterministic fingerprint of an outbound context: the
+/// dispatched model plus every message's role + content blocks. Timestamps and
+/// cache hints are deliberately EXCLUDED — providers never see them
+/// (`build_messages()` sends role + content only), so two requests that are
+/// byte-identical on the wire fingerprint identically even when their local
+/// `Message.timestamp`s differ (e.g. a host that rebuilds the same wedged
+/// conversation on a retry or a resume).
+fn context_fingerprint(model: &str, messages: &[Message]) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    model.hash(&mut hasher);
+    for msg in messages {
+        // `Role` is a small serde enum; its JSON tag is a stable per-variant
+        // string. Serialization of these shapes cannot fail in practice; the
+        // fallback keeps the fingerprint total rather than skipping content.
+        serde_json::to_string(&msg.role)
+            .unwrap_or_default()
+            .hash(&mut hasher);
+        for block in &msg.content {
+            serde_json::to_string(block)
+                .unwrap_or_default()
+                .hash(&mut hasher);
+        }
+    }
+    hasher.finish()
+}
+
+/// Spec v1 Task 5 (clean retry) — the compact stub that replaces a failed
+/// tool-result body in the outbound retry context. `short_error` is the first
+/// line of the original body, capped, so the model still sees WHAT failed
+/// without the engine re-sending the full contaminated transcript.
+fn retry_stub(tool_name: &str, error_body: &str) -> String {
+    const MAX_ERR_CHARS: usize = 200;
+    let mut short: String = error_body
+        .lines()
+        .next()
+        .unwrap_or("")
+        .chars()
+        .take(MAX_ERR_CHARS)
+        .collect();
+    if short.len() < error_body.lines().next().unwrap_or("").len() {
+        short.push('…');
+    }
+    format!("[tool {tool_name} failed: {short}; retrying]")
+}
+
+/// Spec v1 Task 5 (clean retry) — before a stream retry re-sends the outbound
+/// context, replace the FAILED tool-result bodies of the most recent tool
+/// round with a compact [`retry_stub`]. Only the retry's outbound copy is
+/// rewritten (the caller passes `request.messages`, never the persisted
+/// history), and only the LAST tool-result round — older rounds are part of
+/// the already-cached prefix and rewriting them would bust the prompt cache.
+///
+/// Returns the names of the failing tools in that round (whether or not their
+/// bodies were rewritten on this call — a second retry sees the already-
+/// stubbed bodies but must still report the failing tools so the progress
+/// gate can count consecutive no-progress retries). Empty when the most
+/// recent tool round has no failed results (or there is no tool round).
+fn stub_failed_tool_results_for_retry(messages: &mut [Message]) -> Vec<String> {
+    // Map tool_use_id → tool name across the transcript (ids are unique).
+    let names: std::collections::HashMap<String, String> = messages
+        .iter()
+        .flat_map(|m| &m.content)
+        .filter_map(|b| match b {
+            ContentBlock::ToolUse { id, name, .. } => Some((id.clone(), name.clone())),
+            _ => None,
+        })
+        .collect();
+    // The most recent tool round = the last message carrying any ToolResult.
+    let Some(idx) = messages.iter().rposition(|m| {
+        m.content
+            .iter()
+            .any(|b| matches!(b, ContentBlock::ToolResult { .. }))
+    }) else {
+        return Vec::new();
+    };
+    let mut failing: Vec<String> = Vec::new();
+    for block in &mut messages[idx].content {
+        if let ContentBlock::ToolResult {
+            tool_use_id,
+            content,
+            is_error: true,
+        } = block
+        {
+            let name = names
+                .get(tool_use_id.as_str())
+                .cloned()
+                .unwrap_or_else(|| "unknown".to_string());
+            // Idempotent: a body this helper already stubbed on a prior
+            // retry is left alone (but still reported as failing above).
+            if !(content.starts_with("[tool ") && content.ends_with("; retrying]")) {
+                *content = retry_stub(&name, content);
+            }
+            failing.push(name);
+        }
+    }
+    failing
+}
+
 /// FluxRouter web_search grounding (contract §5.4): render the "Sources" block
 /// appended after a grounded answer. The answer text already carries inline
 /// `[n]` markers; this maps `[n]` → `citations[n-1]` (1-indexed) and lists the
@@ -1796,6 +1895,16 @@ pub struct AgentEngine {
     /// fire, then consumed via `std::mem::take` inside `run_compaction` so the
     /// existing autocompact path runs even though the static threshold is unmet.
     smart_compact_force: bool,
+    /// LENGTH-WEDGE GATE — fingerprint ([`context_fingerprint`]) of the last
+    /// outbound context that came back `finish_reason=length` while at/over
+    /// the resolved input ceiling. Once set, a byte-identical context is
+    /// refused before dispatch: re-sending it can only reproduce the same
+    /// instant `length` truncation (observed in the field as 3 identical
+    /// sub-500ms retries at identical token counts, wedging the conversation
+    /// permanently). `None` until a wedge is observed; an exact-match guard,
+    /// so any context that actually changed (compaction, new user turn)
+    /// passes.
+    length_wedge_fingerprint: Option<u64>,
 }
 
 impl Drop for AgentEngine {
@@ -2068,6 +2177,7 @@ impl AgentEngine {
             smart_compact_last_turn: None,
             smart_compact_exhausted: false,
             smart_compact_force: false,
+            length_wedge_fingerprint: None,
         }
     }
 
@@ -2248,6 +2358,7 @@ impl AgentEngine {
             smart_compact_last_turn: None,
             smart_compact_exhausted: false,
             smart_compact_force: false,
+            length_wedge_fingerprint: None,
         }
     }
 
@@ -5055,6 +5166,16 @@ impl AgentEngine {
             // infinite-loop. After the single retry, a recurring overflow is
             // surfaced as a clean terminal error below.
             let mut overflow_retried = false;
+            // LENGTH-WEDGE GATE: a turn that ends `finish_reason=length` while
+            // at/over the resolved input ceiling gets ONE forced compaction +
+            // retry; this guard bounds it so the turn can never loop. After
+            // the single retry a recurring wedge is a clean terminal error.
+            let mut length_wedge_retried = false;
+            // Spec v1 Task 5 progress gate: consecutive failed stream attempts
+            // whose outbound context carried a failed tool round and which
+            // produced no output at all. Two in a row = no realistic chance
+            // the next full-context re-send fares better — stop instead.
+            let mut no_progress_failures: u32 = 0;
             'stream: loop {
                 // Reset per-attempt accumulators so a retry never
                 // double-commits text/tool-calls from a failed attempt.
@@ -5089,6 +5210,36 @@ impl AgentEngine {
                 let mut grounding_citations: Vec<String> = Vec::new();
                 let mut grounding_search_results: Vec<wcore_types::llm::FluxSearchResult> =
                     Vec::new();
+
+                // LENGTH-WEDGE GATE (dispatch guard) — never re-send a context
+                // that is byte-identical (on the wire) to one that already
+                // came back `finish_reason=length` at/over the input ceiling.
+                // An identical over-budget request can only reproduce the
+                // instant truncation, so re-sending it burns a full-window
+                // input bill for nothing and wedges the conversation. This
+                // covers both the in-loop retry (a compaction that freed
+                // nothing leaves the fingerprint unchanged) and a host-driven
+                // retry of the identical wedged conversation on a later run.
+                // Hashing only happens once a wedge has been observed — the
+                // common path pays nothing.
+                if let Some(wedge) = self.length_wedge_fingerprint
+                    && context_fingerprint(&request.model, &request.messages) == wedge
+                {
+                    self.output.emit_error(
+                        &format!(
+                            "Run stopped: the conversation has exceeded the context \
+                             window of model '{}' (a previous attempt ended with \
+                             finish_reason=length at the window ceiling) and the \
+                             request is unchanged — re-sending it cannot succeed. \
+                             Compact the conversation or start a new session.",
+                            request.model,
+                        ),
+                        false,
+                    );
+                    return self
+                        .finish_run_terminated(user_input, turn, FinishReason::Length)
+                        .await;
+                }
 
                 // P1 Bug#3 — `stream()` runs `builder_send_with_retry`
                 // internally and can surface a *retryable*
@@ -5258,6 +5409,124 @@ impl AgentEngine {
                 // OR a channel that closed with no `Done` (truncated /
                 // dropped stream) is a FAILED attempt.
                 if done_seen && stream_error.is_none() {
+                    // LENGTH-WEDGE GATE — `finish_reason=length` while the
+                    // context sits at/over the resolved input ceiling is the
+                    // permanent-wedge signature: the prompt has consumed the
+                    // window, the output was clamped to (near) nothing, and
+                    // re-sending the same context can only reproduce it
+                    // (observed in the field as 3 identical sub-500ms retries
+                    // at identical token counts). Force a compaction and retry
+                    // ONCE with the shrunk context; if compaction cannot free
+                    // meaningful space — or would re-send identical bytes —
+                    // end the turn with a clear terminal error instead.
+                    //
+                    // A plain `length` BELOW the ceiling (ordinary max_tokens
+                    // output cap) is untouched, as is an unknown window
+                    // (ceiling `None` = fail open, matching the #255 guard).
+                    if attempt_finish_reason == FinishReason::Length {
+                        // Ceiling resolved exactly like the #255 pre-flight
+                        // guard, including the Flux served-window signal-back
+                        // (which may have just updated via ProviderMeta on
+                        // THIS stream).
+                        let mut ctx = wcore_config::context_window::ContextWindow::resolve(
+                            input_token_estimate as u64,
+                            self.compat.provider_type(),
+                            &request.model,
+                            self.compact_config.context_window as u64,
+                        );
+                        if wcore_providers::is_flux_tier_alias(&request.model)
+                            && let Some(window) = self.flux_served_window
+                        {
+                            ctx.window = Some(window);
+                        }
+                        let ceiling = ctx.input_ceiling(
+                            self.compact_config.output_reserve as u64,
+                            self.compact_config.emergency_buffer as u64,
+                        );
+                        // At/over on either count: the provider-billed input is
+                        // authoritative when present — providers can count
+                        // higher than our estimate, which is exactly how a
+                        // wedge slips past the pre-flight guard.
+                        let sent_tokens =
+                            attempt_usage.input_tokens.max(input_token_estimate as u64);
+                        if let Some(ceiling) = ceiling
+                            && sent_tokens >= ceiling
+                        {
+                            let sent_fingerprint =
+                                context_fingerprint(&request.model, &request.messages);
+                            // Arm the never-resend dispatch guard for this
+                            // exact context FIRST, so no path out of here can
+                            // be followed by an identical re-send — in this
+                            // run or a later one.
+                            self.length_wedge_fingerprint = Some(sent_fingerprint);
+                            if !length_wedge_retried {
+                                length_wedge_retried = true;
+                                self.output.emit_info(&format!(
+                                    "Turn ended with finish_reason=length at the context \
+                                     ceiling ({sent_tokens} tokens >= {ceiling}) — forcing \
+                                     compaction before retry"
+                                ));
+                                // Whether compaction achieved anything is
+                                // judged on the PERSISTED history, not the
+                                // dispatched copy: the request carries
+                                // transient per-turn injections (date block,
+                                // skill hint, PrePrompt contributions) that a
+                                // rebuild from `self.messages` drops — which
+                                // would make a no-op compaction look like a
+                                // changed context and defeat the gate.
+                                let history_before =
+                                    context_fingerprint(&request.model, &self.messages);
+                                // Force the autocompact machinery
+                                // (compact/auto.rs) even though the static
+                                // watermark trigger is unmet — same one-shot
+                                // flag the #280 smart pre-gate uses.
+                                self.smart_compact_force = true;
+                                if let Err(e) = self.run_compaction().await {
+                                    self.fire_on_session_end(turn).await;
+                                    self.save_session();
+                                    return Err(e);
+                                }
+                                let history_after =
+                                    context_fingerprint(&request.model, &self.messages);
+                                // Rebuild the outbound context from the
+                                // compacted history (mirrors the #282
+                                // ContextOverflow compact-and-retry).
+                                request.messages = self.messages.clone();
+                                let recount = estimate::estimate_request_tokens(
+                                    &self.messages,
+                                    &request.system,
+                                    &request.tools,
+                                ) as u64;
+                                request.client_context_tokens = Some(recount);
+                                input_token_estimate = recount as usize;
+                                if history_after != history_before && recount < ceiling {
+                                    // Compaction freed real space AND changed
+                                    // the context — retry the turn. (The
+                                    // dispatch guard passes because the
+                                    // rebuilt outbound differs from the
+                                    // recorded wedged bytes.)
+                                    continue 'stream;
+                                }
+                                // Compaction was a no-op or the request is
+                                // still over the ceiling — fall through to
+                                // the terminal error. NEVER re-send.
+                            }
+                            self.output.emit_error(
+                                &format!(
+                                    "Run stopped: the conversation has exceeded the context \
+                                     window of model '{}' (finish_reason=length at \
+                                     {sent_tokens} tokens, input ceiling {ceiling}) and \
+                                     compaction could not free meaningful space. Compact \
+                                     the conversation or start a new session.",
+                                    request.model,
+                                ),
+                                false,
+                            );
+                            return self
+                                .finish_run_terminated(user_input, turn, FinishReason::Length)
+                                .await;
+                        }
+                    }
                     // FluxRouter web_search grounding (contract §5.4): render
                     // the "Sources" block after a SUCCESSFUL grounded answer.
                     // Done only on the committed attempt (inside the success
@@ -5275,6 +5544,11 @@ impl AgentEngine {
                         self.output.emit_text_delta(&block, &self.current_msg_id);
                         assistant_text.push_str(&block);
                     }
+                    // LENGTH-WEDGE GATE — a committed attempt that got past
+                    // the wedge check above completed below the ceiling, so
+                    // the conversation is not wedged: drop any armed
+                    // fingerprint (e.g. the post-compaction retry succeeded).
+                    self.length_wedge_fingerprint = None;
                     stop_reason = attempt_stop_reason;
                     finish_reason = attempt_finish_reason;
                     turn_usage = attempt_usage;
@@ -5308,6 +5582,47 @@ impl AgentEngine {
                     MAX_STREAM_RETRIES
                 };
                 if !is_client_error && stream_attempt < effective_max_retries {
+                    // Spec v1 Task 5 (clean retry): a retry re-sends the whole
+                    // outbound context. When the most recent tool round
+                    // carries FAILED tool results, that context is
+                    // contaminated with the full error bodies (observed:
+                    // desktop stage6 = 4 retries × ~350k tokens of failed
+                    // transcript). Replace each failed body with a compact
+                    // stub before re-sending. Retry-scoped: only
+                    // `request.messages` (this turn's outbound copy) is
+                    // rewritten — `self.messages` (persisted history) keeps
+                    // the full body, and older tool rounds are untouched so
+                    // the cached prefix stays byte-stable.
+                    let failed_tools = stub_failed_tool_results_for_retry(&mut request.messages);
+                    // Spec v1 Task 5 progress gate: two consecutive attempts
+                    // that carried the same failing tool round and produced
+                    // NO output at all (no text, no thinking, no tool calls,
+                    // no billed output tokens) mean the next full-context
+                    // re-send has no realistic chance — stop with a clear
+                    // error instead of burning another full-input bill. (The
+                    // tool round is constant within one turn's retry loop, so
+                    // "same failing tool" holds by construction.)
+                    let produced_output = !assistant_text.is_empty()
+                        || !thinking_text.is_empty()
+                        || !tool_calls.is_empty()
+                        || attempt_usage.output_tokens > 0;
+                    if !failed_tools.is_empty() && !produced_output {
+                        no_progress_failures += 1;
+                    } else if produced_output {
+                        no_progress_failures = 0;
+                    }
+                    if no_progress_failures >= 2 {
+                        let gate_msg = format!(
+                            "Provider stream failed twice in a row with no output while \
+                             the last tool round had failed (`{}`) — retrying the same \
+                             context is burning tokens without progress. Fix the failing \
+                             tool call (see its error above) or try a different approach. \
+                             (last stream error: {reason})",
+                            failed_tools.join("`, `"),
+                        );
+                        self.output.emit_error(&gate_msg, false);
+                        return Err(AgentError::ApiError(gate_msg));
+                    }
                     stream_attempt += 1;
                     // Linear backoff: 500ms, 1000ms.
                     let backoff = std::time::Duration::from_millis(500 * stream_attempt as u64);
@@ -9239,6 +9554,7 @@ mod set_config_tests {
             smart_compact_last_turn: None,
             smart_compact_exhausted: false,
             smart_compact_force: false,
+            length_wedge_fingerprint: None,
         }
     }
 
@@ -10413,6 +10729,7 @@ mod phase6_tests {
             smart_compact_last_turn: None,
             smart_compact_exhausted: false,
             smart_compact_force: false,
+            length_wedge_fingerprint: None,
         }
     }
 
@@ -10709,6 +11026,7 @@ mod compact_tests {
             smart_compact_last_turn: None,
             smart_compact_exhausted: false,
             smart_compact_force: false,
+            length_wedge_fingerprint: None,
         }
     }
 
@@ -12035,6 +12353,7 @@ mod plan_mode_tests {
             smart_compact_last_turn: None,
             smart_compact_exhausted: false,
             smart_compact_force: false,
+            length_wedge_fingerprint: None,
         }
     }
 
@@ -12464,6 +12783,7 @@ mod hook_integration_tests {
             smart_compact_last_turn: None,
             smart_compact_exhausted: false,
             smart_compact_force: false,
+            length_wedge_fingerprint: None,
         }
     }
 
@@ -13303,6 +13623,7 @@ mod approval_bridge_engine_tests {
             smart_compact_last_turn: None,
             smart_compact_exhausted: false,
             smart_compact_force: false,
+            length_wedge_fingerprint: None,
         }
     }
 
@@ -14299,6 +14620,7 @@ mod user_model_writeback_tests {
             smart_compact_last_turn: None,
             smart_compact_exhausted: false,
             smart_compact_force: false,
+            length_wedge_fingerprint: None,
         }
     }
 
@@ -16918,6 +17240,448 @@ mod overflow_retry_tests {
             calls.load(Ordering::SeqCst),
             2,
             "the overflow-retry is bounded to ONE: one initial + one retry, then terminal"
+        );
+    }
+}
+
+// ===========================================================================
+// LENGTH-WEDGE GATE + spec v1 Task 5 (clean retry / progress gate) tests.
+//
+// Field failure this protects against: a conversation at the model's window
+// ceiling ends `finish_reason=length`, the identical request is retried 3
+// times at identical token counts (<0.5s each), and the conversation is
+// permanently wedged. And the desktop stage6 thrash: a failed tool round's
+// full contaminated body re-sent on every stream retry (4 × ~350k tokens).
+// ===========================================================================
+#[cfg(test)]
+mod retry_wedge_protection_tests {
+    use std::sync::Arc;
+    use std::sync::Mutex;
+
+    use async_trait::async_trait;
+    use wcore_providers::{LlmProvider, ProviderError};
+    use wcore_tools::registry::ToolRegistry;
+    use wcore_types::llm::{LlmEvent, LlmRequest};
+    use wcore_types::message::{ContentBlock, FinishReason, Message, Role, StopReason, TokenUsage};
+
+    use crate::output::OutputSink;
+
+    struct NullOutput;
+    impl OutputSink for NullOutput {
+        fn emit_text_delta(&self, _: &str, _: &str) {}
+        fn emit_thinking(&self, _: &str, _: &str) {}
+        fn emit_tool_call(&self, _: &str, _: &str) {}
+        fn emit_tool_result(&self, _: &str, _: bool, _: &str) {}
+        fn emit_stream_start(&self, _: &str) {}
+        fn emit_stream_end(
+            &self,
+            _: &str,
+            _: usize,
+            _: u64,
+            _: u64,
+            _: u64,
+            _: u64,
+            _: FinishReason,
+        ) {
+        }
+        fn emit_error(&self, _: &str, _: bool) {}
+        fn emit_info(&self, _: &str) {}
+    }
+
+    /// A scripted provider that RECORDS every `LlmRequest` it is asked to
+    /// stream, so tests can assert on the exact outbound context of each
+    /// attempt (the wedge fingerprint / retry-stub assertions).
+    struct RecordingProvider {
+        scripts: Mutex<std::collections::VecDeque<Vec<LlmEvent>>>,
+        requests: Arc<Mutex<Vec<LlmRequest>>>,
+    }
+
+    impl RecordingProvider {
+        fn new(scripts: Vec<Vec<LlmEvent>>) -> Self {
+            Self {
+                scripts: Mutex::new(scripts.into_iter().collect()),
+                requests: Arc::new(Mutex::new(Vec::new())),
+            }
+        }
+        fn recorded(&self) -> Arc<Mutex<Vec<LlmRequest>>> {
+            Arc::clone(&self.requests)
+        }
+    }
+
+    #[async_trait]
+    impl LlmProvider for RecordingProvider {
+        async fn stream(
+            &self,
+            request: &LlmRequest,
+        ) -> Result<tokio::sync::mpsc::Receiver<LlmEvent>, ProviderError> {
+            self.requests.lock().unwrap().push(request.clone());
+            let script = self.scripts.lock().unwrap().pop_front().unwrap_or_default();
+            let (tx, rx) = tokio::sync::mpsc::channel(16);
+            tokio::spawn(async move {
+                for ev in script {
+                    let _ = tx.send(ev).await;
+                }
+            });
+            Ok(rx)
+        }
+    }
+
+    fn done(stop: StopReason, finish: FinishReason, input_tokens: u64) -> LlmEvent {
+        LlmEvent::Done {
+            stop_reason: stop,
+            finish_reason: finish,
+            usage: TokenUsage {
+                input_tokens,
+                ..Default::default()
+            },
+        }
+    }
+
+    /// An engine whose resolved input ceiling is small enough for a scripted
+    /// provider-billed `input_tokens` to sit at/over it, while the tiny local
+    /// history estimate stays well below (that mismatch is exactly how the
+    /// field wedge slipped past the #255 pre-flight guard).
+    fn wedge_engine(provider: Arc<dyn LlmProvider>) -> super::AgentEngine {
+        let mut e = super::AgentEngine::new_with_provider(
+            provider,
+            wcore_config::config::Config::default(),
+            ToolRegistry::new(),
+            Arc::new(NullOutput),
+        );
+        e.max_turns = Some(20);
+        // Unknown test model → the window falls back to compact_config.
+        // Ceiling = 50_000 − 100 − 50 = 49_850.
+        e.compact_config.context_window = 50_000;
+        e.compact_config.output_reserve = 100;
+        e.compact_config.emergency_buffer = 50;
+        e
+    }
+
+    // --- A: length-wedge gate ---------------------------------------------
+
+    #[tokio::test]
+    async fn length_at_ceiling_compacts_then_retries_with_changed_context() {
+        // Turn ends Length with a provider-billed input over the ceiling →
+        // the gate forces a compaction (call 2 = the summarizer), then
+        // retries with the CHANGED context (call 3) — never an identical
+        // re-send.
+        let provider = Arc::new(RecordingProvider::new(vec![
+            // call 1 — the wedged turn: instant Length at the ceiling.
+            vec![done(StopReason::EndTurn, FinishReason::Length, 1_000_000)],
+            // call 2 — the forced autocompact summarization call.
+            vec![
+                LlmEvent::TextDelta("<summary>compacted history</summary>".into()),
+                done(StopReason::EndTurn, FinishReason::Stop, 0),
+            ],
+            // call 3 — the retry with the compacted context succeeds.
+            vec![
+                LlmEvent::TextDelta("recovered".into()),
+                done(StopReason::EndTurn, FinishReason::Stop, 100),
+            ],
+        ]));
+        let requests = provider.recorded();
+        let mut engine = wedge_engine(provider);
+        let result = engine
+            .run("task", "m-wedge-1")
+            .await
+            .expect("a shrunk retry after forced compaction must recover");
+        assert_eq!(result.text, "recovered");
+
+        let reqs = requests.lock().unwrap();
+        assert_eq!(reqs.len(), 3, "wedged turn + compaction call + one retry");
+        // The retried context must differ from the wedged one — assert via
+        // the same outbound-context fingerprint the gate uses.
+        let fp_first = super::context_fingerprint(&reqs[0].model, &reqs[0].messages);
+        let fp_retry = super::context_fingerprint(&reqs[2].model, &reqs[2].messages);
+        assert_ne!(
+            fp_first, fp_retry,
+            "the retry must never re-send the identical over-budget context"
+        );
+    }
+
+    #[tokio::test]
+    async fn length_at_ceiling_with_failed_compaction_ends_clean_without_resend() {
+        // Compaction is attempted but fails (the summarizer call errors) →
+        // the outbound context is unchanged, so the gate must END the turn
+        // with a clean Length verdict — NOT re-send the identical request.
+        // Note the local estimate stays under the ceiling here (only the
+        // provider-billed count was over), so without the fingerprint check
+        // the engine would have happily re-sent the identical request.
+        let provider = Arc::new(RecordingProvider::new(vec![
+            // call 1 — the wedged turn.
+            vec![done(StopReason::EndTurn, FinishReason::Length, 1_000_000)],
+            // call 2 — the forced compaction call fails.
+            vec![LlmEvent::Error("summarizer unavailable".into())],
+        ]));
+        let requests = provider.recorded();
+        let mut engine = wedge_engine(provider);
+        let result = engine
+            .run("task", "m-wedge-2")
+            .await
+            .expect("a wedge with failed compaction is a CLEAN terminal verdict, not an Err");
+        assert_eq!(result.stop_reason, StopReason::MaxTurns);
+        assert_eq!(result.finish_reason, FinishReason::Length);
+        assert_eq!(
+            requests.lock().unwrap().len(),
+            2,
+            "wedged turn + compaction attempt only — the identical over-budget \
+             request must NEVER be re-sent"
+        );
+    }
+
+    #[tokio::test]
+    async fn identical_wedged_context_is_refused_before_dispatch() {
+        // The dispatch guard: once a context fingerprint is recorded as
+        // wedged, a run that would send the byte-identical context is
+        // refused BEFORE the provider is called (models a host that retries
+        // the identical wedged conversation, e.g. after a resume). A control
+        // run on an identically-configured engine captures the exact
+        // outbound bytes `run("task")` produces (per-turn injections
+        // included); the engine under test is seeded with that fingerprint.
+        let control = Arc::new(RecordingProvider::new(vec![vec![
+            LlmEvent::TextDelta("control".into()),
+            done(StopReason::EndTurn, FinishReason::Stop, 0),
+        ]]));
+        let control_requests = control.recorded();
+        let mut control_engine = wedge_engine(control);
+        control_engine
+            .run("task", "m-wedge-3a")
+            .await
+            .expect("control run completes");
+        let wedged_fingerprint = {
+            let reqs = control_requests.lock().unwrap();
+            assert_eq!(reqs.len(), 1);
+            super::context_fingerprint(&reqs[0].model, &reqs[0].messages)
+        };
+
+        let provider = Arc::new(RecordingProvider::new(vec![
+            // Would-be call — must never be consumed.
+            vec![
+                LlmEvent::TextDelta("must not run".into()),
+                done(StopReason::EndTurn, FinishReason::Stop, 0),
+            ],
+        ]));
+        let requests = provider.recorded();
+        let mut engine = wedge_engine(provider);
+        engine.length_wedge_fingerprint = Some(wedged_fingerprint);
+        let result = engine
+            .run("task", "m-wedge-3b")
+            .await
+            .expect("refusing a wedged re-send is a clean terminal verdict");
+        assert_eq!(result.stop_reason, StopReason::MaxTurns);
+        assert_eq!(result.finish_reason, FinishReason::Length);
+        assert_eq!(
+            requests.lock().unwrap().len(),
+            0,
+            "a byte-identical wedged context must be refused BEFORE dispatch"
+        );
+    }
+
+    // --- B: clean-retry stub + progress gate (spec v1 Task 5) --------------
+
+    /// History whose most recent tool round FAILED with a huge error body.
+    fn failed_tool_round_history(huge_error: &str) -> Vec<Message> {
+        vec![
+            Message::now(
+                Role::User,
+                vec![ContentBlock::Text {
+                    text: "do the thing".into(),
+                }],
+            ),
+            Message::now(
+                Role::Assistant,
+                vec![ContentBlock::ToolUse {
+                    id: "t1".into(),
+                    name: "BigTool".into(),
+                    input: serde_json::json!({}),
+                    extra: None,
+                }],
+            ),
+            Message::now(
+                Role::User,
+                vec![ContentBlock::ToolResult {
+                    tool_use_id: "t1".into(),
+                    content: huge_error.into(),
+                    is_error: true,
+                }],
+            ),
+        ]
+    }
+
+    #[tokio::test]
+    async fn failing_stream_with_failed_tool_round_stubs_body_and_stops_at_progress_gate() {
+        let huge_error = format!("CONTAMINATED-MARKER {}", "x".repeat(50_000));
+        let provider = Arc::new(RecordingProvider::new(vec![
+            // attempt 0 fails with no output …
+            vec![LlmEvent::Error("boom".into())],
+            // … retry 1 (stubbed context) also fails with no output —
+            // the progress gate must stop here, before a third attempt.
+            vec![LlmEvent::Error("boom again".into())],
+            // a third script would be consumed only if the gate failed.
+            vec![
+                LlmEvent::TextDelta("must not run".into()),
+                done(StopReason::EndTurn, FinishReason::Stop, 0),
+            ],
+        ]));
+        let requests = provider.recorded();
+        let mut engine = wedge_engine(provider);
+        engine.messages = failed_tool_round_history(&huge_error);
+        let result = engine.run("try again", "m-stub-1").await;
+
+        let reqs = requests.lock().unwrap();
+        assert_eq!(
+            reqs.len(),
+            2,
+            "the progress gate must stop after 2 consecutive no-output \
+             failures on a failed tool round — not burn a third full-context send"
+        );
+        // Attempt 0 carried the full contaminated body …
+        let first = serde_json::to_string(&reqs[0].messages).unwrap();
+        assert!(
+            first.contains("CONTAMINATED-MARKER"),
+            "the initial attempt sends the real tool result"
+        );
+        // … the retry carried the compact stub instead.
+        let retried = serde_json::to_string(&reqs[1].messages).unwrap();
+        assert!(
+            !retried.contains(&huge_error),
+            "the retry must NOT re-send the full contaminated body"
+        );
+        assert!(
+            retried.contains("[tool BigTool failed:"),
+            "the retry must carry the compact error stub, got: {}",
+            &retried[..retried.len().min(2_000)]
+        );
+        // The stop is a clear error naming the failing tool.
+        match result {
+            Err(super::AgentError::ApiError(msg)) => {
+                assert!(
+                    msg.contains("BigTool"),
+                    "the progress-gate error must name the failing tool: {msg}"
+                );
+            }
+            other => panic!("expected the progress-gate ApiError, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn transient_stream_failure_with_failed_tool_round_still_recovers() {
+        // Regression guard (spec gate 5.3): fail once, succeed on the (stubbed)
+        // retry — the stub and gate must not kill retry resilience.
+        let huge_error = format!("CONTAMINATED-MARKER {}", "x".repeat(50_000));
+        let provider = Arc::new(RecordingProvider::new(vec![
+            vec![LlmEvent::Error("transient".into())],
+            vec![
+                LlmEvent::TextDelta("recovered".into()),
+                done(StopReason::EndTurn, FinishReason::Stop, 100),
+            ],
+        ]));
+        let requests = provider.recorded();
+        let mut engine = wedge_engine(provider);
+        engine.messages = failed_tool_round_history(&huge_error);
+        let result = engine
+            .run("try again", "m-stub-2")
+            .await
+            .expect("a single transient failure must still recover");
+        assert_eq!(result.text, "recovered");
+        assert_eq!(requests.lock().unwrap().len(), 2, "1 initial + 1 retry");
+    }
+
+    #[test]
+    fn stub_helper_rewrites_only_failed_results_in_last_round() {
+        let mut messages = vec![
+            Message::now(
+                Role::Assistant,
+                vec![
+                    ContentBlock::ToolUse {
+                        id: "ok1".into(),
+                        name: "GoodTool".into(),
+                        input: serde_json::json!({}),
+                        extra: None,
+                    },
+                    ContentBlock::ToolUse {
+                        id: "bad1".into(),
+                        name: "BadTool".into(),
+                        input: serde_json::json!({}),
+                        extra: None,
+                    },
+                ],
+            ),
+            Message::now(
+                Role::User,
+                vec![
+                    ContentBlock::ToolResult {
+                        tool_use_id: "ok1".into(),
+                        content: "fine output".into(),
+                        is_error: false,
+                    },
+                    ContentBlock::ToolResult {
+                        tool_use_id: "bad1".into(),
+                        content: "line one of a huge error\nline two".into(),
+                        is_error: true,
+                    },
+                ],
+            ),
+        ];
+        let failing = super::stub_failed_tool_results_for_retry(&mut messages);
+        assert_eq!(failing, vec!["BadTool".to_string()]);
+        match &messages[1].content[0] {
+            ContentBlock::ToolResult { content, .. } => {
+                assert_eq!(content, "fine output", "successful results untouched")
+            }
+            _ => unreachable!(),
+        }
+        match &messages[1].content[1] {
+            ContentBlock::ToolResult { content, .. } => {
+                assert_eq!(
+                    content,
+                    "[tool BadTool failed: line one of a huge error; retrying]"
+                );
+            }
+            _ => unreachable!(),
+        }
+        // Idempotent + still reports the failing tool on a second pass
+        // (the progress gate needs the name every retry).
+        let failing_again = super::stub_failed_tool_results_for_retry(&mut messages);
+        assert_eq!(failing_again, vec!["BadTool".to_string()]);
+        match &messages[1].content[1] {
+            ContentBlock::ToolResult { content, .. } => {
+                assert_eq!(
+                    content, "[tool BadTool failed: line one of a huge error; retrying]",
+                    "a second pass must not re-stub the stub"
+                );
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    #[test]
+    fn context_fingerprint_ignores_timestamps_but_not_content() {
+        let a = vec![Message::now(
+            Role::User,
+            vec![ContentBlock::Text { text: "hi".into() }],
+        )];
+        let mut b = a.clone();
+        b[0].timestamp = Some(chrono::Utc::now() + chrono::Duration::hours(1));
+        assert_eq!(
+            super::context_fingerprint("m", &a),
+            super::context_fingerprint("m", &b),
+            "timestamps are not sent to the provider and must not change the fingerprint"
+        );
+        let c = vec![Message::now(
+            Role::User,
+            vec![ContentBlock::Text {
+                text: "different".into(),
+            }],
+        )];
+        assert_ne!(
+            super::context_fingerprint("m", &a),
+            super::context_fingerprint("m", &c)
+        );
+        assert_ne!(
+            super::context_fingerprint("model-a", &a),
+            super::context_fingerprint("model-b", &a),
+            "the dispatched model is part of the request identity"
         );
     }
 }

--- a/crates/wcore-agent/src/output/mod.rs
+++ b/crates/wcore-agent/src/output/mod.rs
@@ -7,7 +7,7 @@ pub mod terminal;
 use crossterm::execute;
 use crossterm::style::{Attribute, Color, Print, ResetColor, SetAttribute, SetForegroundColor};
 use std::io::{self, Write};
-use wcore_types::message::FinishReason;
+use wcore_types::message::{FinishReason, TokenUsage};
 
 /// Abstraction over output channels (terminal vs JSON stream protocol)
 pub trait OutputSink: Send + Sync {
@@ -49,6 +49,11 @@ pub trait OutputSink: Send + Sync {
     /// and run-correlation id. Default delegates to emit_stream_end (dropping
     /// the extras) so existing sinks/mocks need no change; ProtocolSink
     /// overrides to populate Usage.active_window_percent + StreamEnd.agent_run_id.
+    ///
+    /// CORE-2: `usage_delta` is the run-scoped usage (this run's provider
+    /// round-trips only), emitted as the `usage_delta` sibling of the
+    /// session-cumulative `usage` on the `stream_end` event. None on paths
+    /// that don't track a per-run delta.
     #[allow(clippy::too_many_arguments)]
     fn emit_stream_end_full(
         &self,
@@ -61,6 +66,7 @@ pub trait OutputSink: Send + Sync {
         finish_reason: FinishReason,
         _active_window_percent: Option<u32>,
         _agent_run_id: Option<&str>,
+        _usage_delta: Option<&TokenUsage>,
     ) {
         self.emit_stream_end(
             msg_id,

--- a/crates/wcore-agent/src/output/protocol_sink.rs
+++ b/crates/wcore-agent/src/output/protocol_sink.rs
@@ -577,6 +577,7 @@ impl OutputSink for ProtocolSink {
                 },
                 active_window_percent: None,
             }),
+            usage_delta: None,
             agent_run_id: None,
         });
     }
@@ -593,6 +594,7 @@ impl OutputSink for ProtocolSink {
         finish_reason: FinishReason,
         active_window_percent: Option<u32>,
         agent_run_id: Option<&str>,
+        usage_delta: Option<&wcore_types::message::TokenUsage>,
     ) {
         let _ = self.writer.emit(&ProtocolEvent::StreamEnd {
             msg_id: msg_id.to_string(),
@@ -611,6 +613,24 @@ impl OutputSink for ProtocolSink {
                     None
                 },
                 active_window_percent,
+            }),
+            // CORE-2: the run-scoped delta rides as a sibling of the
+            // cumulative usage, same inner field shape (window gauge is
+            // a session-level reading — it stays on `usage` only).
+            usage_delta: usage_delta.map(|d| Usage {
+                input_tokens: d.input_tokens,
+                output_tokens: d.output_tokens,
+                cache_read_tokens: if d.cache_read_tokens > 0 {
+                    Some(d.cache_read_tokens)
+                } else {
+                    None
+                },
+                cache_write_tokens: if d.cache_creation_tokens > 0 {
+                    Some(d.cache_creation_tokens)
+                } else {
+                    None
+                },
+                active_window_percent: None,
             }),
             agent_run_id: agent_run_id.map(str::to_string),
         });

--- a/crates/wcore-agent/src/spawner.rs
+++ b/crates/wcore-agent/src/spawner.rs
@@ -1343,6 +1343,7 @@ mod fail_loud_tests {
             stop_reason: StopReason::MaxTurns,
             finish_reason: finish,
             usage: TokenUsage::default(),
+            usage_delta: TokenUsage::default(),
             turns: 3,
             active_window_percent: None,
             agent_run_id: None,

--- a/crates/wcore-agent/src/test_utils/mod.rs
+++ b/crates/wcore-agent/src/test_utils/mod.rs
@@ -217,6 +217,59 @@ impl OutputSink for TestSink {
             agent_run_id: None,
         });
     }
+    #[allow(clippy::too_many_arguments)]
+    fn emit_stream_end_full(
+        &self,
+        msg_id: &str,
+        _turns: usize,
+        input_tokens: u64,
+        output_tokens: u64,
+        cache_creation_tokens: u64,
+        cache_read_tokens: u64,
+        finish_reason: FinishReason,
+        active_window_percent: Option<u32>,
+        agent_run_id: Option<&str>,
+        usage_delta: Option<&wcore_types::message::TokenUsage>,
+    ) {
+        // CORE-2: mirror ProtocolSink's enriched mapping (gauge, run id,
+        // per-run delta) so tests can assert the terminal stream_end
+        // carries the delta the same way the real wire does.
+        self.record(&ProtocolEvent::StreamEnd {
+            msg_id: msg_id.to_string(),
+            finish_reason,
+            usage: Some(Usage {
+                input_tokens,
+                output_tokens,
+                cache_read_tokens: if cache_read_tokens > 0 {
+                    Some(cache_read_tokens)
+                } else {
+                    None
+                },
+                cache_write_tokens: if cache_creation_tokens > 0 {
+                    Some(cache_creation_tokens)
+                } else {
+                    None
+                },
+                active_window_percent,
+            }),
+            usage_delta: usage_delta.map(|d| Usage {
+                input_tokens: d.input_tokens,
+                output_tokens: d.output_tokens,
+                cache_read_tokens: if d.cache_read_tokens > 0 {
+                    Some(d.cache_read_tokens)
+                } else {
+                    None
+                },
+                cache_write_tokens: if d.cache_creation_tokens > 0 {
+                    Some(d.cache_creation_tokens)
+                } else {
+                    None
+                },
+                active_window_percent: None,
+            }),
+            agent_run_id: agent_run_id.map(str::to_string),
+        });
+    }
     fn emit_error(&self, msg: &str, retryable: bool) {
         self.record(&ProtocolEvent::Error {
             msg_id: None,

--- a/crates/wcore-agent/src/test_utils/mod.rs
+++ b/crates/wcore-agent/src/test_utils/mod.rs
@@ -213,6 +213,7 @@ impl OutputSink for TestSink {
                 },
                 active_window_percent: None,
             }),
+            usage_delta: None,
             agent_run_id: None,
         });
     }

--- a/crates/wcore-cli/src/acp_engine.rs
+++ b/crates/wcore-cli/src/acp_engine.rs
@@ -317,6 +317,7 @@ impl Drop for TerminalGuard {
             msg_id: std::mem::take(&mut self.msg_id),
             finish_reason: FinishReason::Error,
             usage: None,
+            usage_delta: None,
             agent_run_id: None,
         });
     }
@@ -352,6 +353,16 @@ fn stream_end_event(msg_id: &str, result: &AgentResult) -> ProtocolEvent {
             cache_write_tokens: (result.usage.cache_creation_tokens > 0)
                 .then_some(result.usage.cache_creation_tokens),
             active_window_percent: result.active_window_percent,
+        }),
+        // CORE-2: run-scoped delta rides beside the cumulative usage.
+        usage_delta: Some(wcore_protocol::events::Usage {
+            input_tokens: result.usage_delta.input_tokens,
+            output_tokens: result.usage_delta.output_tokens,
+            cache_read_tokens: (result.usage_delta.cache_read_tokens > 0)
+                .then_some(result.usage_delta.cache_read_tokens),
+            cache_write_tokens: (result.usage_delta.cache_creation_tokens > 0)
+                .then_some(result.usage_delta.cache_creation_tokens),
+            active_window_percent: None,
         }),
         agent_run_id: result.agent_run_id.clone(),
     }
@@ -653,6 +664,7 @@ impl EngineSession {
                         msg_id: msg_id.clone(),
                         finish_reason: FinishReason::Error,
                         usage: None,
+                        usage_delta: None,
                         agent_run_id: None,
                     });
                     term.disarm();
@@ -1082,6 +1094,7 @@ mod tests {
                 msg_id: "m".into(),
                 finish_reason: FinishReason::Length,
                 usage: None,
+                usage_delta: None,
                 agent_run_id: None,
             },
             // Anything after the terminal frame must NOT appear.
@@ -1138,6 +1151,7 @@ mod tests {
                 msg_id: "m".into(),
                 finish_reason: FinishReason::Stop,
                 usage: None,
+                usage_delta: None,
                 agent_run_id: None,
             },
         ];
@@ -1221,6 +1235,7 @@ mod tests {
                 msg_id: "m".into(),
                 finish_reason: FinishReason::Stop,
                 usage: None,
+                usage_delta: None,
                 agent_run_id: None,
             })
             .unwrap();

--- a/crates/wcore-cli/src/main.rs
+++ b/crates/wcore-cli/src/main.rs
@@ -3214,6 +3214,7 @@ async fn run_json_stream_mode(
                                             result.finish_reason,
                                             result.active_window_percent,
                                             result.agent_run_id.as_deref(),
+                                            Some(&result.usage_delta),
                                         );
                                     }
                                     Err(e) => {

--- a/crates/wcore-cli/src/main.rs
+++ b/crates/wcore-cli/src/main.rs
@@ -3180,6 +3180,13 @@ async fn run_json_stream_mode(
                 let mut stopped = false;
                 let mut pending_config: Option<PendingConfig> = None;
                 let mut mode_changed = false;
+                // CORE-2: an errored run may still have consumed provider
+                // round-trips (total_usage/run_usage grew before the Err),
+                // but `run()` returned no AgentResult to read them from.
+                // Defer the error-path terminal stream_end to AFTER this
+                // block — `engine_fut` borrows `engine` until then — so it
+                // can carry the engine's usage snapshot instead of zeros.
+                let mut run_failed = false;
 
                 {
                     let engine_fut = engine.run(&content, &msg_id);
@@ -3219,15 +3226,10 @@ async fn run_json_stream_mode(
                                     }
                                     Err(e) => {
                                         output.emit_error(&format!("{e:#}"), false);
-                                        output.emit_stream_end(
-                                            &msg_id,
-                                            0,
-                                            0,
-                                            0,
-                                            0,
-                                            0,
-                                            FinishReason::Error,
-                                        );
+                                        // stream_end deferred (see run_failed
+                                        // above): emitted after this block with
+                                        // the engine's usage snapshot.
+                                        run_failed = true;
                                     }
                                 }
                                 break;
@@ -3351,6 +3353,36 @@ async fn run_json_stream_mode(
                                 }
                             }
                         }
+                    }
+                }
+
+                if run_failed {
+                    // CORE-2: the failed run's terminal stream_end. When the
+                    // run consumed provider round-trips before dying, report
+                    // the cumulative usage + this run's delta from the
+                    // engine's snapshot (the counters already grew and will
+                    // be persisted); otherwise keep the legacy zero-usage
+                    // emission byte-identical.
+                    let (total, delta) = engine.usage_snapshot();
+                    let delta_nonzero = delta.input_tokens > 0
+                        || delta.output_tokens > 0
+                        || delta.cache_creation_tokens > 0
+                        || delta.cache_read_tokens > 0;
+                    if delta_nonzero {
+                        output.emit_stream_end_full(
+                            &msg_id,
+                            0,
+                            total.input_tokens,
+                            total.output_tokens,
+                            total.cache_creation_tokens,
+                            total.cache_read_tokens,
+                            FinishReason::Error,
+                            None,
+                            None,
+                            Some(&delta),
+                        );
+                    } else {
+                        output.emit_stream_end(&msg_id, 0, 0, 0, 0, 0, FinishReason::Error);
                     }
                 }
 

--- a/crates/wcore-cli/src/tui/engine_bridge.rs
+++ b/crates/wcore-cli/src/tui/engine_bridge.rs
@@ -332,6 +332,7 @@ impl OutputSink for ChannelSink {
                 cache_write_tokens: (cache_creation_tokens > 0).then_some(cache_creation_tokens),
                 active_window_percent: None,
             }),
+            usage_delta: None,
             agent_run_id: None,
         });
     }
@@ -574,6 +575,7 @@ impl Drop for TerminalGuard {
             msg_id: std::mem::take(&mut self.msg_id),
             finish_reason: FinishReason::Error,
             usage: None,
+            usage_delta: None,
             agent_run_id: None,
         });
     }
@@ -1034,6 +1036,16 @@ impl TuiEngine {
                                 .then_some(result.usage.cache_creation_tokens),
                             active_window_percent: result.active_window_percent,
                         }),
+                        // CORE-2: run-scoped delta beside the cumulative usage.
+                        usage_delta: Some(Usage {
+                            input_tokens: result.usage_delta.input_tokens,
+                            output_tokens: result.usage_delta.output_tokens,
+                            cache_read_tokens: (result.usage_delta.cache_read_tokens > 0)
+                                .then_some(result.usage_delta.cache_read_tokens),
+                            cache_write_tokens: (result.usage_delta.cache_creation_tokens > 0)
+                                .then_some(result.usage_delta.cache_creation_tokens),
+                            active_window_percent: None,
+                        }),
                         agent_run_id: result.agent_run_id.clone(),
                     });
                     term.disarm();
@@ -1051,6 +1063,7 @@ impl TuiEngine {
                         msg_id: msg_id.clone(),
                         finish_reason: FinishReason::Error,
                         usage: None,
+                        usage_delta: None,
                         agent_run_id: None,
                     });
                     term.disarm();
@@ -1093,6 +1106,7 @@ impl TuiEngine {
                 msg_id: String::new(),
                 finish_reason: FinishReason::Error,
                 usage: None,
+                usage_delta: None,
                 agent_run_id: None,
             });
         }

--- a/crates/wcore-cli/src/tui/fixtures.rs
+++ b/crates/wcore-cli/src/tui/fixtures.rs
@@ -49,6 +49,7 @@ pub fn full_conversation() -> Vec<ProtocolEvent> {
                 cache_write_tokens: None,
                 active_window_percent: None,
             }),
+            usage_delta: None,
             agent_run_id: None,
         },
     ]

--- a/crates/wcore-cli/src/tui/protocol_bridge.rs
+++ b/crates/wcore-cli/src/tui/protocol_bridge.rs
@@ -200,11 +200,20 @@ fn apply_event_inner(app: &mut App, event: ProtocolEvent) {
                 }
             }
         }
-        ProtocolEvent::StreamEnd { usage, .. } => {
+        ProtocolEvent::StreamEnd {
+            usage, usage_delta, ..
+        } => {
             // W3 D3: roll up output_tokens from the optional Usage payload
             // before flushing — the status widget shows the per-turn total
             // just before phase → Idle.
-            if let Some(u) = usage.as_ref() {
+            //
+            // CORE-2: `usage` is session-CUMULATIVE (it grows across turns
+            // and survives --resume), so summing it per turn overcounts.
+            // Prefer the per-run `usage_delta` sibling for turn-local
+            // counters, falling back to `usage` only when the delta is
+            // absent (old producers / synthetic stream-ends).
+            let turn_usage = usage_delta.as_ref().or(usage.as_ref());
+            if let Some(u) = turn_usage {
                 app.session.tokens_out = app.session.tokens_out.saturating_add(u.output_tokens);
             }
             // ── v0.9.3 W1.3 — persist captured reasoning as Thinking ─────
@@ -213,16 +222,17 @@ fn apply_event_inner(app: &mut App, event: ProtocolEvent) {
             // extended the filter to also accumulate the stripped content
             // into a capture buffer. Drain it here. `secs` is the turn-level
             // proxy (`now − turn_started_at`) per SPEC v1.3 §0 criterion
-            // #11; `tokens` is `StreamEnd.usage.output_tokens` (default 0
-            // when usage is None — the projection gates the `· N tok` meta
-            // on `tokens > 0` so a 0 reads cleanly without tail meta).
+            // #11; `tokens` is the turn-local output count (usage_delta,
+            // falling back to the cumulative usage for old producers;
+            // default 0 when both are None — the projection gates the
+            // `· N tok` meta on `tokens > 0` so a 0 reads cleanly).
             let captured = app.session.reasoning_filter.take_captured();
             let thinking_to_push: Option<TurnElement> = if captured.is_empty() {
                 None
             } else {
                 let now = Instant::now();
                 let secs = now.duration_since(app.session.turn_started_at).as_secs();
-                let tokens = usage.as_ref().map(|u| u.output_tokens).unwrap_or(0);
+                let tokens = turn_usage.map(|u| u.output_tokens).unwrap_or(0);
                 Some(TurnElement::Thinking {
                     body: captured,
                     secs,
@@ -2056,6 +2066,86 @@ mod tests {
         }
         // The `.text()` accessor preserves the old human-readable view.
         assert_eq!(app.session.turns[0].text(), "Hello, world.");
+    }
+
+    /// CORE-2 audit fix: `StreamEnd.usage` is session-CUMULATIVE, so the
+    /// per-turn roll-up must prefer the `usage_delta` sibling — summing the
+    /// cumulative field overcounts on every turn after the first. Old
+    /// producers without a delta still fall back to `usage`.
+    #[test]
+    fn tokens_out_prefers_usage_delta_over_cumulative_usage() {
+        fn usage(output_tokens: u64) -> wcore_protocol::events::Usage {
+            wcore_protocol::events::Usage {
+                input_tokens: 0,
+                output_tokens,
+                cache_read_tokens: None,
+                cache_write_tokens: None,
+                active_window_percent: None,
+            }
+        }
+        let mut app = App::new();
+        // Turn 1: cumulative 42, delta 42.
+        apply_event(
+            &mut app,
+            ProtocolEvent::StreamStart {
+                msg_id: "m1".into(),
+            },
+        );
+        apply_event(
+            &mut app,
+            ProtocolEvent::StreamEnd {
+                msg_id: "m1".into(),
+                finish_reason: wcore_protocol::events::FinishReason::Stop,
+                usage: Some(usage(42)),
+                usage_delta: Some(usage(42)),
+                agent_run_id: None,
+            },
+        );
+        assert_eq!(app.session.tokens_out, 42);
+        // Turn 2: cumulative grew to 142; THIS turn produced 100. The
+        // per-turn counter (reset at StreamStart) must show 100 — reading
+        // the cumulative field would show 142.
+        apply_event(
+            &mut app,
+            ProtocolEvent::StreamStart {
+                msg_id: "m2".into(),
+            },
+        );
+        apply_event(
+            &mut app,
+            ProtocolEvent::StreamEnd {
+                msg_id: "m2".into(),
+                finish_reason: wcore_protocol::events::FinishReason::Stop,
+                usage: Some(usage(142)),
+                usage_delta: Some(usage(100)),
+                agent_run_id: None,
+            },
+        );
+        assert_eq!(
+            app.session.tokens_out, 100,
+            "the per-turn counter must show THIS turn's delta, not the cumulative 142"
+        );
+        // Old producer (no delta): fall back to usage.
+        apply_event(
+            &mut app,
+            ProtocolEvent::StreamStart {
+                msg_id: "m3".into(),
+            },
+        );
+        apply_event(
+            &mut app,
+            ProtocolEvent::StreamEnd {
+                msg_id: "m3".into(),
+                finish_reason: wcore_protocol::events::FinishReason::Stop,
+                usage: Some(usage(8)),
+                usage_delta: None,
+                agent_run_id: None,
+            },
+        );
+        assert_eq!(
+            app.session.tokens_out, 8,
+            "a delta-less stream_end still rolls up its usage"
+        );
     }
 
     #[test]

--- a/crates/wcore-cli/src/tui/protocol_bridge.rs
+++ b/crates/wcore-cli/src/tui/protocol_bridge.rs
@@ -2037,6 +2037,7 @@ mod tests {
                 msg_id: "m1".into(),
                 finish_reason: wcore_protocol::events::FinishReason::Stop,
                 usage: None,
+                usage_delta: None,
                 agent_run_id: None,
             },
         );
@@ -2092,6 +2093,7 @@ mod tests {
                 msg_id: "m1".into(),
                 finish_reason: wcore_protocol::events::FinishReason::Stop,
                 usage: None,
+                usage_delta: None,
                 agent_run_id: None,
             },
         );
@@ -2139,6 +2141,7 @@ mod tests {
                     cache_write_tokens: None,
                     active_window_percent: None,
                 }),
+                usage_delta: None,
                 agent_run_id: None,
             },
         );
@@ -2192,6 +2195,7 @@ mod tests {
                 msg_id: "m1".into(),
                 finish_reason: wcore_protocol::events::FinishReason::Stop,
                 usage: None,
+                usage_delta: None,
                 agent_run_id: None,
             },
         );
@@ -3033,6 +3037,7 @@ mod tests {
                 msg_id: "m1".into(),
                 finish_reason: wcore_protocol::events::FinishReason::Stop,
                 usage: None,
+                usage_delta: None,
                 agent_run_id: None,
             },
         );
@@ -3095,6 +3100,7 @@ mod tests {
                 msg_id: "m1".into(),
                 finish_reason: wcore_protocol::events::FinishReason::Stop,
                 usage: None,
+                usage_delta: None,
                 agent_run_id: None,
             },
         );
@@ -3485,6 +3491,7 @@ mod tests {
                 msg_id: "m1".into(),
                 finish_reason: wcore_protocol::events::FinishReason::Stop,
                 usage: None,
+                usage_delta: None,
                 agent_run_id: None,
             },
         );
@@ -3570,6 +3577,7 @@ mod tests {
                 msg_id: "m1".into(),
                 finish_reason: wcore_protocol::events::FinishReason::Stop,
                 usage: None,
+                usage_delta: None,
                 agent_run_id: None,
             },
         );
@@ -3673,6 +3681,7 @@ mod tests {
                 msg_id: "m1".into(),
                 finish_reason: wcore_protocol::events::FinishReason::Stop,
                 usage: None,
+                usage_delta: None,
                 agent_run_id: None,
             },
         );
@@ -3754,6 +3763,7 @@ mod tests {
                 msg_id: "m1".into(),
                 finish_reason: wcore_protocol::events::FinishReason::Stop,
                 usage: None,
+                usage_delta: None,
                 agent_run_id: None,
             },
         );
@@ -3826,6 +3836,7 @@ mod tests {
                 msg_id: "m1".into(),
                 finish_reason: wcore_protocol::events::FinishReason::Stop,
                 usage: None,
+                usage_delta: None,
                 agent_run_id: None,
             },
         );
@@ -3895,6 +3906,7 @@ mod tests {
                 msg_id: "m1".into(),
                 finish_reason: wcore_protocol::events::FinishReason::Stop,
                 usage: None,
+                usage_delta: None,
                 agent_run_id: None,
             },
         );
@@ -4091,6 +4103,7 @@ mod tests {
                 msg_id: "m1".into(),
                 finish_reason: wcore_protocol::events::FinishReason::Stop,
                 usage: None,
+                usage_delta: None,
                 agent_run_id: None,
             },
         );
@@ -4185,6 +4198,7 @@ mod tests {
                 msg_id: "m1".into(),
                 finish_reason: wcore_protocol::events::FinishReason::Stop,
                 usage: None,
+                usage_delta: None,
                 agent_run_id: None,
             },
         );

--- a/crates/wcore-cli/src/tui/surfaces/workspace.rs
+++ b/crates/wcore-cli/src/tui/surfaces/workspace.rs
@@ -8356,6 +8356,7 @@ mod tests {
                 msg_id: "m1".into(),
                 finish_reason: FinishReason::Stop,
                 usage: None,
+                usage_delta: None,
                 agent_run_id: None,
             },
         ];

--- a/crates/wcore-cli/src/tui/widgets/streaming_status.rs
+++ b/crates/wcore-cli/src/tui/widgets/streaming_status.rs
@@ -566,6 +566,7 @@ mod tests {
                     cache_write_tokens: None,
                     active_window_percent: None,
                 }),
+                usage_delta: None,
                 agent_run_id: None,
             },
         );

--- a/crates/wcore-config/src/compact.rs
+++ b/crates/wcore-config/src/compact.rs
@@ -120,7 +120,7 @@ pub struct CompactConfig {
 ///
 /// Unlike the tool-RESULT micro-compaction above (trigger-gated), this pass
 /// runs on every compaction pipeline pass: an old Write body stops riding in
-/// resent history the turn it leaves the protected tail.
+/// resent history at the first epoch tick after it leaves the protected tail.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ToolCallArgsConfig {
     /// Master gate for the pass. Default ON.
@@ -137,6 +137,16 @@ pub struct ToolCallArgsConfig {
     /// stubbed. Tiny args (Read paths, short Bash commands) are never touched.
     #[serde(default = "default_tca_min_args_bytes")]
     pub min_args_bytes: usize,
+
+    /// Epoch quantization of the stub boundary (cache economics): the
+    /// boundary advances only every `epoch_turns` assistant turns, stubbing a
+    /// batch at once, instead of flipping one message per turn inside the
+    /// provider's cached prefix (which would re-bill the byte-identical
+    /// protected tail at full price every turn). Between ticks the boundary
+    /// is frozen and the whole prefix stays cache-hittable. `1` = advance
+    /// every turn (no quantization). Floored to 1 at the use site.
+    #[serde(default = "default_tca_epoch_turns")]
+    pub epoch_turns: usize,
 }
 
 impl Default for ToolCallArgsConfig {
@@ -145,6 +155,7 @@ impl Default for ToolCallArgsConfig {
             enabled: default_true(),
             keep_recent_turns: default_tca_keep_recent_turns(),
             min_args_bytes: default_tca_min_args_bytes(),
+            epoch_turns: default_tca_epoch_turns(),
         }
     }
 }
@@ -229,6 +240,9 @@ fn default_tca_keep_recent_turns() -> usize {
 }
 fn default_tca_min_args_bytes() -> usize {
     768
+}
+fn default_tca_epoch_turns() -> usize {
+    4
 }
 
 #[cfg(test)]
@@ -416,6 +430,7 @@ smart_handoff_to_memory = false
         assert!(cfg.tool_call_args.enabled);
         assert_eq!(cfg.tool_call_args.keep_recent_turns, 2);
         assert_eq!(cfg.tool_call_args.min_args_bytes, 768);
+        assert_eq!(cfg.tool_call_args.epoch_turns, 4);
     }
 
     #[test]
@@ -431,11 +446,13 @@ smart_handoff_to_memory = false
 enabled = false
 keep_recent_turns = 4
 min_args_bytes = 2048
+epoch_turns = 6
 "#;
         let cfg: CompactConfig = toml::from_str(toml_str).unwrap();
         assert!(!cfg.tool_call_args.enabled);
         assert_eq!(cfg.tool_call_args.keep_recent_turns, 4);
         assert_eq!(cfg.tool_call_args.min_args_bytes, 2048);
+        assert_eq!(cfg.tool_call_args.epoch_turns, 6);
     }
 
     #[test]
@@ -445,6 +462,7 @@ min_args_bytes = 2048
         assert!(cfg.tool_call_args.enabled);
         assert_eq!(cfg.tool_call_args.keep_recent_turns, 3);
         assert_eq!(cfg.tool_call_args.min_args_bytes, 768);
+        assert_eq!(cfg.tool_call_args.epoch_turns, 4);
     }
 
     #[test]

--- a/crates/wcore-config/src/compact.rs
+++ b/crates/wcore-config/src/compact.rs
@@ -107,6 +107,46 @@ pub struct CompactConfig {
     /// the memory write be soaked/disabled independently for NullMemory hosts.
     #[serde(default = "default_true")]
     pub smart_handoff_to_memory: bool,
+
+    /// Continuous compaction of HISTORICAL assistant tool-call arguments
+    /// (parity gap 2): large `tool_calls[].function.arguments` payloads (e.g.
+    /// Write file bodies) older than the last N assistant turns are replaced
+    /// with a compact stub. TOML table: `[compact.tool_call_args]`.
+    #[serde(default)]
+    pub tool_call_args: ToolCallArgsConfig,
+}
+
+/// Config for continuous tool-call-argument compaction (parity gap 2).
+///
+/// Unlike the tool-RESULT micro-compaction above (trigger-gated), this pass
+/// runs on every compaction pipeline pass: an old Write body stops riding in
+/// resent history the turn it leaves the protected tail.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ToolCallArgsConfig {
+    /// Master gate for the pass. Default ON.
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+
+    /// Assistant turns whose tool-call arguments stay verbatim, counted from
+    /// the end of history — the model may still reference recent args.
+    /// Floored to 1 at the use site.
+    #[serde(default = "default_tca_keep_recent_turns")]
+    pub keep_recent_turns: usize,
+
+    /// Minimum serialized size (bytes) of an argument object before it is
+    /// stubbed. Tiny args (Read paths, short Bash commands) are never touched.
+    #[serde(default = "default_tca_min_args_bytes")]
+    pub min_args_bytes: usize,
+}
+
+impl Default for ToolCallArgsConfig {
+    fn default() -> Self {
+        Self {
+            enabled: default_true(),
+            keep_recent_turns: default_tca_keep_recent_turns(),
+            min_args_bytes: default_tca_min_args_bytes(),
+        }
+    }
 }
 
 impl Default for CompactConfig {
@@ -131,6 +171,7 @@ impl Default for CompactConfig {
             smart_cooldown_turns: default_smart_cooldown_turns(),
             smart_min_shrink_tokens: default_smart_min_shrink_tokens(),
             smart_handoff_to_memory: true,
+            tool_call_args: ToolCallArgsConfig::default(),
         }
     }
 }
@@ -182,6 +223,12 @@ fn default_smart_cooldown_turns() -> u32 {
 }
 fn default_smart_min_shrink_tokens() -> u64 {
     2_000
+}
+fn default_tca_keep_recent_turns() -> usize {
+    2
+}
+fn default_tca_min_args_bytes() -> usize {
+    768
 }
 
 #[cfg(test)]
@@ -359,6 +406,45 @@ smart_handoff_to_memory = false
         assert_eq!(cfg.smart_cooldown_turns, 4);
         assert_eq!(cfg.smart_min_shrink_tokens, 5_000);
         assert!(!cfg.smart_handoff_to_memory);
+    }
+
+    #[test]
+    fn tool_call_args_defaults() {
+        // Parity gap 2: default ON, protect the last 2 assistant turns,
+        // never stub argument payloads under 768 serialized bytes.
+        let cfg = CompactConfig::default();
+        assert!(cfg.tool_call_args.enabled);
+        assert_eq!(cfg.tool_call_args.keep_recent_turns, 2);
+        assert_eq!(cfg.tool_call_args.min_args_bytes, 768);
+    }
+
+    #[test]
+    fn toml_empty_keeps_tool_call_args_defaults() {
+        let cfg: CompactConfig = toml::from_str("").unwrap();
+        assert_eq!(cfg.tool_call_args, ToolCallArgsConfig::default());
+    }
+
+    #[test]
+    fn toml_tool_call_args_override() {
+        let toml_str = r#"
+[tool_call_args]
+enabled = false
+keep_recent_turns = 4
+min_args_bytes = 2048
+"#;
+        let cfg: CompactConfig = toml::from_str(toml_str).unwrap();
+        assert!(!cfg.tool_call_args.enabled);
+        assert_eq!(cfg.tool_call_args.keep_recent_turns, 4);
+        assert_eq!(cfg.tool_call_args.min_args_bytes, 2048);
+    }
+
+    #[test]
+    fn toml_tool_call_args_partial_override() {
+        let cfg: CompactConfig =
+            toml::from_str("[tool_call_args]\nkeep_recent_turns = 3\n").unwrap();
+        assert!(cfg.tool_call_args.enabled);
+        assert_eq!(cfg.tool_call_args.keep_recent_turns, 3);
+        assert_eq!(cfg.tool_call_args.min_args_bytes, 768);
     }
 
     #[test]

--- a/crates/wcore-config/src/context_window.rs
+++ b/crates/wcore-config/src/context_window.rs
@@ -22,7 +22,7 @@
 //! cannot call the kernel: protocol transports the computed integer percent as
 //! an opaque serde number, matching the observability crate's decoupling.
 
-use crate::limits::model_output_ceiling;
+use crate::limits::{flux_tier_context_window, model_output_ceiling};
 
 /// One turn's assembled-tokens-over-active-window view.
 ///
@@ -45,13 +45,22 @@ impl ContextWindow {
     /// fed to `size_output_cap`). A KNOWN model's real window
     /// ([`model_output_ceiling`]`.1`) ALWAYS wins — this is the #255 root-cause
     /// fix: a swapped-in gpt-4o (128k) must not be measured against a stale
-    /// 200k default. `config_window` is a fail-open fallback used ONLY when the
+    /// 200k default. A Flux tier alias (`flux-auto` / `flux-fast` /
+    /// `flux-standard` / `flux-reasoning`) resolves to the conservative
+    /// 128k pool-minimum floor ([`flux_tier_context_window`], CORE-4) and,
+    /// like a known model, beats `config_window` — a 200k config default over
+    /// a tier that can route to a 128k backend is exactly the wedge where
+    /// compaction never fired and a session grew to 17M cumulative input
+    /// (callers that receive the real served-model window from Flux, #282,
+    /// override this struct's `window` directly and still win).
+    /// `config_window` is a fail-open fallback used ONLY when the
     /// model is unknown AND the user supplied a positive override (their TOML
     /// `context_window`); when both are absent the window is `None` and no
     /// denominator is fabricated.
     pub fn resolve(used_tokens: u64, provider: &str, model: &str, config_window: u64) -> Self {
         let window = model_output_ceiling(provider, model)
             .map(|(_, ctx)| ctx as u64)
+            .or_else(|| flux_tier_context_window(model).map(u64::from))
             .or(if config_window > 0 {
                 Some(config_window)
             } else {
@@ -108,17 +117,55 @@ mod tests {
 
     #[test]
     fn resolve_unknown_model_falls_back_to_config() {
-        // flux-auto is unlisted -> fail open to the user/config value, NOT a
-        // hardcoded 200k inside the kernel.
-        let ctx = ContextWindow::resolve(1_000, "flux-router", "flux-auto", 200_000);
+        // A genuinely unknown model -> fail open to the user/config value, NOT
+        // a hardcoded 200k inside the kernel. (flux-auto no longer qualifies:
+        // the tier aliases resolve to the CORE-4 floor, tested below.)
+        let ctx = ContextWindow::resolve(1_000, "some-provider", "mystery-model", 200_000);
         assert_eq!(ctx.window, Some(200_000));
     }
 
     #[test]
     fn resolve_unknown_model_and_zero_config_is_none() {
         // No real window and no positive config -> no fabricated denominator.
-        let ctx = ContextWindow::resolve(1_000, "flux-router", "flux-auto", 0);
+        let ctx = ContextWindow::resolve(1_000, "some-provider", "mystery-model", 0);
         assert_eq!(ctx.window, None);
+    }
+
+    #[test]
+    fn resolve_flux_tier_aliases_get_conservative_floor() {
+        // CORE-4: every Flux tier alias resolves to the 128k pool-minimum
+        // floor even with NO config fallback — this is the denominator the
+        // smart-compact trigger divides by, so compaction now fires
+        // proactively instead of the session growing until
+        // `finish_reason: length` (customer hit 17M cumulative input).
+        for alias in ["flux-auto", "flux-fast", "flux-standard", "flux-reasoning"] {
+            let ctx = ContextWindow::resolve(1_000, "flux-router", alias, 0);
+            assert_eq!(
+                ctx.window,
+                Some(128_000),
+                "{alias} must resolve the conservative 128k floor"
+            );
+        }
+        // Provider-independent: the customer-log path reaches Flux through the
+        // plain `openai` provider key.
+        let ctx = ContextWindow::resolve(1_000, "openai", "flux-auto", 0);
+        assert_eq!(ctx.window, Some(128_000));
+        // Case-insensitive, like every other model match in limits.rs.
+        let ctx = ContextWindow::resolve(1_000, "flux-router", "Flux-Auto", 0);
+        assert_eq!(ctx.window, Some(128_000));
+    }
+
+    #[test]
+    fn flux_tier_floor_beats_larger_config_window() {
+        // The wedge scenario: a 200k config default over a tier alias that can
+        // route to a 128k backend meant `used/200k` never crossed the trigger.
+        // The conservative floor must win over config, exactly like a known
+        // model's real window does (#255 doctrine).
+        let ctx = ContextWindow::resolve(96_000, "openai", "flux-auto", 200_000);
+        assert_eq!(ctx.window, Some(128_000));
+        // 96k/128k = 0.75 -> above the smart-compact trigger band (0.60-0.70);
+        // against the stale 200k it was 0.48 and never fired.
+        assert_eq!(ctx.percent(), Some(75));
     }
 
     #[test]

--- a/crates/wcore-config/src/limits.rs
+++ b/crates/wcore-config/src/limits.rs
@@ -191,6 +191,43 @@ pub fn model_output_ceiling(_provider: &str, model: &str) -> Option<(u32, u32)> 
     None
 }
 
+/// CORE-4 — conservative CONTEXT-WINDOW floor for the four Flux Router tier
+/// aliases (`flux-auto` / `flux-fast` / `flux-standard` / `flux-reasoning`).
+///
+/// Deliberately a SEPARATE table from [`model_output_ceiling`]: the tier
+/// aliases must stay UNKNOWN to that lookup so the engine's output sizing
+/// keeps its router-alias behavior — `size_output_cap` clamps to the
+/// conservative unknown floor (8192 / 32768 reasoning, #426) and
+/// `should_omit_max_tokens` keeps omitting the wire max-tokens field on the
+/// omit-safe Flux preset (#112), letting the SERVED model's natural output
+/// ceiling apply. Listing the aliases in `model_output_ceiling` would silently
+/// revoke both contracts.
+///
+/// What compaction needs is only the INPUT denominator. Flux routes a tier
+/// alias to varying backends per request, so the only safe pre-route window is
+/// the MINIMUM across each tier's realistic pool. No authoritative per-tier
+/// pool manifest exists in this repo, so all four tiers use 128,000 — the safe
+/// common denominator: the pools include 128k-class backends (gpt-4o = 128_000,
+/// grok-3 = 131_072, the gpt-5.x chat tiers = 128_000), and every other
+/// realistic member is larger. Erring LOW is safe here (compaction fires a
+/// little early); erring high is the customer-reported wedge — with no window
+/// the smart-compact trigger never fired and one session grew to 17M cumulative
+/// input before dying at `finish_reason: length`.
+///
+/// Once Flux signals the real served-model window back (`x-flux-model-window`,
+/// #282), the engine prefers THAT over this floor — this value only governs
+/// turns before the first signal (or routes that never send one).
+///
+/// Matched case-insensitively against the four documented aliases, same set as
+/// `wcore_providers::is_flux_tier_alias` (which lives downstream of this crate
+/// and so cannot be called from here).
+pub fn flux_tier_context_window(model: &str) -> Option<u32> {
+    match model.to_ascii_lowercase().as_str() {
+        "flux-auto" | "flux-fast" | "flux-standard" | "flux-reasoning" => Some(128_000),
+        _ => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -379,10 +416,39 @@ mod tests {
 
     #[test]
     fn unknown_and_router_aliases_return_none() {
-        assert_eq!(model_output_ceiling("flux-router", "flux-auto"), None);
-        assert_eq!(model_output_ceiling("flux-router", "flux-standard"), None);
+        // LOAD-BEARING for CORE-4: the Flux tier aliases must stay UNKNOWN to
+        // this OUTPUT-sizing lookup even though they now have a context-window
+        // floor in `flux_tier_context_window` — a Some() here would make
+        // `size_output_cap` clamp Flux output to a fixed ceiling and flip
+        // `should_omit_max_tokens` off (#112/#426 router-alias contracts).
+        for alias in ["flux-auto", "flux-fast", "flux-standard", "flux-reasoning"] {
+            assert_eq!(model_output_ceiling("flux-router", alias), None);
+        }
         assert_eq!(model_output_ceiling("openai", "some-future-model"), None);
         assert_eq!(model_output_ceiling("ollama", "llama3.1"), None);
+    }
+
+    #[test]
+    fn flux_tier_aliases_resolve_conservative_context_window() {
+        // CORE-4: all four tier aliases carry the 128k pool-minimum window so
+        // the compaction kernel gets a real denominator (customer evidence:
+        // with None the smart trigger never fired and a session wedged at
+        // finish_reason=length after 17M cumulative input tokens).
+        for alias in ["flux-auto", "flux-fast", "flux-standard", "flux-reasoning"] {
+            assert_eq!(
+                flux_tier_context_window(alias),
+                Some(128_000),
+                "{alias} must resolve the conservative 128k floor"
+            );
+        }
+        // Case-insensitive, consistent with model_output_ceiling.
+        assert_eq!(flux_tier_context_window("Flux-Reasoning"), Some(128_000));
+        // Concrete model ids and non-flux names stay None — the floor is for
+        // the four documented tier aliases ONLY (a pinned model resolves its
+        // real window via model_output_ceiling).
+        assert_eq!(flux_tier_context_window("flux-pinned-gpt-5"), None);
+        assert_eq!(flux_tier_context_window("gpt-4o"), None);
+        assert_eq!(flux_tier_context_window(""), None);
     }
 
     #[test]

--- a/crates/wcore-pricing/pricing.toml
+++ b/crates/wcore-pricing/pricing.toml
@@ -135,6 +135,52 @@ output_per_mtok_usd = 15.0
 input_per_mtok_usd = 0.0
 output_per_mtok_usd = 0.0
 
+# --- Flux Router tier aliases (CORE-4) ----------------------------------
+# Router-priced, same convention as [openrouter.auto]: the local rate is 0.0
+# because Flux bills per-request on whatever backend it routes to — a real
+# per-model rate here would be confidently wrong. Authoritative per-request
+# cost comes from Flux itself (FerroxLabs/wayland#319); until then a $0 row
+# marks "router-priced" and stops the W7 catalog-miss warning ("unknown model
+# flux-auto for provider openai", 365 occurrences in customer logs) so the
+# engine no longer falls to the heuristic on every Flux turn.
+#
+# Listed under BOTH provider keys Core reaches Flux through: `flux-router`
+# (ProviderCompat::flux_router_defaults() provider_type) and `openai` (Flux
+# configured as a plain OpenAI-compatible endpoint — the key the customer-log
+# misses fired with). `flux-*` are not real OpenAI model ids, so the openai
+# rows can never shadow a genuine OpenAI price.
+[flux-router.flux-auto]
+input_per_mtok_usd = 0.0
+output_per_mtok_usd = 0.0
+
+[flux-router.flux-fast]
+input_per_mtok_usd = 0.0
+output_per_mtok_usd = 0.0
+
+[flux-router.flux-standard]
+input_per_mtok_usd = 0.0
+output_per_mtok_usd = 0.0
+
+[flux-router.flux-reasoning]
+input_per_mtok_usd = 0.0
+output_per_mtok_usd = 0.0
+
+[openai.flux-auto]
+input_per_mtok_usd = 0.0
+output_per_mtok_usd = 0.0
+
+[openai.flux-fast]
+input_per_mtok_usd = 0.0
+output_per_mtok_usd = 0.0
+
+[openai.flux-standard]
+input_per_mtok_usd = 0.0
+output_per_mtok_usd = 0.0
+
+[openai.flux-reasoning]
+input_per_mtok_usd = 0.0
+output_per_mtok_usd = 0.0
+
 # Fix(pricing-audit-2026-05-24): bedrock/vertex claude-opus-4-7 corrected from $15/$75 → $5/$25.
 [bedrock.claude-opus-4-7]
 input_per_mtok_usd = 5.0

--- a/crates/wcore-pricing/src/lib.rs
+++ b/crates/wcore-pricing/src/lib.rs
@@ -392,6 +392,36 @@ output_per_mtok_usd = 15.0
         ));
     }
 
+    /// CORE-4: the four Flux tier aliases must be IN the bundled catalog under
+    /// both provider keys Core reaches Flux through (`flux-router` and plain
+    /// `openai`), priced $0 = "router-priced" (the [openrouter.auto]
+    /// convention). This is what stops the W7 catalog-miss warning ("unknown
+    /// model flux-auto for provider openai" — 365 occurrences in customer
+    /// logs) from firing on every Flux turn.
+    #[test]
+    fn flux_tier_aliases_priced_in_bundled_catalog() {
+        let cat = PricingCatalog::load_default().expect("bundled catalog parses");
+        for provider in ["flux-router", "openai"] {
+            for alias in ["flux-auto", "flux-fast", "flux-standard", "flux-reasoning"] {
+                let p = cat.get(provider, alias).unwrap_or_else(|e| {
+                    panic!("{provider}/{alias} must be in the bundled catalog: {e}")
+                });
+                assert_eq!(
+                    p.input_per_mtok_usd, 0.0,
+                    "{provider}/{alias} is router-priced: local rate must be $0"
+                );
+                assert_eq!(p.output_per_mtok_usd, 0.0);
+                // And the cost path resolves (Ok(0)) instead of erroring into
+                // the heuristic fallback.
+                assert_eq!(
+                    cat.estimate_cost_microcents(provider, alias, 1_000_000, 1_000_000)
+                        .expect("tier alias must price"),
+                    0
+                );
+            }
+        }
+    }
+
     #[test]
     fn flux_pinned_native_maps_vendor_to_catalog_provider() {
         // Vendor token → catalog provider; the FULL remainder is the native id.

--- a/crates/wcore-protocol/src/events.rs
+++ b/crates/wcore-protocol/src/events.rs
@@ -81,6 +81,13 @@ pub enum ProtocolEvent {
         finish_reason: FinishReason,
         #[serde(skip_serializing_if = "Option::is_none")]
         usage: Option<Usage>,
+        /// CORE-2: per-run usage delta — the tokens consumed by THIS run only
+        /// (summing every provider round-trip of the run's tool loop), while
+        /// `usage` stays session-cumulative for back-compat. Same inner field
+        /// names as `usage`. None on synthetic stream-ends and on paths that
+        /// don't track a run-scoped delta.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        usage_delta: Option<Usage>,
         /// #279(c): stable per-run correlation handle grouping every event of
         /// one agent run (survives multi-message / --resume). None on synthetic
         /// stream-ends (slash/exit/stop) that aren't a model run.
@@ -917,6 +924,7 @@ mod tests {
                 cache_write_tokens: None,
                 active_window_percent: None,
             }),
+            usage_delta: None,
             agent_run_id: None,
         };
         let json = serde_json::to_value(&event).unwrap();
@@ -924,6 +932,41 @@ mod tests {
         assert_eq!(json["finish_reason"], "stop");
         assert_eq!(json["usage"]["input_tokens"], 100);
         assert!(json["usage"].get("cache_write_tokens").is_none());
+        // CORE-2 back-compat: a None delta must not appear on the wire.
+        assert!(json.get("usage_delta").is_none());
+    }
+
+    #[test]
+    fn test_stream_end_usage_delta_is_sibling_with_same_field_names() {
+        // CORE-2: the per-run delta rides as a SIBLING of the cumulative
+        // usage, with the same inner field names.
+        let event = ProtocolEvent::StreamEnd {
+            msg_id: "m1".to_string(),
+            finish_reason: FinishReason::Stop,
+            usage: Some(Usage {
+                input_tokens: 300,
+                output_tokens: 30,
+                cache_read_tokens: Some(20),
+                cache_write_tokens: None,
+                active_window_percent: Some(42),
+            }),
+            usage_delta: Some(Usage {
+                input_tokens: 200,
+                output_tokens: 20,
+                cache_read_tokens: Some(15),
+                cache_write_tokens: Some(5),
+                active_window_percent: None,
+            }),
+            agent_run_id: None,
+        };
+        let json = serde_json::to_value(&event).unwrap();
+        assert_eq!(json["usage"]["input_tokens"], 300);
+        assert_eq!(json["usage_delta"]["input_tokens"], 200);
+        assert_eq!(json["usage_delta"]["output_tokens"], 20);
+        assert_eq!(json["usage_delta"]["cache_read_tokens"], 15);
+        assert_eq!(json["usage_delta"]["cache_write_tokens"], 5);
+        // The window gauge is a session-level reading; it stays on `usage`.
+        assert!(json["usage_delta"].get("active_window_percent").is_none());
     }
 
     #[test]
@@ -940,6 +983,7 @@ mod tests {
                 msg_id: "m1".to_string(),
                 finish_reason: variant,
                 usage: None,
+                usage_delta: None,
                 agent_run_id: None,
             };
             let json = serde_json::to_value(&event).unwrap();
@@ -954,6 +998,7 @@ mod tests {
             msg_id: "m1".to_string(),
             finish_reason: FinishReason::Length,
             usage: None,
+            usage_delta: None,
             agent_run_id: None,
         };
         let json = serde_json::to_value(&event).unwrap();

--- a/crates/wcore-protocol/tests/golden_v0_1_21.rs
+++ b/crates/wcore-protocol/tests/golden_v0_1_21.rs
@@ -111,6 +111,7 @@ fn golden_stream_end_stop_v0_1_21() {
             cache_write_tokens: None,
             active_window_percent: None,
         }),
+        usage_delta: None,
         agent_run_id: None,
     };
     assert_eq!(
@@ -134,6 +135,7 @@ fn golden_stream_end_length_v0_1_21() {
         msg_id: "m-1".into(),
         finish_reason: FinishReason::Length,
         usage: None,
+        usage_delta: None,
         agent_run_id: None,
     };
     assert_eq!(
@@ -154,6 +156,7 @@ fn golden_stream_end_error_v0_1_21() {
         msg_id: "m-1".into(),
         finish_reason: FinishReason::Error,
         usage: None,
+        usage_delta: None,
         agent_run_id: None,
     };
     assert_eq!(
@@ -182,6 +185,7 @@ fn golden_stream_end_every_finish_reason_serializes_snake_case() {
             msg_id: "m".into(),
             finish_reason: fr,
             usage: None,
+            usage_delta: None,
             agent_run_id: None,
         };
         let got = serialize(&event);
@@ -207,6 +211,7 @@ fn golden_usage_with_full_cache_fields_v0_1_21() {
             cache_write_tokens: Some(200),
             active_window_percent: None,
         }),
+        usage_delta: None,
         agent_run_id: None,
     };
     assert_eq!(
@@ -237,6 +242,7 @@ fn golden_stream_end_no_new_keys_when_unset_279() {
             cache_write_tokens: Some(200),
             active_window_percent: None,
         }),
+        usage_delta: None,
         agent_run_id: None,
     };
     assert_eq!(
@@ -268,6 +274,7 @@ fn golden_stream_end_with_new_keys_when_set_279() {
             cache_write_tokens: None,
             active_window_percent: Some(73),
         }),
+        usage_delta: None,
         agent_run_id: Some("agent-run-abc".into()),
     };
     assert_eq!(

--- a/crates/wcore-providers/src/openai.rs
+++ b/crates/wcore-providers/src/openai.rs
@@ -788,7 +788,7 @@ impl OpenAIProvider {
         // can 400 on unknown fields.
         if is_flux_tier_alias(&request.model)
             && let Some(id) = request.conversation_id.as_deref()
-            && !id.is_empty()
+            && !id.trim().is_empty()
         {
             body["prompt_cache_key"] = json!(id);
         }
@@ -3358,6 +3358,11 @@ mod tests {
         assert!(body.get("prompt_cache_key").is_none());
 
         req.conversation_id = Some(String::new());
+        let body = stop_provider().build_request_body(&req);
+        assert!(body.get("prompt_cache_key").is_none());
+
+        // Whitespace-only ids are degenerate cache keys too (GLM-5.2 audit).
+        req.conversation_id = Some("   ".into());
         let body = stop_provider().build_request_body(&req);
         assert!(body.get("prompt_cache_key").is_none());
     }

--- a/crates/wcore-providers/src/openai.rs
+++ b/crates/wcore-providers/src/openai.rs
@@ -777,6 +777,22 @@ impl OpenAIProvider {
             body["tools"] = json!(Self::build_tools(&request.tools));
         }
 
+        // Flux sticky-session / prefix-cache key. On a Flux tier alias the
+        // conversation id doubles as the OpenAI `prompt_cache_key`: the router
+        // uses it to pin the whole conversation to one backend (a mid-session
+        // backend hop is a cold cache pool, re-billing the full prefix at full
+        // price), and OpenAI-compatible upstreams use it as their documented
+        // cache-routing hint. Gated exactly like the x-wl-* context headers: a
+        // concrete model id (or an absent conversation_id) keeps the body
+        // byte-identical to today, since generic OpenAI-compatible endpoints
+        // can 400 on unknown fields.
+        if is_flux_tier_alias(&request.model)
+            && let Some(id) = request.conversation_id.as_deref()
+            && !id.is_empty()
+        {
+            body["prompt_cache_key"] = json!(id);
+        }
+
         // Gate `reasoning_effort` on the model family. gpt-4o (and other
         // classic chat families) 400 on the field; only o1*/o3*/gpt-5*
         // accept it. This MUST stay per-request: one OpenAIProvider serves
@@ -3303,6 +3319,47 @@ mod tests {
             json!(["\n\nLet me know if", "\n\nFeel free to"]),
             "OpenAI must emit stops under the `stop` key as an array"
         );
+    }
+
+    // --- SPEC-V2 CORE-1: Flux sticky-session prompt_cache_key -------------
+
+    /// On a Flux tier alias with a conversation id, the body carries
+    /// `prompt_cache_key = conversation_id` so the router can pin the
+    /// conversation to one backend (cache affinity) and OpenAI-compatible
+    /// upstreams get their cache-routing hint.
+    #[test]
+    fn build_request_body_stamps_prompt_cache_key_on_tier_alias() {
+        let mut req = stop_req();
+        req.model = "flux-auto".into();
+        req.conversation_id = Some("conv-abc".into());
+        let body = stop_provider().build_request_body(&req);
+        assert_eq!(body["prompt_cache_key"], json!("conv-abc"));
+    }
+
+    /// A concrete model id opts OUT: the body must stay byte-identical to
+    /// today (generic OpenAI-compatible endpoints can 400 on unknown fields).
+    #[test]
+    fn build_request_body_no_prompt_cache_key_for_concrete_model() {
+        let mut req = stop_req();
+        req.model = "gpt-4o".into();
+        req.conversation_id = Some("conv-abc".into());
+        let body = stop_provider().build_request_body(&req);
+        assert!(body.get("prompt_cache_key").is_none());
+    }
+
+    /// Absent (or empty) conversation_id skips the field entirely — never
+    /// emit an empty cache key.
+    #[test]
+    fn build_request_body_no_prompt_cache_key_without_conversation_id() {
+        let mut req = stop_req();
+        req.model = "flux-auto".into();
+        req.conversation_id = None;
+        let body = stop_provider().build_request_body(&req);
+        assert!(body.get("prompt_cache_key").is_none());
+
+        req.conversation_id = Some(String::new());
+        let body = stop_provider().build_request_body(&req);
+        assert!(body.get("prompt_cache_key").is_none());
     }
 
     // --- Crucible #3: per-tier temperature emission -----------------------


### PR DESCRIPTION
Token-efficiency phase 1 for Wayland Core: prompt_cache_key stamping on Flux-routed requests, per-run usage_delta emission, flux-* tier catalog entries, and length-wedge + clean-retry gates.

## Per-commit audit trail

- e759da07 — CORE-1 (prompt_cache_key stamping). Codex audit: GLM whitespace finding FIXED at da29e1e2; prefix-match and model-rewrite findings REFUTED — is_flux_tier_alias is exact-match with a covering test, and no model rewrite occurs after the stamp.
- c40b6b13 + bfc379af — CORE-2 per-run usage_delta. Audited; fixes applied.
- 5369b4de — CORE-4 flux-* catalog entries. Context-window floors verified against real tier pools; the 128k floor stands.
- 113a995e + df1d9595 — CORE-5 length-wedge + clean-retry gates. Sha256 request_wire_fingerprint covers the full wire request. Gemini adversarial audit: GO. 2170 tests passing.

Pairs with the desktop cost-meter usage_delta consumer (FerroxLabs/wayland) landing separately.
