### PR TITLE
feat(cache): Anthropic 4-breakpoint cache_control layout + permanent anchor (parity gap 1)

### DIFF
--- a/crates/wcore-agent/src/compact/micro.rs
+++ b/crates/wcore-agent/src/compact/micro.rs
@@ -415,6 +415,59 @@ fn args_stub(name: &str, input: &serde_json::Value, original_bytes: usize) -> se
     serde_json::Value::Object(obj)
 }
 
+// ── Permanent cache anchor (gap-1 + gap-2 coupling) ─────────────────────────
+
+/// Cache-anchor epoch size: the anchor advances at most once per this many
+/// stubbed messages. Each anchor move costs one prompt-cache re-write from
+/// the anchor point, so moves must be rare; within an epoch the anchor is
+/// byte-frozen and every turn's prefix up to it replays from cache.
+pub const CACHE_ANCHOR_EPOCH: usize = 8;
+
+/// Pick the message to pin the PERMANENT prompt-cache breakpoint on.
+///
+/// Residual cache cost of continuous args-compaction: each turn, the message
+/// at the `keep_recent_turns` boundary transitions verbatim→stub INSIDE the
+/// previously cached prefix, so the provider's prefix match ends there and
+/// everything after re-bills. The fix is a breakpoint pinned to an IMMUTABLE
+/// ANCHOR — a message whose arguments are already stubbed. Stubbing is
+/// marker-gated and monotonic ([`COMPACTED_ARGS_KEY`]): a stubbed assistant
+/// message never changes bytes again, so the prefix ending at the anchor is
+/// permanently cache-valid no matter what transitions happen after it.
+///
+/// Pure function of the marker state — no stored engine state:
+/// - stub indices only APPEND (new stubs happen where the advancing
+///   `keep_recent_turns` cutoff exposes them, always after existing stubs),
+///   so the pick is deterministic and advances monotonically;
+/// - epoch policy: the anchor is the FIRST stub of the current
+///   [`CACHE_ANCHOR_EPOCH`]-sized epoch — it moves at most once per
+///   `CACHE_ANCHOR_EPOCH` newly stubbed messages, never on every turn;
+/// - if autocompact restructures history, the next call simply recomputes
+///   from the surviving markers (the cache is invalidated then anyway).
+///
+/// Returns `None` until the first stub exists.
+pub fn cache_anchor_index(messages: &[Message]) -> Option<usize> {
+    let stubbed: Vec<usize> = messages
+        .iter()
+        .enumerate()
+        .filter(|(_, m)| {
+            m.role == Role::Assistant
+                && m.content.iter().any(|b| {
+                    matches!(
+                        b,
+                        ContentBlock::ToolUse { input, .. }
+                            if input.get(COMPACTED_ARGS_KEY).is_some()
+                    )
+                })
+        })
+        .map(|(i, _)| i)
+        .collect();
+    if stubbed.is_empty() {
+        return None;
+    }
+    let epoch = (stubbed.len() - 1) / CACHE_ANCHOR_EPOCH;
+    Some(stubbed[epoch * CACHE_ANCHOR_EPOCH])
+}
+
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
 /// Build a map from tool_use_id → tool name by scanning ToolUse blocks
@@ -1417,5 +1470,103 @@ mod tests {
         ];
         let (count, _) = prune_superseded_reads(&mut msgs, &read_only_cfg());
         assert_eq!(count, 0, "errored reads carry signal and are never stubbed");
+    }
+
+    // ── Permanent cache anchor (gap-1 + gap-2 coupling) ─────────────────────
+
+    #[test]
+    fn cache_anchor_none_without_stubs() {
+        let body = "x".repeat(4000);
+        let mut msgs = Vec::new();
+        write_turn(&mut msgs, "w1", "a.rs", &body);
+        // No compaction has run — no stub, no anchor.
+        assert_eq!(cache_anchor_index(&msgs), None);
+    }
+
+    /// 5-turn growing conversation with compaction active: the anchor pins
+    /// to the FIRST stubbed message and stays CONSTANT across turns while
+    /// stubs accumulate past it (within the first epoch).
+    #[test]
+    fn cache_anchor_constant_across_growing_turns() {
+        let body = "x".repeat(4000);
+        let cfg = tca_cfg(1, 768);
+        let mut msgs = Vec::new();
+        let mut anchors = Vec::new();
+
+        for turn in 1..=5 {
+            write_turn(&mut msgs, &format!("w{turn}"), "f.rs", &body);
+            compact_tool_call_args(&mut msgs, &cfg);
+            anchors.push(cache_anchor_index(&msgs));
+        }
+
+        // Turn 1: nothing older than the protected tail — no stub, no anchor.
+        assert_eq!(anchors[0], None);
+        // Turns 2..=5: stubs accumulate (1..=4, all within epoch 0) — the
+        // anchor is the first stubbed message (index 0) and NEVER moves.
+        assert_eq!(
+            &anchors[1..],
+            &[Some(0), Some(0), Some(0), Some(0)],
+            "anchor must stay constant while stubs accumulate within the epoch"
+        );
+    }
+
+    /// The anchor advances ONLY at the epoch condition — after
+    /// CACHE_ANCHOR_EPOCH stubs it jumps to the first stub of the next
+    /// epoch — and only monotonically forward.
+    #[test]
+    fn cache_anchor_advances_only_at_epoch_boundary() {
+        let body = "x".repeat(4000);
+        let cfg = tca_cfg(1, 768);
+        let mut msgs = Vec::new();
+        let mut last_anchor = None;
+
+        for turn in 1..=(CACHE_ANCHOR_EPOCH + 4) {
+            write_turn(&mut msgs, &format!("w{turn}"), "f.rs", &body);
+            compact_tool_call_args(&mut msgs, &cfg);
+            let anchor = cache_anchor_index(&msgs);
+            let stub_count = turn - 1; // keep=1 protects only the last turn
+
+            match stub_count {
+                0 => assert_eq!(anchor, None),
+                // Epoch 0: stubs 1..=CACHE_ANCHOR_EPOCH all anchor at the
+                // very first stub (assistant of turn 1 = message index 0).
+                n if n <= CACHE_ANCHOR_EPOCH => assert_eq!(
+                    anchor,
+                    Some(0),
+                    "stub #{n} must keep the epoch-0 anchor at index 0"
+                ),
+                // Epoch 1: the anchor jumps exactly once, to the
+                // (CACHE_ANCHOR_EPOCH+1)-th stubbed message. write_turn
+                // pushes 2 messages/turn with the assistant first, so the
+                // k-th stub (0-based) lives at message index 2*k.
+                n => assert_eq!(
+                    anchor,
+                    Some(2 * CACHE_ANCHOR_EPOCH),
+                    "stub #{n} must anchor at the first stub of epoch 1"
+                ),
+            }
+
+            // Monotonic: the anchor never moves backward.
+            if let (Some(prev), Some(curr)) = (last_anchor, anchor) {
+                assert!(curr >= prev, "anchor must never move backward");
+            }
+            last_anchor = anchor;
+        }
+    }
+
+    /// The anchor is a pure function of the marker state: recomputing on the
+    /// same messages yields the same answer, and un-stubbed histories that
+    /// differ only in verbatim content agree.
+    #[test]
+    fn cache_anchor_deterministic() {
+        let body = "x".repeat(4000);
+        let cfg = tca_cfg(1, 768);
+        let mut msgs = Vec::new();
+        for turn in 1..=4 {
+            write_turn(&mut msgs, &format!("w{turn}"), "f.rs", &body);
+        }
+        compact_tool_call_args(&mut msgs, &cfg);
+        assert_eq!(cache_anchor_index(&msgs), cache_anchor_index(&msgs));
+        assert_eq!(cache_anchor_index(&msgs), Some(0));
     }
 }

