### PR TITLE
chore: bump crossbeam-epoch 0.9.18 -> 0.9.20 (RUSTSEC-2026-0204)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1929,9 +1929,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Summary
- RUSTSEC-2026-0204 (crossbeam-epoch 0.9.18, invalid pointer dereference in `fmt::Pointer` for `Atomic`/`Shared`) published 2026-07-06 and has been failing the `cargo audit` step on every CI leg since — the repeated `CI (Array)` / `CI (macos-latest)` / `CI (linux-containerized)` failures on #192/#189 were this, not runner infra.
- Lock-only patch bump to 0.9.20 per the advisory's stated solution. `cargo audit` is clean locally (7 pre-existing allowed unmaintained warnings remain allowed).

Unblocks #192 and #189 once merged (their merge refs pick this up on update-branch).