### PR TITLE
chore: release 0.12.24

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8983,7 +8983,7 @@ dependencies = [
 
 [[package]]
 name = "wayland-browser"
-version = "0.12.22"
+version = "0.12.24"
 dependencies = [
  "async-trait",
  "inventory",
@@ -9000,7 +9000,7 @@ dependencies = [
 
 [[package]]
 name = "wayland-cua"
-version = "0.12.22"
+version = "0.12.24"
 dependencies = [
  "async-trait",
  "inventory",
@@ -9017,7 +9017,7 @@ dependencies = [
 
 [[package]]
 name = "wayland-honcho"
-version = "0.12.22"
+version = "0.12.24"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9038,7 +9038,7 @@ dependencies = [
 
 [[package]]
 name = "wayland-ijfw"
-version = "0.12.22"
+version = "0.12.24"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9057,7 +9057,7 @@ dependencies = [
 
 [[package]]
 name = "wayland-ollama"
-version = "0.12.22"
+version = "0.12.24"
 dependencies = [
  "async-trait",
  "futures",
@@ -9078,7 +9078,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-acp"
-version = "0.12.22"
+version = "0.12.24"
 dependencies = [
  "async-trait",
  "axum",
@@ -9101,7 +9101,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-agent"
-version = "0.12.22"
+version = "0.12.24"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9191,7 +9191,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-agents-pack"
-version = "0.12.22"
+version = "0.12.24"
 dependencies = [
  "dirs",
  "serde",
@@ -9204,7 +9204,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-browser"
-version = "0.12.22"
+version = "0.12.24"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9234,7 +9234,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-budget"
-version = "0.12.22"
+version = "0.12.24"
 dependencies = [
  "chrono",
  "parking_lot",
@@ -9247,7 +9247,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-discord"
-version = "0.12.22"
+version = "0.12.24"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9268,7 +9268,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-email"
-version = "0.12.22"
+version = "0.12.24"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9287,7 +9287,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-imessage"
-version = "0.12.22"
+version = "0.12.24"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9304,7 +9304,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-matrix"
-version = "0.12.22"
+version = "0.12.24"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9323,7 +9323,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-msteams"
-version = "0.12.22"
+version = "0.12.24"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -9344,7 +9344,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-signal"
-version = "0.12.22"
+version = "0.12.24"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9359,7 +9359,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-slack"
-version = "0.12.22"
+version = "0.12.24"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9382,7 +9382,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-sms"
-version = "0.12.22"
+version = "0.12.24"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -9405,7 +9405,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-telegram"
-version = "0.12.22"
+version = "0.12.24"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9424,7 +9424,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-whatsapp"
-version = "0.12.22"
+version = "0.12.24"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9447,7 +9447,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channels"
-version = "0.12.22"
+version = "0.12.24"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9463,7 +9463,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channels-registry"
-version = "0.12.22"
+version = "0.12.24"
 dependencies = [
  "dirs",
  "serde",
@@ -9488,7 +9488,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-cli"
-version = "0.12.22"
+version = "0.12.24"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9571,7 +9571,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-compact"
-version = "0.12.22"
+version = "0.12.24"
 dependencies = [
  "regex",
  "serde",
@@ -9580,7 +9580,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-config"
-version = "0.12.22"
+version = "0.12.24"
 dependencies = [
  "anyhow",
  "argon2",
@@ -9618,7 +9618,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-cron"
-version = "0.12.22"
+version = "0.12.24"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9635,7 +9635,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-cua"
-version = "0.12.22"
+version = "0.12.24"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9671,7 +9671,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-dispatch"
-version = "0.12.22"
+version = "0.12.24"
 dependencies = [
  "rand 0.9.4",
  "rand_distr",
@@ -9684,7 +9684,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-egress"
-version = "0.12.22"
+version = "0.12.24"
 dependencies = [
  "async-trait",
  "http 1.4.1",
@@ -9697,7 +9697,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-eval"
-version = "0.12.22"
+version = "0.12.24"
 dependencies = [
  "rstest",
  "serde",
@@ -9714,7 +9714,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-eval-scenarios"
-version = "0.12.22"
+version = "0.12.24"
 dependencies = [
  "anyhow",
  "clap",
@@ -9734,7 +9734,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-evolve"
-version = "0.12.22"
+version = "0.12.24"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9774,7 +9774,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-honcho-adapter"
-version = "0.12.22"
+version = "0.12.24"
 dependencies = [
  "async-trait",
  "serde",
@@ -9789,7 +9789,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-mcp"
-version = "0.12.22"
+version = "0.12.24"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9816,7 +9816,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-memory"
-version = "0.12.22"
+version = "0.12.24"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9857,7 +9857,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-observability"
-version = "0.12.22"
+version = "0.12.24"
 dependencies = [
  "chrono",
  "opentelemetry",
@@ -9881,7 +9881,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-permissions"
-version = "0.12.22"
+version = "0.12.24"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9898,7 +9898,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-plugin-api"
-version = "0.12.22"
+version = "0.12.24"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9925,7 +9925,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-plugin-subprocess"
-version = "0.12.22"
+version = "0.12.24"
 dependencies = [
  "anyhow",
  "serde",
@@ -9944,7 +9944,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-plugin-wasm"
-version = "0.12.22"
+version = "0.12.24"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9966,7 +9966,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-pluginsrc"
-version = "0.12.22"
+version = "0.12.24"
 dependencies = [
  "serde",
  "serde_json",
@@ -9981,7 +9981,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-pricing"
-version = "0.12.22"
+version = "0.12.24"
 dependencies = [
  "chrono",
  "dirs",
@@ -10000,7 +10000,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-protocol"
-version = "0.12.22"
+version = "0.12.24"
 dependencies = [
  "rstest",
  "serde",
@@ -10012,7 +10012,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-providers"
-version = "0.12.22"
+version = "0.12.24"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10047,7 +10047,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-replay"
-version = "0.12.22"
+version = "0.12.24"
 dependencies = [
  "serde",
  "serde_json",
@@ -10058,7 +10058,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-repomap"
-version = "0.12.22"
+version = "0.12.24"
 dependencies = [
  "ignore",
  "regex",
@@ -10071,7 +10071,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-safety"
-version = "0.12.22"
+version = "0.12.24"
 dependencies = [
  "async-trait",
  "regex",
@@ -10084,7 +10084,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-sandbox"
-version = "0.12.22"
+version = "0.12.24"
 dependencies = [
  "async-trait",
  "bollard",
@@ -10104,7 +10104,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-skills"
-version = "0.12.22"
+version = "0.12.24"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10141,7 +10141,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-swarm"
-version = "0.12.22"
+version = "0.12.24"
 dependencies = [
  "futures",
  "humantime-serde",
@@ -10160,7 +10160,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-tools"
-version = "0.12.22"
+version = "0.12.24"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10210,7 +10210,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-types"
-version = "0.12.22"
+version = "0.12.24"
 dependencies = [
  "async-trait",
  "chrono",
@@ -10220,7 +10220,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-user-model"
-version = "0.12.22"
+version = "0.12.24"
 dependencies = [
  "async-trait",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,7 +143,7 @@ members = [
 exclude = ["templates/**", "examples/**"]
 
 [workspace.package]
-version = "0.12.23"
+version = "0.12.24"
 edition = "2024"
 rust-version = "1.95"
 license = "Apache-2.0"


### PR DESCRIPTION
Version bump 0.12.23 → 0.12.24 for the token-efficiency release.

Bundles (all already merged to main):
- CORE-1 prompt_cache_key conversation-id stamping + CORE-2 usage_delta + CORE-4 flux-* catalog + CORE-5 SHA256 wire fingerprint (#184)
- Tool catalog fold / cold-tool deferral / hydration (−86.2% tools bytes) (#186)
- Anthropic 4-breakpoint cache_control layout + permanent anchor coupling (#187)

Retest v3 (measured, live-deployed Flux): Core 1.18× Direct cost (near parity), down from 11.99×. Cache 70.6% with sticky pinning holding one backend.

Workspace version bump only (Cargo.toml + Cargo.lock). Tag v0.12.24 after merge triggers the CI build + npm publish; desktop 0.11.17 then bundles this tag.