--- a/crates/wcore-agent/src/engine.rs
+++ b/crates/wcore-agent/src/engine.rs
@@ -612,11 +612,18 @@ fn is_http_4xx_error(reason: &str) -> bool {
 /// messages under a different system prompt or tool set) as an "unchanged"
 /// wedge.
 ///
-/// Timestamps and cache hints are deliberately EXCLUDED — providers never see
-/// them (`build_messages()` sends role + content only), so two requests that
-/// are byte-identical on the wire fingerprint identically even when their
-/// local `Message.timestamp`s differ (e.g. a host that rebuilds the same
-/// wedged conversation on a retry or a resume).
+/// Timestamps and cache hints are deliberately EXCLUDED. Timestamps are
+/// never provider-visible. Cache hints CAN reach the wire — anthropic-family
+/// `build_messages()` translates the tail hint into a `cache_control`
+/// marker — but the marker is position-derived (always the tail message)
+/// and pure cache metadata: two requests with identical model / system /
+/// messages / tools produce identical markers, and providers exclude
+/// `cache_control` from content identity. Hashing hints would add no
+/// discriminating power while letting a hint-only difference (e.g. a
+/// re-marked retry) make an unchanged wedge look changed. So two requests
+/// that are semantically identical on the wire fingerprint identically even
+/// when their local `Message.timestamp`s differ (e.g. a host that rebuilds
+/// the same wedged conversation on a retry or a resume).
 ///
 /// Sha256, not a 64-bit `DefaultHasher`: this identity gates whether a
 /// request is ever allowed to be sent again, so it gets a collision-proof

--- a/crates/wcore-agent/src/engine.rs
+++ b/crates/wcore-agent/src/engine.rs
@@ -4866,10 +4866,21 @@ impl AgentEngine {
                 Self::apply_pre_prompt_contribution(&mut request.messages, &outcome);
             }
 
-            // W1 S3: place per-message cache breakpoint at the tail when the
-            // provider honours it. Idempotent across turns: previous turns'
-            // markers are cleared and the new tail is marked.
-            mark_cache_boundaries(&mut request, &self.compat);
+            // W1 S3: place per-message cache breakpoints when the provider
+            // honours them. Idempotent across turns: previous turns' markers
+            // are cleared and the new tail is marked. Gap-1+gap-2 coupling:
+            // a PERMANENT anchor breakpoint is additionally pinned to an
+            // immutable already-stubbed message (pure function of the
+            // compaction markers; `request.messages` is an index-aligned
+            // clone of `self.messages`, so the index maps 1:1). The anchor
+            // keeps the long prefix cache-valid while continuous
+            // args-compaction transitions the message at the
+            // keep_recent_turns boundary inside it.
+            mark_cache_boundaries(
+                &mut request,
+                &self.compat,
+                micro::cache_anchor_index(&self.messages),
+            );
 
             // W1 v0.6.3: stamp a smart-routing hint onto the request so
             // `ProviderChain` can surface the router's decision in dispatch

--- a/crates/wcore-config/src/config.rs
+++ b/crates/wcore-config/src/config.rs
@@ -677,6 +677,65 @@ impl ApprovalMode {
     }
 }
 
