### PR TITLE
fix: deflake uid/offset/chatgpt tests, fence release smoke (#190)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,8 +109,14 @@ jobs:
       # of regression where `inventory::submit!` items get dead-code-stripped
       # under `profile.release` (lto="thin" + codegen-units=1) but survive
       # in the debug binary that test-ci exercises. Gating, no continue-on-error.
+      # WCORE_SMOKE_REQUIRE_PREBUILT=1 makes a missing artifact a hard failure
+      # here (dev checkouts without the env var skip instead — #190), so a
+      # dropped/broken "Pre-build wcore-cli release binary" step cannot
+      # silently degrade this gate into a skip.
       - name: Release binary smoke (catches plugin dead-code-strip)
         run: vx cargo nextest run -p wcore-cli --test release_binary_smoke
+        env:
+          WCORE_SMOKE_REQUIRE_PREBUILT: "1"
 
       # Z0 STABILITY MAJOR #4 — eval-gate runs on every PR/main commit so
       # the W10A LOCKED acceptance gate (precision/recall >= 0.80) is enforced
@@ -245,8 +251,10 @@ jobs:
           max_attempts: 2
           command: $DOCKER_RUN "$CI_IMAGE" cargo nextest run --workspace --profile ci
 
+      # WCORE_SMOKE_REQUIRE_PREBUILT=1 (passed into the container): a missing
+      # release artifact is a hard failure here, never a silent skip (#190).
       - name: Release binary smoke (catches plugin dead-code-strip)
-        run: $DOCKER_RUN "$CI_IMAGE" cargo nextest run -p wcore-cli --test release_binary_smoke
+        run: $DOCKER_RUN -e WCORE_SMOKE_REQUIRE_PREBUILT=1 "$CI_IMAGE" cargo nextest run -p wcore-cli --test release_binary_smoke
 
       - name: Security audit
         run: $DOCKER_RUN "$CI_IMAGE" cargo audit

--- a/crates/wcore-channel-email/src/uid_store.rs
+++ b/crates/wcore-channel-email/src/uid_store.rs
@@ -64,11 +64,12 @@ mod tests {
     use super::*;
 
     fn unique_tmp() -> PathBuf {
-        std::env::temp_dir().join(format!(
-            "wcore-email-uid-{}-{:p}.uid",
-            std::process::id(),
-            &() as *const ()
-        ))
+        // Per-call unique path. A monotonic counter (not a pointer to a
+        // zero-sized temporary, which is the same constant address for every
+        // call) keeps parallel tests in this module from sharing a file.
+        static SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+        let n = SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        std::env::temp_dir().join(format!("wcore-email-uid-{}-{n}.uid", std::process::id()))
     }
 
     #[test]

--- a/crates/wcore-channel-telegram/src/offset_store.rs
+++ b/crates/wcore-channel-telegram/src/offset_store.rs
@@ -61,10 +61,14 @@ mod tests {
     use super::*;
 
     fn unique_tmp() -> PathBuf {
+        // Per-call unique path. A monotonic counter (not a pointer to a
+        // zero-sized temporary, which is the same constant address for every
+        // call) keeps parallel tests in this module from sharing a file.
+        static SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+        let n = SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         std::env::temp_dir().join(format!(
-            "wcore-telegram-offset-{}-{:p}.offset",
-            std::process::id(),
-            &() as *const ()
+            "wcore-telegram-offset-{}-{n}.offset",
+            std::process::id()
         ))
     }
 

--- a/crates/wcore-cli/src/tui/surfaces/config.rs
+++ b/crates/wcore-cli/src/tui/surfaces/config.rs
@@ -1507,9 +1507,19 @@ fn resolve_voice_mode_status() -> ProviderStatus {
 /// otherwise `OAuthConnected` (a token with no recorded expiry is treated as
 /// valid, mirroring the google-meet row's missing-expiry handling).
 fn resolve_chatgpt_status() -> ProviderStatus {
-    let status = wcore_agent::oauth::OAuthStorage::from_home()
+    let Ok(storage) = wcore_agent::oauth::OAuthStorage::from_home() else {
+        return ProviderStatus::NotConfigured;
+    };
+    chatgpt_status_from_storage(&storage)
+}
+
+/// Classify the ChatGPT OAuth status from an explicit token store. Split from
+/// [`resolve_chatgpt_status`] so tests can inject an `OAuthStorage::at_root`
+/// tempdir instead of racing on process-global `HOME`/`WAYLAND_HOME` env vars.
+fn chatgpt_status_from_storage(storage: &wcore_agent::oauth::OAuthStorage) -> ProviderStatus {
+    let status = wcore_agent::oauth::chatgpt_login_status(storage)
         .ok()
-        .and_then(|s| wcore_agent::oauth::chatgpt_login_status(&s).ok().flatten());
+        .flatten();
     let Some(status) = status else {
         return ProviderStatus::NotConfigured;
     };
@@ -3855,17 +3865,21 @@ mod tests {
 
     // ── FIX 3: openai-chatgpt OAuth status row ───────────────────────────
 
-    /// Seed (or omit) `$HOME/.wayland/oauth/chatgpt.json` under a tempdir HOME,
-    /// run `resolve_chatgpt_status`, and restore HOME. The `token` arg:
+    /// Seed (or omit) `chatgpt.json` inside a tempdir-rooted `OAuthStorage`
+    /// and classify it via `chatgpt_status_from_storage`. Injecting the store
+    /// keeps these tests hermetic: the previous HOME-swapping helper raced
+    /// against parallel tests that mutate `WAYLAND_HOME` (which
+    /// `OAuthStorage::from_home` prefers over HOME) under a different lock.
+    /// The `token` arg:
     /// - `None` → write NO token file (not signed in).
     /// - `Some(None)` → write a token with no `expires_at_unix_secs` field.
     /// - `Some(Some(exp))` → write a token whose expiry is `exp`.
-    #[cfg(unix)]
-    fn chatgpt_status_with_home(token: Option<Option<u64>>) -> ProviderStatus {
+    fn chatgpt_status_with_token(token: Option<Option<u64>>) -> ProviderStatus {
         let tmp = tempfile::tempdir().expect("tempdir");
+        let oauth_dir = tmp.path().join("oauth");
+        let storage = wcore_agent::oauth::OAuthStorage::at_root(oauth_dir.clone())
+            .expect("oauth storage at tempdir root");
         if let Some(expires_at) = token {
-            let oauth_dir = tmp.path().join(".wayland").join("oauth");
-            std::fs::create_dir_all(&oauth_dir).expect("mkdir");
             // A JWT-less access_token is fine: the plan decode just yields None,
             // and the status row only reads expiry. The struct must round-trip
             // through `OAuthTokens`'s serde shape.
@@ -3880,30 +3894,18 @@ mod tests {
             };
             std::fs::write(oauth_dir.join("chatgpt.json"), body).expect("write token");
         }
-        let saved = std::env::var_os("HOME");
-        // SAFETY: serial test; HOME reverted before return.
-        unsafe { std::env::set_var("HOME", tmp.path()) };
-        let status = resolve_chatgpt_status();
-        match saved {
-            Some(v) => unsafe { std::env::set_var("HOME", v) },
-            None => unsafe { std::env::remove_var("HOME") },
-        }
-        status
+        chatgpt_status_from_storage(&storage)
     }
 
-    #[cfg(unix)]
     #[test]
-    #[serial_test::serial]
     fn chatgpt_status_not_configured_when_no_token() {
         assert_eq!(
-            chatgpt_status_with_home(None),
+            chatgpt_status_with_token(None),
             ProviderStatus::NotConfigured
         );
     }
 
-    #[cfg(unix)]
     #[test]
-    #[serial_test::serial]
     fn chatgpt_status_connected_when_future_expiry() {
         let far_future = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -3911,29 +3913,25 @@ mod tests {
             .unwrap_or(0)
             + 3600;
         assert_eq!(
-            chatgpt_status_with_home(Some(Some(far_future))),
+            chatgpt_status_with_token(Some(Some(far_future))),
             ProviderStatus::OAuthConnected
         );
     }
 
-    #[cfg(unix)]
     #[test]
-    #[serial_test::serial]
     fn chatgpt_status_expired_when_past_expiry() {
         assert_eq!(
-            chatgpt_status_with_home(Some(Some(1))),
+            chatgpt_status_with_token(Some(Some(1))),
             ProviderStatus::OAuthExpired
         );
     }
 
-    #[cfg(unix)]
     #[test]
-    #[serial_test::serial]
     fn chatgpt_status_connected_when_no_expiry_field() {
         // A token with no recorded expiry is treated as valid (mirrors the
         // google-meet missing-expiry handling).
         assert_eq!(
-            chatgpt_status_with_home(Some(None)),
+            chatgpt_status_with_token(Some(None)),
             ProviderStatus::OAuthConnected
         );
     }

--- a/crates/wcore-cli/tests/release_binary_smoke.rs
+++ b/crates/wcore-cli/tests/release_binary_smoke.rs
@@ -95,9 +95,29 @@ fn ensure_release_binary_or_fail() -> PathBuf {
     );
 }
 
-/// Back-compat alias for existing call sites in this file. Same body.
-fn ensure_release_binary() -> PathBuf {
-    ensure_release_binary_or_fail()
+/// Skip-aware variant for the smoke tests themselves: on a dev checkout the
+/// release binary is usually absent (`cargo test --workspace` never builds
+/// it), and hard-failing there makes the whole workspace suite permanently
+/// red (#190). Returns `None` to skip with a notice when the artifact is
+/// missing — UNLESS `WCORE_SMOKE_REQUIRE_PREBUILT` is set, in which case a
+/// missing binary is still the hard `WCORE_PREBUILD_REQUIRED` panic. CI sets
+/// that variable on its "Release binary smoke" steps (after the dedicated
+/// pre-build step), so the gate cannot silently degrade into a skip there.
+fn release_binary_or_skip() -> Option<PathBuf> {
+    let bin = release_binary_path();
+    if bin.exists() {
+        return Some(bin);
+    }
+    if std::env::var("WCORE_SMOKE_REQUIRE_PREBUILT").is_ok() {
+        ensure_release_binary_or_fail();
+    }
+    eprintln!(
+        "[release_binary_smoke] release binary not found at {} — skipping.\n\
+         Build it first (`vx cargo build --release -p wcore-cli`), or set\n\
+         WCORE_SMOKE_REQUIRE_PREBUILT=1 to make a missing artifact a failure.",
+        bin.display()
+    );
+    None
 }
 
 /// Run the release binary with the given args; return (status, stdout, stderr).
@@ -115,7 +135,9 @@ fn run_with(bin: &PathBuf, args: &[&str]) -> (std::process::ExitStatus, String, 
 
 #[test]
 fn release_binary_help_and_version_succeed() {
-    let bin = ensure_release_binary();
+    let Some(bin) = release_binary_or_skip() else {
+        return;
+    };
 
     let (help_status, help_stdout, help_stderr) = run_with(&bin, &["--help"]);
     assert!(
@@ -152,14 +174,12 @@ fn release_binary_help_and_version_succeed() {
 /// Mirrors `plugin_discovery_e2e.rs::first_ready_event` but targets the
 /// release artifact at `target/release/wayland-core` instead of the
 /// debug binary Cargo wires through `CARGO_BIN_EXE_wayland-core`.
-fn first_ready_event_release() -> serde_json::Value {
-    let bin = ensure_release_binary();
-
+fn first_ready_event_release(bin: &PathBuf) -> serde_json::Value {
     // Clean cwd + HOME so no `.wayland-core.toml` from the dev environment
     // perturbs config resolution.
     let tmp = TempDir::new().expect("create tmp workspace");
 
-    let mut child = Command::new(&bin)
+    let mut child = Command::new(bin)
         .args([
             "--json-stream",
             "--provider",
@@ -218,7 +238,10 @@ fn first_ready_event_release() -> serde_json::Value {
 
 #[test]
 fn release_binary_ready_event_advertises_plugin_capabilities() {
-    let event = first_ready_event_release();
+    let Some(bin) = release_binary_or_skip() else {
+        return;
+    };
+    let event = first_ready_event_release(&bin);
 
     assert_eq!(
         event["type"], "ready",


### PR DESCRIPTION
Three unit tests failed on every clean-main `cargo test --workspace`,
and two release_binary_* integration tests hard-failed on any dev
checkout without a pre-built release binary. Root causes:

- uid_store / offset_store `save_then_load_round_trips`: the test
  helper `unique_tmp()` derived "uniqueness" from `&() as *const ()` —
  a reference to a zero-sized temporary, which is the same constant
  address for every call. All four tests in each module therefore
  shared ONE tmp file and raced under the parallel test runner (e.g.
  `load_from_garbage_is_none` overwrote the round-trip file between
  its save and load). Fixed with a per-process AtomicUsize counter so
  every call really is unique.

- tui config `chatgpt_status_*`: the helper swapped `$HOME` under
  `#[serial_test::serial]`, but `OAuthStorage::from_home` resolves via
  `profile_home()`, which prefers `$WAYLAND_HOME` — an env var other
  tests in the same binary mutate under a DIFFERENT lock
  (EXPERT_ENV_LOCK). Two disjoint serialization domains guarded one
  process-global, so a concurrent test's WAYLAND_HOME tempdir won and
  the token was never found. Fixed by splitting the classification
  into `chatgpt_status_from_storage()` and injecting an
  `OAuthStorage::at_root` tempdir in the tests — hermetic, no env
  mutation, no serial/cfg(unix) needed.

- release_binary_smoke: `release_binary_help_and_version_succeed` and
  `release_binary_ready_event_advertises_plugin_capabilities` now skip
  with a notice when `target/release/wayland-core` is absent, so
  `cargo test --workspace` is meaningful on dev checkouts. Setting
  WCORE_SMOKE_REQUIRE_PREBUILT=1 keeps a missing artifact a hard
  WCORE_PREBUILD_REQUIRED failure; both CI "Release binary smoke"
  steps now set it (native + containerized), so a dropped pre-build
  step cannot silently degrade the gate into a skip.

Verified: full `cargo test --workspace --quiet` — 195 suites,
4832 passed, 0 failed, 18 ignored; clippy clean on touched crates.
