### PR TITLE
chore: add SECURITY.md, CODEOWNERS, and PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+## What and why
+
+<!-- one line: what this changes and why -->
+
+## Scope
+
+- [ ] In scope per CONTRIBUTING.md (out-of-scope requests are declined, not merged)
+
+## Checks
+
+- [ ] The gate is green (tests/build pass)
+- [ ] No secrets, keys, or credentials committed
+- [ ] No AI-generated signatures in commits or the PR body

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# Default reviewers for everything in waylandcore.
+# Refine to teams/paths as the project grows, e.g. `/src/ @FerroxLabs/core`.
+* @FerroxLabs

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Report security issues **privately**: use GitHub's private vulnerability reporting (the repo Security tab, "Report a vulnerability"), or contact the FerroxLabs maintainers directly. Do not open a public issue for a vulnerability.
+
+We aim to acknowledge a report within 3 business days and to ship a fix or mitigation before any public disclosure.
+
+## Supported versions
+
+Security fixes target the latest released version of `waylandcore`.


### PR DESCRIPTION
Governance starter files scaffolded via `ratchet govern waylandcore --scaffold`:

- **SECURITY.md** — private vulnerability reporting via the repo Security tab
- **CODEOWNERS** — default reviewer `@FerroxLabs`; refine per-path as the tree grows
- **.github/PULL_REQUEST_TEMPLATE.md** — standard PR checklist

These are starters with TODOs — review before merge, especially CODEOWNERS ownership.