### PR TITLE
feat(tools): deterministic ordering, cold-tool deferral + catalog fold, hydration admission, cache-health telemetry (-86.2% tools bytes)

### DIFF
--- a/crates/wcore-agent/src/bootstrap.rs
+++ b/crates/wcore-agent/src/bootstrap.rs
@@ -2042,7 +2042,17 @@ impl AgentBootstrap {
             self.config.advertised_capabilities.online_evolution = true;
         }
 
-        let tool_defs_snapshot = registry.to_tool_defs();
+        let mut tool_defs_snapshot = registry.to_tool_defs();
+        // Layer D1 (token-opt): mark cold tools deferred in the snapshot so
+        // ToolSearch can find and hydrate them — it only searches defs with
+        // `deferred == true`. Same pure config-driven split the engine
+        // applies to every outbound tools[] array.
+        if self.config.builtin_tools.defer_cold.enabled {
+            wcore_tools::registry::apply_cold_deferral(
+                &mut tool_defs_snapshot,
+                &self.config.builtin_tools.defer_cold.hot_allowlist,
+            );
+        }
         registry.register(Box::new(wcore_tools::tool_search::ToolSearchTool::new(
             tool_defs_snapshot,
         )));

--- a/crates/wcore-agent/src/cache_diagnostics.rs
+++ b/crates/wcore-agent/src/cache_diagnostics.rs
@@ -46,6 +46,31 @@ pub enum CacheBreakCause {
     FirstRequest,
 }
 
