### PR TITLE
test(env): converge wcore-agent env tests onto #[serial]

### DIFF
--- a/crates/wcore-agent/src/engine.rs
+++ b/crates/wcore-agent/src/engine.rs
@@ -14179,10 +14179,10 @@ mod hook_integration_tests {
     /// `assert_fact` even though the session messages carry extractable
     /// facts. `WAYLAND_AUTO_MEMORIZE=off` is the hermetic kill switch.
     #[tokio::test]
-    #[serial_test::serial(env)]
+    #[serial_test::serial]
     async fn w3_auto_memorize_skips_without_consent() {
         let prior = std::env::var(wcore_memory::auto_memorize::ENV_AUTO_MEMORIZE).ok();
-        // SAFETY: #[serial(env)] serializes all env writes in this group.
+        // SAFETY: #[serial_test::serial] serializes every env-mutating test in this binary.
         unsafe {
             std::env::set_var(wcore_memory::auto_memorize::ENV_AUTO_MEMORIZE, "off");
         }
@@ -14207,7 +14207,7 @@ mod hook_integration_tests {
             "no facts may be persisted when consent is off"
         );
 
-        // SAFETY: #[serial(env)] serializes all env writes in this group.
+        // SAFETY: #[serial_test::serial] serializes every env-mutating test in this binary.
         unsafe {
             match prior {
                 Some(v) => std::env::set_var(wcore_memory::auto_memorize::ENV_AUTO_MEMORIZE, v),
@@ -14222,10 +14222,10 @@ mod hook_integration_tests {
     /// persistence. The consent file is created and removed within the
     /// test (state restored on exit) under `#[serial]`.
     #[tokio::test]
-    #[serial_test::serial(env)]
+    #[serial_test::serial]
     async fn w3_auto_memorize_persists_with_consent() {
         let prior_env = std::env::var(wcore_memory::auto_memorize::ENV_AUTO_MEMORIZE).ok();
-        // SAFETY: #[serial(env)] serializes all env writes in this group.
+        // SAFETY: #[serial_test::serial] serializes every env-mutating test in this binary.
         unsafe {
             std::env::remove_var(wcore_memory::auto_memorize::ENV_AUTO_MEMORIZE);
         }
@@ -14262,7 +14262,7 @@ mod hook_integration_tests {
         if !consent_existed {
             let _ = std::fs::remove_file(&consent_path);
         }
-        // SAFETY: #[serial(env)] serializes all env writes in this group.
+        // SAFETY: #[serial_test::serial] serializes every env-mutating test in this binary.
         unsafe {
             if let Some(v) = prior_env {
                 std::env::set_var(wcore_memory::auto_memorize::ENV_AUTO_MEMORIZE, v);

--- a/crates/wcore-agent/src/health.rs
+++ b/crates/wcore-agent/src/health.rs
@@ -228,6 +228,7 @@ async fn classify(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
     use std::time::Instant;
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -283,6 +284,7 @@ mod tests {
         }
     }
 
+    #[serial]
     #[tokio::test]
     async fn provider_health_yellow_when_no_key() {
         let mut env = EnvBatch::new();
@@ -293,6 +295,7 @@ mod tests {
         assert_eq!(h.detail, "no key");
     }
 
+    #[serial]
     #[tokio::test]
     async fn provider_health_yellow_when_key_empty_string() {
         // R-H2: empty string is "no key", not "key set to empty".
@@ -303,6 +306,7 @@ mod tests {
         assert_eq!(h.status, HealthStatus::Yellow);
     }
 
+    #[serial]
     #[tokio::test]
     async fn provider_health_green_on_200() {
         let server = MockServer::start().await;
@@ -320,6 +324,7 @@ mod tests {
         assert_eq!(h.detail, "reachable");
     }
 
+    #[serial]
     #[tokio::test]
     async fn provider_health_red_on_401() {
         let server = MockServer::start().await;
@@ -342,6 +347,7 @@ mod tests {
         );
     }
 
+    #[serial]
     #[tokio::test]
     async fn provider_health_red_on_timeout() {
         // TEST-NET-1 (192.0.2.0/24) per RFC 5737 — IANA-reserved for
@@ -366,6 +372,7 @@ mod tests {
         );
     }
 
+    #[serial]
     #[tokio::test]
     async fn provider_health_times_out_at_5s() {
         // Spin a TCP listener that accepts but never replies. The
@@ -406,6 +413,7 @@ mod tests {
         server.abort();
     }
 
+    #[serial]
     #[tokio::test]
     async fn gemini_unreachable_detail_omits_api_key() {
         // SECRETS-29: when Gemini is unreachable, the `/doctor` row detail
@@ -434,6 +442,7 @@ mod tests {
         );
     }
 
+    #[serial]
     #[tokio::test]
     async fn provider_health_check_all_returns_four_entries_in_order() {
         // Clear every key — the all-yellow path is what we're after.

--- a/crates/wcore-agent/src/host_send_transport.rs
+++ b/crates/wcore-agent/src/host_send_transport.rs
@@ -271,6 +271,7 @@ impl MessageTransport for HostDelegatedTransport {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use wcore_tools::send_message::MessagingPlatform;
 
@@ -385,12 +386,11 @@ mod tests {
         }
     }
 
+    #[serial]
     #[test]
     fn env_gate_requires_exactly_one() {
-        // Uses a scoped set/remove; the var name is unique to this feature so
-        // no other test in this crate races it.
-        // SAFETY (Rust 2024 set_var): single-threaded test context for this
-        // env var; no concurrent readers of this name.
+        // SAFETY (Rust 2024 set_var): `#[serial]` serializes every env-mutating
+        // test in this binary, so this scoped set/remove cannot race another.
         unsafe {
             std::env::remove_var("WAYLAND_SEND_MESSAGE_HOST_DELEGATE");
         }

--- a/crates/wcore-agent/src/plugins/loader.rs
+++ b/crates/wcore-agent/src/plugins/loader.rs
@@ -1061,6 +1061,7 @@ mod tests {
         );
     }
 
+    #[serial_test::serial]
     #[test]
     fn try_discover_rejects_verification_enabled_with_no_trusted_keys() {
         // Point filesystem trust dir at an empty temp dir so the union is
@@ -1068,13 +1069,8 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let empty_dir = tmp.path().join("empty-keys");
         std::fs::create_dir_all(&empty_dir).unwrap();
-        // Serialize against other tests that touch the same env vars.
-        // Set only inside this scope; clean up at end.
-        // SAFETY: tests run single-threaded per process by default for env;
-        // wcore-agent uses #[test] which runs concurrent threads, so we
-        // explicitly clear the unsigned-trust escape too.
-        // SAFETY: env mutation in tests is acceptable here; this test
-        // group is the only one in this module that touches these vars.
+        // SAFETY: `#[serial_test::serial]` serializes every env-mutating test
+        // in this binary, so this scoped set/clear cannot race another.
         unsafe {
             std::env::set_var("WAYLAND_TRUSTED_KEYS_DIR", &empty_dir);
             std::env::remove_var(ENV_TRUST_UNSIGNED);

--- a/crates/wcore-agent/src/plugins/sig_verifier.rs
+++ b/crates/wcore-agent/src/plugins/sig_verifier.rs
@@ -245,7 +245,7 @@ mod tests {
     /// profile has its OWN trust set, and the explicit `$WAYLAND_TRUSTED_KEYS_DIR`
     /// override still wins over it.
     #[test]
-    #[serial_test::serial(wayland_home_env)]
+    #[serial_test::serial]
     fn trusted_keys_dir_follows_wayland_home_and_env_override() {
         let wh = "WAYLAND_HOME";
         let tk = ENV_TRUSTED_KEYS_DIR;

--- a/crates/wcore-agent/src/tool_backends/discord.rs
+++ b/crates/wcore-agent/src/tool_backends/discord.rs
@@ -404,6 +404,7 @@ fn urlencode(s: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
     use wcore_tools::discord_tool::{DiscordOutcome, DiscordTool};
     use wiremock::matchers::{header, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -427,6 +428,7 @@ mod tests {
 
     // ----- Resolver behaviour ------------------------------------------------
 
+    #[serial]
     #[test]
     fn build_discord_backend_returns_none_when_token_unset() {
         // SAFETY: tests run sequentially per crate; we restore env after.
@@ -438,6 +440,7 @@ mod tests {
         }
     }
 
+    #[serial]
     #[test]
     fn build_discord_backend_returns_none_when_token_empty_string() {
         // R-H2: empty string must be treated as unset.

--- a/crates/wcore-agent/src/tool_backends/google_meet.rs
+++ b/crates/wcore-agent/src/tool_backends/google_meet.rs
@@ -534,6 +534,7 @@ pub fn build_google_meet_backend() -> Option<HttpGoogleMeetBackend> {
 mod tests {
     use super::*;
     use crate::oauth::PkceMode;
+    use serial_test::serial;
     use tempfile::TempDir;
     use wcore_tools::google_meet_tool::MeetMode;
     use wiremock::matchers::{header, method, path as wm_path};
@@ -572,6 +573,7 @@ mod tests {
 
     // ── Resolver / env sniffing ─────────────────────────────────────
 
+    #[serial]
     #[test]
     fn build_google_meet_backend_returns_none_when_client_id_unset() {
         // SAFETY: stash + restore the env var so we don't trample on
@@ -587,6 +589,7 @@ mod tests {
         }
     }
 
+    #[serial]
     #[test]
     fn google_meet_returns_none_when_env_var_empty_string() {
         // R-H2 contract: empty string must NOT count as configured.
@@ -635,6 +638,7 @@ mod tests {
         );
     }
 
+    #[serial]
     #[test]
     fn google_meet_oauth_uses_correct_endpoints_and_scopes() {
         // Sanity-check the well-known Google constants — a typo here

--- a/crates/wcore-agent/src/tool_backends/homeassistant.rs
+++ b/crates/wcore-agent/src/tool_backends/homeassistant.rs
@@ -429,6 +429,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn null_default_skips_registration() {
         // Parallel test in homeassistant_tool.rs (Tool layer)
         // already enforces this. This test confirms the resolver +

--- a/crates/wcore-agent/src/tool_backends/shared.rs
+++ b/crates/wcore-agent/src/tool_backends/shared.rs
@@ -121,6 +121,7 @@ pub fn urlencode(s: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
 
     #[test]
     fn read_env_key_returns_none_for_unset() {
@@ -132,6 +133,7 @@ mod tests {
         assert!(read_env_key("WAYLAND_TEST_DEFINITELY_UNSET_12345").is_none());
     }
 
+    #[serial]
     #[test]
     fn read_env_key_returns_none_for_empty() {
         // SAFETY: tests in this module run on isolated threads; we never
@@ -143,6 +145,7 @@ mod tests {
         unsafe { std::env::remove_var("WAYLAND_TEST_EMPTY_KEY_VAR") };
     }
 
+    #[serial]
     #[test]
     fn read_env_key_returns_some_for_set_nonempty() {
         unsafe { std::env::set_var("WAYLAND_TEST_NONEMPTY_KEY_VAR", "secret123") };

--- a/crates/wcore-agent/src/tool_backends/video_analyze.rs
+++ b/crates/wcore-agent/src/tool_backends/video_analyze.rs
@@ -526,6 +526,7 @@ pub async fn build_video_analyze_backend() -> Option<Arc<dyn VideoAnalysisBacken
 mod tests {
     use super::*;
     use parking_lot::Mutex;
+    use serial_test::serial;
 
     // -- Path validation (S-H5 closure) ----------------------------------
 
@@ -619,6 +620,7 @@ mod tests {
 
     // -- Resolver gating (`video_backend_hidden_when_*`) -----------------
 
+    #[serial]
     #[tokio::test]
     async fn video_backend_hidden_when_vision_backend_unset() {
         // Clear every known vision-key env var for this process. We then
@@ -640,6 +642,7 @@ mod tests {
         assert!(got.is_none(), "no vision key must hide the tool");
     }
 
+    #[serial]
     #[tokio::test]
     async fn video_backend_hidden_when_ffmpeg_missing() {
         // We cannot remove ffmpeg from PATH inside the test process

--- a/crates/wcore-agent/tests/bootstrap_test.rs
+++ b/crates/wcore-agent/tests/bootstrap_test.rs
@@ -841,6 +841,7 @@ async fn w2_v063_bootstrap_initializes_kg_when_memory_enabled() {
         .expect("search on live memory should not error");
 }
 
+#[serial]
 #[tokio::test]
 async fn w2_v063_bootstrap_skips_kg_when_disabled() {
     // W2 v0.6.3 inverse path: WAYLAND_KG=off must not block bootstrap. We

--- a/crates/wcore-agent/tests/declarative_plugin_e2e.rs
+++ b/crates/wcore-agent/tests/declarative_plugin_e2e.rs
@@ -10,6 +10,7 @@
 //!     → `resolve_server_for_plugin` binds plugin→server
 //!     → `McpHookDispatcher` fires the hook → returns the MCP tool's text.
 
+use serial_test::serial;
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::{Arc, Mutex, OnceLock};
@@ -112,6 +113,7 @@ async fn discover_and_apply(
 
 /// T12 — integration: a declarative plugin's hooks + mcp_server reach the
 /// applied outcome through the real on-disk discovery + apply pipeline.
+#[serial]
 #[tokio::test]
 async fn declarative_plugin_flows_into_applied_outcome() {
     let tmp = tempfile::TempDir::new().unwrap();
@@ -181,6 +183,7 @@ impl McpToolCaller for FakeCaller {
     }
 }
 
+#[serial]
 #[tokio::test]
 async fn declarative_plugin_hook_dispatches_through_c1() {
     let tmp = tempfile::TempDir::new().unwrap();
@@ -248,6 +251,7 @@ url = "https://example.invalid/sse"
 // --- T14 security: declarative plugin outside allowed roots → load Err ------
 
 #[cfg(unix)]
+#[serial]
 #[tokio::test]
 async fn declarative_plugin_outside_roots_via_symlink_skipped() {
     use std::os::unix::fs::symlink;
@@ -295,6 +299,7 @@ tool = "steal"
 
 // --- T15 security: [mcp_server] without register_mcp_server → load Err -------
 
+#[serial]
 #[tokio::test]
 async fn declarative_mcp_server_without_permission_rejected() {
     let tmp = tempfile::TempDir::new().unwrap();

--- a/crates/wcore-agent/tests/plugin_hybrid_end_to_end.rs
+++ b/crates/wcore-agent/tests/plugin_hybrid_end_to_end.rs
@@ -19,6 +19,7 @@
 //! 4. Inventory-discovered static plugins still flow through
 //!    `apply_initialize_outcome` unchanged.
 
+use serial_test::serial;
 use std::path::Path;
 use std::sync::{Arc, Mutex, OnceLock};
 
@@ -87,6 +88,7 @@ impl Drop for EnvGuard {
     }
 }
 
+#[serial]
 #[tokio::test]
 async fn hybrid_pipeline_dispatches_wasm_and_threads_through_synthesizer() {
     // One on-disk WASM manifest; load succeeds (minimal-component bytes),
@@ -213,6 +215,7 @@ kind = "wasm"
     drop(keepalives);
 }
 
+#[serial]
 #[tokio::test]
 async fn hybrid_pipeline_routes_subprocess_and_mcp_bridge_through_dispatch() {
     // Two manifests: subprocess + mcp-bridge. Both load FAIL (binary
@@ -301,6 +304,7 @@ binary_path = "does-not-exist"
     assert!(mcp_bridge_seen, "mcp-bridge manifest not dispatched");
 }
 
+#[serial]
 #[tokio::test]
 async fn hybrid_pipeline_preserves_inventory_static_plugins() {
     // Static-link inventory plugins must still flow through

--- a/crates/wcore-agent/tests/plugin_on_disk_discovery.rs
+++ b/crates/wcore-agent/tests/plugin_on_disk_discovery.rs
@@ -11,6 +11,7 @@
 //! (real loads require live wasmtime / a real binary). The minimum-
 //! viable wasm component header is reused from Task 2.6's runner tests.
 
+use serial_test::serial;
 use std::path::Path;
 use std::sync::{Arc, Mutex, OnceLock};
 
@@ -91,6 +92,7 @@ fn config() -> PluginsConfig {
     }
 }
 
+#[serial]
 #[tokio::test]
 async fn on_disk_wasm_plugin_discovered_and_dispatched() {
     let tmp = tempfile::TempDir::new().unwrap();
@@ -141,6 +143,7 @@ kind = "wasm"
     assert!(!runner.is_disabled("wasm-fixture"));
 }
 
+#[serial]
 #[tokio::test]
 async fn on_disk_subprocess_plugin_discovered_and_dispatched() {
     let tmp = tempfile::TempDir::new().unwrap();
@@ -188,6 +191,7 @@ binary_path = "does-not-exist"
     assert!(!runner.is_disabled("subprocess-fixture"));
 }
 
+#[serial]
 #[tokio::test]
 async fn on_disk_mcp_bridge_plugin_discovered_and_dispatched() {
     let tmp = tempfile::TempDir::new().unwrap();
@@ -229,6 +233,7 @@ binary_path = "does-not-exist"
     );
 }
 
+#[serial]
 #[tokio::test]
 async fn invalid_runtime_kind_skipped_with_log() {
     let tmp = tempfile::TempDir::new().unwrap();
@@ -272,6 +277,7 @@ kind = "garbage"
     );
 }
 
+#[serial]
 #[tokio::test]
 async fn mixed_static_and_on_disk_coexist() {
     // Static-plugin path through inventory + on-disk path via dir scan.
@@ -333,6 +339,7 @@ binary_path = "does-not-exist"
 //      We skip symlink entries in the plugins root with a warn log.
 // ---------------------------------------------------------------------------
 
+#[serial]
 #[tokio::test]
 async fn traversal_relative_binary_path_rejected() {
     let tmp = tempfile::TempDir::new().unwrap();
@@ -374,6 +381,7 @@ binary_path = "../../../etc/passwd"
     );
 }
 
+#[serial]
 #[tokio::test]
 async fn absolute_binary_path_rejected() {
     let tmp = tempfile::TempDir::new().unwrap();
@@ -431,6 +439,7 @@ binary_path = "{abs_path_literal}"
     );
 }
 
+#[serial]
 #[tokio::test]
 async fn legit_relative_binary_path_accepted() {
     // A clean relative `binary_path` that stays inside the plugin dir
@@ -493,6 +502,7 @@ binary_path = "bin/plugin"
 
 /// T10 — a declarative manifest dispatches to `Declarative`, loads Ok, and the
 /// handle carries the declared hooks + mcp_server spec.
+#[serial]
 #[tokio::test]
 async fn on_disk_declarative_plugin_discovered_and_dispatched() {
     use wcore_agent::plugins::LoadedRuntimeHandle;
@@ -561,6 +571,7 @@ url = "https://example.invalid/sse"
 
 /// T11 — a declarative plugin declaring `[[hooks]]` without `register_hooks`
 /// fails to load (manifest validation rejects it before dispatch).
+#[serial]
 #[tokio::test]
 async fn on_disk_declarative_hooks_without_permission_rejected() {
     let tmp = tempfile::TempDir::new().unwrap();
@@ -603,6 +614,7 @@ tool = "memory_prelude"
 }
 
 #[cfg(unix)]
+#[serial]
 #[tokio::test]
 async fn symlink_entry_in_plugins_root_skipped() {
     use std::os::unix::fs::symlink;
@@ -697,6 +709,7 @@ impl Drop for ProfileHomeEnvGuard {
 /// C3 — a declarative plugin under `profile_home()/plugins` (the C3 profile
 /// home, where IJFW's installer drops it) is discovered via the multi-root
 /// path, WITHOUT setting `$WAYLAND_PLUGINS_DIR`.
+#[serial]
 #[tokio::test]
 async fn on_disk_declarative_plugin_under_profile_home_discovered() {
     use wcore_agent::plugins::LoadedRuntimeHandle;

--- a/crates/wcore-agent/tests/plugin_user_model_delivery.rs
+++ b/crates/wcore-agent/tests/plugin_user_model_delivery.rs
@@ -9,6 +9,7 @@
 //!
 //! No live HTTP / network — pure in-memory data shuttling.
 
+use serial_test::serial;
 use wcore_agent::plugins::runner::CapturedUserModel;
 use wcore_agent::plugins::{InitializeOutcome, apply_initialize_outcome};
 use wcore_plugin_api::UserModelSpec;
@@ -130,8 +131,8 @@ fn honcho_spec_with_env(env_var: &str) -> UserModelSpec {
 }
 
 /// `backend = "honcho"` reifies into a live `HonchoClient` via
-/// `HonchoClient::from_spec`. Uses a unique env var name so we don't
-/// collide with concurrent tests.
+/// `HonchoClient::from_spec`.
+#[serial]
 #[test]
 fn honcho_user_model_reifies() {
     let key_var = "WAYLAND_TASK_1_5_HONCHO_KEY";
@@ -223,11 +224,12 @@ fn unknown_backend_typed_error() {
 /// — no reified client AND no surfaced error (so boot emits no nagging WARN
 /// about a key the user never set up). The local-backend fallback in
 /// bootstrap covers the actual user-model context.
+#[serial]
 #[test]
 fn honcho_missing_api_key_degrades_silently() {
     let key_var = "WAYLAND_TASK_1_5_DEFINITELY_UNSET_KEY";
     // Make extra sure it's not set from a prior test.
-    // SAFETY: unique env-var name, safe to remove.
+    // SAFETY: `#[serial]` serializes every env-mutating test in this binary.
     unsafe {
         env::remove_var(key_var);
     }


### PR DESCRIPTION
## What

Third PR in the env-race `#[serial]` sweep. Converges every env-mutating test
in `wcore-agent` onto the default `serial_test` group so concurrent tests in the
single lib test binary can never race on process-global environment variables.

All `#[cfg(test)] mod tests` across a crate's `src/*.rs` compile into ONE test
binary and run on a thread pool. `std::env::set_var`/`remove_var` mutate the
process-global environ — concurrent mutation from a plain `#[test]` running
alongside an env test is UB. `serial_test`'s default `#[serial]` only serializes
against other default-group serial tests, NOT against plain `#[test]`,
`#[serial(named)]`, or bespoke `Mutex` guards.

## Change (additive, test-only)

- Every env-mutating test gets the default `#[serial]` attribute.
- Bespoke mutexes (e.g. `ENV_LOCK`, wrapped by the `EnvBatch` guard in
  `health.rs`) are kept as redundant belt-and-suspenders — not removed.
- `#[serial_test::serial(env)]` / `(named)` forms normalized to the default
  group so they actually serialize against each other.
- Stale `// SAFETY:` comments that claimed unique-var or single-threaded safety
  corrected to reference the `#[serial]` serialization.
- Where the only `#[serial]` users are `#[cfg]`-gated, the fully-qualified
  `#[serial_test::serial]` is used with no `use` import, to avoid an
  unused-import `-D warnings` failure on other platforms.

15 files, +65/-21, test-only. No production code paths touched.

## Verification

Verified green on the build box (clippy `-D warnings` exit 0; `wcore-agent`
lib 1577 passed / 0 failed; plugin integration tests pass). Adversarially
reviewed: one BLOCKER found and fixed (`homeassistant.rs` `null_default_skips_registration`
was a plain `#[test]` mutating `HASS_URL`/`HASS_TOKEN` — now `#[serial]`), plus
4 stale false-safety comments corrected; re-verified green after the fix.