+/// Default `min_prefix_tokens` floor for prompt-cache breakpoint injection.
+/// Below this estimated prompt size, `cache_control` markers are skipped:
+/// Anthropic charges a 25% cache-write premium, so caching a tiny context
+/// costs more than it can ever save (and Anthropic ignores cache segments
+/// under its own per-model minimum anyway).
+pub const DEFAULT_CACHE_MIN_PREFIX_TOKENS: usize = 1024;
+
+/// Prompt-caching preference for a provider entry. Accepts both TOML shapes:
+///
+/// ```toml
+/// [providers.anthropic]
+/// prompt_caching = false            # legacy bool form
+/// ```
+///
+/// ```toml
+/// [providers.anthropic.prompt_caching]  # detailed table form
+/// enabled = true
+/// min_prefix_tokens = 1024
+/// ```
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+#[serde(untagged)]
+pub enum PromptCachingConfig {
+    /// Legacy bool form: `prompt_caching = true|false`.
+    Enabled(bool),
+    /// Detailed table form with the breakpoint floor.
+    Detailed(PromptCachingDetail),
+}
+
+/// Body of the detailed `[providers.<name>.prompt_caching]` table.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Default)]
+pub struct PromptCachingDetail {
+    /// Enable prompt caching. `None` → provider default (ON for Anthropic).
+    pub enabled: Option<bool>,
+    /// Skip `cache_control` breakpoint injection when the estimated prompt
+    /// prefix is smaller than this many tokens. `None` →
+    /// [`DEFAULT_CACHE_MIN_PREFIX_TOKENS`].
+    pub min_prefix_tokens: Option<usize>,
+}
+
+impl PromptCachingConfig {
+    /// The configured enabled state, if any. `None` (only possible in the
+    /// table form with `enabled` omitted) defers to the provider default.
+    pub fn enabled(&self) -> Option<bool> {
+        match self {
+            PromptCachingConfig::Enabled(b) => Some(*b),
+            PromptCachingConfig::Detailed(d) => d.enabled,
+        }
+    }
+
+    /// The configured breakpoint floor, if any. The legacy bool form carries
+    /// no floor, so it defers to [`DEFAULT_CACHE_MIN_PREFIX_TOKENS`].
+    pub fn min_prefix_tokens(&self) -> Option<usize> {
+        match self {
+            PromptCachingConfig::Enabled(_) => None,
+            PromptCachingConfig::Detailed(d) => d.min_prefix_tokens,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct ProviderConfig {
     /// Underlying built-in provider type for a custom provider alias.
@@ -685,8 +744,10 @@ pub struct ProviderConfig {
     pub model: Option<String>,
     pub api_key: Option<String>,
     pub base_url: Option<String>,
-    /// Enable prompt caching (Anthropic only, default: true)
-    pub prompt_caching: Option<bool>,
+    /// Enable prompt caching (Anthropic only, default: true). Accepts the
+    /// legacy bool form or the detailed `[providers.<name>.prompt_caching]`
+    /// table — see [`PromptCachingConfig`].
+    pub prompt_caching: Option<PromptCachingConfig>,
     /// Provider compatibility overrides
     pub compat: Option<ProviderCompat>,
 }
@@ -932,6 +993,12 @@ pub struct Config {
     pub system_prompt: Option<String>,
     pub thinking: Option<ThinkingConfig>,
     pub prompt_caching: bool,
+    /// Breakpoint floor for prompt-cache marker injection: providers skip
+    /// `cache_control` breakpoints when the estimated prompt prefix is
+    /// smaller than this many tokens. From the detailed
+    /// `[providers.<name>.prompt_caching]` table;
+    /// default [`DEFAULT_CACHE_MIN_PREFIX_TOKENS`].
+    pub prompt_caching_min_prefix_tokens: usize,
     pub compat: ProviderCompat,
     pub tools: ToolsConfig,
     /// W4 builtin-tools registration gates (Script on/off, RepoMap on/off).
@@ -1022,6 +1089,10 @@ impl std::fmt::Debug for Config {
             .field("system_prompt", &self.system_prompt)
             .field("thinking", &self.thinking)
             .field("prompt_caching", &self.prompt_caching)
+            .field(
+                "prompt_caching_min_prefix_tokens",
+                &self.prompt_caching_min_prefix_tokens,
+            )
             .field("compat", &self.compat)
             .field("tools", &self.tools)
             .field("builtin_tools", &self.builtin_tools)
@@ -1081,6 +1152,7 @@ impl Default for Config {
             system_prompt: None,
             thinking: None,
             prompt_caching: false,
+            prompt_caching_min_prefix_tokens: DEFAULT_CACHE_MIN_PREFIX_TOKENS,
             compat: crate::compat::ProviderCompat::default(),
             tools: ToolsConfig::default(),
             builtin_tools: crate::tools::BuiltinToolsConfig::default(),
@@ -1803,7 +1875,14 @@ impl Config {
         // Resolve prompt_caching: default true for Anthropic
         let prompt_caching = provider_config
             .prompt_caching
+            .as_ref()
+            .and_then(PromptCachingConfig::enabled)
             .unwrap_or(matches!(provider, ProviderType::Anthropic));
+        let prompt_caching_min_prefix_tokens = provider_config
+            .prompt_caching
+            .as_ref()
+            .and_then(PromptCachingConfig::min_prefix_tokens)
+            .unwrap_or(DEFAULT_CACHE_MIN_PREFIX_TOKENS);
 
         // Resolve compat: provider-type defaults + user overrides.
         //
@@ -1871,6 +1950,7 @@ impl Config {
             system_prompt,
             thinking: None,
             prompt_caching,
+            prompt_caching_min_prefix_tokens,
             compat,
             tools,
             builtin_tools: crate::tools::BuiltinToolsConfig::default(),
@@ -2202,7 +2282,14 @@ pub fn resolve_council_provider(
 
     let prompt_caching = provider_config
         .prompt_caching
+        .as_ref()
+        .and_then(PromptCachingConfig::enabled)
         .unwrap_or(matches!(provider, ProviderType::Anthropic));
+    let prompt_caching_min_prefix_tokens = provider_config
+        .prompt_caching
+        .as_ref()
+        .and_then(PromptCachingConfig::min_prefix_tokens)
+        .unwrap_or(DEFAULT_CACHE_MIN_PREFIX_TOKENS);
 
     let compat_defaults = if let Some(entry) = catalog_entry.as_ref() {
         ProviderCompat::from_catalog_entry(&entry.id, entry.api_path.as_deref())
@@ -2239,6 +2326,7 @@ pub fn resolve_council_provider(
         base_url,
         model,
         prompt_caching,
+        prompt_caching_min_prefix_tokens,
         compat,
         ..base.clone()
     };
@@ -5159,7 +5247,78 @@ prompt_caching = false
 
         let anthropic = config.providers.get("anthropic").unwrap();
         assert_eq!(anthropic.api_key.as_deref(), Some("sk-ant-test"));
-        assert_eq!(anthropic.prompt_caching, Some(false));
+        assert_eq!(
+            anthropic.prompt_caching,
+            Some(PromptCachingConfig::Enabled(false))
+        );
+    }
+
+    /// Detailed `[providers.anthropic.prompt_caching]` table form parses
+    /// alongside the legacy bool form and resolves enabled + floor.
+    #[test]
+    fn test_prompt_caching_detailed_table_form_parses() {
+        let toml_str = r#"
+[default]
+provider = "anthropic"
+
+[providers.anthropic]
+api_key = "sk-ant-test"
+
+[providers.anthropic.prompt_caching]
+enabled = true
+min_prefix_tokens = 2048
+"#;
+        let config: ConfigFile = toml::from_str(toml_str).unwrap();
+        let pc = config
+            .providers
+            .get("anthropic")
+            .unwrap()
+            .prompt_caching
+            .as_ref()
+            .expect("prompt_caching table must parse");
+        assert_eq!(pc.enabled(), Some(true));
+        assert_eq!(pc.min_prefix_tokens(), Some(2048));
+    }
+
+    /// Table form with only the floor set defers `enabled` to the provider
+    /// default (ON for Anthropic); the legacy bool form carries no floor.
+    #[test]
+    fn test_prompt_caching_partial_table_and_bool_accessors() {
+        let toml_str = r#"
+[default]
+provider = "anthropic"
+
+[providers.anthropic.prompt_caching]
+min_prefix_tokens = 512
+"#;
+        let config: ConfigFile = toml::from_str(toml_str).unwrap();
+        let pc = config
+            .providers
+            .get("anthropic")
+            .unwrap()
+            .prompt_caching
+            .clone()
+            .unwrap();
+        assert_eq!(pc.enabled(), None, "enabled omitted → provider default");
+        assert_eq!(pc.min_prefix_tokens(), Some(512));
+
+        let legacy = PromptCachingConfig::Enabled(false);
+        assert_eq!(legacy.enabled(), Some(false));
+        assert_eq!(
+            legacy.min_prefix_tokens(),
+            None,
+            "bool form must defer the floor to DEFAULT_CACHE_MIN_PREFIX_TOKENS"
+        );
+    }
+
+    /// The resolved Config default carries the 1024-token breakpoint floor.
+    #[test]
+    fn test_config_default_min_prefix_tokens_floor() {
+        assert_eq!(
+            Config::default().prompt_caching_min_prefix_tokens,
+            DEFAULT_CACHE_MIN_PREFIX_TOKENS
+        );
+        assert_eq!(DEFAULT_CACHE_MIN_PREFIX_TOKENS, 1024);
     }
 
     #[test]
@@ -5218,7 +5377,7 @@ base_url = "https://my-service.example.com/api/openai"
             api_key: Some("base-key".to_string()),
             base_url: Some("https://base.example.com".to_string()),
             model: Some("base-model".to_string()),
-            prompt_caching: Some(true),
+            prompt_caching: Some(PromptCachingConfig::Enabled(true)),
             provider: Some("openai".to_string()),
             ..Default::default()
         };
@@ -5228,7 +5387,10 @@ base_url = "https://my-service.example.com/api/openai"
         assert_eq!(merged.api_key.as_deref(), Some("base-key"));
         assert_eq!(merged.base_url.as_deref(), Some("https://base.example.com"));
         assert_eq!(merged.model.as_deref(), Some("base-model"));
-        assert_eq!(merged.prompt_caching, Some(true));
+        assert_eq!(
+            merged.prompt_caching,
+            Some(PromptCachingConfig::Enabled(true))
+        );
         assert_eq!(merged.provider.as_deref(), Some("openai"));
     }
 

--- a/crates/wcore-observability/src/cache.rs
+++ b/crates/wcore-observability/src/cache.rs
@@ -17,19 +17,42 @@ use wcore_types::message::MessageCacheHint;
 ///
 /// **System prompt + tools markers** are still emitted by individual provider
 /// `build_request_body()` functions (Anthropic-family puts `cache_control`
-/// directly on the system block and the last tool entry). This helper adds the
-/// third marker: the **last message in `req.messages`** — typically the latest
-/// user turn or tool-result turn. Combined with the existing two markers, every
-/// turn after the first benefits from a long cacheable prefix.
+/// directly on the system block and the last tool entry). This helper adds
+/// up to two more:
+///
+/// - the **last message in `req.messages`** — typically the latest user turn
+///   or tool-result turn; the moving cache-write point;
+/// - the **permanent anchor** (`anchor_index`, when `Some` and not the tail)
+///   — an immutable already-compacted message picked by
+///   `wcore-agent::compact::micro::cache_anchor_index`. Continuous
+///   args-compaction transitions one message verbatim→stub inside the
+///   previously cached prefix each turn; the anchor breakpoint keeps the
+///   long prefix up to the anchor cache-valid across those transitions.
+///
+/// The provider-side budget (`apply_cache_zones`) counts these hints before
+/// spending its own markers, so system + tools + anchor + tail come out at
+/// exactly Anthropic's 4-marker limit (the moving previous-boundary marker
+/// yields its slot to the anchor).
 ///
 /// No-op when `compat.cache_message_breakpoints()` returns false.
-pub fn mark_cache_boundaries(req: &mut LlmRequest, compat: &ProviderCompat) {
+pub fn mark_cache_boundaries(
+    req: &mut LlmRequest,
+    compat: &ProviderCompat,
+    anchor_index: Option<usize>,
+) {
     if !compat.cache_message_breakpoints() {
         return;
     }
     // Clear any breakpoint set by a previous call so we don't accumulate.
     for msg in &mut req.messages {
         msg.cache_breakpoint = None;
+    }
+    // Permanent anchor first; skipped when it would collide with the tail
+    // (the tail marker below covers that message already).
+    if let Some(idx) = anchor_index
+        && idx + 1 < req.messages.len()
+    {
+        req.messages[idx].cache_breakpoint = Some(MessageCacheHint::Breakpoint);
     }
     if let Some(last) = req.messages.last_mut() {
         last.cache_breakpoint = Some(MessageCacheHint::Breakpoint);
@@ -70,7 +93,7 @@ mod tests {
         let mut req = request_with(vec![user_msg("first"), user_msg("second")]);
         let compat = ProviderCompat::anthropic_defaults();
 
-        mark_cache_boundaries(&mut req, &compat);
+        mark_cache_boundaries(&mut req, &compat, None);
 
         assert!(req.messages[0].cache_breakpoint.is_none());
         assert_eq!(
@@ -85,7 +108,7 @@ mod tests {
         let mut req = request_with(vec![user_msg("first")]);
         let compat = ProviderCompat::openai_defaults();
 
-        mark_cache_boundaries(&mut req, &compat);
+        mark_cache_boundaries(&mut req, &compat, None);
 
         assert!(
             req.messages[0].cache_breakpoint.is_none(),
@@ -98,9 +121,9 @@ mod tests {
         let mut req = request_with(vec![user_msg("a"), user_msg("b"), user_msg("c")]);
         let compat = ProviderCompat::anthropic_defaults();
 
-        mark_cache_boundaries(&mut req, &compat);
-        mark_cache_boundaries(&mut req, &compat);
-        mark_cache_boundaries(&mut req, &compat);
+        mark_cache_boundaries(&mut req, &compat, None);
+        mark_cache_boundaries(&mut req, &compat, None);
+        mark_cache_boundaries(&mut req, &compat, None);
 
         let count = req
             .messages
@@ -116,11 +139,11 @@ mod tests {
         let mut req = request_with(vec![user_msg("turn1")]);
         let compat = ProviderCompat::anthropic_defaults();
 
-        mark_cache_boundaries(&mut req, &compat);
+        mark_cache_boundaries(&mut req, &compat, None);
         assert!(req.messages[0].cache_breakpoint.is_some());
 
         req.messages.push(user_msg("turn2"));
-        mark_cache_boundaries(&mut req, &compat);
+        mark_cache_boundaries(&mut req, &compat, None);
 
         assert!(
             req.messages[0].cache_breakpoint.is_none(),
@@ -136,8 +159,80 @@ mod tests {
     fn no_panic_on_empty_messages() {
         let mut req = request_with(vec![]);
         let compat = ProviderCompat::anthropic_defaults();
-        mark_cache_boundaries(&mut req, &compat);
+        mark_cache_boundaries(&mut req, &compat, None);
         // No panic; nothing to mark.
         assert!(req.messages.is_empty());
+    }
+
+    // --- Permanent anchor (gap-1 + gap-2 coupling) ---------------------------
+
+    #[test]
+    fn anchor_and_tail_both_marked() {
+        let mut req = request_with(vec![
+            user_msg("a"),
+            user_msg("b"),
+            user_msg("c"),
+            user_msg("d"),
+        ]);
+        let compat = ProviderCompat::anthropic_defaults();
+
+        mark_cache_boundaries(&mut req, &compat, Some(1));
+
+        let marked: Vec<usize> = req
+            .messages
+            .iter()
+            .enumerate()
+            .filter(|(_, m)| m.cache_breakpoint.is_some())
+            .map(|(i, _)| i)
+            .collect();
+        assert_eq!(
+            marked,
+            vec![1, 3],
+            "anchor (1) and tail (3) must both carry the breakpoint hint"
+        );
+    }
+
+    #[test]
+    fn anchor_colliding_with_tail_yields_single_marker() {
+        let mut req = request_with(vec![user_msg("a"), user_msg("b")]);
+        let compat = ProviderCompat::anthropic_defaults();
+
+        mark_cache_boundaries(&mut req, &compat, Some(1));
+
+        let count = req
+            .messages
+            .iter()
+            .filter(|m| m.cache_breakpoint.is_some())
+            .count();
+        assert_eq!(count, 1, "anchor == tail must not double-mark");
+        assert!(req.messages[1].cache_breakpoint.is_some());
+    }
+
+    #[test]
+    fn out_of_range_anchor_is_ignored() {
+        let mut req = request_with(vec![user_msg("a"), user_msg("b")]);
+        let compat = ProviderCompat::anthropic_defaults();
+
+        mark_cache_boundaries(&mut req, &compat, Some(99));
+
+        let count = req
+            .messages
+            .iter()
+            .filter(|m| m.cache_breakpoint.is_some())
+            .count();
+        assert_eq!(count, 1, "an out-of-range anchor must mark only the tail");
+    }
+
+    #[test]
+    fn anchor_respects_family_gating() {
+        let mut req = request_with(vec![user_msg("a"), user_msg("b"), user_msg("c")]);
+        let compat = ProviderCompat::openai_defaults();
+
+        mark_cache_boundaries(&mut req, &compat, Some(0));
+
+        assert!(
+            req.messages.iter().all(|m| m.cache_breakpoint.is_none()),
+            "openai compat must suppress the anchor hint too"
+        );
     }
 }

--- a/crates/wcore-observability/tests/cache_boundaries_test.rs
+++ b/crates/wcore-observability/tests/cache_boundaries_test.rs
@@ -46,7 +46,7 @@ fn anthropic_build_messages_places_cache_control_on_marked_message() {
     ]);
     let compat = ProviderCompat::anthropic_defaults();
 
-    mark_cache_boundaries(&mut req, &compat);
+    mark_cache_boundaries(&mut req, &compat, None);
     let built = anthropic_shared::build_messages(&req.messages, &compat);
 
     // Last message's last content block must carry cache_control.
@@ -76,7 +76,7 @@ fn openai_compat_results_in_no_cache_control_anywhere() {
     )]);
     let compat = ProviderCompat::openai_defaults();
 
-    mark_cache_boundaries(&mut req, &compat);
+    mark_cache_boundaries(&mut req, &compat, None);
     let built = anthropic_shared::build_messages(&req.messages, &compat);
 
     for msg in built {

--- a/crates/wcore-providers/src/anthropic.rs
+++ b/crates/wcore-providers/src/anthropic.rs
@@ -1169,6 +1169,98 @@ mod tests {
         );
     }
 
+    /// Gap-1+gap-2 coupling: the engine sends TWO hints — the permanent
+    /// compaction anchor plus the tail — and the budget lands at exactly 4
+    /// (system + tools + anchor + tail). The moving previous-boundary marker
+    /// YIELDS its slot to the anchor: the anchor guarantees the long prefix.
+    #[test]
+    fn anchor_plus_tail_hints_budget_exactly_four_prev_boundary_yields() {
+        let mut body = json!({
+            "system": [ { "type": "text", "text": "sys" } ],
+            "tools": [ { "name": "t", "description": "d" } ],
+            "messages": [
+                // Permanent anchor (stubbed compaction message), hint-marked
+                // by mark_cache_boundaries via build_messages.
+                { "role": "assistant", "content": [
+                    { "type": "tool_use", "id": "w1", "name": "Write",
+                      "input": { "_args_cleared": "[stub]" },
+                      "cache_control": { "type": "ephemeral" } }
+                ] },
+                user("r1"),
+                assistant("a2"),
+                user("u2"),
+                assistant("a3"),
+                // Tail, hint-marked by mark_cache_boundaries.
+                { "role": "user", "content": [
+                    { "type": "text", "text": "u3",
+                      "cache_control": { "type": "ephemeral" } }
+                ] }
+            ]
+        });
+        apply_cache_zones(&mut body, CacheTier::Ephemeral5m, 0);
+
+        assert_eq!(
+            total_markers(&body),
+            4,
+            "system + tools + anchor + tail must land exactly at the limit"
+        );
+        let marked = marked_message_indices(&body);
+        assert_eq!(
+            marked,
+            vec![0, 5],
+            "anchor (0) and tail (5) hold the message slots; the moving \
+             previous-boundary marker (3) must yield, got {marked:?}"
+        );
+    }
+
+    /// Config-off stripping (Codex finding 1) also removes the anchor
+    /// marker: with caching disabled, neither the tail hint nor the anchor
+    /// hint may leak to the wire.
+    #[test]
+    fn config_off_strips_anchor_and_tail_hints() {
+        let off = AnthropicProvider::new(
+            "test-key",
+            "https://api.anthropic.com",
+            ProviderCompat::anthropic_defaults(),
+            DebugConfig::default(),
+        )
+        .with_cache(false);
+
+        let mut req = cache_req(None);
+        req.messages = vec![
+            {
+                let mut m = wcore_types::message::Message::new(
+                    wcore_types::message::Role::Assistant,
+                    vec![wcore_types::message::ContentBlock::Text {
+                        text: "anchor".into(),
+                    }],
+                );
+                m.cache_breakpoint = Some(wcore_types::message::MessageCacheHint::Breakpoint);
+                m
+            },
+            wcore_types::message::Message::new(
+                wcore_types::message::Role::User,
+                vec![wcore_types::message::ContentBlock::Text { text: "mid".into() }],
+            ),
+            {
+                let mut m = wcore_types::message::Message::new(
+                    wcore_types::message::Role::User,
+                    vec![wcore_types::message::ContentBlock::Text {
+                        text: "tail".into(),
+                    }],
+                );
+                m.cache_breakpoint = Some(wcore_types::message::MessageCacheHint::Breakpoint);
+                m
+            },
+        ];
+        let body = off.build_request_body(&req);
+        assert_eq!(
+            total_markers(&body),
+            0,
+            "config-off must strip BOTH the anchor and tail hint markers"
+        );
+    }
+
     // --- Task 9: min_prefix_tokens floor ------------------------------------
 
     /// Tiny context + the default 1024-token floor → no markers at all.

--- a/crates/wcore-providers/src/anthropic.rs
+++ b/crates/wcore-providers/src/anthropic.rs
@@ -25,6 +25,11 @@ pub struct AnthropicProvider {
     keys: Arc<Mutex<KeyPool>>,
     base_url: String,
     cache_enabled: bool,
+    /// Breakpoint floor: skip `cache_control` injection when the estimated
+    /// prompt prefix is below this many tokens (see `apply_cache_zones`).
+    /// From `[providers.anthropic.prompt_caching] min_prefix_tokens`;
+    /// defaults to `wcore_config::config::DEFAULT_CACHE_MIN_PREFIX_TOKENS`.
+    min_prefix_tokens: usize,
     /// Provider key used to look up the offline `/model` fallback catalog
     /// (`wcore_types::model_aliases::models_for_provider`) when live model
     /// discovery fails. Defaults to `"anthropic"`; Anthropic-wire third parties
@@ -47,6 +52,7 @@ impl AnthropicProvider {
             keys: Arc::new(Mutex::new(KeyPool::new(split_keys(api_key)))),
             base_url: base_url.to_string(),
             cache_enabled: true,
+            min_prefix_tokens: wcore_config::config::DEFAULT_CACHE_MIN_PREFIX_TOKENS,
             alias_key: "anthropic".to_string(),
             compat,
             debug,
@@ -56,6 +62,13 @@ impl AnthropicProvider {
 
     pub fn with_cache(mut self, enabled: bool) -> Self {
         self.cache_enabled = enabled;
+        self
+    }
+
+    /// Override the breakpoint floor (`min_prefix_tokens`). `0` disables the
+    /// floor — every cache-enabled request gets breakpoint markers.
+    pub fn with_min_prefix_tokens(mut self, min_prefix_tokens: usize) -> Self {
+        self.min_prefix_tokens = min_prefix_tokens;
         self
     }
 
@@ -262,6 +275,7 @@ impl AnthropicProvider {
             apply_cache_zones(
                 &mut body,
                 request.cache_tier.unwrap_or(CacheTier::Ephemeral5m),
+                self.min_prefix_tokens,
             );
         }
 
@@ -269,21 +283,63 @@ impl AnthropicProvider {
     }
 }
 
-/// Inject `cache_control` markers at the 3 standard Anthropic prompt-cache
-/// zones: the last `system` block, the last `tools` entry, and the last
-/// `messages` entry. Idempotent — re-running on the same body produces the
-/// same output. Skips zones cleanly when empty (no system text / no tools /
-/// no messages).
+/// Anthropic's hard limit on `cache_control` blocks per request.
+pub const ANTHROPIC_CACHE_CONTROL_LIMIT: usize = 4;
+
+/// Rough bytes-per-token divisor for the `min_prefix_tokens` floor estimate.
+/// The serialized JSON of the cacheable zones over 4 is a slight
+/// over-estimate of true tokens (JSON scaffolding inflates bytes), which
+/// errs toward injecting markers a little early — harmless — rather than
+/// skipping a prefix that would have cleared the floor.
+const BYTES_PER_TOKEN_ESTIMATE: usize = 4;
+
+/// Inject `cache_control` markers at the 4 Anthropic prompt-cache zones
+/// (moving-breakpoint layout, ported from openclaw/hermes-agent):
+///
+///   1. the last `system` block — stable prefix,
+///   2. the last `tools` entry — stable prefix,
+///   3. the previous user-boundary message (last user-role message before
+///      the tail) — this is exactly the message the PREVIOUS turn marked as
+///      its write point, so re-marking it guarantees the previous turn's
+///      cached prefix is an addressable cache-read boundary this turn,
+///      regardless of how many content blocks the new turn appended,
+///   4. the last `messages` entry — the new cache-write point.
+///
+/// Zones 3+4 form a moving pair: turn *k* marks boundaries {k−1, k}, turn
+/// *k+1* marks {k, k+1} — consecutive turns always overlap on one marked
+/// boundary, keeping the layout cache-stable across turns.
+///
+/// Hard budget: at most [`ANTHROPIC_CACHE_CONTROL_LIMIT`] markers total,
+/// counting any marker already present (the engine's
+/// `mark_cache_boundaries` hint path may have pre-marked the tail block —
+/// re-marking the same block is free). Message markers are spent
+/// newest-first so the write point always wins over the read boundary.
+///
+/// Floor: when the estimated token size of the cacheable zones
+/// (system + tools + messages) is below `min_prefix_tokens`, no markers are
+/// injected at all — caching a tiny context costs more (25% cache-write
+/// premium) than it can save. Pass `0` to disable the floor.
+///
+/// Idempotent — re-running on the same body produces the same output.
+/// Skips zones cleanly when empty (no system text / no tools / no
+/// messages). Markers are pure key inserts on existing objects: serde_json
+/// maps are BTreeMap-backed (sorted keys), so injection never perturbs the
+/// serialization order of any other field.
 ///
 /// `tier` controls the ephemeral TTL marker:
 ///   - [`CacheTier::Ephemeral5m`] -> `{ "type": "ephemeral" }` (default 5m)
 ///   - [`CacheTier::Ephemeral1h`] -> `{ "type": "ephemeral", "ttl": "1h" }`
 ///   - [`CacheTier::None`]        -> no-op (caching disabled for this request)
-pub fn apply_cache_zones(body: &mut Value, tier: CacheTier) {
+pub fn apply_cache_zones(body: &mut Value, tier: CacheTier, min_prefix_tokens: usize) {
     let marker = match cache_control_marker(tier) {
         Some(m) => m,
         None => return,
     };
+
+    // Floor: skip injection entirely for tiny contexts.
+    if estimated_prefix_tokens(body) < min_prefix_tokens {
+        return;
+    }
 
     // Zone 1: system prompt — mark the last text block.
     if let Some(system_blocks) = body.get_mut("system").and_then(Value::as_array_mut)
@@ -301,13 +357,111 @@ pub fn apply_cache_zones(body: &mut Value, tier: CacheTier) {
         last["cache_control"] = marker.clone();
     }
 
-    // Zone 3: messages — mark the last message so the running context up to
-    // and including that message becomes a cache prefix for the next turn.
+    // Zones 3+4: the moving message-breakpoint pair, spent from whatever
+    // budget the fixed zones (plus any pre-existing hint marker) left over.
+    let fixed_markers = count_cache_markers(body.get("system"))
+        + count_cache_markers(body.get("tools"))
+        + count_message_cache_markers(body.get("messages"));
+    let mut budget = ANTHROPIC_CACHE_CONTROL_LIMIT.saturating_sub(fixed_markers);
+
     if let Some(messages) = body.get_mut("messages").and_then(Value::as_array_mut)
-        && let Some(last) = messages.last_mut()
+        && !messages.is_empty()
     {
-        apply_message_zone_marker(last, &marker);
+        let last_idx = messages.len() - 1;
+
+        // Zone 4 first (newest wins the budget): the tail write point.
+        apply_message_zone_marker_budgeted(&mut messages[last_idx], &marker, &mut budget);
+
+        // Zone 3: the previous user boundary — the last user-role message
+        // strictly before the tail (= the previous turn's write point).
+        if let Some(prev) = messages[..last_idx]
+            .iter()
+            .rposition(|m| m.get("role").and_then(Value::as_str) == Some("user"))
+        {
+            apply_message_zone_marker_budgeted(&mut messages[prev], &marker, &mut budget);
+        }
     }
+
+    debug_assert!(
+        count_cache_markers(body.get("system"))
+            + count_cache_markers(body.get("tools"))
+            + count_message_cache_markers(body.get("messages"))
+            <= ANTHROPIC_CACHE_CONTROL_LIMIT,
+        "cache_control markers must never exceed Anthropic's limit of {ANTHROPIC_CACHE_CONTROL_LIMIT}"
+    );
+}
+
+/// Estimate the token size of the cacheable prompt zones (system + tools +
+/// messages) as serialized-JSON bytes over [`BYTES_PER_TOKEN_ESTIMATE`].
+fn estimated_prefix_tokens(body: &Value) -> usize {
+    let mut bytes = 0usize;
+    for zone in ["system", "tools", "messages"] {
+        if let Some(v) = body.get(zone) {
+            bytes += serde_json::to_string(v).map(|s| s.len()).unwrap_or(0);
+        }
+    }
+    bytes / BYTES_PER_TOKEN_ESTIMATE
+}
+
+/// Count `cache_control` markers on the direct entries of a system/tools
+/// zone array. `None` / non-array → 0.
+fn count_cache_markers(zone: Option<&Value>) -> usize {
+    zone.and_then(Value::as_array)
+        .map(|entries| {
+            entries
+                .iter()
+                .filter(|e| e.get("cache_control").is_some())
+                .count()
+        })
+        .unwrap_or(0)
+}
+
+/// Count `cache_control` markers anywhere in the messages zone: on content
+/// blocks and (defensively) on message objects themselves.
+fn count_message_cache_markers(zone: Option<&Value>) -> usize {
+    zone.and_then(Value::as_array)
+        .map(|messages| {
+            messages
+                .iter()
+                .map(|m| {
+                    let on_message = usize::from(m.get("cache_control").is_some());
+                    let on_blocks = m
+                        .get("content")
+                        .and_then(Value::as_array)
+                        .map(|blocks| {
+                            blocks
+                                .iter()
+                                .filter(|b| b.get("cache_control").is_some())
+                                .count()
+                        })
+                        .unwrap_or(0);
+                    on_message + on_blocks
+                })
+                .sum()
+        })
+        .unwrap_or(0)
+}
+
+/// Mark `message` if (and only if) its target block is not already marked
+/// and `budget` allows. An already-marked target is free (idempotent);
+/// a fresh marker consumes one budget unit.
+fn apply_message_zone_marker_budgeted(message: &mut Value, marker: &Value, budget: &mut usize) {
+    // Already marked (e.g. by the engine's tail hint, or a repeat call)?
+    // Nothing to spend.
+    let already_marked = message
+        .get("content")
+        .and_then(Value::as_array)
+        .and_then(|blocks| blocks.last())
+        .map(|b| b.get("cache_control").is_some())
+        .unwrap_or_else(|| message.get("cache_control").is_some());
+    if already_marked {
+        return;
+    }
+    if *budget == 0 {
+        return;
+    }
+    apply_message_zone_marker(message, marker);
+    *budget -= 1;
 }
 
 /// Attach the cache_control marker to a single message. Prefers the last
@@ -641,9 +795,9 @@ mod tests {
     }
 
     #[test]
-    fn all_three_zones_injected_when_present() {
+    fn all_four_zones_injected_when_present() {
         let mut body = body_with_all_zones();
-        apply_cache_zones(&mut body, CacheTier::Ephemeral5m);
+        apply_cache_zones(&mut body, CacheTier::Ephemeral5m, 0);
 
         // System: last block has marker, first does not.
         let system = body["system"].as_array().unwrap();
@@ -655,9 +809,14 @@ mod tests {
         assert!(tools[0].get("cache_control").is_none());
         assert_eq!(tools[1]["cache_control"], marker_5m());
 
-        // Messages: last message's last content block has marker.
+        // Messages: the moving pair — the tail (write point) AND the previous
+        // user boundary both carry markers. Total = 4 (system+tools+2).
         let messages = body["messages"].as_array().unwrap();
-        assert!(messages[0]["content"][0].get("cache_control").is_none());
+        assert_eq!(
+            messages[0]["content"][0]["cache_control"],
+            marker_5m(),
+            "previous user boundary must carry the read-boundary marker"
+        );
         assert_eq!(messages[1]["content"][0]["cache_control"], marker_5m());
     }
 
@@ -669,7 +828,7 @@ mod tests {
                 { "role": "user", "content": [ { "type": "text", "text": "hi" } ] }
             ]
         });
-        apply_cache_zones(&mut body, CacheTier::Ephemeral5m);
+        apply_cache_zones(&mut body, CacheTier::Ephemeral5m, 0);
 
         assert_eq!(body["system"][0]["cache_control"], marker_5m());
         assert_eq!(
@@ -688,7 +847,7 @@ mod tests {
                 { "role": "user", "content": [ { "type": "text", "text": "hi" } ] }
             ]
         });
-        apply_cache_zones(&mut body, CacheTier::Ephemeral5m);
+        apply_cache_zones(&mut body, CacheTier::Ephemeral5m, 0);
 
         // Empty system array -> nothing to mark, no panic.
         assert!(body["system"].as_array().unwrap().is_empty());
@@ -706,7 +865,7 @@ mod tests {
                 { "role": "user", "content": [ { "type": "text", "text": "hi" } ] }
             ]
         });
-        apply_cache_zones(&mut body, CacheTier::Ephemeral5m);
+        apply_cache_zones(&mut body, CacheTier::Ephemeral5m, 0);
 
         assert_eq!(
             body["messages"][0]["content"][0]["cache_control"],
@@ -719,21 +878,21 @@ mod tests {
     #[test]
     fn idempotent_when_applied_twice() {
         let mut body = body_with_all_zones();
-        apply_cache_zones(&mut body, CacheTier::Ephemeral5m);
+        apply_cache_zones(&mut body, CacheTier::Ephemeral5m, 0);
         let after_first = body.clone();
-        apply_cache_zones(&mut body, CacheTier::Ephemeral5m);
+        apply_cache_zones(&mut body, CacheTier::Ephemeral5m, 0);
         assert_eq!(body, after_first, "second apply must be a no-op shape");
     }
 
     #[test]
     fn ttl_propagates_5m_vs_1h() {
         let mut body_5m = body_with_all_zones();
-        apply_cache_zones(&mut body_5m, CacheTier::Ephemeral5m);
+        apply_cache_zones(&mut body_5m, CacheTier::Ephemeral5m, 0);
         assert_eq!(body_5m["system"][1]["cache_control"], marker_5m());
         assert!(body_5m["system"][1]["cache_control"].get("ttl").is_none());
 
         let mut body_1h = body_with_all_zones();
-        apply_cache_zones(&mut body_1h, CacheTier::Ephemeral1h);
+        apply_cache_zones(&mut body_1h, CacheTier::Ephemeral1h, 0);
         assert_eq!(body_1h["system"][1]["cache_control"], marker_1h());
         assert_eq!(body_1h["tools"][1]["cache_control"]["ttl"], "1h");
         assert_eq!(
@@ -746,7 +905,7 @@ mod tests {
     fn cache_tier_none_is_noop() {
         let mut body = body_with_all_zones();
         let before = body.clone();
-        apply_cache_zones(&mut body, CacheTier::None);
+        apply_cache_zones(&mut body, CacheTier::None, 0);
         assert_eq!(body, before);
     }
 
@@ -759,7 +918,7 @@ mod tests {
                 { "role": "user", "content": [ { "type": "text", "text": "U" } ] }
             ]
         });
-        apply_cache_zones(&mut body, CacheTier::Ephemeral5m);
+        apply_cache_zones(&mut body, CacheTier::Ephemeral5m, 0);
 
         let expected = json!({
             "system": [
@@ -786,7 +945,7 @@ mod tests {
             "system": [ { "type": "text", "text": "S" } ],
             "messages": []
         });
-        apply_cache_zones(&mut body, CacheTier::Ephemeral5m);
+        apply_cache_zones(&mut body, CacheTier::Ephemeral5m, 0);
 
         // System still marked.
         assert_eq!(body["system"][0]["cache_control"], marker_5m());
@@ -804,12 +963,353 @@ mod tests {
                 { "role": "user", "content": "plain string" }
             ]
         });
-        apply_cache_zones(&mut body, CacheTier::Ephemeral5m);
+        apply_cache_zones(&mut body, CacheTier::Ephemeral5m, 0);
         assert_eq!(body["messages"][0]["cache_control"], marker_5m());
+    }
+
+    // --- Task 9: moving breakpoint pair + budget + floor + gating -----------
+
+    /// Collect the indices of messages carrying a cache_control marker
+    /// (on any content block or on the message object itself).
+    fn marked_message_indices(body: &Value) -> Vec<usize> {
+        body["messages"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .enumerate()
+            .filter(|(_, m)| {
+                m.get("cache_control").is_some()
+                    || m["content"].as_array().is_some_and(|blocks| {
+                        blocks.iter().any(|b| b.get("cache_control").is_some())
+                    })
+            })
+            .map(|(i, _)| i)
+            .collect()
+    }
+
+    fn total_markers(body: &Value) -> usize {
+        serde_json::to_string(body)
+            .unwrap()
+            .matches("\"cache_control\"")
+            .count()
+    }
+
+    fn user(text: &str) -> Value {
+        json!({ "role": "user", "content": [ { "type": "text", "text": text } ] })
+    }
+
+    fn assistant(text: &str) -> Value {
+        json!({ "role": "assistant", "content": [ { "type": "text", "text": text } ] })
+    }
+
+    /// The moving pair over a growing 3-turn conversation: every turn stays
+    /// within Anthropic's 4-marker limit, marked positions move monotonically
+    /// forward, and the previous turn's write point (its tail) is re-marked
+    /// as this turn's read boundary — the cross-turn stability guarantee.
+    #[test]
+    fn three_turn_growing_conversation_markers_monotonic_and_bounded() {
+        let turn_messages: [Vec<Value>; 3] = [
+            vec![user("u1")],
+            vec![user("u1"), assistant("a1"), user("u2")],
+            vec![
+                user("u1"),
+                assistant("a1"),
+                user("u2"),
+                assistant("a2"),
+                user("u3"),
+            ],
+        ];
+
+        let mut prev_tail: Option<usize> = None;
+        let mut prev_max: usize = 0;
+        for (turn, messages) in turn_messages.into_iter().enumerate() {
+            let mut body = json!({
+                "system": [ { "type": "text", "text": "sys" } ],
+                "tools": [ { "name": "t", "description": "d" } ],
+                "messages": messages
+            });
+            apply_cache_zones(&mut body, CacheTier::Ephemeral5m, 0);
+
+            assert!(
+                total_markers(&body) <= 4,
+                "turn {turn}: markers must never exceed Anthropic's limit of 4"
+            );
+
+            let marked = marked_message_indices(&body);
+            let tail = body["messages"].as_array().unwrap().len() - 1;
+            assert!(
+                marked.contains(&tail),
+                "turn {turn}: the tail write point must always be marked"
+            );
+            assert!(
+                marked.iter().all(|&i| i >= prev_max.min(tail)),
+                "turn {turn}: marked positions must move monotonically forward, got {marked:?}"
+            );
+            if let Some(prev) = prev_tail {
+                assert!(
+                    marked.contains(&prev),
+                    "turn {turn}: the previous turn's write point (index {prev}) must be \
+                     re-marked as this turn's read boundary, got {marked:?}"
+                );
+            }
+            prev_max = *marked.iter().max().unwrap();
+            prev_tail = Some(tail);
+        }
+    }
+
+    /// Budget enforcement with a pre-existing hint marker: the engine's
+    /// `mark_cache_boundaries` path may have already marked the tail block
+    /// via `build_messages`. Re-marking it is free; the total must still
+    /// come out at exactly the 4-marker limit, never above.
+    #[test]
+    fn budget_holds_at_four_with_preexisting_hint_marker() {
+        let mut body = json!({
+            "system": [ { "type": "text", "text": "sys" } ],
+            "tools": [ { "name": "t", "description": "d" } ],
+            "messages": [
+                user("u1"),
+                assistant("a1"),
+                // Tail pre-marked, as the hint path emits it.
+                { "role": "user", "content": [
+                    { "type": "text", "text": "u2",
+                      "cache_control": { "type": "ephemeral" } }
+                ] }
+            ]
+        });
+        apply_cache_zones(&mut body, CacheTier::Ephemeral5m, 0);
+
+        assert_eq!(
+            total_markers(&body),
+            4,
+            "system + tools + boundary pair must land exactly at the limit"
+        );
+        assert_eq!(
+            marked_message_indices(&body),
+            vec![0, 2],
+            "previous user boundary (0) and tail (2) must be the marked pair"
+        );
+    }
+
+    /// When the fixed zones leave only one message slot, the tail write
+    /// point wins it and the read boundary is skipped — never a 5th marker.
+    #[test]
+    fn tail_wins_budget_when_only_one_message_slot_remains() {
+        // Pre-marked NON-tail message eats one budget unit (pathological
+        // upstream state), leaving one slot for two candidates.
+        let mut body = json!({
+            "system": [ { "type": "text", "text": "sys" } ],
+            "tools": [ { "name": "t", "description": "d" } ],
+            "messages": [
+                { "role": "user", "content": [
+                    { "type": "text", "text": "u1",
+                      "cache_control": { "type": "ephemeral" } }
+                ] },
+                assistant("a1"),
+                user("u2"),
+                assistant("a2"),
+                user("u3")
+            ]
+        });
+        apply_cache_zones(&mut body, CacheTier::Ephemeral5m, 0);
+
+        assert_eq!(total_markers(&body), 4, "hard cap must hold");
+        let marked = marked_message_indices(&body);
+        assert!(
+            marked.contains(&4),
+            "the tail write point must win the last budget slot, got {marked:?}"
+        );
+        assert!(
+            !marked.contains(&2),
+            "the read boundary must be skipped when the budget is spent, got {marked:?}"
+        );
+    }
+
+    // --- Task 9: min_prefix_tokens floor ------------------------------------
+
+    /// Tiny context + the default 1024-token floor → no markers at all.
+    /// Cache-writing a tiny prefix costs a 25% premium for nothing.
+    #[test]
+    fn tiny_context_default_floor_skips_all_markers() {
+        let default_floor_provider = AnthropicProvider::new(
+            "test-key",
+            "https://api.anthropic.com",
+            ProviderCompat::anthropic_defaults(),
+            DebugConfig::default(),
+        );
+        let body = default_floor_provider.build_request_body(&cache_req(None));
+        assert_eq!(
+            total_markers(&body),
+            0,
+            "a tiny prompt under the 1024-token floor must get no cache_control markers"
+        );
+    }
+
+    /// A prompt that clears the floor gets the full marker layout with the
+    /// same default-floor provider.
+    #[test]
+    fn large_context_clears_default_floor_and_gets_markers() {
+        let default_floor_provider = AnthropicProvider::new(
+            "test-key",
+            "https://api.anthropic.com",
+            ProviderCompat::anthropic_defaults(),
+            DebugConfig::default(),
+        );
+        let mut req = cache_req(None);
+        // ~8k bytes ≈ ~2k estimated tokens — comfortably over the 1024 floor.
+        req.system = "x".repeat(8_192);
+        let body = default_floor_provider.build_request_body(&req);
+        assert!(
+            total_markers(&body) >= 2,
+            "a prompt over the floor must carry cache_control markers"
+        );
+        assert_eq!(body["system"][0]["cache_control"], marker_5m());
+    }
+
+    /// The floor gates on the estimate, exactly at the boundary semantics
+    /// of `estimated < floor` → skip.
+    #[test]
+    fn floor_boundary_semantics() {
+        let mut body = json!({
+            "system": [ { "type": "text", "text": "sys" } ],
+            "messages": [ user("hi") ]
+        });
+        let estimate = super::estimated_prefix_tokens(&body);
+        apply_cache_zones(&mut body, CacheTier::Ephemeral5m, estimate + 1);
+        assert_eq!(total_markers(&body), 0, "estimate < floor must skip");
+
+        apply_cache_zones(&mut body, CacheTier::Ephemeral5m, estimate);
+        assert!(total_markers(&body) > 0, "estimate >= floor must inject");
+    }
+
+    // --- Task 9: config-off byte identity + family gating -------------------
+
+    /// `prompt_caching = false` (config off): the request body is
+    /// byte-identical to a body that never saw the cache injector.
+    #[test]
+    fn config_off_body_is_byte_identical_to_uninjected() {
+        let off = AnthropicProvider::new(
+            "test-key",
+            "https://api.anthropic.com",
+            ProviderCompat::anthropic_defaults(),
+            DebugConfig::default(),
+        )
+        .with_cache(false);
+
+        let req = cache_req(Some(CacheTier::Ephemeral1h));
+        let body = off.build_request_body(&req);
+        let bytes = serde_json::to_string(&body).unwrap();
+        assert!(
+            !bytes.contains("cache_control"),
+            "config-off body must carry no cache_control anywhere"
+        );
+
+        let expected = json!({
+            "model": "claude-sonnet-4-6",
+            "max_tokens": 16,
+            "system": [ { "type": "text", "text": "you are a test" } ],
+            "messages": [
+                { "role": "user", "content": [ { "type": "text", "text": "hi" } ] }
+            ],
+            "stream": true
+        });
+        assert_eq!(
+            bytes,
+            serde_json::to_string(&expected).unwrap(),
+            "config-off body must serialize byte-identically to the uninjected shape"
+        );
+    }
+
+    /// Family gating: the message-hint translation in `build_messages` obeys
+    /// `compat.cache_message_breakpoints()` — Anthropic-family compat emits
+    /// the marker, OpenAI-family compat leaves the message untouched.
+    #[test]
+    fn family_gating_hint_translation_anthropic_yes_openai_no() {
+        let mut msg = wcore_types::message::Message::new(
+            wcore_types::message::Role::User,
+            vec![wcore_types::message::ContentBlock::Text { text: "hi".into() }],
+        );
+        msg.cache_breakpoint = Some(wcore_types::message::MessageCacheHint::Breakpoint);
+        let messages = vec![msg];
+
+        let anthropic_wire =
+            anthropic_shared::build_messages(&messages, &ProviderCompat::anthropic_defaults());
+        assert!(
+            anthropic_wire[0]["content"][0]
+                .get("cache_control")
+                .is_some(),
+            "anthropic-family compat must translate the hint into cache_control"
+        );
+
+        let openai_wire =
+            anthropic_shared::build_messages(&messages, &ProviderCompat::openai_defaults());
+        assert!(
+            !serde_json::to_string(&openai_wire)
+                .unwrap()
+                .contains("cache_control"),
+            "openai-family compat must never emit cache_control"
+        );
+    }
+
+    /// Family gating at the provider level: an Anthropic-wire third party
+    /// with unverified caching support (the MiniMax reuse) is constructed
+    /// `with_cache(false)` — its bodies carry no markers.
+    #[test]
+    fn family_gating_minimax_reuse_emits_no_markers() {
+        let minimax = AnthropicProvider::new(
+            "k",
+            "https://api.minimax.io/anthropic",
+            ProviderCompat::minimax_defaults(),
+            DebugConfig::default(),
+        )
+        .with_cache(false)
+        .with_alias_key("minimax");
+        let body = minimax.build_request_body(&cache_req(Some(CacheTier::Ephemeral5m)));
+        assert_eq!(
+            total_markers(&body),
+            0,
+            "a cache-disabled Anthropic-wire reuse must emit no cache_control"
+        );
+    }
+
+    /// Byte-stability: injecting markers must not perturb the serialization
+    /// of anything else — stripping the injected `cache_control` keys from
+    /// the marked body must reproduce the unmarked body byte-for-byte.
+    #[test]
+    fn injection_does_not_perturb_sibling_serialization() {
+        let mut marked = body_with_all_zones();
+        apply_cache_zones(&mut marked, CacheTier::Ephemeral5m, 0);
+
+        fn strip(v: &mut Value) {
+            match v {
+                Value::Object(map) => {
+                    map.remove("cache_control");
+                    for child in map.values_mut() {
+                        strip(child);
+                    }
+                }
+                Value::Array(items) => {
+                    for child in items {
+                        strip(child);
+                    }
+                }
+                _ => {}
+            }
+        }
+        strip(&mut marked);
+
+        assert_eq!(
+            serde_json::to_string(&marked).unwrap(),
+            serde_json::to_string(&body_with_all_zones()).unwrap(),
+            "removing only the injected markers must reproduce the original bytes"
+        );
     }
 
     // --- W8 v0.6.3: build_request_body consumes request.cache_tier ---------
 
+    /// Test provider with the breakpoint floor disabled — the tiny request
+    /// bodies these tests build would otherwise (correctly) fall under the
+    /// default 1024-token floor and get no markers at all. The floor itself
+    /// is covered by the dedicated floor tests below.
     fn provider() -> AnthropicProvider {
         AnthropicProvider::new(
             "test-key",
@@ -817,6 +1317,7 @@ mod tests {
             ProviderCompat::anthropic_defaults(),
             DebugConfig::default(),
         )
+        .with_min_prefix_tokens(0)
     }
 
     fn cache_req(tier: Option<CacheTier>) -> LlmRequest {

--- a/crates/wcore-providers/src/anthropic.rs
+++ b/crates/wcore-providers/src/anthropic.rs
@@ -277,6 +277,14 @@ impl AnthropicProvider {
                 request.cache_tier.unwrap_or(CacheTier::Ephemeral5m),
                 self.min_prefix_tokens,
             );
+        } else {
+            // Codex audit (e399feb1 finding 1): `build_messages` above runs
+            // BEFORE this gate and — for anthropic-family compat — has
+            // already translated the engine's tail cache hint
+            // (`mark_cache_boundaries`) into a wire `cache_control` marker.
+            // `prompt_caching = false` must mean a body byte-identical to an
+            // uninjected request, so strip that leak here.
+            strip_message_cache_markers(&mut body);
         }
 
         body
@@ -287,11 +295,13 @@ impl AnthropicProvider {
 pub const ANTHROPIC_CACHE_CONTROL_LIMIT: usize = 4;
 
 /// Rough bytes-per-token divisor for the `min_prefix_tokens` floor estimate.
-/// The serialized JSON of the cacheable zones over 4 is a slight
-/// over-estimate of true tokens (JSON scaffolding inflates bytes), which
-/// errs toward injecting markers a little early — harmless — rather than
-/// skipping a prefix that would have cleared the floor.
-const BYTES_PER_TOKEN_ESTIMATE: usize = 4;
+/// Deliberately 2 — NOT the usual ~4 bytes/token English heuristic — because
+/// the floor must never under-count: CJK text and repeated short-token
+/// runs sit near ~2 bytes/token, and bytes/4 would deny caching to contexts
+/// genuinely above the floor. Erring toward caching costs at most the
+/// one-time 25% cache-write premium; erring away forfeits the ~90% read
+/// discount on every subsequent turn.
+const BYTES_PER_TOKEN_ESTIMATE: usize = 2;
 
 /// Inject `cache_control` markers at the 4 Anthropic prompt-cache zones
 /// (moving-breakpoint layout, ported from openclaw/hermes-agent):
@@ -317,8 +327,11 @@ const BYTES_PER_TOKEN_ESTIMATE: usize = 4;
 ///
 /// Floor: when the estimated token size of the cacheable zones
 /// (system + tools + messages) is below `min_prefix_tokens`, no markers are
-/// injected at all — caching a tiny context costs more (25% cache-write
-/// premium) than it can save. Pass `0` to disable the floor.
+/// injected — and any marker already present (the engine's hint path) is
+/// STRIPPED, so a sub-floor request carries zero `cache_control` on the
+/// wire. Caching a tiny context costs more (25% cache-write premium) than
+/// it can save. Pass `0` to disable the floor. [`CacheTier::None`] strips
+/// the same way: per-request "caching off" must mean off.
 ///
 /// Idempotent — re-running on the same body produces the same output.
 /// Skips zones cleanly when empty (no system text / no tools / no
@@ -329,15 +342,22 @@ const BYTES_PER_TOKEN_ESTIMATE: usize = 4;
 /// `tier` controls the ephemeral TTL marker:
 ///   - [`CacheTier::Ephemeral5m`] -> `{ "type": "ephemeral" }` (default 5m)
 ///   - [`CacheTier::Ephemeral1h`] -> `{ "type": "ephemeral", "ttl": "1h" }`
-///   - [`CacheTier::None`]        -> no-op (caching disabled for this request)
+///   - [`CacheTier::None`]        -> strip + return (caching disabled for
+///     this request — pre-existing hint markers must not leak to the wire)
 pub fn apply_cache_zones(body: &mut Value, tier: CacheTier, min_prefix_tokens: usize) {
     let marker = match cache_control_marker(tier) {
         Some(m) => m,
-        None => return,
+        None => {
+            strip_message_cache_markers(body);
+            return;
+        }
     };
 
-    // Floor: skip injection entirely for tiny contexts.
+    // Floor: for tiny contexts, skip injection AND remove any marker the
+    // engine's hint path already placed — otherwise a sub-floor request
+    // still pays cache-write behavior through the leaked tail marker.
     if estimated_prefix_tokens(body) < min_prefix_tokens {
+        strip_message_cache_markers(body);
         return;
     }
 
@@ -389,6 +409,31 @@ pub fn apply_cache_zones(body: &mut Value, tier: CacheTier, min_prefix_tokens: u
             <= ANTHROPIC_CACHE_CONTROL_LIMIT,
         "cache_control markers must never exceed Anthropic's limit of {ANTHROPIC_CACHE_CONTROL_LIMIT}"
     );
+}
+
+/// Remove every `cache_control` marker from the messages zone — from
+/// content blocks and (defensively) from message objects themselves. Used
+/// when caching is off (config, per-request tier, or sub-floor context) to
+/// undo the engine-hint marker that `build_messages` already translated.
+/// Removal is byte-safe for siblings: serde_json objects are BTreeMap-backed
+/// (sorted keys, no `preserve_order` swap-remove hazard), so deleting a key
+/// cannot reorder the remaining fields.
+fn strip_message_cache_markers(body: &mut Value) {
+    let Some(messages) = body.get_mut("messages").and_then(Value::as_array_mut) else {
+        return;
+    };
+    for message in messages {
+        if let Some(obj) = message.as_object_mut() {
+            obj.remove("cache_control");
+        }
+        if let Some(blocks) = message.get_mut("content").and_then(Value::as_array_mut) {
+            for block in blocks {
+                if let Some(obj) = block.as_object_mut() {
+                    obj.remove("cache_control");
+                }
+            }
+        }
+    }
 }
 
 /// Estimate the token size of the cacheable prompt zones (system + tools +
@@ -1183,8 +1228,24 @@ mod tests {
 
     // --- Task 9: config-off byte identity + family gating -------------------
 
+    /// A request carrying the engine's tail cache hint, exactly as
+    /// `wcore-observability::cache::mark_cache_boundaries` stamps it before
+    /// every dispatch. The production path ALWAYS carries this for
+    /// anthropic-family compat — a caching test without it misses the
+    /// hint-translation leak in `build_messages` (Codex audit finding 1).
+    fn hinted_req(tier: Option<CacheTier>) -> LlmRequest {
+        let mut req = cache_req(tier);
+        req.messages
+            .last_mut()
+            .expect("cache_req always has a message")
+            .cache_breakpoint = Some(wcore_types::message::MessageCacheHint::Breakpoint);
+        req
+    }
+
     /// `prompt_caching = false` (config off): the request body is
-    /// byte-identical to a body that never saw the cache injector.
+    /// byte-identical to a body that never saw the cache injector — EVEN
+    /// when the engine's tail hint is present (which `build_messages`
+    /// translates into a wire marker before the config gate runs).
     #[test]
     fn config_off_body_is_byte_identical_to_uninjected() {
         let off = AnthropicProvider::new(
@@ -1195,7 +1256,7 @@ mod tests {
         )
         .with_cache(false);
 
-        let req = cache_req(Some(CacheTier::Ephemeral1h));
+        let req = hinted_req(Some(CacheTier::Ephemeral1h));
         let body = off.build_request_body(&req);
         let bytes = serde_json::to_string(&body).unwrap();
         assert!(
@@ -1216,6 +1277,58 @@ mod tests {
             bytes,
             serde_json::to_string(&expected).unwrap(),
             "config-off body must serialize byte-identically to the uninjected shape"
+        );
+    }
+
+    /// Sub-floor request WITH the engine hint: the leaked tail marker from
+    /// `build_messages` must be stripped, not merely left uninjected —
+    /// a tiny request must carry zero `cache_control` on the wire.
+    #[test]
+    fn sub_floor_request_with_engine_hint_emits_zero_markers() {
+        let default_floor_provider = AnthropicProvider::new(
+            "test-key",
+            "https://api.anthropic.com",
+            ProviderCompat::anthropic_defaults(),
+            DebugConfig::default(),
+        );
+        let body = default_floor_provider.build_request_body(&hinted_req(None));
+        assert_eq!(
+            total_markers(&body),
+            0,
+            "a sub-floor request must strip the engine's hint marker, not leak it"
+        );
+    }
+
+    /// `cache_tier = Some(None)` (per-request caching off) strips the
+    /// engine-hint marker the same way the config gate does.
+    #[test]
+    fn cache_tier_none_strips_engine_hint_marker() {
+        let body = provider().build_request_body(&hinted_req(Some(CacheTier::None)));
+        assert_eq!(
+            total_markers(&body),
+            0,
+            "per-request caching-off must strip the hint marker from the wire body"
+        );
+    }
+
+    /// Marker stripping is byte-safe for siblings: stripping a hinted body
+    /// reproduces the never-hinted body exactly (BTreeMap removal cannot
+    /// reorder remaining keys).
+    #[test]
+    fn strip_reproduces_unhinted_body_bytes() {
+        let off = AnthropicProvider::new(
+            "test-key",
+            "https://api.anthropic.com",
+            ProviderCompat::anthropic_defaults(),
+            DebugConfig::default(),
+        )
+        .with_cache(false);
+        let hinted = off.build_request_body(&hinted_req(None));
+        let unhinted = off.build_request_body(&cache_req(None));
+        assert_eq!(
+            serde_json::to_string(&hinted).unwrap(),
+            serde_json::to_string(&unhinted).unwrap(),
+            "hinted and never-hinted config-off bodies must be byte-identical"
         );
     }
 

--- a/crates/wcore-providers/src/lib.rs
+++ b/crates/wcore-providers/src/lib.rs
@@ -324,7 +324,8 @@ pub fn create_native_provider(config: &Config) -> Arc<dyn LlmProvider> {
     match config.provider {
         ProviderType::Anthropic => Arc::new(
             anthropic::AnthropicProvider::new(&config.api_key, &config.base_url, compat, debug)
-                .with_cache(config.prompt_caching),
+                .with_cache(config.prompt_caching)
+                .with_min_prefix_tokens(config.prompt_caching_min_prefix_tokens),
         ),
         ProviderType::OpenAI => Arc::new(openai::OpenAIProvider::new(
             &config.api_key,


### PR DESCRIPTION
## What
Parity gap 1 of the token-efficiency wave: adds explicit Anthropic `cache_control` breakpoints on the wire so the provider caches the growing prefix (hermes-agent/openclaw parity).

- **Moving 4-breakpoint layout** (ccf525ed): the {k-1,k} moving pair + anchors on the Anthropic Messages wire.
- **Codex FIX-FIRST fixes** (ef4aa608): config-off/sub-floor cache-hint leak closed; floor-estimator direction corrected; strip markers when disabled (fail-safe).
- **Permanent anchor coupling** (30340ae5): the permanent breakpoint is pinned to the immutable stubbed compaction anchor (`micro::cache_anchor_index`, epoch K=8) so there is zero mid-prefix cache invalidation when history compacts. DeepSeek GO-WITH-COUPLING design.

## Verification
- Codex adversarial audit (final): GO (`scratchpad/token-exp/audit_gap1_final_codex.out`).
- Couples to the gap-2 compaction anchor (landed in #184). Rebased onto main (phase1 squash-merged), gap-1-only diff, fmt-clean.

## Sequence
Stacks conceptually after #184 (merged) and #186 (tools). Part of the wave projecting 5.08x → ~2.8x raw / ~0.3x cost. Ships in the Core binary bundled into desktop 0.11.17.