+/// Layer E1 — warm-session cache-health warn threshold: a warm round-trip
+/// whose `cache_read / input` ratio falls below this fires a
+/// `cache_health_warn` telemetry event.
+pub const CACHE_HEALTH_WARN_RATIO: f64 = 0.3;
+
+/// Layer E1 — a session counts as "warm" strictly AFTER this many
+/// round-trips have completed (the prefix has had two chances to be
+/// written to the provider cache).
+pub const CACHE_HEALTH_WARM_AFTER_ROUND_TRIPS: u64 = 2;
+
+/// Layer E1 — a warm round-trip whose cache hit-ratio fell below
+/// [`CACHE_HEALTH_WARN_RATIO`]. Detection-side fields only; the engine
+/// wraps this in the wire-shaped
+/// `wcore_providers::cache_observation::CacheHealthWarn` (adding
+/// conversation_id + routed model) before emitting.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CacheHealthAlert {
+    /// 1-based round-trip index within the conversation.
+    pub round_trip: u64,
+    pub input_tokens: u64,
+    pub cache_read_tokens: u64,
+    /// `cache_read_tokens / input_tokens`.
+    pub ratio: f64,
+}
+
 /// Detects prompt cache breaks by comparing consecutive turns.
 pub struct CacheBreakDetector {
     /// Snapshot from the PREVIOUS turn (used for attribution on cache break).
@@ -54,6 +79,16 @@ pub struct CacheBreakDetector {
     current_snapshot: Option<PromptSnapshot>,
     /// Cache stats from the previous API response.
     prev_stats: Option<CacheStats>,
+    /// Layer E1 — completed round-trips (responses seen via
+    /// [`check_response`]). Drives the warm-session gate for
+    /// [`check_cache_health`].
+    round_trips: u64,
+    /// Layer E1 — whether ANY response in this session ever reported cache
+    /// tokens (read or creation). Providers with no prompt-cache support
+    /// report all-zeros forever; without this gate they would fire a
+    /// `cache_health_warn` on every warm turn (mirrors the
+    /// `openai_no_false_alarm` guard in [`Self::compute_diagnostic`]).
+    seen_cache_tokens: bool,
 }
 
 impl CacheBreakDetector {
@@ -62,6 +97,8 @@ impl CacheBreakDetector {
             prev_snapshot: None,
             current_snapshot: None,
             prev_stats: None,
+            round_trips: 0,
+            seen_cache_tokens: false,
         }
     }
 
@@ -95,8 +132,43 @@ impl CacheBreakDetector {
     pub fn check_response(&mut self, stats: CacheStats) -> Option<CacheDiagnostic> {
         let current = self.current_snapshot.as_ref()?;
         let diagnostic = self.compute_diagnostic(current, &stats);
+        // Layer E1 — track warmth for check_cache_health.
+        self.round_trips += 1;
+        if stats.cache_read_tokens > 0 || stats.cache_creation_tokens > 0 {
+            self.seen_cache_tokens = true;
+        }
         self.prev_stats = Some(stats);
         Some(diagnostic)
+    }
+
+    /// Layer E1 — warm-session cache-health probe. Call AFTER
+    /// [`check_response`] for the same turn (so `round_trips` includes the
+    /// turn being probed). Returns `Some` when the session is warm (more
+    /// than [`CACHE_HEALTH_WARM_AFTER_ROUND_TRIPS`] round-trips), the
+    /// provider has demonstrated prompt-cache support at least once, and
+    /// this turn's `cache_read / input` ratio fell below
+    /// [`CACHE_HEALTH_WARN_RATIO`]. Warning-only telemetry — callers must
+    /// never alter the request based on it.
+    pub fn check_cache_health(&self, stats: &CacheStats) -> Option<CacheHealthAlert> {
+        if self.round_trips <= CACHE_HEALTH_WARM_AFTER_ROUND_TRIPS {
+            return None;
+        }
+        if !self.seen_cache_tokens {
+            return None;
+        }
+        if stats.input_tokens == 0 {
+            return None;
+        }
+        let ratio = stats.cache_read_tokens as f64 / stats.input_tokens as f64;
+        if ratio >= CACHE_HEALTH_WARN_RATIO {
+            return None;
+        }
+        Some(CacheHealthAlert {
+            round_trip: self.round_trips,
+            input_tokens: stats.input_tokens,
+            cache_read_tokens: stats.cache_read_tokens,
+            ratio,
+        })
     }
 
     fn compute_diagnostic(&self, current: &PromptSnapshot, stats: &CacheStats) -> CacheDiagnostic {
@@ -390,6 +462,138 @@ mod tests {
 
         // Should be Healthy, not FullMiss
         assert!(matches!(diag, CacheDiagnostic::Healthy { .. }));
+    }
+
+    // --- Layer E1: check_cache_health ---
+
+    /// Drive one round-trip through the detector and return the health probe
+    /// for that same turn (mirrors the engine call order: record_request →
+    /// check_response → check_cache_health).
+    fn round_trip(detector: &mut CacheBreakDetector, stats: CacheStats) -> Option<CacheHealthAlert> {
+        detector.record_request("prompt", &make_tools());
+        detector.check_response(stats.clone());
+        detector.check_cache_health(&stats)
+    }
+
+    #[test]
+    fn warm_session_low_cache_read_fires_health_warn() {
+        let mut detector = CacheBreakDetector::new();
+
+        // Turn 1: cold — prefix written to cache. Turn 2: still inside the
+        // warm-up window. Neither may warn.
+        assert!(
+            round_trip(
+                &mut detector,
+                CacheStats {
+                    input_tokens: 10_000,
+                    cache_read_tokens: 0,
+                    cache_creation_tokens: 9_000,
+                }
+            )
+            .is_none(),
+            "turn 1 (cold) must not warn"
+        );
+        assert!(
+            round_trip(
+                &mut detector,
+                CacheStats {
+                    input_tokens: 10_000,
+                    cache_read_tokens: 128,
+                    cache_creation_tokens: 0,
+                }
+            )
+            .is_none(),
+            "turn 2 (warm-up window) must not warn"
+        );
+
+        // Turn 3: warm session, cache_read stuck at 128 on a 15k input —
+        // the exact 128-flat signature. Must warn.
+        let alert = round_trip(
+            &mut detector,
+            CacheStats {
+                input_tokens: 15_000,
+                cache_read_tokens: 128,
+                cache_creation_tokens: 0,
+            },
+        )
+        .expect("warm turn with dead cache must fire cache_health_warn");
+        assert_eq!(alert.round_trip, 3);
+        assert_eq!(alert.input_tokens, 15_000);
+        assert_eq!(alert.cache_read_tokens, 128);
+        assert!(alert.ratio < CACHE_HEALTH_WARN_RATIO);
+    }
+
+    #[test]
+    fn warm_session_healthy_ratio_does_not_warn() {
+        let mut detector = CacheBreakDetector::new();
+        for _ in 0..2 {
+            round_trip(
+                &mut detector,
+                CacheStats {
+                    input_tokens: 10_000,
+                    cache_read_tokens: 8_000,
+                    cache_creation_tokens: 2_000,
+                },
+            );
+        }
+        // Turn 3: ratio 0.8 >= 0.3 — healthy, no warn.
+        assert!(
+            round_trip(
+                &mut detector,
+                CacheStats {
+                    input_tokens: 10_000,
+                    cache_read_tokens: 8_000,
+                    cache_creation_tokens: 0,
+                }
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn provider_without_cache_support_never_warns() {
+        // A provider that never reports cache tokens (all zeros forever) is
+        // indistinguishable from "no prompt-cache support" — suppress, same
+        // as the openai_no_false_alarm diagnostic guard.
+        let mut detector = CacheBreakDetector::new();
+        for turn in 0..4 {
+            let alert = round_trip(
+                &mut detector,
+                CacheStats {
+                    input_tokens: 10_000,
+                    cache_read_tokens: 0,
+                    cache_creation_tokens: 0,
+                },
+            );
+            assert!(alert.is_none(), "turn {turn} must not warn");
+        }
+    }
+
+    #[test]
+    fn zero_input_tokens_does_not_warn() {
+        let mut detector = CacheBreakDetector::new();
+        for _ in 0..3 {
+            round_trip(
+                &mut detector,
+                CacheStats {
+                    input_tokens: 10_000,
+                    cache_read_tokens: 5_000,
+                    cache_creation_tokens: 0,
+                },
+            );
+        }
+        assert!(
+            round_trip(
+                &mut detector,
+                CacheStats {
+                    input_tokens: 0,
+                    cache_read_tokens: 0,
+                    cache_creation_tokens: 0,
+                }
+            )
+            .is_none(),
+            "zero-input turn cannot produce a meaningful ratio"
+        );
     }
 
     #[test]

--- a/crates/wcore-agent/src/cache_diagnostics.rs
+++ b/crates/wcore-agent/src/cache_diagnostics.rs
@@ -469,7 +469,10 @@ mod tests {
     /// Drive one round-trip through the detector and return the health probe
     /// for that same turn (mirrors the engine call order: record_request →
     /// check_response → check_cache_health).
-    fn round_trip(detector: &mut CacheBreakDetector, stats: CacheStats) -> Option<CacheHealthAlert> {
+    fn round_trip(
+        detector: &mut CacheBreakDetector,
+        stats: CacheStats,
+    ) -> Option<CacheHealthAlert> {
         detector.record_request("prompt", &make_tools());
         detector.check_response(stats.clone());
         detector.check_cache_health(&stats)

--- a/crates/wcore-agent/src/engine.rs
+++ b/crates/wcore-agent/src/engine.rs
@@ -194,6 +194,14 @@ const MIN_THINKING_BUDGET: u32 = 1_024;
 /// auto-continue loop as the net for longer outputs.
 const UNKNOWN_REASONING_CAP: u32 = 32_768;
 
+/// Layer D1 follow-up (hydrated-tool admission) — hard bound on remembered
+/// ToolSearch hydrations (`AgentEngine::hydrated_tool_names`). Keeps the set
+/// (and the per-turn admission/exemption scans over it) O(1)-bounded on a
+/// long session with many broad ToolSearch queries; overflow evicts the
+/// OLDEST hydration. Sized to comfortably exceed a provider's realistic MCP
+/// slot budget (OpenAI hard cap = 128 total tools minus ~40 built-ins).
+const HYDRATED_TOOLS_CAP: usize = 64;
+
 /// #426 — shrink a requested reasoning budget so the visible answer can never be
 /// starved: the budget may use at most `max_tokens - MIN_VISIBLE_OUTPUT`. Returns
 /// the budget to actually send (0 when no room remains; the caller drops thinking
@@ -4707,24 +4715,15 @@ impl AgentEngine {
             let tools = self.apply_provider_tool_cap(tools);
 
             // Layer D1 (token-opt): defer cold tools to name-only stubs —
-            // only the configured hot allowlist ships full schemas; the
-            // model hydrates a stub on demand via ToolSearch (the system
-            // prompt states that rule once, `tool_usage_guidance`).
-            // CRITICAL: the hot/stub split is a pure function of static
-            // config, never per-turn state, so the serialized tools[] array
-            // stays byte-identical across turns (cache guard:
-            // `tools_array_byte_stable_across_roundtrips`).
-            let tools = {
-                let mut tools = tools;
-                let defer_cfg = &self.config.builtin_tools.defer_cold;
-                if defer_cfg.enabled {
-                    wcore_tools::registry::apply_cold_deferral(
-                        &mut tools,
-                        &defer_cfg.hot_allowlist,
-                    );
-                }
-                tools
-            };
+            // only the configured hot allowlist (plus ToolSearch-hydrated
+            // tools) ships full schemas; the model hydrates a stub on demand
+            // via ToolSearch (the system prompt states that rule once,
+            // `tool_usage_guidance`). The hot/stub split is a pure function
+            // of static config + the monotonic hydrated set, so the
+            // serialized tools[] array stays byte-identical across turns
+            // (cache guard: `tools_array_byte_stable_across_roundtrips`);
+            // a hydration changes it once.
+            let tools = self.apply_tool_deferral(tools);
 
             // Build system prompt: append plan mode instructions when active
             let system = if self.plan_state.is_active {
@@ -8729,10 +8728,12 @@ impl AgentEngine {
         // the provider cap below to admit it into the outbound tools[].
         // Cache-safe: appended at the END, once (the hydrated list only
         // grows), a legitimate one-turn miss that is stable afterwards.
+        let curation_mcp_names: std::collections::HashSet<&str> =
+            mcp_tools.iter().map(|t| t.name.as_str()).collect();
         let hydrated_mcp: Vec<String> = self
             .hydrated_tool_names
             .iter()
-            .filter(|n| mcp_tools.iter().any(|t| &t.name == *n))
+            .filter(|n| curation_mcp_names.contains(n.as_str()))
             .cloned()
             .collect();
         if let Some((_, order)) = self.mcp_curation_cache.as_mut() {
@@ -8891,47 +8892,67 @@ impl AgentEngine {
         // hydrated via ToolSearch must be genuinely callable — providers
         // validate tool calls against the CURRENT tools[] array, so a
         // hydrated-but-trimmed MCP tool would be learnable yet uncallable.
+        //
+        // Stale hydrations are pruned first: a hydrated tool whose MCP
+        // server disconnected is gone from the LIVE registry. The check is
+        // against the registry — NOT the per-turn filtered list — so
+        // plan-mode category filtering or cap trimming never misclassifies
+        // a live tool as stale.
+        self.prune_stale_hydrated_tools();
+        //
         // Force-admit hydrated MCP names: appended at the END while budget
         // remains (a cache-safe append); when the union is FULL, the LAST
         // non-hydrated slot is evicted to make room (hydration is a stronger
         // relevance signal than the BM25 guess that admitted that slot).
-        // Either way the change lands once — a legitimate one-turn cache
-        // miss — and the set is stable afterwards because
-        // `hydrated_tool_names` only grows.
-        let hydrated_all: std::collections::HashSet<&str> = self
-            .hydrated_tool_names
-            .iter()
-            .map(String::as_str)
-            .collect();
+        // When EVERY kept slot is itself hydrated, the OLDEST hydrated slot
+        // (front-most in the union) is evicted AND demoted from the hydrated
+        // set — without the demotion it would force itself back next turn
+        // and the two tools would thrash the array forever. Each change
+        // lands once — a legitimate one-turn cache miss — and the set is
+        // stable afterwards.
+        let mut hydrated_all: std::collections::HashSet<String> =
+            self.hydrated_tool_names.iter().cloned().collect();
+        let mcp_names: std::collections::HashSet<&str> =
+            mcp_tools.iter().map(|t| t.name.as_str()).collect();
         let hydrated_mcp: Vec<String> = self
             .hydrated_tool_names
             .iter()
-            .filter(|n| mcp_tools.iter().any(|t| &t.name == *n))
+            .filter(|n| mcp_names.contains(n.as_str()))
             .cloned()
             .collect();
         let mut evicted: Vec<String> = Vec::new();
+        let mut demoted: Vec<String> = Vec::new();
         if let Some((_, order)) = self.mcp_cap_cache.as_mut() {
             for name in hydrated_mcp {
                 if order.contains(&name) {
                     continue;
                 }
                 if order.len() >= mcp_budget {
-                    match order.iter().rposition(|n| !hydrated_all.contains(n.as_str())) {
-                        Some(idx) => evicted.push(order.remove(idx)),
-                        // Every kept slot is itself hydrated — no eviction
-                        // candidate; the budget genuinely cannot fit this one.
-                        None => continue,
+                    // Last non-hydrated slot first; when all slots are
+                    // hydrated, index 0 = the oldest hydrated slot (LRU).
+                    let idx = order
+                        .iter()
+                        .rposition(|n| !hydrated_all.contains(n))
+                        .unwrap_or(0);
+                    let out = order.remove(idx);
+                    if hydrated_all.remove(&out) {
+                        demoted.push(out.clone());
                     }
+                    evicted.push(out);
                 }
                 order.push(name);
             }
+        }
+        if !demoted.is_empty() {
+            self.hydrated_tool_names.retain(|n| !demoted.contains(n));
         }
         if !evicted.is_empty() {
             tracing::info!(
                 target: "wcore_agent::engine",
                 "provider tool cap: evicted {:?} to admit ToolSearch-hydrated tools \
-                 (one-turn cache miss; set stable afterwards)",
-                evicted
+                 (demoted from hydrated set: {:?}; one-turn cache miss, set stable afterwards)",
+                evicted,
+                demoted
             );
         }
         let keep_order: Vec<String> = self
@@ -8971,7 +8992,8 @@ impl AgentEngine {
     /// Layer D1 follow-up (hydrated-tool admission): parse a successful
     /// `ToolSearch` result body (a JSON array of `{name, description,
     /// parameters}` matches) and record every returned tool name in
-    /// [`Self::hydrated_tool_names`] (FIRST-HYDRATION order, deduped). The
+    /// [`Self::hydrated_tool_names`] (FIRST-HYDRATION order, deduped,
+    /// bounded by [`HYDRATED_TOOLS_CAP`] with evict-oldest). The
     /// curation/cap passes force-include these names in the outbound
     /// `tools[]` on subsequent turns so a hydrated tool is genuinely
     /// callable. A no-match result is a plain string, not JSON — it parses
@@ -8986,9 +9008,81 @@ impl AgentEngine {
             if let Some(name) = m.get("name").and_then(|v| v.as_str())
                 && !self.hydrated_tool_names.iter().any(|n| n == name)
             {
+                if self.hydrated_tool_names.len() >= HYDRATED_TOOLS_CAP {
+                    let dropped = self.hydrated_tool_names.remove(0);
+                    tracing::debug!(
+                        target: "wcore_agent::engine",
+                        "hydrated-tool set at cap ({HYDRATED_TOOLS_CAP}); \
+                         evicting oldest hydration {dropped:?}"
+                    );
+                }
                 self.hydrated_tool_names.push(name.to_string());
             }
         }
+    }
+
+    /// Layer D1 follow-up: drop hydrated names that no longer exist in the
+    /// LIVE tool registry (e.g. their MCP server disconnected after the
+    /// ToolSearch snapshot was taken at bootstrap). Without this, a stale
+    /// hydration would sit in the admission set forever, and — worse — could
+    /// hold a cap slot for a tool that can never dispatch. Checked against
+    /// the registry rather than the per-turn filtered def list, so plan-mode
+    /// category filtering / cap trimming never misclassifies a live tool as
+    /// stale.
+    fn prune_stale_hydrated_tools(&mut self) {
+        if self.hydrated_tool_names.is_empty() {
+            return;
+        }
+        let registry = Arc::clone(&self.tools);
+        let stale: Vec<String> = self
+            .hydrated_tool_names
+            .iter()
+            .filter(|n| registry.get(n).is_none())
+            .cloned()
+            .collect();
+        if stale.is_empty() {
+            return;
+        }
+        tracing::info!(
+            target: "wcore_agent::engine",
+            "dropping stale hydrated tools no longer in the registry \
+             (MCP server disconnected?): {:?}",
+            stale
+        );
+        self.hydrated_tool_names.retain(|n| !stale.contains(n));
+    }
+
+    /// Layer D1 (token-opt): cold-deferral + hydration exemption for the
+    /// outbound tools[]. Cold tools (not on the static hot allowlist)
+    /// serialize as name-only stubs; a tool the model has HYDRATED via
+    /// ToolSearch ships its FULL schema — whether the deferral above stubbed
+    /// it or it is natively deferred (`Tool::is_deferred`, e.g. MCP proxies)
+    /// — because hydration means the model explicitly fetched the schema and
+    /// is about to call it. Runs AFTER the cap/admission pass so a
+    /// force-admitted hydrated tool is never flipped back to a stub. Pure
+    /// function of static config + the monotonic hydrated set: byte-stable
+    /// across turns, one-turn change on hydration.
+    fn apply_tool_deferral(
+        &self,
+        mut tools: Vec<wcore_types::tool::ToolDef>,
+    ) -> Vec<wcore_types::tool::ToolDef> {
+        let defer_cfg = &self.config.builtin_tools.defer_cold;
+        if defer_cfg.enabled {
+            wcore_tools::registry::apply_cold_deferral(&mut tools, &defer_cfg.hot_allowlist);
+        }
+        if !self.hydrated_tool_names.is_empty() {
+            let hydrated: std::collections::HashSet<&str> = self
+                .hydrated_tool_names
+                .iter()
+                .map(String::as_str)
+                .collect();
+            for def in tools.iter_mut() {
+                if def.deferred && hydrated.contains(def.name.as_str()) {
+                    def.deferred = false;
+                }
+            }
+        }
+        tools
     }
 
     /// W6 F17 recency input for `McpCurator`. Reads the M2 audit log via the
@@ -10208,49 +10302,89 @@ mod set_config_tests {
         );
     }
 
+    /// Minimal dispatchable MCP-provenance tool fixture for the
+    /// hydrated-tool-admission tests.
+    struct NamedTool(String);
+    #[async_trait::async_trait]
+    impl wcore_tools::Tool for NamedTool {
+        fn name(&self) -> &str {
+            &self.0
+        }
+        fn description(&self) -> &str {
+            "mcp fixture"
+        }
+        fn input_schema(&self) -> serde_json::Value {
+            serde_json::json!({"type": "object"})
+        }
+        fn is_concurrency_safe(&self, _: &serde_json::Value) -> bool {
+            true
+        }
+        async fn execute(&self, _: serde_json::Value) -> wcore_types::tool::ToolResult {
+            wcore_types::tool::ToolResult {
+                content: "ok".to_string(),
+                is_error: false,
+            }
+        }
+        fn category(&self) -> wcore_protocol::events::ToolCategory {
+            wcore_protocol::events::ToolCategory::Info
+        }
+        fn mcp_server(&self) -> Option<&str> {
+            Some("srv")
+        }
+    }
+
+    /// Registry holding the given MCP fixture tools (the live-registry
+    /// counterpart of the ToolDef lists the cap tests feed in).
+    fn hydration_registry(names: &[&str]) -> ToolRegistry {
+        let mut reg = ToolRegistry::new();
+        for name in names {
+            reg.register(Box::new(NamedTool(name.to_string())));
+        }
+        reg
+    }
+
+    /// The exact hydration flow, end to end against real components: build a
+    /// ToolSearchTool on the cold-deferred bootstrap-style snapshot of the
+    /// engine's LIVE registry, run the query, and feed its real result body
+    /// into the engine's recorder.
+    async fn hydrate_via_tool_search(engine: &mut super::AgentEngine, query: &str) {
+        use wcore_tools::Tool as _;
+        let mut snapshot = engine.tools().to_tool_defs();
+        wcore_tools::registry::apply_cold_deferral(
+            &mut snapshot,
+            &engine.config.builtin_tools.defer_cold.hot_allowlist,
+        );
+        let search = wcore_tools::tool_search::ToolSearchTool::new(snapshot);
+        let result = search.execute(serde_json::json!({"query": query})).await;
+        assert!(!result.is_error, "ToolSearch must find {query}: {result:?}");
+        assert!(
+            result.content.contains("parameters"),
+            "hydration must return the full schema"
+        );
+        engine.record_hydrated_tools(&result.content);
+    }
+
     /// Layer D1 follow-up (hydrated-tool admission): an MCP tool the provider
-    /// cap trimmed on turn N, then hydrated via ToolSearch, must be present
-    /// in turn N+1's outbound tools[] — providers validate tool calls against
-    /// the CURRENT array, so discoverable-but-undeclared = uncallable — and
-    /// must genuinely dispatch. The admission is a one-turn tools[] change;
-    /// the set must be byte-stable again from turn N+2.
+    /// cap trimmed on turn N, then hydrated via a REAL ToolSearch built on the
+    /// registry snapshot, must be present in turn N+1's outbound tools[] with
+    /// deferred == false (full schema — providers validate tool calls against
+    /// the CURRENT array, and a stub is not a callable schema), and must
+    /// genuinely dispatch through the SAME registry ToolSearch snapshotted.
+    /// The admission is a one-turn tools[] change; byte-stable from turn N+2.
     #[tokio::test]
     async fn hydrated_tool_admitted_to_next_turn_tools_and_dispatches() {
         use wcore_tools::dispatcher::ToolDispatcher;
         use wcore_types::message::{ContentBlock, Message, Role};
 
-        /// Minimal dispatchable MCP-provenance tool fixture.
-        struct NamedTool(String);
-        #[async_trait::async_trait]
-        impl wcore_tools::Tool for NamedTool {
-            fn name(&self) -> &str {
-                &self.0
-            }
-            fn description(&self) -> &str {
-                "mcp fixture"
-            }
-            fn input_schema(&self) -> serde_json::Value {
-                serde_json::json!({"type": "object"})
-            }
-            fn is_concurrency_safe(&self, _: &serde_json::Value) -> bool {
-                true
-            }
-            async fn execute(&self, _: serde_json::Value) -> wcore_types::tool::ToolResult {
-                wcore_types::tool::ToolResult {
-                    content: "ok".to_string(),
-                    is_error: false,
-                }
-            }
-            fn category(&self) -> wcore_protocol::events::ToolCategory {
-                wcore_protocol::events::ToolCategory::Info
-            }
-            fn mcp_server(&self) -> Option<&str> {
-                Some("srv")
-            }
-        }
-
-        // Cap = 4: 2 non-MCP + budget for 2 of the 3 MCP tools.
+        // Cap = 4: 2 non-MCP + budget for 2 of the 3 MCP tools. The LIVE
+        // registry carries all three MCP tools (they are trimmed from the
+        // outbound declarations, not from the registry).
         let mut engine = make_engine("m");
+        engine.tools = Arc::new(hydration_registry(&[
+            "mcp__srv__alpha",
+            "mcp__srv__bravo",
+            "mcp__srv__zulu",
+        ]));
         engine.compat.max_tools = Some(4);
         engine.mcp_curation = wcore_config::config::McpCurationPolicy::Off;
         engine.audit_log = None; // keyword-only ranking → deterministic
@@ -10269,8 +10403,9 @@ mod set_config_tests {
             cap_mcp_tool("mcp__srv__zulu"),
         ];
 
-        // Turn N: the cap trims exactly one MCP tool.
-        let turn_n = engine.apply_provider_tool_cap(tools.clone());
+        // Turn N: cap + deferral, exactly one MCP tool trimmed.
+        let capped_n = engine.apply_provider_tool_cap(tools.clone());
+        let turn_n = engine.apply_tool_deferral(capped_n);
         assert_eq!(turn_n.len(), 4, "capped to the provider limit");
         let kept_n: Vec<&str> = turn_n.iter().map(|t| t.name.as_str()).collect();
         let trimmed: Vec<&str> = ["mcp__srv__alpha", "mcp__srv__bravo", "mcp__srv__zulu"]
@@ -10280,46 +10415,207 @@ mod set_config_tests {
         assert_eq!(trimmed.len(), 1, "exactly one MCP tool trimmed");
         let hydrated_name = trimmed[0];
 
-        // Turn N, later in the round: the model hydrates the trimmed tool.
-        // This is the exact result-body shape ToolSearchTool emits.
-        let tool_search_result = serde_json::to_string_pretty(&serde_json::json!([{
-            "name": hydrated_name,
-            "description": "trimmed mcp tool",
-            "parameters": {"type": "object"},
-        }]))
-        .unwrap();
-        engine.record_hydrated_tools(&tool_search_result);
+        // Turn N, later in the round: the model hydrates the trimmed tool
+        // through the real ToolSearch (registry snapshot, real result body).
+        hydrate_via_tool_search(&mut engine, hydrated_name).await;
 
         // Turn N+1: the hydrated tool is force-admitted into the outbound
-        // tools[] (evicting the last non-hydrated slot), cap still enforced.
-        let turn_n1 = engine.apply_provider_tool_cap(tools.clone());
+        // tools[] (evicting the last non-hydrated slot), cap still enforced,
+        // and — critically — its def is NOT deferred: the deferral pass runs
+        // after admission and must exempt hydrated names, or the name would
+        // ship with an empty stub schema.
+        let capped_n1 = engine.apply_provider_tool_cap(tools.clone());
+        let turn_n1 = engine.apply_tool_deferral(capped_n1);
         assert_eq!(turn_n1.len(), 4, "cap still enforced after admission");
-        let kept_n1: Vec<&str> = turn_n1.iter().map(|t| t.name.as_str()).collect();
+        let admitted = turn_n1
+            .iter()
+            .find(|t| t.name == hydrated_name)
+            .unwrap_or_else(|| {
+                panic!(
+                    "hydrated tool must be in the next turn's outbound tools[] (got {:?})",
+                    turn_n1.iter().map(|t| &t.name).collect::<Vec<_>>()
+                )
+            });
         assert!(
-            kept_n1.contains(&hydrated_name),
-            "hydrated tool must be in the next turn's outbound tools[] \
-             (got {kept_n1:?})"
+            !admitted.deferred,
+            "admitted hydrated tool must ship its FULL schema, not a stub"
+        );
+        // A non-hydrated kept MCP tool is still a cold stub — the exemption
+        // is hydration-scoped, not a blanket un-defer.
+        let other_kept_mcp = turn_n1
+            .iter()
+            .find(|t| t.server.is_some() && t.name != hydrated_name)
+            .expect("one more MCP tool is kept");
+        assert!(
+            other_kept_mcp.deferred,
+            "non-hydrated cold MCP tool stays a stub"
         );
 
-        // Turn N+2: the admission was a ONE-turn change — the set is
-        // byte-stable again.
-        let turn_n2 = engine.apply_provider_tool_cap(tools);
-        let kept_n2: Vec<&str> = turn_n2.iter().map(|t| t.name.as_str()).collect();
+        // Turn N+2: the admission was a ONE-turn change — names AND deferred
+        // flags are stable again.
+        let capped_n2 = engine.apply_provider_tool_cap(tools);
+        let turn_n2 = engine.apply_tool_deferral(capped_n2);
+        let shape = |defs: &[wcore_types::tool::ToolDef]| -> Vec<(String, bool)> {
+            defs.iter().map(|t| (t.name.clone(), t.deferred)).collect()
+        };
         assert_eq!(
-            kept_n1, kept_n2,
+            shape(&turn_n1),
+            shape(&turn_n2),
             "post-admission set must be byte-stable across turns"
         );
 
-        // ...and the hydrated tool genuinely dispatches through the registry.
-        let mut reg = ToolRegistry::new();
-        reg.register(Box::new(NamedTool(hydrated_name.to_string())));
-        engine.tools = Arc::new(reg);
+        // ...and the hydrated tool genuinely dispatches through the SAME
+        // registry the ToolSearch snapshot came from.
         let result = engine
             .tools()
             .dispatch(hydrated_name, serde_json::json!({}))
             .await;
         assert!(!result.is_error, "hydrated tool must dispatch: {result:?}");
         assert_eq!(result.content, "ok");
+    }
+
+    /// Layer D1 follow-up, full-union edge: when EVERY kept cap slot is
+    /// already hydrated and one more hydrated tool needs admission, the
+    /// OLDEST hydrated slot is evicted (LRU) and DEMOTED from the hydrated
+    /// set — without the demotion the evicted tool would force itself back
+    /// next turn and the pair would thrash the tools[] array forever.
+    #[tokio::test]
+    async fn hydration_eviction_is_lru_and_does_not_thrash() {
+        use wcore_types::message::{ContentBlock, Message, Role};
+
+        let mut engine = make_engine("m");
+        engine.tools = Arc::new(hydration_registry(&[
+            "mcp__srv__alpha",
+            "mcp__srv__bravo",
+            "mcp__srv__zulu",
+        ]));
+        engine.compat.max_tools = Some(4); // budget for 2 of the 3 MCP tools
+        engine.mcp_curation = wcore_config::config::McpCurationPolicy::Off;
+        engine.audit_log = None;
+        engine.messages = vec![Message::new(
+            Role::User,
+            vec![ContentBlock::Text {
+                text: "alpha database query".to_string(),
+            }],
+        )];
+
+        let tools = vec![
+            builtin_tool("Read"),
+            builtin_tool("ToolSearch"),
+            cap_mcp_tool("mcp__srv__alpha"),
+            cap_mcp_tool("mcp__srv__bravo"),
+            cap_mcp_tool("mcp__srv__zulu"),
+        ];
+
+        // Turn 1 fills the 2 MCP slots; one tool is trimmed.
+        let turn1 = engine.apply_provider_tool_cap(tools.clone());
+        let kept1: Vec<String> = turn1
+            .iter()
+            .filter(|t| t.server.is_some())
+            .map(|t| t.name.clone())
+            .collect();
+        assert_eq!(kept1.len(), 2);
+        let trimmed = ["mcp__srv__alpha", "mcp__srv__bravo", "mcp__srv__zulu"]
+            .into_iter()
+            .find(|n| !kept1.iter().any(|k| k == n))
+            .expect("one trimmed");
+
+        // Hydrate BOTH kept slots, then the trimmed tool (in that order).
+        hydrate_via_tool_search(&mut engine, &kept1[0]).await;
+        hydrate_via_tool_search(&mut engine, &kept1[1]).await;
+        hydrate_via_tool_search(&mut engine, trimmed).await;
+
+        // Turn 2: every slot is hydrated → the OLDEST hydrated slot
+        // (kept1[0], front of the union) is evicted and demoted; the newly
+        // hydrated tool takes the slot.
+        let turn2 = engine.apply_provider_tool_cap(tools.clone());
+        let kept2: Vec<String> = turn2
+            .iter()
+            .filter(|t| t.server.is_some())
+            .map(|t| t.name.clone())
+            .collect();
+        assert_eq!(kept2.len(), 2, "cap still enforced");
+        assert!(
+            kept2.iter().any(|n| n == trimmed),
+            "newly hydrated tool admitted (kept: {kept2:?})"
+        );
+        assert!(
+            !kept2.iter().any(|n| n == &kept1[0]),
+            "oldest hydrated slot evicted (LRU)"
+        );
+        assert!(
+            !engine.hydrated_tool_names.iter().any(|n| n == &kept1[0]),
+            "evicted tool demoted from the hydrated set (anti-thrash)"
+        );
+
+        // Turn 3: stable — the demoted tool must NOT force itself back.
+        let turn3 = engine.apply_provider_tool_cap(tools);
+        let kept3: Vec<String> = turn3
+            .iter()
+            .filter(|t| t.server.is_some())
+            .map(|t| t.name.clone())
+            .collect();
+        assert_eq!(kept2, kept3, "post-eviction set is stable (no thrash)");
+    }
+
+    /// Layer D1 follow-up, stale-hydration regression: ToolSearch serves a
+    /// BOOTSTRAP snapshot, so after an MCP server disconnects the model can
+    /// hydrate a tool that no longer exists in the live registry. The
+    /// admission pass must prune it (never spend a cap slot on it) and keep
+    /// the live hydrations.
+    #[tokio::test]
+    async fn stale_hydration_pruned_when_tool_leaves_registry() {
+        use wcore_types::message::{ContentBlock, Message, Role};
+
+        // Live registry has alpha + bravo. "ghost" was hydratable from the
+        // bootstrap snapshot but its server has since disconnected.
+        let mut engine = make_engine("m");
+        engine.tools = Arc::new(hydration_registry(&["mcp__srv__alpha", "mcp__srv__bravo"]));
+        engine.compat.max_tools = Some(3); // 2 non-MCP + budget for 1 MCP
+        engine.mcp_curation = wcore_config::config::McpCurationPolicy::Off;
+        engine.audit_log = None;
+        engine.messages = vec![Message::new(
+            Role::User,
+            vec![ContentBlock::Text {
+                text: "alpha database query".to_string(),
+            }],
+        )];
+
+        // The model hydrated ghost (pre-disconnect, via the stale snapshot)
+        // and bravo (live). Feed the recorder the exact ToolSearch shape.
+        engine.record_hydrated_tools(
+            &serde_json::to_string_pretty(&serde_json::json!([
+                {"name": "mcp__srv__ghost", "description": "gone", "parameters": {"type": "object"}},
+                {"name": "mcp__srv__bravo", "description": "live", "parameters": {"type": "object"}},
+            ]))
+            .unwrap(),
+        );
+
+        let tools = vec![
+            builtin_tool("Read"),
+            builtin_tool("ToolSearch"),
+            cap_mcp_tool("mcp__srv__alpha"),
+            cap_mcp_tool("mcp__srv__bravo"),
+        ];
+        let kept = engine.apply_provider_tool_cap(tools);
+        let names: Vec<&str> = kept.iter().map(|t| t.name.as_str()).collect();
+
+        // Stale hydration pruned: gone from the hydrated set, never emitted.
+        assert!(
+            !engine.hydrated_tool_names.iter().any(|n| n == "mcp__srv__ghost"),
+            "stale hydration must be pruned from the hydrated set"
+        );
+        assert!(!names.contains(&"mcp__srv__ghost"));
+        // Live hydration survives the prune and is admitted.
+        assert!(
+            engine.hydrated_tool_names.iter().any(|n| n == "mcp__srv__bravo"),
+            "live hydration must survive the prune"
+        );
+        assert!(
+            names.contains(&"mcp__srv__bravo"),
+            "live hydrated tool must be admitted (kept: {names:?})"
+        );
+        assert_eq!(kept.len(), 3, "cap still enforced");
     }
 
     /// #359 regression — a BARE-named MCP tool is subject to curation. The

--- a/crates/wcore-agent/src/engine.rs
+++ b/crates/wcore-agent/src/engine.rs
@@ -6511,6 +6511,15 @@ impl AgentEngine {
                     // callable.
                     if tool_name == "ToolSearch" && !*is_error {
                         self.record_hydrated_tools(content);
+                    } else if tool_name != "unknown" {
+                        // Layer D3 follow-up: a DIRECT call to a
+                        // deferred/folded tool (lax providers can emit calls
+                        // for catalog-only names) also counts as hydration —
+                        // its tool_call now sits in history, so the tool must
+                        // be DECLARED in subsequent tools[] instead of
+                        // staying folded out indefinitely. No-op for hot
+                        // tools and names not in the registry.
+                        self.record_called_deferred_tool(tool_name);
                     }
 
                     // B7 writer-side wiring: bump the per-tool call counter in
@@ -9005,20 +9014,58 @@ impl AgentEngine {
             return;
         };
         for m in matches {
-            if let Some(name) = m.get("name").and_then(|v| v.as_str())
-                && !self.hydrated_tool_names.iter().any(|n| n == name)
-            {
-                if self.hydrated_tool_names.len() >= HYDRATED_TOOLS_CAP {
-                    let dropped = self.hydrated_tool_names.remove(0);
-                    tracing::debug!(
-                        target: "wcore_agent::engine",
-                        "hydrated-tool set at cap ({HYDRATED_TOOLS_CAP}); \
-                         evicting oldest hydration {dropped:?}"
-                    );
-                }
-                self.hydrated_tool_names.push(name.to_string());
+            if let Some(name) = m.get("name").and_then(|v| v.as_str()) {
+                self.push_hydrated_name(name);
             }
         }
+    }
+
+    /// Deduped, [`HYDRATED_TOOLS_CAP`]-bounded (evict-oldest) push into
+    /// [`Self::hydrated_tool_names`]. Shared by the ToolSearch-result
+    /// recorder and the direct-call recorder below.
+    fn push_hydrated_name(&mut self, name: &str) {
+        if self.hydrated_tool_names.iter().any(|n| n == name) {
+            return;
+        }
+        if self.hydrated_tool_names.len() >= HYDRATED_TOOLS_CAP {
+            let dropped = self.hydrated_tool_names.remove(0);
+            tracing::debug!(
+                target: "wcore_agent::engine",
+                "hydrated-tool set at cap ({HYDRATED_TOOLS_CAP}); \
+                 evicting oldest hydration {dropped:?}"
+            );
+        }
+        self.hydrated_tool_names.push(name.to_string());
+    }
+
+    /// Layer D3 follow-up (catalog fold): a DIRECT call to a deferred tool
+    /// counts as hydration too. Lax providers (no constrained decoding —
+    /// Ollama, llama.cpp) can emit a call for a catalog-only name; the
+    /// engine dispatches it by registry name, which leaves a `tool_calls`
+    /// entry in history referencing a tool that the catalog fold keeps OUT
+    /// of the outbound tools[] — indefinitely, because only ToolSearch
+    /// results used to trigger admission. (Stub mode never had this state:
+    /// every deferred name was at least declared.) Recording the called
+    /// name here makes the tool DECLARED with its full schema from the next
+    /// round-trip — the same one-turn tools[] change as a ToolSearch
+    /// hydration. Recorded regardless of the result's error flag: the
+    /// tool_call sits in history either way.
+    ///
+    /// Hot-allowlist tools and unknown names are skipped so the bounded
+    /// hydrated set is not churned by Read/Bash traffic or hallucinated
+    /// names that never dispatched.
+    fn record_called_deferred_tool(&mut self, tool_name: &str) {
+        let cfg = &self.config.builtin_tools.defer_cold;
+        if !cfg.enabled || tool_name == "ToolSearch" {
+            return;
+        }
+        if cfg.hot_allowlist.iter().any(|hot| hot == tool_name) {
+            return;
+        }
+        if self.tools.get(tool_name).is_none() {
+            return;
+        }
+        self.push_hydrated_name(tool_name);
     }
 
     /// Layer D1 follow-up: drop hydrated names that no longer exist in the
@@ -10590,6 +10637,73 @@ mod set_config_tests {
         assert!(
             wire_stub.contains("(Deferred)"),
             "stub mode serializes per-tool stub entries"
+        );
+    }
+
+    /// Codex verify finding (catalog fold edge): on lax providers (no
+    /// constrained decoding) the model can call a catalog-only tool
+    /// DIRECTLY; the engine dispatches it by registry name, leaving a
+    /// tool_calls entry in history that references a name the fold keeps
+    /// out of tools[] — and only ToolSearch results used to trigger
+    /// admission, so the undeclared state persisted indefinitely (stub mode
+    /// always declared every deferred name). A direct call must count as
+    /// hydration: declared, full schema, out of the catalog line, from the
+    /// next round-trip.
+    #[test]
+    fn called_deferred_tool_is_declared_on_subsequent_turns() {
+        let mut engine = make_engine("m");
+        engine.tools = Arc::new(hydration_registry(&["session_search"]));
+
+        let tools = vec![
+            builtin_tool("Read"),
+            builtin_tool("ToolSearch"),
+            builtin_tool("session_search"), // cold built-in
+        ];
+
+        // Round-trip K: session_search is folded into the catalog line.
+        let turn_k = engine.apply_tool_deferral(tools.clone());
+        assert!(
+            !turn_k.iter().any(|t| t.name == "session_search"),
+            "cold tool starts folded out of the array"
+        );
+        assert!(
+            turn_k
+                .iter()
+                .find(|t| t.name == "ToolSearch")
+                .unwrap()
+                .description
+                .contains("session_search"),
+            "cold tool starts in the catalog line"
+        );
+
+        // The model calls it directly (lax provider) — the result loop
+        // records the call as hydration. Hot tools and unknown names are
+        // no-ops (bounded set must not churn on Read/Bash traffic).
+        engine.record_called_deferred_tool("session_search");
+        engine.record_called_deferred_tool("Read");
+        engine.record_called_deferred_tool("ghost_never_registered");
+        assert_eq!(
+            engine.hydrated_tool_names,
+            vec!["session_search".to_string()],
+            "only the called deferred registry tool is recorded"
+        );
+
+        // Round-trip K+1: the called tool is DECLARED with its full schema
+        // and has left the catalog line.
+        let turn_k1 = engine.apply_tool_deferral(tools);
+        let declared = turn_k1
+            .iter()
+            .find(|t| t.name == "session_search")
+            .expect("called deferred tool must be declared in tools[]");
+        assert!(!declared.deferred, "ships full schema, not a stub");
+        assert!(
+            !turn_k1
+                .iter()
+                .find(|t| t.name == "ToolSearch")
+                .unwrap()
+                .description
+                .contains("session_search"),
+            "called tool left the catalog line"
         );
     }
 

--- a/crates/wcore-agent/src/engine.rs
+++ b/crates/wcore-agent/src/engine.rs
@@ -4782,6 +4782,12 @@ impl AgentEngine {
             // THIS (not `self.model`) so attribution follows any swap.
             let mut effective_model = self.model.clone();
 
+            // Layer E1 — the model Flux ACTUALLY routed this turn to
+            // (ProviderMeta signal-back). `None` on non-Flux paths / before
+            // the signal arrives; the cache_health_warn emission below falls
+            // back to `effective_model`.
+            let mut last_routed_model: Option<String> = None;
+
             let mut request = LlmRequest {
                 model: self.model.clone(),
                 system,
@@ -5441,6 +5447,11 @@ impl AgentEngine {
                             // actually served this turn, not the pre-route guess.
                             self.flux_context_pressure = context_pressure;
                             self.flux_served_window = model_window;
+                            // Layer E1 — remember the served model for the
+                            // cache_health_warn attribution below.
+                            if routed_model.is_some() {
+                                last_routed_model = routed_model.clone();
+                            }
                             if let Some(window) = model_window {
                                 // Reconcile the #255 gauge through the kernel:
                                 // recompute the active-window fraction against the
@@ -5857,7 +5868,7 @@ impl AgentEngine {
                 cache_read_tokens: turn_usage.cache_read_tokens,
                 cache_creation_tokens: turn_usage.cache_creation_tokens,
             };
-            if let Some(diagnostic) = self.cache_detector.check_response(cache_stats) {
+            if let Some(diagnostic) = self.cache_detector.check_response(cache_stats.clone()) {
                 match &diagnostic {
                     CacheDiagnostic::FullMiss { cause } => {
                         // #101: a full cache miss is diagnostic telemetry, NOT a
@@ -5887,6 +5898,41 @@ impl AgentEngine {
                         }
                     }
                 }
+            }
+
+            // Layer E1 — warm-session cache-health warn. On a round-trip
+            // after the 2nd of a warm session, a `cache_read / input` ratio
+            // below the threshold means the cached prefix is not being read
+            // back (the 128-flat signature). Warning-only structured
+            // telemetry: greppable in the engine log, never alters the
+            // request.
+            if let Some(alert) = self.cache_detector.check_cache_health(&cache_stats) {
+                let warn = wcore_providers::cache_observation::CacheHealthWarn {
+                    conversation_id: self.conversation_id.clone(),
+                    round_trip: alert.round_trip,
+                    input_tokens: alert.input_tokens,
+                    cache_read_tokens: alert.cache_read_tokens,
+                    ratio: alert.ratio,
+                    routed_model: last_routed_model
+                        .clone()
+                        .unwrap_or_else(|| effective_model.clone()),
+                };
+                tracing::warn!(
+                    target: "cache_health",
+                    conversation_id = %warn.conversation_id,
+                    round_trip = warn.round_trip,
+                    input_tokens = warn.input_tokens,
+                    cache_read_tokens = warn.cache_read_tokens,
+                    ratio = warn.ratio,
+                    routed_model = %warn.routed_model,
+                    "cache_health_warn: warm-session cache hit-ratio {:.3} below {} \
+                     (input={}, cache_read={}, model={})",
+                    warn.ratio,
+                    crate::cache_diagnostics::CACHE_HEALTH_WARN_RATIO,
+                    warn.input_tokens,
+                    warn.cache_read_tokens,
+                    warn.routed_model,
+                );
             }
 
             let mut assistant_content: Vec<ContentBlock> = Vec::new();

--- a/crates/wcore-agent/src/engine.rs
+++ b/crates/wcore-agent/src/engine.rs
@@ -9052,16 +9052,27 @@ impl AgentEngine {
         self.hydrated_tool_names.retain(|n| !stale.contains(n));
     }
 
-    /// Layer D1 (token-opt): cold-deferral + hydration exemption for the
-    /// outbound tools[]. Cold tools (not on the static hot allowlist)
-    /// serialize as name-only stubs; a tool the model has HYDRATED via
-    /// ToolSearch ships its FULL schema — whether the deferral above stubbed
-    /// it or it is natively deferred (`Tool::is_deferred`, e.g. MCP proxies)
-    /// — because hydration means the model explicitly fetched the schema and
-    /// is about to call it. Runs AFTER the cap/admission pass so a
-    /// force-admitted hydrated tool is never flipped back to a stub. Pure
-    /// function of static config + the monotonic hydrated set: byte-stable
-    /// across turns, one-turn change on hydration.
+    /// Layer D1/D3 (token-opt): cold-deferral + hydration exemption +
+    /// catalog fold for the outbound tools[].
+    ///
+    /// 1. Cold tools (not on the static hot allowlist) are marked deferred.
+    /// 2. A tool the model has HYDRATED via ToolSearch ships its FULL
+    ///    schema — whether the deferral above marked it or it is natively
+    ///    deferred (`Tool::is_deferred`, e.g. MCP proxies) — because
+    ///    hydration means the model explicitly fetched the schema and is
+    ///    about to call it.
+    /// 3. Catalog mode (default): the remaining deferred defs are removed
+    ///    from the array entirely and folded into ONE sorted name-only
+    ///    inventory line on ToolSearch's description (openclaw parity —
+    ///    per-tool stubs measured MORE expensive than the hot schemas).
+    ///    A hydrated tool leaves the catalog line and ships full, in the
+    ///    same one-turn tools[] change as its admission. Catalog off:
+    ///    deferred defs stay as per-tool stub entries.
+    ///
+    /// Runs AFTER the cap/admission pass so a force-admitted hydrated tool
+    /// is never flipped back to a stub. Pure function of static config +
+    /// the monotonic hydrated set: byte-stable across turns, one-turn
+    /// change on hydration.
     fn apply_tool_deferral(
         &self,
         mut tools: Vec<wcore_types::tool::ToolDef>,
@@ -9081,6 +9092,12 @@ impl AgentEngine {
                     def.deferred = false;
                 }
             }
+        }
+        if defer_cfg.enabled && defer_cfg.catalog {
+            tools = wcore_tools::registry::fold_deferred_into_catalog(
+                tools,
+                defer_cfg.catalog_max_chars,
+            );
         }
         tools
     }
@@ -10403,17 +10420,44 @@ mod set_config_tests {
             cap_mcp_tool("mcp__srv__zulu"),
         ];
 
-        // Turn N: cap + deferral, exactly one MCP tool trimmed.
+        // Turn N: the cap keeps 2 of the 3 MCP tools; deferral then folds
+        // the kept-but-cold MCP defs into ToolSearch's catalog line (Layer
+        // D3), so the outbound array is just the hot tools.
         let capped_n = engine.apply_provider_tool_cap(tools.clone());
-        let turn_n = engine.apply_tool_deferral(capped_n);
-        assert_eq!(turn_n.len(), 4, "capped to the provider limit");
-        let kept_n: Vec<&str> = turn_n.iter().map(|t| t.name.as_str()).collect();
+        assert_eq!(capped_n.len(), 4, "capped to the provider limit");
+        let kept_mcp_n: Vec<String> = capped_n
+            .iter()
+            .filter(|t| t.server.is_some())
+            .map(|t| t.name.clone())
+            .collect();
         let trimmed: Vec<&str> = ["mcp__srv__alpha", "mcp__srv__bravo", "mcp__srv__zulu"]
             .into_iter()
-            .filter(|n| !kept_n.contains(n))
+            .filter(|n| !kept_mcp_n.iter().any(|k| k == n))
             .collect();
         assert_eq!(trimmed.len(), 1, "exactly one MCP tool trimmed");
         let hydrated_name = trimmed[0];
+
+        let turn_n = engine.apply_tool_deferral(capped_n);
+        assert!(
+            turn_n.iter().all(|t| !t.deferred),
+            "catalog mode: no stub entries in the outbound tools[]"
+        );
+        assert_eq!(
+            turn_n.len(),
+            2,
+            "cold MCP defs folded out of the array (hot Read + ToolSearch remain)"
+        );
+        let catalog_n = &turn_n
+            .iter()
+            .find(|t| t.name == "ToolSearch")
+            .expect("ToolSearch carries the catalog")
+            .description;
+        for kept in &kept_mcp_n {
+            assert!(
+                catalog_n.contains(kept.as_str()),
+                "kept cold MCP tool listed in the catalog line: {catalog_n}"
+            );
+        }
 
         // Turn N, later in the round: the model hydrates the trimmed tool
         // through the real ToolSearch (registry snapshot, real result body).
@@ -10423,10 +10467,10 @@ mod set_config_tests {
         // tools[] (evicting the last non-hydrated slot), cap still enforced,
         // and — critically — its def is NOT deferred: the deferral pass runs
         // after admission and must exempt hydrated names, or the name would
-        // ship with an empty stub schema.
+        // be folded away / shipped as a stub.
         let capped_n1 = engine.apply_provider_tool_cap(tools.clone());
+        assert_eq!(capped_n1.len(), 4, "cap still enforced after admission");
         let turn_n1 = engine.apply_tool_deferral(capped_n1);
-        assert_eq!(turn_n1.len(), 4, "cap still enforced after admission");
         let admitted = turn_n1
             .iter()
             .find(|t| t.name == hydrated_name)
@@ -10440,23 +10484,30 @@ mod set_config_tests {
             !admitted.deferred,
             "admitted hydrated tool must ship its FULL schema, not a stub"
         );
-        // A non-hydrated kept MCP tool is still a cold stub — the exemption
-        // is hydration-scoped, not a blanket un-defer.
-        let other_kept_mcp = turn_n1
+        // The hydrated name LEAVES the catalog line; the remaining cold MCP
+        // slot is still listed there (folded, not shipped as a stub entry).
+        let catalog_n1 = &turn_n1
             .iter()
-            .find(|t| t.server.is_some() && t.name != hydrated_name)
-            .expect("one more MCP tool is kept");
+            .find(|t| t.name == "ToolSearch")
+            .expect("ToolSearch carries the catalog")
+            .description;
         assert!(
-            other_kept_mcp.deferred,
-            "non-hydrated cold MCP tool stays a stub"
+            !catalog_n1.contains(hydrated_name),
+            "hydrated tool must leave the catalog line: {catalog_n1}"
+        );
+        assert!(
+            turn_n1.iter().all(|t| !t.deferred),
+            "catalog mode: still no stub entries after admission"
         );
 
-        // Turn N+2: the admission was a ONE-turn change — names AND deferred
-        // flags are stable again.
+        // Turn N+2: the admission was a ONE-turn change — names, deferred
+        // flags AND the catalog line are stable again.
         let capped_n2 = engine.apply_provider_tool_cap(tools);
         let turn_n2 = engine.apply_tool_deferral(capped_n2);
-        let shape = |defs: &[wcore_types::tool::ToolDef]| -> Vec<(String, bool)> {
-            defs.iter().map(|t| (t.name.clone(), t.deferred)).collect()
+        let shape = |defs: &[wcore_types::tool::ToolDef]| -> Vec<(String, bool, String)> {
+            defs.iter()
+                .map(|t| (t.name.clone(), t.deferred, t.description.clone()))
+                .collect()
         };
         assert_eq!(
             shape(&turn_n1),
@@ -10472,6 +10523,74 @@ mod set_config_tests {
             .await;
         assert!(!result.is_error, "hydrated tool must dispatch: {result:?}");
         assert_eq!(result.content, "ok");
+    }
+
+    /// Layer D3 (catalog fold): cold tools produce NO per-tool stub entries
+    /// on the wire — they are folded into one sorted, deterministic catalog
+    /// line on ToolSearch's description — and flipping the config knob off
+    /// restores the previous per-tool stub behavior.
+    #[test]
+    fn catalog_mode_emits_no_stub_entries_and_config_off_restores_stubs() {
+        let mut engine = make_engine("m");
+        let tools = vec![
+            builtin_tool("Read"),
+            builtin_tool("ToolSearch"),
+            builtin_tool("session_search"), // cold built-in
+            builtin_tool("clarify"),        // cold built-in
+        ];
+
+        // Catalog mode (default ON): cold defs leave the array entirely.
+        let turn1 = engine.apply_tool_deferral(tools.clone());
+        assert!(
+            turn1.iter().all(|t| !t.deferred),
+            "no deferred defs reach the serializer"
+        );
+        assert_eq!(turn1.len(), 2, "hot Read + ToolSearch only");
+        let ts = turn1.iter().find(|t| t.name == "ToolSearch").unwrap();
+        assert!(
+            ts.description.contains("clarify, session_search"),
+            "sorted name-only catalog on ToolSearch: {}",
+            ts.description
+        );
+
+        // The serializer therefore emits NO stub entries at all.
+        let wire =
+            serde_json::to_string(&wcore_providers::anthropic_shared::build_tools(&turn1))
+                .unwrap();
+        assert!(
+            !wire.contains("(Deferred)"),
+            "no per-tool stub entries on the wire"
+        );
+
+        // Deterministic + byte-stable across turns (same deferral state).
+        let turn2 = engine.apply_tool_deferral(tools.clone());
+        let wire2 =
+            serde_json::to_string(&wcore_providers::anthropic_shared::build_tools(&turn2))
+                .unwrap();
+        assert_eq!(wire, wire2, "catalog line byte-stable across turns");
+
+        // Config off: per-tool stub entries restored, catalog absent.
+        engine.config.builtin_tools.defer_cold.catalog = false;
+        let stubbed = engine.apply_tool_deferral(tools);
+        assert_eq!(stubbed.len(), 4, "stub mode keeps every def in the array");
+        assert!(
+            stubbed
+                .iter()
+                .any(|t| t.name == "clarify" && t.deferred),
+            "cold tool is a stub entry again"
+        );
+        let ts_stub = stubbed.iter().find(|t| t.name == "ToolSearch").unwrap();
+        assert!(
+            !ts_stub.description.contains("Deferred tools"),
+            "no catalog line in stub mode"
+        );
+        let wire_stub =
+            serde_json::to_string(&wcore_providers::anthropic_shared::build_tools(&stubbed))
+                .unwrap();
+        assert!(
+            wire_stub.contains("(Deferred)"),
+            "stub mode serializes per-tool stub entries"
+        );
     }
 
     /// Layer D1 follow-up, full-union edge: when EVERY kept cap slot is

--- a/crates/wcore-agent/src/engine.rs
+++ b/crates/wcore-agent/src/engine.rs
@@ -4694,6 +4694,26 @@ impl AgentEngine {
             // relevance trim above.
             let tools = self.apply_provider_tool_cap(tools);
 
+            // Layer D1 (token-opt): defer cold tools to name-only stubs —
+            // only the configured hot allowlist ships full schemas; the
+            // model hydrates a stub on demand via ToolSearch (the system
+            // prompt states that rule once, `tool_usage_guidance`).
+            // CRITICAL: the hot/stub split is a pure function of static
+            // config, never per-turn state, so the serialized tools[] array
+            // stays byte-identical across turns (cache guard:
+            // `tools_array_byte_stable_across_roundtrips`).
+            let tools = {
+                let mut tools = tools;
+                let defer_cfg = &self.config.builtin_tools.defer_cold;
+                if defer_cfg.enabled {
+                    wcore_tools::registry::apply_cold_deferral(
+                        &mut tools,
+                        &defer_cfg.hot_allowlist,
+                    );
+                }
+                tools
+            };
+
             // Build system prompt: append plan mode instructions when active
             let system = if self.plan_state.is_active {
                 format!(

--- a/crates/wcore-agent/src/engine.rs
+++ b/crates/wcore-agent/src/engine.rs
@@ -1623,6 +1623,16 @@ pub struct AgentEngine {
     /// (a cache READ, not a per-turn prefix rewrite). Reset when the MCP
     /// inventory or the MCP budget changes.
     mcp_cap_cache: Option<(u64, Vec<String>)>,
+    /// Layer D1 follow-up (hydrated-tool admission): tool names the model has
+    /// hydrated via a successful `ToolSearch` this session, in FIRST-HYDRATION
+    /// order. Providers validate tool calls against the CURRENT `tools[]`
+    /// array, so a tool that `apply_mcp_curation` / `apply_provider_tool_cap`
+    /// trimmed would be learnable through ToolSearch yet uncallable. Both
+    /// passes force-include these names on subsequent turns (evicting the
+    /// last non-hydrated cap slot when the budget is full). Grows
+    /// monotonically — admission changes `tools[]` once (a legitimate
+    /// one-turn cache miss) and the set is stable afterwards.
+    hydrated_tool_names: Vec<String>,
     /// Token-opt (diff-resend): handle to the shared file-state cache (the same
     /// `Arc` the Read/Edit/Write tools hold). Used only to bump the cache's
     /// compaction generation after a compaction pass, so stale read bases stop
@@ -2145,6 +2155,7 @@ impl AgentEngine {
             mcp_curation: config.mcp.curation.clone(),
             mcp_curation_cache: None,
             mcp_cap_cache: None,
+            hydrated_tool_names: Vec::new(),
             file_cache: None,
             session_state: None,
             audit_log: None,
@@ -2327,6 +2338,7 @@ impl AgentEngine {
             mcp_curation: config.mcp.curation.clone(),
             mcp_curation_cache: None,
             mcp_cap_cache: None,
+            hydrated_tool_names: Vec::new(),
             file_cache: None,
             session_state: None,
             audit_log: None,
@@ -6490,6 +6502,18 @@ impl AgentEngine {
 
                     self.output.emit_tool_result(tool_name, *is_error, content);
 
+                    // Layer D1 follow-up (hydrated-tool admission): a
+                    // successful ToolSearch teaches the model a tool's
+                    // schema. Record the returned names so the curation/cap
+                    // passes force-include them in the outbound tools[] on
+                    // subsequent turns — providers validate tool calls
+                    // against the CURRENT tools[] array, so a hydrated tool
+                    // the cap trimmed would otherwise be learnable but not
+                    // callable.
+                    if tool_name == "ToolSearch" && !*is_error {
+                        self.record_hydrated_tools(content);
+                    }
+
                     // B7 writer-side wiring: bump the per-tool call counter in
                     // the live introspection state (one increment per executed
                     // tool result) so `wayland_status` reports real tool-call
@@ -8686,20 +8710,39 @@ impl AgentEngine {
         // newly-surfaced name is pushed at the END. This makes every
         // union-growth turn a cache-safe append (stable prefix) rather than a
         // mid-array insert that would invalidate the cached tool-zone prefix.
-        let keep_order: &Vec<String> = match self.mcp_curation_cache.as_mut() {
+        match self.mcp_curation_cache.as_mut() {
             Some((hash, order)) if *hash == inventory_hash => {
                 for name in this_turn {
                     if !order.contains(&name) {
                         order.push(name);
                     }
                 }
-                &*order
             }
             _ => {
                 self.mcp_curation_cache = Some((inventory_hash, this_turn));
-                &self.mcp_curation_cache.as_ref().expect("just set").1
             }
-        };
+        }
+
+        // Layer D1 follow-up (hydrated-tool admission): union in every MCP
+        // tool the model has hydrated via ToolSearch, so curation can never
+        // trim a tool the model has learned — it must survive this pass for
+        // the provider cap below to admit it into the outbound tools[].
+        // Cache-safe: appended at the END, once (the hydrated list only
+        // grows), a legitimate one-turn miss that is stable afterwards.
+        let hydrated_mcp: Vec<String> = self
+            .hydrated_tool_names
+            .iter()
+            .filter(|n| mcp_tools.iter().any(|t| &t.name == *n))
+            .cloned()
+            .collect();
+        if let Some((_, order)) = self.mcp_curation_cache.as_mut() {
+            for name in hydrated_mcp {
+                if !order.contains(&name) {
+                    order.push(name);
+                }
+            }
+        }
+        let keep_order: &Vec<String> = &self.mcp_curation_cache.as_ref().expect("just set").1;
 
         // Emit kept MCP tools in FIRST-ADD order (not registry-iteration
         // order). Built-in/non-MCP tools in `keep` retain their original
@@ -8722,7 +8765,12 @@ impl AgentEngine {
     /// skills, plan) and fills the remaining budget with the most RELEVANT MCP
     /// tools (BM25 over the current user message), truncating the rest. Dropped
     /// MCP tools stay DISCOVERABLE via the `ToolSearch` meta-tool (its registry
-    /// is a full bootstrap snapshot). `None` cap = no-op.
+    /// is a full bootstrap snapshot) — and once the model HYDRATES one, its
+    /// name is recorded in `hydrated_tool_names` and force-admitted into the
+    /// kept set on subsequent turns (evicting the last non-hydrated BM25 slot
+    /// when the budget is full), because providers validate tool calls against
+    /// the CURRENT tools[] array: discoverable-but-undeclared = uncallable.
+    /// `None` cap = no-op.
     ///
     /// Cache-stability (token-opt): when the cap must trim, the kept MCP set is
     /// emitted in an inventory-keyed APPEND-ONLY UNION order (mirroring
@@ -8766,7 +8814,8 @@ impl AgentEngine {
             tracing::info!(
                 target: "wcore_agent::engine",
                 "provider tool cap: {} tools exceeded the provider limit of {}; kept {} \
-                 (incl. all {} non-MCP), {} MCP tools hidden but reachable via ToolSearch",
+                 (incl. all {} non-MCP), {} MCP tools hidden — discoverable via ToolSearch \
+                 but NOT callable (no MCP budget under the provider cap)",
                 non_mcp_count + mcp_total,
                 limit,
                 non_mcp_count,
@@ -8820,7 +8869,7 @@ impl AgentEngine {
         // length at `mcp_budget` so the kept set never exceeds the provider
         // limit even as the union grows across turns — once full, no new tool
         // displaces an admitted one for the life of this inventory/budget.
-        let keep_order: Vec<String> = match self.mcp_cap_cache.as_mut() {
+        match self.mcp_cap_cache.as_mut() {
             Some((hash, order)) if *hash == inventory_hash => {
                 for name in this_turn {
                     if order.len() >= mcp_budget {
@@ -8830,15 +8879,66 @@ impl AgentEngine {
                         order.push(name);
                     }
                 }
-                order.clone()
             }
             _ => {
                 let mut order = this_turn;
                 order.truncate(mcp_budget);
-                self.mcp_cap_cache = Some((inventory_hash, order.clone()));
-                order
+                self.mcp_cap_cache = Some((inventory_hash, order));
             }
-        };
+        }
+
+        // Layer D1 follow-up (hydrated-tool admission): a tool the model
+        // hydrated via ToolSearch must be genuinely callable — providers
+        // validate tool calls against the CURRENT tools[] array, so a
+        // hydrated-but-trimmed MCP tool would be learnable yet uncallable.
+        // Force-admit hydrated MCP names: appended at the END while budget
+        // remains (a cache-safe append); when the union is FULL, the LAST
+        // non-hydrated slot is evicted to make room (hydration is a stronger
+        // relevance signal than the BM25 guess that admitted that slot).
+        // Either way the change lands once — a legitimate one-turn cache
+        // miss — and the set is stable afterwards because
+        // `hydrated_tool_names` only grows.
+        let hydrated_all: std::collections::HashSet<&str> = self
+            .hydrated_tool_names
+            .iter()
+            .map(String::as_str)
+            .collect();
+        let hydrated_mcp: Vec<String> = self
+            .hydrated_tool_names
+            .iter()
+            .filter(|n| mcp_tools.iter().any(|t| &t.name == *n))
+            .cloned()
+            .collect();
+        let mut evicted: Vec<String> = Vec::new();
+        if let Some((_, order)) = self.mcp_cap_cache.as_mut() {
+            for name in hydrated_mcp {
+                if order.contains(&name) {
+                    continue;
+                }
+                if order.len() >= mcp_budget {
+                    match order.iter().rposition(|n| !hydrated_all.contains(n.as_str())) {
+                        Some(idx) => evicted.push(order.remove(idx)),
+                        // Every kept slot is itself hydrated — no eviction
+                        // candidate; the budget genuinely cannot fit this one.
+                        None => continue,
+                    }
+                }
+                order.push(name);
+            }
+        }
+        if !evicted.is_empty() {
+            tracing::info!(
+                target: "wcore_agent::engine",
+                "provider tool cap: evicted {:?} to admit ToolSearch-hydrated tools \
+                 (one-turn cache miss; set stable afterwards)",
+                evicted
+            );
+        }
+        let keep_order: Vec<String> = self
+            .mcp_cap_cache
+            .as_ref()
+            .map(|(_, order)| order.clone())
+            .unwrap_or_default();
 
         // Emit non-MCP tools first (preserving their relative order), then the
         // kept MCP block in FIRST-ADD union order.
@@ -8856,7 +8956,8 @@ impl AgentEngine {
             tracing::info!(
                 target: "wcore_agent::engine",
                 "provider tool cap: {} tools exceeded the provider limit of {}; kept {} \
-                 (incl. all {} non-MCP), {} MCP tools hidden but reachable via ToolSearch",
+                 (incl. all {} non-MCP), {} MCP tools hidden — discoverable via ToolSearch \
+                 and admitted to tools[] on the turn after hydration",
                 non_mcp_count + mcp_total,
                 limit,
                 kept.len(),
@@ -8865,6 +8966,29 @@ impl AgentEngine {
             );
         }
         kept
+    }
+
+    /// Layer D1 follow-up (hydrated-tool admission): parse a successful
+    /// `ToolSearch` result body (a JSON array of `{name, description,
+    /// parameters}` matches) and record every returned tool name in
+    /// [`Self::hydrated_tool_names`] (FIRST-HYDRATION order, deduped). The
+    /// curation/cap passes force-include these names in the outbound
+    /// `tools[]` on subsequent turns so a hydrated tool is genuinely
+    /// callable. A no-match result is a plain string, not JSON — it parses
+    /// to nothing and records nothing.
+    fn record_hydrated_tools(&mut self, content: &str) {
+        let Ok(serde_json::Value::Array(matches)) =
+            serde_json::from_str::<serde_json::Value>(content)
+        else {
+            return;
+        };
+        for m in matches {
+            if let Some(name) = m.get("name").and_then(|v| v.as_str())
+                && !self.hydrated_tool_names.iter().any(|n| n == name)
+            {
+                self.hydrated_tool_names.push(name.to_string());
+            }
+        }
     }
 
     /// W6 F17 recency input for `McpCurator`. Reads the M2 audit log via the
@@ -9645,6 +9769,7 @@ mod set_config_tests {
             mcp_curation: wcore_config::config::McpCurationPolicy::default(),
             mcp_curation_cache: None,
             mcp_cap_cache: None,
+            hydrated_tool_names: Vec::new(),
             file_cache: None,
             session_state: None,
             audit_log: None,
@@ -10081,6 +10206,120 @@ mod set_config_tests {
             names1, names2,
             "cap emission must be byte-stable across same-context turns"
         );
+    }
+
+    /// Layer D1 follow-up (hydrated-tool admission): an MCP tool the provider
+    /// cap trimmed on turn N, then hydrated via ToolSearch, must be present
+    /// in turn N+1's outbound tools[] — providers validate tool calls against
+    /// the CURRENT array, so discoverable-but-undeclared = uncallable — and
+    /// must genuinely dispatch. The admission is a one-turn tools[] change;
+    /// the set must be byte-stable again from turn N+2.
+    #[tokio::test]
+    async fn hydrated_tool_admitted_to_next_turn_tools_and_dispatches() {
+        use wcore_tools::dispatcher::ToolDispatcher;
+        use wcore_types::message::{ContentBlock, Message, Role};
+
+        /// Minimal dispatchable MCP-provenance tool fixture.
+        struct NamedTool(String);
+        #[async_trait::async_trait]
+        impl wcore_tools::Tool for NamedTool {
+            fn name(&self) -> &str {
+                &self.0
+            }
+            fn description(&self) -> &str {
+                "mcp fixture"
+            }
+            fn input_schema(&self) -> serde_json::Value {
+                serde_json::json!({"type": "object"})
+            }
+            fn is_concurrency_safe(&self, _: &serde_json::Value) -> bool {
+                true
+            }
+            async fn execute(&self, _: serde_json::Value) -> wcore_types::tool::ToolResult {
+                wcore_types::tool::ToolResult {
+                    content: "ok".to_string(),
+                    is_error: false,
+                }
+            }
+            fn category(&self) -> wcore_protocol::events::ToolCategory {
+                wcore_protocol::events::ToolCategory::Info
+            }
+            fn mcp_server(&self) -> Option<&str> {
+                Some("srv")
+            }
+        }
+
+        // Cap = 4: 2 non-MCP + budget for 2 of the 3 MCP tools.
+        let mut engine = make_engine("m");
+        engine.compat.max_tools = Some(4);
+        engine.mcp_curation = wcore_config::config::McpCurationPolicy::Off;
+        engine.audit_log = None; // keyword-only ranking → deterministic
+        engine.messages = vec![Message::new(
+            Role::User,
+            vec![ContentBlock::Text {
+                text: "alpha database query".to_string(),
+            }],
+        )];
+
+        let tools = vec![
+            builtin_tool("Read"),
+            builtin_tool("ToolSearch"),
+            cap_mcp_tool("mcp__srv__alpha"),
+            cap_mcp_tool("mcp__srv__bravo"),
+            cap_mcp_tool("mcp__srv__zulu"),
+        ];
+
+        // Turn N: the cap trims exactly one MCP tool.
+        let turn_n = engine.apply_provider_tool_cap(tools.clone());
+        assert_eq!(turn_n.len(), 4, "capped to the provider limit");
+        let kept_n: Vec<&str> = turn_n.iter().map(|t| t.name.as_str()).collect();
+        let trimmed: Vec<&str> = ["mcp__srv__alpha", "mcp__srv__bravo", "mcp__srv__zulu"]
+            .into_iter()
+            .filter(|n| !kept_n.contains(n))
+            .collect();
+        assert_eq!(trimmed.len(), 1, "exactly one MCP tool trimmed");
+        let hydrated_name = trimmed[0];
+
+        // Turn N, later in the round: the model hydrates the trimmed tool.
+        // This is the exact result-body shape ToolSearchTool emits.
+        let tool_search_result = serde_json::to_string_pretty(&serde_json::json!([{
+            "name": hydrated_name,
+            "description": "trimmed mcp tool",
+            "parameters": {"type": "object"},
+        }]))
+        .unwrap();
+        engine.record_hydrated_tools(&tool_search_result);
+
+        // Turn N+1: the hydrated tool is force-admitted into the outbound
+        // tools[] (evicting the last non-hydrated slot), cap still enforced.
+        let turn_n1 = engine.apply_provider_tool_cap(tools.clone());
+        assert_eq!(turn_n1.len(), 4, "cap still enforced after admission");
+        let kept_n1: Vec<&str> = turn_n1.iter().map(|t| t.name.as_str()).collect();
+        assert!(
+            kept_n1.contains(&hydrated_name),
+            "hydrated tool must be in the next turn's outbound tools[] \
+             (got {kept_n1:?})"
+        );
+
+        // Turn N+2: the admission was a ONE-turn change — the set is
+        // byte-stable again.
+        let turn_n2 = engine.apply_provider_tool_cap(tools);
+        let kept_n2: Vec<&str> = turn_n2.iter().map(|t| t.name.as_str()).collect();
+        assert_eq!(
+            kept_n1, kept_n2,
+            "post-admission set must be byte-stable across turns"
+        );
+
+        // ...and the hydrated tool genuinely dispatches through the registry.
+        let mut reg = ToolRegistry::new();
+        reg.register(Box::new(NamedTool(hydrated_name.to_string())));
+        engine.tools = Arc::new(reg);
+        let result = engine
+            .tools()
+            .dispatch(hydrated_name, serde_json::json!({}))
+            .await;
+        assert!(!result.is_error, "hydrated tool must dispatch: {result:?}");
+        assert_eq!(result.content, "ok");
     }
 
     /// #359 regression — a BARE-named MCP tool is subject to curation. The
@@ -10819,6 +11058,7 @@ mod phase6_tests {
             mcp_curation: wcore_config::config::McpCurationPolicy::default(),
             mcp_curation_cache: None,
             mcp_cap_cache: None,
+            hydrated_tool_names: Vec::new(),
             file_cache: None,
             session_state: None,
             audit_log: None,
@@ -11116,6 +11356,7 @@ mod compact_tests {
             mcp_curation: wcore_config::config::McpCurationPolicy::default(),
             mcp_curation_cache: None,
             mcp_cap_cache: None,
+            hydrated_tool_names: Vec::new(),
             file_cache: None,
             session_state: None,
             audit_log: None,
@@ -12443,6 +12684,7 @@ mod plan_mode_tests {
             mcp_curation: wcore_config::config::McpCurationPolicy::default(),
             mcp_curation_cache: None,
             mcp_cap_cache: None,
+            hydrated_tool_names: Vec::new(),
             file_cache: None,
             session_state: None,
             audit_log: None,
@@ -12873,6 +13115,7 @@ mod hook_integration_tests {
             mcp_curation: wcore_config::config::McpCurationPolicy::default(),
             mcp_curation_cache: None,
             mcp_cap_cache: None,
+            hydrated_tool_names: Vec::new(),
             file_cache: None,
             session_state: None,
             audit_log: None,
@@ -13713,6 +13956,7 @@ mod approval_bridge_engine_tests {
             mcp_curation: wcore_config::config::McpCurationPolicy::default(),
             mcp_curation_cache: None,
             mcp_cap_cache: None,
+            hydrated_tool_names: Vec::new(),
             file_cache: None,
             session_state: None,
             audit_log: None,
@@ -14717,6 +14961,7 @@ mod user_model_writeback_tests {
             mcp_curation: wcore_config::config::McpCurationPolicy::default(),
             mcp_curation_cache: None,
             mcp_cap_cache: None,
+            hydrated_tool_names: Vec::new(),
             file_cache: None,
             session_state: None,
             audit_log: None,

--- a/crates/wcore-agent/src/engine.rs
+++ b/crates/wcore-agent/src/engine.rs
@@ -10602,8 +10602,7 @@ mod set_config_tests {
 
         // The serializer therefore emits NO stub entries at all.
         let wire =
-            serde_json::to_string(&wcore_providers::anthropic_shared::build_tools(&turn1))
-                .unwrap();
+            serde_json::to_string(&wcore_providers::anthropic_shared::build_tools(&turn1)).unwrap();
         assert!(
             !wire.contains("(Deferred)"),
             "no per-tool stub entries on the wire"
@@ -10612,8 +10611,7 @@ mod set_config_tests {
         // Deterministic + byte-stable across turns (same deferral state).
         let turn2 = engine.apply_tool_deferral(tools.clone());
         let wire2 =
-            serde_json::to_string(&wcore_providers::anthropic_shared::build_tools(&turn2))
-                .unwrap();
+            serde_json::to_string(&wcore_providers::anthropic_shared::build_tools(&turn2)).unwrap();
         assert_eq!(wire, wire2, "catalog line byte-stable across turns");
 
         // Config off: per-tool stub entries restored, catalog absent.
@@ -10621,9 +10619,7 @@ mod set_config_tests {
         let stubbed = engine.apply_tool_deferral(tools);
         assert_eq!(stubbed.len(), 4, "stub mode keeps every def in the array");
         assert!(
-            stubbed
-                .iter()
-                .any(|t| t.name == "clarify" && t.deferred),
+            stubbed.iter().any(|t| t.name == "clarify" && t.deferred),
             "cold tool is a stub entry again"
         );
         let ts_stub = stubbed.iter().find(|t| t.name == "ToolSearch").unwrap();
@@ -10835,13 +10831,19 @@ mod set_config_tests {
 
         // Stale hydration pruned: gone from the hydrated set, never emitted.
         assert!(
-            !engine.hydrated_tool_names.iter().any(|n| n == "mcp__srv__ghost"),
+            !engine
+                .hydrated_tool_names
+                .iter()
+                .any(|n| n == "mcp__srv__ghost"),
             "stale hydration must be pruned from the hydrated set"
         );
         assert!(!names.contains(&"mcp__srv__ghost"));
         // Live hydration survives the prune and is admitted.
         assert!(
-            engine.hydrated_tool_names.iter().any(|n| n == "mcp__srv__bravo"),
+            engine
+                .hydrated_tool_names
+                .iter()
+                .any(|n| n == "mcp__srv__bravo"),
             "live hydration must survive the prune"
         );
         assert!(

--- a/crates/wcore-config/src/tools.rs
+++ b/crates/wcore-config/src/tools.rs
@@ -14,6 +14,49 @@ use serde::{Deserialize, Serialize};
 pub struct BuiltinToolsConfig {
     pub script: ScriptToolConfig,
     pub repomap: RepoMapToolConfig,
+    pub defer_cold: DeferColdConfig,
+}
+
+/// Layer D1 (token-opt): defer cold built-ins to name-only stubs.
+///
+/// ~30 built-in tool schemas (~7k tokens) are re-serialized on every model
+/// round-trip. With deferral on, only the tools on `hot_allowlist` ship
+/// their full schema; everything else (cold built-ins + MCP tools) is sent
+/// as a name + truncated-description stub that the model hydrates on demand
+/// via `ToolSearch`.
+///
+/// CRITICAL caching constraint: the hot/stub split is a pure function of
+/// this static config — never of per-turn state — so the serialized
+/// `tools[]` array stays byte-identical across the turns of a conversation
+/// (the cached-prefix guard is `tools_array_byte_stable_across_roundtrips`
+/// in `wcore-providers`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct DeferColdConfig {
+    /// Default ON. `false` restores full schemas for every tool.
+    pub enabled: bool,
+    /// Tools that always ship their full schema. `ToolSearch` is never
+    /// deferred regardless of this list (it is the hydration path).
+    pub hot_allowlist: Vec<String>,
+}
+
+impl DeferColdConfig {
+    /// The high-frequency core loop tools plus the hydration tool.
+    pub fn default_hot_allowlist() -> Vec<String> {
+        ["Read", "Edit", "Write", "Bash", "Grep", "Glob", "ToolSearch"]
+            .into_iter()
+            .map(String::from)
+            .collect()
+    }
+}
+
+impl Default for DeferColdConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            hot_allowlist: Self::default_hot_allowlist(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]

--- a/crates/wcore-config/src/tools.rs
+++ b/crates/wcore-config/src/tools.rs
@@ -59,10 +59,18 @@ pub struct DeferColdConfig {
 impl DeferColdConfig {
     /// The high-frequency core loop tools plus the hydration tool.
     pub fn default_hot_allowlist() -> Vec<String> {
-        ["Read", "Edit", "Write", "Bash", "Grep", "Glob", "ToolSearch"]
-            .into_iter()
-            .map(String::from)
-            .collect()
+        [
+            "Read",
+            "Edit",
+            "Write",
+            "Bash",
+            "Grep",
+            "Glob",
+            "ToolSearch",
+        ]
+        .into_iter()
+        .map(String::from)
+        .collect()
     }
 }
 

--- a/crates/wcore-config/src/tools.rs
+++ b/crates/wcore-config/src/tools.rs
@@ -17,19 +17,23 @@ pub struct BuiltinToolsConfig {
     pub defer_cold: DeferColdConfig,
 }
 
-/// Layer D1 (token-opt): defer cold built-ins to name-only stubs.
+/// Layer D1 (token-opt): defer cold built-ins out of the tools[] array.
 ///
 /// ~30 built-in tool schemas (~7k tokens) are re-serialized on every model
 /// round-trip. With deferral on, only the tools on `hot_allowlist` ship
-/// their full schema; everything else (cold built-ins + MCP tools) is sent
-/// as a name + truncated-description stub that the model hydrates on demand
-/// via `ToolSearch`.
+/// their full schema. Everything else (cold built-ins + MCP tools) is —
+/// with `catalog` on (default) — folded into a single compact,
+/// name-only inventory line inside ToolSearch's own description (the
+/// openclaw pattern: no per-tool stub entries at all). With `catalog`
+/// off, cold tools fall back to individual name + truncated-description
+/// stub entries. Either way the model hydrates on demand via `ToolSearch`.
 ///
-/// CRITICAL caching constraint: the hot/stub split is a pure function of
-/// this static config — never of per-turn state — so the serialized
-/// `tools[]` array stays byte-identical across the turns of a conversation
-/// (the cached-prefix guard is `tools_array_byte_stable_across_roundtrips`
-/// in `wcore-providers`).
+/// CRITICAL caching constraint: the hot/deferred split is a pure function
+/// of this static config — never of per-turn state — so the serialized
+/// `tools[]` array (including the catalog line) stays byte-identical across
+/// the turns of a conversation (the cached-prefix guard is
+/// `tools_array_byte_stable_across_roundtrips` in `wcore-providers`); a
+/// ToolSearch hydration changes it once.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct DeferColdConfig {
@@ -38,6 +42,15 @@ pub struct DeferColdConfig {
     /// Tools that always ship their full schema. `ToolSearch` is never
     /// deferred regardless of this list (it is the hydration path).
     pub hot_allowlist: Vec<String>,
+    /// Default ON: deferred tools ship as ONE sorted name-only catalog line
+    /// in ToolSearch's description instead of per-tool stub entries
+    /// (measured: 43 stubs cost ~2.5k tokens/request — more than the hot
+    /// schemas). `false` restores per-tool stub entries.
+    pub catalog: bool,
+    /// Defensive cap on the catalog line's name-list length in chars
+    /// (suffix "+N more — search to discover" replaces the overflow, so an
+    /// MCP swarm cannot balloon the prompt). Applies to the names portion.
+    pub catalog_max_chars: usize,
 }
 
 impl DeferColdConfig {
@@ -55,6 +68,8 @@ impl Default for DeferColdConfig {
         Self {
             enabled: true,
             hot_allowlist: Self::default_hot_allowlist(),
+            catalog: true,
+            catalog_max_chars: 4096,
         }
     }
 }

--- a/crates/wcore-config/src/tools.rs
+++ b/crates/wcore-config/src/tools.rs
@@ -47,9 +47,12 @@ pub struct DeferColdConfig {
     /// (measured: 43 stubs cost ~2.5k tokens/request — more than the hot
     /// schemas). `false` restores per-tool stub entries.
     pub catalog: bool,
-    /// Defensive cap on the catalog line's name-list length in chars
-    /// (suffix "+N more — search to discover" replaces the overflow, so an
-    /// MCP swarm cannot balloon the prompt). Applies to the names portion.
+    /// HARD cap on the catalog line's name-list length in chars — even a
+    /// single name is dropped when it alone exceeds the budget (the suffix
+    /// "+N more — search to discover" replaces the overflow, so an MCP
+    /// swarm or a pathological name cannot balloon the prompt). Applies
+    /// strictly to the names portion; the fixed prefix and the
+    /// constant-size suffix sit outside it.
     pub catalog_max_chars: usize,
 }
 

--- a/crates/wcore-providers/src/anthropic_shared.rs
+++ b/crates/wcore-providers/src/anthropic_shared.rs
@@ -208,9 +208,19 @@ pub fn build_tools(tools: &[ToolDef]) -> Vec<Value> {
     // tool name — so the tools[] array is byte-identical across round-trips
     // of one conversation regardless of registration / curation order. The
     // array is part of the cached prompt prefix; a reordered array changes
-    // the prefix bytes and silently busts prompt caching.
+    // the prefix bytes and silently busts prompt caching. Schema /
+    // description / deferred are the DUPLICATE-NAME tiebreak: the registry
+    // does not forbid duplicate registration, and a name-only (stable) sort
+    // would keep input order for equal names — byte-unstable again.
     let mut ordered: Vec<&ToolDef> = tools.iter().collect();
-    ordered.sort_by(|a, b| a.name.cmp(&b.name));
+    ordered.sort_by_cached_key(|t| {
+        (
+            t.name.clone(),
+            serde_json::to_string(&t.input_schema).unwrap_or_default(),
+            t.description.clone(),
+            t.deferred,
+        )
+    });
     ordered
         .iter()
         .map(|t| {
@@ -1034,6 +1044,31 @@ mod tests {
         assert_eq!(
             turn1, reordered,
             "reordered input must serialize byte-identically (deterministic name sort)"
+        );
+
+        // DUPLICATE names must not reintroduce input-order dependence: the
+        // registry does not forbid duplicate registration, and a stable
+        // name-only sort keeps input order for equal names. The
+        // schema/description tiebreak makes duplicates order-independent too.
+        let dup_a = ToolDef {
+            name: "Read".into(),
+            description: "Read a file (duplicate registration)".into(),
+            input_schema: serde_json::json!({"type": "object", "properties": {"offset": {"type": "integer"}}}),
+            deferred: false,
+            server: None,
+        };
+        let dup_b = ToolDef {
+            name: "Read".into(),
+            description: "Read a file".into(),
+            input_schema: serde_json::json!({"type": "object", "properties": {"path": {"type": "string"}}}),
+            deferred: false,
+            server: None,
+        };
+        let one = serde_json::to_string(&build_tools(&[dup_a.clone(), dup_b.clone()])).unwrap();
+        let other = serde_json::to_string(&build_tools(&[dup_b, dup_a])).unwrap();
+        assert_eq!(
+            one, other,
+            "duplicate names must serialize byte-identically regardless of input order"
         );
     }
 

--- a/crates/wcore-providers/src/anthropic_shared.rs
+++ b/crates/wcore-providers/src/anthropic_shared.rs
@@ -218,9 +218,9 @@ pub fn build_tools(tools: &[ToolDef]) -> Vec<Value> {
                 let short_desc = truncate_deferred_description(&t.description);
                 json!({
                     "name": encode_tool_name(&t.name),
-                    "description": format!(
-                        "(Deferred) {short_desc} — Use ToolSearch to load full schema before calling."
-                    ),
+                    // Layer D2: no per-stub "use ToolSearch" boilerplate —
+                    // the system prompt states the hydration rule once.
+                    "description": format!("(Deferred) {short_desc}"),
                     "input_schema": {
                         "type": "object",
                         "properties": {}
@@ -987,7 +987,10 @@ mod tests {
                 .is_empty()
         );
         let desc = result[1]["description"].as_str().unwrap();
-        assert!(desc.contains("ToolSearch"));
+        assert!(desc.starts_with("(Deferred)"));
+        // Layer D2: the per-stub "use ToolSearch" boilerplate is gone — the
+        // system prompt states the hydration rule once.
+        assert!(!desc.contains("Use ToolSearch"));
     }
 
     /// Layer E1 regression guard: the serialized tools[] array must be

--- a/crates/wcore-providers/src/anthropic_shared.rs
+++ b/crates/wcore-providers/src/anthropic_shared.rs
@@ -204,7 +204,14 @@ fn generate_tool_id() -> String {
 /// emit them at the top level in the first place, but a single bad tool
 /// would otherwise break every Anthropic turn.
 pub fn build_tools(tools: &[ToolDef]) -> Vec<Value> {
-    tools
+    // Layer E1 (token-opt): serialize in a deterministic order — sorted by
+    // tool name — so the tools[] array is byte-identical across round-trips
+    // of one conversation regardless of registration / curation order. The
+    // array is part of the cached prompt prefix; a reordered array changes
+    // the prefix bytes and silently busts prompt caching.
+    let mut ordered: Vec<&ToolDef> = tools.iter().collect();
+    ordered.sort_by(|a, b| a.name.cmp(&b.name));
+    ordered
         .iter()
         .map(|t| {
             if t.deferred {
@@ -981,6 +988,50 @@ mod tests {
         );
         let desc = result[1]["description"].as_str().unwrap();
         assert!(desc.contains("ToolSearch"));
+    }
+
+    /// Layer E1 regression guard: the serialized tools[] array must be
+    /// byte-identical across two consecutive round-trips of one conversation
+    /// — even when the input ToolDef order differs (registration vs curation
+    /// order). The array is part of the cached prompt prefix; any byte drift
+    /// silently busts prompt caching.
+    #[test]
+    fn tools_array_byte_stable_across_roundtrips() {
+        let read = ToolDef {
+            name: "Read".into(),
+            description: "Read a file".into(),
+            input_schema: json!({"type": "object", "properties": {"path": {"type": "string"}}}),
+            deferred: false,
+            server: None,
+        };
+        let bash = ToolDef {
+            name: "Bash".into(),
+            description: "Run a shell command".into(),
+            input_schema: json!({"type": "object", "properties": {"cmd": {"type": "string"}}}),
+            deferred: false,
+            server: None,
+        };
+        let spawn = ToolDef {
+            name: "SpawnTool".into(),
+            description: "Spawn sub-agents".into(),
+            input_schema: json!({"type": "object", "properties": {"agents": {"type": "array"}}}),
+            deferred: true,
+            server: None,
+        };
+
+        // Two builds from the same input (turn N and turn N+1).
+        let defs = vec![read.clone(), bash.clone(), spawn.clone()];
+        let turn1 = serde_json::to_string(&build_tools(&defs)).unwrap();
+        let turn2 = serde_json::to_string(&build_tools(&defs)).unwrap();
+        assert_eq!(turn1, turn2, "same input must serialize byte-identically");
+
+        // A build from a reordered input (e.g. a curation pass shuffled the
+        // registry order mid-conversation) must STILL be byte-identical.
+        let reordered = serde_json::to_string(&build_tools(&[spawn, bash, read])).unwrap();
+        assert_eq!(
+            turn1, reordered,
+            "reordered input must serialize byte-identically (deterministic name sort)"
+        );
     }
 
     // --- parse_sse_data tests ---

--- a/crates/wcore-providers/src/cache_observation.rs
+++ b/crates/wcore-providers/src/cache_observation.rs
@@ -137,6 +137,29 @@ impl PromptCacheObservation {
     }
 }
 
+/// Structured `cache_health_warn` event (Layer E1) — emitted when a warm
+/// session's cache hit-ratio (`cache_read / input`) falls below the warn
+/// threshold on a round-trip where the prefix should already be cached.
+/// Warning-only telemetry: never alters the request. Detection lives in
+/// `wcore-agent::cache_diagnostics` (which tracks per-conversation
+/// round-trips); this is the wire/observability shape.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CacheHealthWarn {
+    /// Stable per-session conversation id (Flux sticky-routing id).
+    pub conversation_id: String,
+    /// 1-based round-trip index within the conversation.
+    pub round_trip: u64,
+    /// Provider-reported input tokens for the turn.
+    pub input_tokens: u64,
+    /// Provider-reported cache-read tokens for the turn.
+    pub cache_read_tokens: u64,
+    /// `cache_read_tokens / input_tokens`.
+    pub ratio: f64,
+    /// Model that served the turn (Flux `ProviderMeta.routed_model` when
+    /// signaled back, else the dispatched model id).
+    pub routed_model: String,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -224,6 +247,21 @@ mod tests {
         let j = serde_json::to_string(&obs).unwrap();
         let back: PromptCacheObservation = serde_json::from_str(&j).unwrap();
         assert_eq!(obs, back);
+    }
+
+    #[test]
+    fn cache_health_warn_serde_round_trip() {
+        let warn = CacheHealthWarn {
+            conversation_id: "conv-123".into(),
+            round_trip: 3,
+            input_tokens: 15_000,
+            cache_read_tokens: 128,
+            ratio: 128.0 / 15_000.0,
+            routed_model: "gpt-5.4".into(),
+        };
+        let j = serde_json::to_string(&warn).unwrap();
+        let back: CacheHealthWarn = serde_json::from_str(&j).unwrap();
+        assert_eq!(warn, back);
     }
 
     #[test]

--- a/crates/wcore-providers/src/gemini.rs
+++ b/crates/wcore-providers/src/gemini.rs
@@ -480,9 +480,9 @@ pub(crate) fn build_function_declarations(tools: &[ToolDef]) -> Vec<Value> {
                 let short_desc = truncate_deferred_description(&t.description);
                 json!({
                     "name": encode_tool_name(&t.name),
-                    "description": format!(
-                        "(Deferred) {short_desc} — Use ToolSearch to load full schema before calling."
-                    ),
+                    // Layer D2: no per-stub "use ToolSearch" boilerplate —
+                    // the system prompt states the hydration rule once.
+                    "description": format!("(Deferred) {short_desc}"),
                     "parameters": {
                         "type": "object",
                         "properties": {}

--- a/crates/wcore-providers/src/gemini.rs
+++ b/crates/wcore-providers/src/gemini.rs
@@ -1804,11 +1804,12 @@ mod tests {
             deferred: false,
             server: None,
         };
-        let one =
-            serde_json::to_string(&build_function_declarations(&[dup_a.clone(), dup_b.clone()]))
-                .unwrap();
-        let other =
-            serde_json::to_string(&build_function_declarations(&[dup_b, dup_a])).unwrap();
+        let one = serde_json::to_string(&build_function_declarations(&[
+            dup_a.clone(),
+            dup_b.clone(),
+        ]))
+        .unwrap();
+        let other = serde_json::to_string(&build_function_declarations(&[dup_b, dup_a])).unwrap();
         assert_eq!(
             one, other,
             "duplicate names must serialize byte-identically regardless of input order"

--- a/crates/wcore-providers/src/gemini.rs
+++ b/crates/wcore-providers/src/gemini.rs
@@ -478,8 +478,19 @@ pub(crate) fn build_function_declarations(tools: &[ToolDef]) -> Vec<Value> {
     // round-trips of one conversation regardless of registration / curation
     // order. The array is part of the cached prompt prefix; a reordered
     // array changes the prefix bytes and silently busts prompt caching.
+    // Schema / description / deferred are the DUPLICATE-NAME tiebreak: the
+    // registry does not forbid duplicate registration, and a name-only
+    // (stable) sort would keep input order for equal names — byte-unstable
+    // again.
     let mut ordered: Vec<&ToolDef> = tools.iter().collect();
-    ordered.sort_by(|a, b| a.name.cmp(&b.name));
+    ordered.sort_by_cached_key(|t| {
+        (
+            t.name.clone(),
+            serde_json::to_string(&t.input_schema).unwrap_or_default(),
+            t.description.clone(),
+            t.deferred,
+        )
+    });
     ordered
         .iter()
         .map(|t| {
@@ -1773,6 +1784,34 @@ mod tests {
         assert_eq!(
             turn1, reordered,
             "reordered input must serialize byte-identically (deterministic name sort)"
+        );
+
+        // DUPLICATE names must not reintroduce input-order dependence: the
+        // registry does not forbid duplicate registration, and a stable
+        // name-only sort keeps input order for equal names. The
+        // schema/description tiebreak makes duplicates order-independent too.
+        let dup_a = ToolDef {
+            name: "Read".into(),
+            description: "Read a file (duplicate registration)".into(),
+            input_schema: serde_json::json!({"type": "object", "properties": {"offset": {"type": "integer"}}}),
+            deferred: false,
+            server: None,
+        };
+        let dup_b = ToolDef {
+            name: "Read".into(),
+            description: "Read a file".into(),
+            input_schema: serde_json::json!({"type": "object", "properties": {"path": {"type": "string"}}}),
+            deferred: false,
+            server: None,
+        };
+        let one =
+            serde_json::to_string(&build_function_declarations(&[dup_a.clone(), dup_b.clone()]))
+                .unwrap();
+        let other =
+            serde_json::to_string(&build_function_declarations(&[dup_b, dup_a])).unwrap();
+        assert_eq!(
+            one, other,
+            "duplicate names must serialize byte-identically regardless of input order"
         );
     }
 

--- a/crates/wcore-providers/src/gemini.rs
+++ b/crates/wcore-providers/src/gemini.rs
@@ -473,7 +473,14 @@ pub(crate) fn build_contents(
 /// - `additionalProperties` (any value — boolean or object)
 /// - Array-form `type` like `["string", "array"]` (collapsed to first non-null)
 pub(crate) fn build_function_declarations(tools: &[ToolDef]) -> Vec<Value> {
-    tools
+    // Layer E1 (token-opt): serialize in a deterministic order — sorted by
+    // tool name — so the functionDeclarations array is byte-identical across
+    // round-trips of one conversation regardless of registration / curation
+    // order. The array is part of the cached prompt prefix; a reordered
+    // array changes the prefix bytes and silently busts prompt caching.
+    let mut ordered: Vec<&ToolDef> = tools.iter().collect();
+    ordered.sort_by(|a, b| a.name.cmp(&b.name));
+    ordered
         .iter()
         .map(|t| {
             if t.deferred {
@@ -1721,6 +1728,51 @@ mod tests {
         assert_eq!(
             params["properties"]["pages"]["type"], "integer",
             "union type [integer, null] must be collapsed to 'integer'"
+        );
+    }
+
+    /// Layer E1 regression guard: the serialized functionDeclarations array
+    /// must be byte-identical across two consecutive round-trips of one
+    /// conversation — even when the input ToolDef order differs
+    /// (registration vs curation order). The array is part of the cached
+    /// prompt prefix; any byte drift silently busts prompt caching.
+    #[test]
+    fn tools_array_byte_stable_across_roundtrips() {
+        let read = ToolDef {
+            name: "Read".into(),
+            description: "Read a file".into(),
+            input_schema: serde_json::json!({"type": "object", "properties": {"path": {"type": "string"}}}),
+            deferred: false,
+            server: None,
+        };
+        let bash = ToolDef {
+            name: "Bash".into(),
+            description: "Run a shell command".into(),
+            input_schema: serde_json::json!({"type": "object", "properties": {"cmd": {"type": "string"}}}),
+            deferred: false,
+            server: None,
+        };
+        let spawn = ToolDef {
+            name: "SpawnTool".into(),
+            description: "Spawn sub-agents".into(),
+            input_schema: serde_json::json!({"type": "object", "properties": {"agents": {"type": "array"}}}),
+            deferred: true,
+            server: None,
+        };
+
+        // Two builds from the same input (turn N and turn N+1).
+        let defs = vec![read.clone(), bash.clone(), spawn.clone()];
+        let turn1 = serde_json::to_string(&build_function_declarations(&defs)).unwrap();
+        let turn2 = serde_json::to_string(&build_function_declarations(&defs)).unwrap();
+        assert_eq!(turn1, turn2, "same input must serialize byte-identically");
+
+        // A build from a reordered input (e.g. a curation pass shuffled the
+        // registry order mid-conversation) must STILL be byte-identical.
+        let reordered =
+            serde_json::to_string(&build_function_declarations(&[spawn, bash, read])).unwrap();
+        assert_eq!(
+            turn1, reordered,
+            "reordered input must serialize byte-identically (deterministic name sort)"
         );
     }
 

--- a/crates/wcore-providers/src/openai.rs
+++ b/crates/wcore-providers/src/openai.rs
@@ -4773,9 +4773,11 @@ mod tests {
             deferred: false,
             server: None,
         };
-        let one =
-            serde_json::to_string(&OpenAIProvider::build_tools(&[dup_a.clone(), dup_b.clone()]))
-                .unwrap();
+        let one = serde_json::to_string(&OpenAIProvider::build_tools(&[
+            dup_a.clone(),
+            dup_b.clone(),
+        ]))
+        .unwrap();
         let other = serde_json::to_string(&OpenAIProvider::build_tools(&[dup_b, dup_a])).unwrap();
         assert_eq!(
             one, other,

--- a/crates/wcore-providers/src/openai.rs
+++ b/crates/wcore-providers/src/openai.rs
@@ -524,9 +524,19 @@ impl OpenAIProvider {
         // round-trips of one conversation regardless of registration /
         // curation order. The array is part of the cached prompt prefix; a
         // reordered array changes the prefix bytes and silently busts prompt
-        // caching.
+        // caching. Schema / description / deferred are the DUPLICATE-NAME
+        // tiebreak: the registry does not forbid duplicate registration, and
+        // a name-only (stable) sort would keep input order for equal names —
+        // byte-unstable again.
         let mut ordered: Vec<&ToolDef> = tools.iter().collect();
-        ordered.sort_by(|a, b| a.name.cmp(&b.name));
+        ordered.sort_by_cached_key(|t| {
+            (
+                t.name.clone(),
+                serde_json::to_string(&t.input_schema).unwrap_or_default(),
+                t.description.clone(),
+                t.deferred,
+            )
+        });
         ordered
             .iter()
             .map(|t| {
@@ -4743,6 +4753,33 @@ mod tests {
         assert_eq!(
             turn1, reordered,
             "reordered input must serialize byte-identically (deterministic name sort)"
+        );
+
+        // DUPLICATE names must not reintroduce input-order dependence: the
+        // registry does not forbid duplicate registration, and a stable
+        // name-only sort keeps input order for equal names. The
+        // schema/description tiebreak makes duplicates order-independent too.
+        let dup_a = ToolDef {
+            name: "Read".into(),
+            description: "Read a file (duplicate registration)".into(),
+            input_schema: serde_json::json!({"type": "object", "properties": {"offset": {"type": "integer"}}}),
+            deferred: false,
+            server: None,
+        };
+        let dup_b = ToolDef {
+            name: "Read".into(),
+            description: "Read a file".into(),
+            input_schema: serde_json::json!({"type": "object", "properties": {"path": {"type": "string"}}}),
+            deferred: false,
+            server: None,
+        };
+        let one =
+            serde_json::to_string(&OpenAIProvider::build_tools(&[dup_a.clone(), dup_b.clone()]))
+                .unwrap();
+        let other = serde_json::to_string(&OpenAIProvider::build_tools(&[dup_b, dup_a])).unwrap();
+        assert_eq!(
+            one, other,
+            "duplicate names must serialize byte-identically regardless of input order"
         );
     }
 

--- a/crates/wcore-providers/src/openai.rs
+++ b/crates/wcore-providers/src/openai.rs
@@ -536,9 +536,10 @@ impl OpenAIProvider {
                         "type": "function",
                         "function": {
                             "name": encode_tool_name(&t.name),
-                            "description": format!(
-                                "(Deferred) {short_desc} — Use ToolSearch to load full schema before calling."
-                            ),
+                            // Layer D2: no per-stub "use ToolSearch"
+                            // boilerplate — the system prompt states the
+                            // hydration rule once.
+                            "description": format!("(Deferred) {short_desc}"),
                             "parameters": {
                                 "type": "object",
                                 "properties": {}
@@ -4694,7 +4695,10 @@ mod tests {
         let spawn_params = &result[1]["function"]["parameters"];
         assert!(spawn_params["properties"].as_object().unwrap().is_empty());
         let spawn_desc = result[1]["function"]["description"].as_str().unwrap();
-        assert!(spawn_desc.contains("ToolSearch"));
+        assert!(spawn_desc.starts_with("(Deferred)"));
+        // Layer D2: the per-stub "use ToolSearch" boilerplate is gone — the
+        // system prompt states the hydration rule once.
+        assert!(!spawn_desc.contains("Use ToolSearch"));
     }
 
     /// Layer E1 regression guard: the serialized tools[] array must be

--- a/crates/wcore-providers/src/openai.rs
+++ b/crates/wcore-providers/src/openai.rs
@@ -519,7 +519,15 @@ impl OpenAIProvider {
     }
 
     fn build_tools(tools: &[ToolDef]) -> Vec<Value> {
-        tools
+        // Layer E1 (token-opt): serialize in a deterministic order — sorted
+        // by tool name — so the tools[] array is byte-identical across
+        // round-trips of one conversation regardless of registration /
+        // curation order. The array is part of the cached prompt prefix; a
+        // reordered array changes the prefix bytes and silently busts prompt
+        // caching.
+        let mut ordered: Vec<&ToolDef> = tools.iter().collect();
+        ordered.sort_by(|a, b| a.name.cmp(&b.name));
+        ordered
             .iter()
             .map(|t| {
                 if t.deferred {
@@ -4689,6 +4697,51 @@ mod tests {
         assert!(spawn_desc.contains("ToolSearch"));
     }
 
+    /// Layer E1 regression guard: the serialized tools[] array must be
+    /// byte-identical across two consecutive round-trips of one conversation
+    /// — even when the input ToolDef order differs (registration vs curation
+    /// order). The array is part of the cached prompt prefix; any byte drift
+    /// silently busts prompt caching.
+    #[test]
+    fn tools_array_byte_stable_across_roundtrips() {
+        let read = ToolDef {
+            name: "Read".into(),
+            description: "Read a file".into(),
+            input_schema: json!({"type": "object", "properties": {"path": {"type": "string"}}}),
+            deferred: false,
+            server: None,
+        };
+        let bash = ToolDef {
+            name: "Bash".into(),
+            description: "Run a shell command".into(),
+            input_schema: json!({"type": "object", "properties": {"cmd": {"type": "string"}}}),
+            deferred: false,
+            server: None,
+        };
+        let spawn = ToolDef {
+            name: "SpawnTool".into(),
+            description: "Spawn sub-agents".into(),
+            input_schema: json!({"type": "object", "properties": {"agents": {"type": "array"}}}),
+            deferred: true,
+            server: None,
+        };
+
+        // Two builds from the same input (turn N and turn N+1).
+        let defs = vec![read.clone(), bash.clone(), spawn.clone()];
+        let turn1 = serde_json::to_string(&OpenAIProvider::build_tools(&defs)).unwrap();
+        let turn2 = serde_json::to_string(&OpenAIProvider::build_tools(&defs)).unwrap();
+        assert_eq!(turn1, turn2, "same input must serialize byte-identically");
+
+        // A build from a reordered input (e.g. a curation pass shuffled the
+        // registry order mid-conversation) must STILL be byte-identical.
+        let reordered =
+            serde_json::to_string(&OpenAIProvider::build_tools(&[spawn, bash, read])).unwrap();
+        assert_eq!(
+            turn1, reordered,
+            "reordered input must serialize byte-identically (deterministic name sort)"
+        );
+    }
+
     /// #297: WCore tool ids contain `:` / `::` / `.`, which OpenAI rejects with
     /// `400 invalid_value` on `tools[N].function.name`. build_tools must emit
     /// names matching `^[a-zA-Z0-9_-]+$`, and a clean snake_case name must be
@@ -4913,21 +4966,30 @@ mod tests {
         ];
         let result = OpenAIProvider::build_tools(&tools);
 
+        // build_tools serializes in deterministic name order (Layer E1), so
+        // look entries up by name instead of input position.
+        let by_name = |name: &str| -> &Value {
+            result
+                .iter()
+                .find(|t| t["function"]["name"] == name)
+                .unwrap_or_else(|| panic!("tool {name} missing from serialized array"))
+        };
+
         // bare {type:object} -> gains properties:{} and required:[]
-        let exec = &result[0]["function"]["parameters"];
+        let exec = &by_name("execute")["function"]["parameters"];
         assert_eq!(exec["type"], "object");
         assert!(exec["properties"].is_object());
         assert!(exec["properties"].as_object().unwrap().is_empty());
         assert!(exec["required"].is_array());
 
         // additionalProperties is preserved; properties + required still added
-        let ijfw = &result[1]["function"]["parameters"];
+        let ijfw = &by_name("ijfw_run")["function"]["parameters"];
         assert!(ijfw["properties"].is_object());
         assert_eq!(ijfw["additionalProperties"], json!(true));
         assert!(ijfw["required"].is_array());
 
         // a well-formed schema is passed through untouched
-        let read = &result[2]["function"]["parameters"];
+        let read = &by_name("Read")["function"]["parameters"];
         assert!(read["properties"].get("path").is_some());
         assert_eq!(read["required"], json!(["path"]));
     }

--- a/crates/wcore-providers/src/openai_responses.rs
+++ b/crates/wcore-providers/src/openai_responses.rs
@@ -960,8 +960,7 @@ mod tests {
             server: None,
         };
         let one =
-            serde_json::to_string(&build_responses_tools(&[dup_a.clone(), dup_b.clone()]))
-                .unwrap();
+            serde_json::to_string(&build_responses_tools(&[dup_a.clone(), dup_b.clone()])).unwrap();
         let other = serde_json::to_string(&build_responses_tools(&[dup_b, dup_a])).unwrap();
         assert_eq!(
             one, other,

--- a/crates/wcore-providers/src/openai_responses.rs
+++ b/crates/wcore-providers/src/openai_responses.rs
@@ -315,9 +315,9 @@ fn build_responses_tools(tools: &[ToolDef]) -> Vec<Value> {
                 json!({
                     "type": "function",
                     "name": encode_tool_name(&t.name),
-                    "description": format!(
-                        "(Deferred) {short_desc} — Use ToolSearch to load full schema before calling."
-                    ),
+                    // Layer D2: no per-stub "use ToolSearch" boilerplate —
+                    // the system prompt states the hydration rule once.
+                    "description": format!("(Deferred) {short_desc}"),
                     "parameters": { "type": "object", "properties": {} },
                 })
             } else {

--- a/crates/wcore-providers/src/openai_responses.rs
+++ b/crates/wcore-providers/src/openai_responses.rs
@@ -311,9 +311,19 @@ fn build_responses_tools(tools: &[ToolDef]) -> Vec<Value> {
     // tool name — so the tools[] array is byte-identical across round-trips
     // of one conversation regardless of registration / curation order. The
     // array is part of the cached prompt prefix; a reordered array changes
-    // the prefix bytes and silently busts prompt caching.
+    // the prefix bytes and silently busts prompt caching. Schema /
+    // description / deferred are the DUPLICATE-NAME tiebreak: the registry
+    // does not forbid duplicate registration, and a name-only (stable) sort
+    // would keep input order for equal names — byte-unstable again.
     let mut ordered: Vec<&ToolDef> = tools.iter().collect();
-    ordered.sort_by(|a, b| a.name.cmp(&b.name));
+    ordered.sort_by_cached_key(|t| {
+        (
+            t.name.clone(),
+            serde_json::to_string(&t.input_schema).unwrap_or_default(),
+            t.description.clone(),
+            t.deferred,
+        )
+    });
     ordered
         .iter()
         .map(|t| {
@@ -929,6 +939,33 @@ mod tests {
         assert_eq!(
             turn1, reordered,
             "reordered input must serialize byte-identically (deterministic name sort)"
+        );
+
+        // DUPLICATE names must not reintroduce input-order dependence: the
+        // registry does not forbid duplicate registration, and a stable
+        // name-only sort keeps input order for equal names. The
+        // schema/description tiebreak makes duplicates order-independent too.
+        let dup_a = ToolDef {
+            name: "Read".into(),
+            description: "Read a file (duplicate registration)".into(),
+            input_schema: serde_json::json!({"type": "object", "properties": {"offset": {"type": "integer"}}}),
+            deferred: false,
+            server: None,
+        };
+        let dup_b = ToolDef {
+            name: "Read".into(),
+            description: "Read a file".into(),
+            input_schema: serde_json::json!({"type": "object", "properties": {"path": {"type": "string"}}}),
+            deferred: false,
+            server: None,
+        };
+        let one =
+            serde_json::to_string(&build_responses_tools(&[dup_a.clone(), dup_b.clone()]))
+                .unwrap();
+        let other = serde_json::to_string(&build_responses_tools(&[dup_b, dup_a])).unwrap();
+        assert_eq!(
+            one, other,
+            "duplicate names must serialize byte-identically regardless of input order"
         );
     }
 

--- a/crates/wcore-providers/src/openai_responses.rs
+++ b/crates/wcore-providers/src/openai_responses.rs
@@ -307,7 +307,14 @@ fn collect_text(msg: &Message) -> String {
 /// { "name", ... } }`. Mirrors `convertResponsesTools` in
 /// `openai-responses-tools.ts`.
 fn build_responses_tools(tools: &[ToolDef]) -> Vec<Value> {
-    tools
+    // Layer E1 (token-opt): serialize in a deterministic order — sorted by
+    // tool name — so the tools[] array is byte-identical across round-trips
+    // of one conversation regardless of registration / curation order. The
+    // array is part of the cached prompt prefix; a reordered array changes
+    // the prefix bytes and silently busts prompt caching.
+    let mut ordered: Vec<&ToolDef> = tools.iter().collect();
+    ordered.sort_by(|a, b| a.name.cmp(&b.name));
+    ordered
         .iter()
         .map(|t| {
             if t.deferred {
@@ -879,6 +886,51 @@ mod tests {
     }
 
     // --- request body mapping --------------------------------------------
+
+    /// Layer E1 regression guard: the serialized tools[] array must be
+    /// byte-identical across two consecutive round-trips of one conversation
+    /// — even when the input ToolDef order differs (registration vs curation
+    /// order). The array is part of the cached prompt prefix; any byte drift
+    /// silently busts prompt caching.
+    #[test]
+    fn tools_array_byte_stable_across_roundtrips() {
+        let read = ToolDef {
+            name: "Read".into(),
+            description: "Read a file".into(),
+            input_schema: serde_json::json!({"type": "object", "properties": {"path": {"type": "string"}}}),
+            deferred: false,
+            server: None,
+        };
+        let bash = ToolDef {
+            name: "Bash".into(),
+            description: "Run a shell command".into(),
+            input_schema: serde_json::json!({"type": "object", "properties": {"cmd": {"type": "string"}}}),
+            deferred: false,
+            server: None,
+        };
+        let spawn = ToolDef {
+            name: "SpawnTool".into(),
+            description: "Spawn sub-agents".into(),
+            input_schema: serde_json::json!({"type": "object", "properties": {"agents": {"type": "array"}}}),
+            deferred: true,
+            server: None,
+        };
+
+        // Two builds from the same input (turn N and turn N+1).
+        let defs = vec![read.clone(), bash.clone(), spawn.clone()];
+        let turn1 = serde_json::to_string(&build_responses_tools(&defs)).unwrap();
+        let turn2 = serde_json::to_string(&build_responses_tools(&defs)).unwrap();
+        assert_eq!(turn1, turn2, "same input must serialize byte-identically");
+
+        // A build from a reordered input (e.g. a curation pass shuffled the
+        // registry order mid-conversation) must STILL be byte-identical.
+        let reordered =
+            serde_json::to_string(&build_responses_tools(&[spawn, bash, read])).unwrap();
+        assert_eq!(
+            turn1, reordered,
+            "reordered input must serialize byte-identically (deterministic name sort)"
+        );
+    }
 
     #[test]
     fn build_body_maps_system_to_instructions_and_messages_to_input() {

--- a/crates/wcore-tools/src/registry.rs
+++ b/crates/wcore-tools/src/registry.rs
@@ -306,8 +306,12 @@ pub fn fold_deferred_into_catalog(mut defs: Vec<ToolDef>, catalog_max_chars: usi
 }
 
 /// Render the sorted, bounded deferred-tool inventory line for
-/// [`fold_deferred_into_catalog`]. `max_chars` bounds the names portion;
-/// the fixed prefix and the overflow suffix sit outside the budget.
+/// [`fold_deferred_into_catalog`]. `max_chars` is a HARD bound on the
+/// name-list portion — even the FIRST name is dropped when it alone exceeds
+/// the budget (a pathological MCP name must not blow past the documented
+/// cap). The fixed prefix and the constant-size `+N more` overflow suffix
+/// sit outside the budget; omitted names remain discoverable via ToolSearch
+/// queries.
 fn render_deferred_catalog(
     names: &std::collections::BTreeSet<String>,
     max_chars: usize,
@@ -319,7 +323,7 @@ fn render_deferred_catalog(
     let mut included = 0usize;
     for name in names {
         let sep = if included == 0 { "" } else { ", " };
-        if included > 0 && list.len() + sep.len() + name.len() > max_chars {
+        if list.len() + sep.len() + name.len() > max_chars {
             break;
         }
         list.push_str(sep);
@@ -328,7 +332,10 @@ fn render_deferred_catalog(
     }
     let omitted = total - included;
     if omitted > 0 {
-        list.push_str(&format!(", +{omitted} more — search to discover"));
+        if included > 0 {
+            list.push_str(", ");
+        }
+        list.push_str(&format!("+{omitted} more — search to discover"));
     }
     format!("{PREFIX}{list}.")
 }
@@ -869,6 +876,41 @@ mod tests {
             .expect("+N marker present");
         let included = ts.description.matches("mcp__srv__tool_").count();
         assert_eq!(included + omitted, 50);
+    }
+
+    /// Codex verify finding: `catalog_max_chars` must be a HARD bound. The
+    /// first renderer version exempted the first name from the length check,
+    /// so a single pathological MCP name could blow past the documented cap.
+    #[test]
+    fn catalog_cap_is_hard_even_for_the_first_name() {
+        let long_name = format!("mcp__srv__{}", "x".repeat(120));
+        let defs = vec![
+            catalog_def("ToolSearch", false),
+            catalog_def(&long_name, true),
+            catalog_def(&format!("{long_name}_2"), true),
+        ];
+        // Budget smaller than the (sorted-first) long name: ZERO names ship;
+        // everything collapses into the +N marker.
+        let folded = fold_deferred_into_catalog(defs, 40);
+        let ts = folded.iter().find(|d| d.name == "ToolSearch").unwrap();
+        assert!(
+            !ts.description.contains(&long_name),
+            "an over-budget first name must NOT ship: {}",
+            ts.description
+        );
+        assert!(
+            ts.description
+                .contains("+2 more — search to discover"),
+            "all names collapse into the omitted marker: {}",
+            ts.description
+        );
+        assert!(
+            !ts.description.contains(", +"),
+            "no dangling separator when zero names are included: {}",
+            ts.description
+        );
+        // The deferred entries are still folded out of the array.
+        assert_eq!(folded.len(), 1);
     }
 
     #[test]

--- a/crates/wcore-tools/src/registry.rs
+++ b/crates/wcore-tools/src/registry.rs
@@ -282,7 +282,10 @@ pub fn apply_cold_deferral(defs: &mut [ToolDef], hot_allowlist: &[String]) {
 /// Fallback: when no non-deferred `ToolSearch` def is present there is no
 /// surface to carry the catalog — the defs are returned unchanged (per-tool
 /// stubs), never silently undiscoverable.
-pub fn fold_deferred_into_catalog(mut defs: Vec<ToolDef>, catalog_max_chars: usize) -> Vec<ToolDef> {
+pub fn fold_deferred_into_catalog(
+    mut defs: Vec<ToolDef>,
+    catalog_max_chars: usize,
+) -> Vec<ToolDef> {
     if !defs.iter().any(|d| d.deferred) {
         return defs;
     }
@@ -312,10 +315,7 @@ pub fn fold_deferred_into_catalog(mut defs: Vec<ToolDef>, catalog_max_chars: usi
 /// cap). The fixed prefix and the constant-size `+N more` overflow suffix
 /// sit outside the budget; omitted names remain discoverable via ToolSearch
 /// queries.
-fn render_deferred_catalog(
-    names: &std::collections::BTreeSet<String>,
-    max_chars: usize,
-) -> String {
+fn render_deferred_catalog(names: &std::collections::BTreeSet<String>, max_chars: usize) -> String {
     const PREFIX: &str =
         "Deferred tools (name-only; load the full schema via this tool before calling): ";
     let total = names.len();
@@ -826,8 +826,7 @@ mod tests {
         // The catalog line is on ToolSearch, sorted, name-only.
         let ts = folded.iter().find(|d| d.name == "ToolSearch").unwrap();
         assert!(
-            ts.description
-                .contains("alpha_tool, mike_tool, zulu_tool"),
+            ts.description.contains("alpha_tool, mike_tool, zulu_tool"),
             "sorted name-only inventory: {}",
             ts.description
         );
@@ -899,8 +898,7 @@ mod tests {
             ts.description
         );
         assert!(
-            ts.description
-                .contains("+2 more — search to discover"),
+            ts.description.contains("+2 more — search to discover"),
             "all names collapse into the omitted marker: {}",
             ts.description
         );
@@ -952,9 +950,7 @@ mod tests {
         // Discoverable + hydratable: ToolSearch built on the deferred defs
         // returns the cold tool's name AND full parameters schema.
         let search = crate::tool_search::ToolSearchTool::new(defs);
-        let found = search
-            .execute(serde_json::json!({"query": "web"}))
-            .await;
+        let found = search.execute(serde_json::json!({"query": "web"})).await;
         assert!(!found.is_error);
         assert!(found.content.contains("\"web\""), "cold tool discoverable");
         assert!(

--- a/crates/wcore-tools/src/registry.rs
+++ b/crates/wcore-tools/src/registry.rs
@@ -261,6 +261,78 @@ pub fn apply_cold_deferral(defs: &mut [ToolDef], hot_allowlist: &[String]) {
     }
 }
 
+/// Layer D3 (token-opt, openclaw parity): fold every deferred def OUT of the
+/// tools[] array entirely, replacing the per-tool name-only stubs with ONE
+/// compact catalog line appended to ToolSearch's description. Measured on
+/// the reference workload the 43 stub entries cost ~2.5k tokens/request —
+/// more than the hot full schemas — so removing them is the bigger half of
+/// the deferral win.
+///
+/// Determinism / caching: deferred names are emitted sorted and deduped
+/// (`BTreeSet`), so the catalog line is a pure function of the deferral
+/// state; combined with the monotonic hydrated-tool union the line is
+/// byte-stable across turns and changes exactly when the tools[] array
+/// already changes (a hydration admission).
+///
+/// `catalog_max_chars` bounds the names portion of the line; overflow is
+/// replaced by a `+N more — search to discover` suffix (openclaw's bounded
+/// directory), keeping an MCP swarm from ballooning the prompt while every
+/// omitted tool stays discoverable through ToolSearch queries.
+///
+/// Fallback: when no non-deferred `ToolSearch` def is present there is no
+/// surface to carry the catalog — the defs are returned unchanged (per-tool
+/// stubs), never silently undiscoverable.
+pub fn fold_deferred_into_catalog(mut defs: Vec<ToolDef>, catalog_max_chars: usize) -> Vec<ToolDef> {
+    if !defs.iter().any(|d| d.deferred) {
+        return defs;
+    }
+    if !defs.iter().any(|d| !d.deferred && d.name == "ToolSearch") {
+        return defs;
+    }
+    let names: std::collections::BTreeSet<String> = defs
+        .iter()
+        .filter(|d| d.deferred)
+        .map(|d| d.name.clone())
+        .collect();
+    defs.retain(|d| !d.deferred);
+    let catalog = render_deferred_catalog(&names, catalog_max_chars);
+    for def in defs.iter_mut() {
+        if def.name == "ToolSearch" {
+            def.description = format!("{} {}", def.description.trim_end(), catalog);
+            break;
+        }
+    }
+    defs
+}
+
+/// Render the sorted, bounded deferred-tool inventory line for
+/// [`fold_deferred_into_catalog`]. `max_chars` bounds the names portion;
+/// the fixed prefix and the overflow suffix sit outside the budget.
+fn render_deferred_catalog(
+    names: &std::collections::BTreeSet<String>,
+    max_chars: usize,
+) -> String {
+    const PREFIX: &str =
+        "Deferred tools (name-only; load the full schema via this tool before calling): ";
+    let total = names.len();
+    let mut list = String::new();
+    let mut included = 0usize;
+    for name in names {
+        let sep = if included == 0 { "" } else { ", " };
+        if included > 0 && list.len() + sep.len() + name.len() > max_chars {
+            break;
+        }
+        list.push_str(sep);
+        list.push_str(name);
+        included += 1;
+    }
+    let omitted = total - included;
+    if omitted > 0 {
+        list.push_str(&format!(", +{omitted} more — search to discover"));
+    }
+    format!("{PREFIX}{list}.")
+}
+
 #[async_trait]
 impl ToolDispatcher for ToolRegistry {
     async fn dispatch(&self, tool: &str, input: serde_json::Value) -> ToolResult {
@@ -711,6 +783,115 @@ mod tests {
             assert_eq!(a.name, b.name);
             assert_eq!(a.deferred, b.deferred);
         }
+    }
+
+    // --- fold_deferred_into_catalog tests (Layer D3) ---
+
+    fn catalog_def(name: &str, deferred: bool) -> ToolDef {
+        ToolDef {
+            name: name.to_string(),
+            description: format!("{name} description"),
+            input_schema: serde_json::json!({"type": "object"}),
+            deferred,
+            server: None,
+        }
+    }
+
+    #[test]
+    fn catalog_line_is_sorted_deterministic_and_replaces_stub_entries() {
+        let defs = vec![
+            catalog_def("ToolSearch", false),
+            catalog_def("Read", false),
+            catalog_def("zulu_tool", true),
+            catalog_def("alpha_tool", true),
+            catalog_def("mike_tool", true),
+        ];
+
+        let folded = fold_deferred_into_catalog(defs.clone(), 4096);
+
+        // No deferred entries survive in the array.
+        assert!(
+            folded.iter().all(|d| !d.deferred),
+            "no stub entries may remain"
+        );
+        assert_eq!(folded.len(), 2, "only non-deferred defs remain");
+
+        // The catalog line is on ToolSearch, sorted, name-only.
+        let ts = folded.iter().find(|d| d.name == "ToolSearch").unwrap();
+        assert!(
+            ts.description
+                .contains("alpha_tool, mike_tool, zulu_tool"),
+            "sorted name-only inventory: {}",
+            ts.description
+        );
+        assert!(
+            !ts.description.contains("alpha_tool description")
+                && !ts.description.contains("zulu_tool description"),
+            "no per-tool description text leaks into the catalog (names only): {}",
+            ts.description
+        );
+
+        // Byte-stable: same fold from a reordered input.
+        let mut reordered = defs;
+        reordered.reverse();
+        let folded2 = fold_deferred_into_catalog(reordered, 4096);
+        let ts2 = folded2.iter().find(|d| d.name == "ToolSearch").unwrap();
+        assert_eq!(
+            ts.description, ts2.description,
+            "catalog line must be byte-identical regardless of input order"
+        );
+    }
+
+    #[test]
+    fn catalog_truncates_with_more_marker_at_cap() {
+        let mut defs = vec![catalog_def("ToolSearch", false)];
+        for i in 0..50 {
+            defs.push(catalog_def(&format!("mcp__srv__tool_{i:03}"), true));
+        }
+        // Budget fits only a handful of ~18-char names.
+        let folded = fold_deferred_into_catalog(defs, 60);
+        let ts = folded.iter().find(|d| d.name == "ToolSearch").unwrap();
+        assert!(
+            ts.description.contains("more — search to discover"),
+            "overflow must be summarized: {}",
+            ts.description
+        );
+        // The first (sorted) name is present; a late name is not.
+        assert!(ts.description.contains("mcp__srv__tool_000"));
+        assert!(!ts.description.contains("mcp__srv__tool_049"));
+        // +N accounting: included + omitted = 50.
+        let omitted: usize = ts
+            .description
+            .split("+")
+            .nth(1)
+            .and_then(|s| s.split(' ').next())
+            .and_then(|s| s.parse().ok())
+            .expect("+N marker present");
+        let included = ts.description.matches("mcp__srv__tool_").count();
+        assert_eq!(included + omitted, 50);
+    }
+
+    #[test]
+    fn catalog_without_tool_search_falls_back_to_stubs() {
+        // No ToolSearch def → nothing can carry the catalog; deferred defs
+        // must be returned unchanged (stub entries), never dropped into
+        // undiscoverability.
+        let defs = vec![catalog_def("Read", false), catalog_def("cold_tool", true)];
+        let folded = fold_deferred_into_catalog(defs.clone(), 4096);
+        assert_eq!(folded.len(), 2);
+        assert!(folded.iter().any(|d| d.name == "cold_tool" && d.deferred));
+    }
+
+    #[test]
+    fn catalog_no_deferred_is_a_noop() {
+        let defs = vec![catalog_def("ToolSearch", false), catalog_def("Read", false)];
+        let folded = fold_deferred_into_catalog(defs.clone(), 4096);
+        assert_eq!(folded.len(), 2);
+        let ts = folded.iter().find(|d| d.name == "ToolSearch").unwrap();
+        assert_eq!(
+            ts.description, "ToolSearch description",
+            "no catalog suffix when nothing is deferred"
+        );
     }
 
     /// Correctness gate for Layer D1: a cold-deferred tool must remain

--- a/crates/wcore-tools/src/registry.rs
+++ b/crates/wcore-tools/src/registry.rs
@@ -234,6 +234,33 @@ impl ToolRegistry {
     }
 }
 
+/// Layer D1 (token-opt): mark every tool NOT on the hot allowlist as
+/// deferred, so providers serialize it as a name + truncated-description
+/// stub instead of its full schema. The model hydrates a stub on demand via
+/// `ToolSearch` (which is never deferred — it is the hydration path — and
+/// is skipped here regardless of the allowlist).
+///
+/// CRITICAL caching constraint: this is a pure function of the def names
+/// and the static allowlist — never of per-turn state — so applying it
+/// every turn yields an identical hot/stub split and the serialized
+/// `tools[]` array stays byte-identical across a conversation (guarded by
+/// `tools_array_byte_stable_across_roundtrips` in `wcore-providers`).
+///
+/// Only the `deferred` flag is flipped; `input_schema`/`description` are
+/// retained on the def so `ToolSearchTool` (which snapshots these defs) can
+/// return the full schema on hydration. Tools already deferred (e.g. MCP
+/// proxies) stay deferred.
+pub fn apply_cold_deferral(defs: &mut [ToolDef], hot_allowlist: &[String]) {
+    for def in defs.iter_mut() {
+        if def.name == "ToolSearch" {
+            continue;
+        }
+        if !hot_allowlist.iter().any(|hot| hot == &def.name) {
+            def.deferred = true;
+        }
+    }
+}
+
 #[async_trait]
 impl ToolDispatcher for ToolRegistry {
     async fn dispatch(&self, tool: &str, input: serde_json::Value) -> ToolResult {
@@ -644,6 +671,78 @@ mod tests {
         }));
         let defs = registry.to_tool_defs();
         assert!(defs[0].deferred, "deferred tool should have deferred=true");
+    }
+
+    // --- apply_cold_deferral tests (Layer D1) ---
+
+    #[test]
+    fn cold_deferral_is_pure_function_of_allowlist() {
+        let mut registry = ToolRegistry::new();
+        registry.register(make_tool("Read", "read files"));
+        registry.register(make_tool("web", "search the web"));
+        registry.register(make_tool("ToolSearch", "hydrate deferred tools"));
+
+        let hot = vec!["Read".to_string()];
+
+        // Applying to two independently-generated def lists yields the
+        // identical split — no per-turn state involved.
+        let mut turn1 = registry.to_tool_defs();
+        let mut turn2 = registry.to_tool_defs();
+        apply_cold_deferral(&mut turn1, &hot);
+        apply_cold_deferral(&mut turn2, &hot);
+
+        for defs in [&turn1, &turn2] {
+            let by_name = |n: &str| defs.iter().find(|d| d.name == n).unwrap();
+            assert!(!by_name("Read").deferred, "hot tool stays full");
+            assert!(by_name("web").deferred, "cold tool defers");
+            assert!(
+                !by_name("ToolSearch").deferred,
+                "ToolSearch is the hydration path — never deferred"
+            );
+            // The full schema survives on the def (only the flag flips) so
+            // ToolSearch hydration can return it.
+            assert_eq!(
+                by_name("web").input_schema,
+                serde_json::json!({"type": "object"})
+            );
+        }
+        assert_eq!(turn1.len(), turn2.len());
+        for (a, b) in turn1.iter().zip(turn2.iter()) {
+            assert_eq!(a.name, b.name);
+            assert_eq!(a.deferred, b.deferred);
+        }
+    }
+
+    /// Correctness gate for Layer D1: a cold-deferred tool must remain
+    /// (1) discoverable via ToolSearch — which returns its FULL schema —
+    /// and (2) callable through the registry (deferral only changes what
+    /// the LLM sees, never dispatch).
+    #[tokio::test]
+    async fn cold_deferred_tool_hydrates_via_tool_search_and_dispatches() {
+        let mut registry = ToolRegistry::new();
+        registry.register(make_tool("Read", "read files"));
+        registry.register(make_tool("web", "search the web"));
+
+        let mut defs = registry.to_tool_defs();
+        apply_cold_deferral(&mut defs, &["Read".to_string()]);
+
+        // Discoverable + hydratable: ToolSearch built on the deferred defs
+        // returns the cold tool's name AND full parameters schema.
+        let search = crate::tool_search::ToolSearchTool::new(defs);
+        let found = search
+            .execute(serde_json::json!({"query": "web"}))
+            .await;
+        assert!(!found.is_error);
+        assert!(found.content.contains("\"web\""), "cold tool discoverable");
+        assert!(
+            found.content.contains("parameters"),
+            "hydration returns the full schema"
+        );
+
+        // Still callable: dispatch routes by name, unaffected by deferral.
+        let result = registry.dispatch("web", serde_json::json!({})).await;
+        assert!(!result.is_error, "deferred tool still dispatches");
+        assert_eq!(result.content, "ok");
     }
 
     /// v0.9.1.1 F8 — the catalog the LLM sees must use the exact

--- a/crates/wcore-types/src/tool.rs
+++ b/crates/wcore-types/src/tool.rs
@@ -4,7 +4,12 @@ use serde_json::Value;
 pub type JsonSchema = Value;
 
 /// Maximum chars kept from a deferred tool's description.
-const DEFERRED_DESC_MAX_CHARS: usize = 200;
+///
+/// Layer D2 (token-opt): 200 → 80. With cold built-ins deferred by default
+/// the stub descriptions dominate the tools[] payload; 80 chars keeps the
+/// first sentence (enough for the model to pick a ToolSearch query) at
+/// ~2.5× less prefix weight per stub.
+const DEFERRED_DESC_MAX_CHARS: usize = 80;
 
 /// Truncate a description for a deferred tool stub.
 ///
@@ -182,15 +187,30 @@ mod tests {
     }
 
     #[test]
-    fn truncate_at_200_chars_before_blank_line() {
-        let desc = format!("{}. More text after.", "A".repeat(200));
+    fn truncate_exactly_80_chars() {
+        let desc = "X".repeat(80);
+        assert_eq!(truncate_deferred_description(&desc), desc);
+    }
+
+    #[test]
+    fn truncate_81_chars() {
+        let desc = "X".repeat(81);
         let result = truncate_deferred_description(&desc);
-        assert!(result.len() <= 200 + '…'.len_utf8());
+        assert!(result.ends_with('…'));
+        // 80 X's + ellipsis
+        assert_eq!(result.len(), 80 + '…'.len_utf8());
+    }
+
+    #[test]
+    fn truncate_at_80_chars_before_blank_line() {
+        let desc = format!("{}. More text after.", "A".repeat(80));
+        let result = truncate_deferred_description(&desc);
+        assert!(result.len() <= 80 + '…'.len_utf8());
         assert!(result.ends_with('…'));
     }
 
     #[test]
-    fn truncate_blank_line_before_200_chars() {
+    fn truncate_blank_line_before_limit() {
         let desc = "Short first paragraph.\n\nLong second paragraph that goes on and on.";
         let result = truncate_deferred_description(desc);
         assert_eq!(result, "Short first paragraph.…");
@@ -202,29 +222,15 @@ mod tests {
     }
 
     #[test]
-    fn truncate_exactly_200_chars() {
-        let desc = "X".repeat(200);
-        assert_eq!(truncate_deferred_description(&desc), desc);
-    }
-
-    #[test]
-    fn truncate_201_chars() {
-        let desc = "X".repeat(201);
-        let result = truncate_deferred_description(&desc);
-        assert!(result.ends_with('…'));
-        // 200 X's + ellipsis
-        assert_eq!(result.len(), 200 + '…'.len_utf8());
-    }
-
-    #[test]
     fn truncate_multibyte_chars_safe() {
-        // 100 two-byte chars = 200 bytes, but only 100 char positions
+        // Two-byte chars: the 80-byte limit must snap back to a char
+        // boundary, never split a code point.
         let desc: String = "é".repeat(150);
         let result = truncate_deferred_description(&desc);
         // Should not panic and should be valid UTF-8
         assert!(result.ends_with('…'));
-        // Should be at most 200 chars (counting code points)
+        // Should be at most 80 chars (counting code points)
         let char_count = result.chars().count();
-        assert!(char_count <= 201); // 200 chars + ellipsis
+        assert!(char_count <= 81); // 80 chars + ellipsis
     }
 }


### PR DESCRIPTION
Token-efficiency tools layer, stacked on feat/token-efficiency-phase1 (#184).

What ships: deterministic tool ordering on all 4 provider serializers (byte-stable prompt prefix, duplicate-name safe); warm-session cache-health telemetry (CacheHealthWarn below 0.3 ratio); cold-tool deferral default ON with hot allowlist; ToolSearch hydration admission (LRU with demotion, 64-bounded, live-registry stale pruning, direct-call-counts-as-hydration); and the deferred-tool catalog fold — deferred tools leave tools[] entirely, replaced by one sorted name-only inventory line in ToolSearch's description.

Measured on the real 47-tool default registry: tools[] serialization 48,777 B raw -> 6,754 B (−86.2%); projected stage-1 prompt ~3-4.5k tokens vs 14,968 baseline.

Audit trail (every commit gated): initial adversarial audit FIX-FIRST x6 (hydrated-but-stubbed ordering, silent no-op admission, unbounded set, stale hydration, duplicate-name sort instability, test honesty) — all fixed in c62d5262 + c795f222; catalog fold 1c971ce3 audited FIX-FIRST (soft cap; plus builder-found direct-call gap on lax providers) — fixed in ea13149e (hard cap, record_called_deferred_tool); final targeted verify: GO. Full suite 4,183 passing, clippy clean (sole warning = pre-existing imap-proto future-incompat note).
