### PR TITLE
test(env): converge wcore-cli env tests onto #[serial]

### DIFF
--- a/crates/wcore-cli/src/crash_sentinel.rs
+++ b/crates/wcore-cli/src/crash_sentinel.rs
@@ -215,13 +215,12 @@ mod tests {
     }
 
     #[test]
-    #[serial(env)]
+    #[serial]
     fn default_path_honors_wayland_home_env() {
         let dir = TempDir::new().unwrap();
-        // R3-B2: gated under `serial_test`'s `env` group to prevent
-        // racing with any other env-mutating test in the binary.
-        // SAFETY: `set_var` is unsafe on 1.83+ per the new contract; this is a
-        // test-only single-threaded usage (enforced by `#[serial(env)]`).
+        // R3-B2: the default `#[serial]` group serializes this against every
+        // other env-mutating test in the binary.
+        // SAFETY: #[serial] serializes every env-mutating test in this binary.
         unsafe {
             std::env::set_var(WAYLAND_HOME_ENV, dir.path());
         }

--- a/crates/wcore-cli/src/doctor/mod.rs
+++ b/crates/wcore-cli/src/doctor/mod.rs
@@ -564,6 +564,7 @@ fn grim_hints() -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
 
     #[test]
     fn check_version_passes_for_non_empty() {
@@ -587,11 +588,10 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn wayland_display_reads_env_var() {
         // Use a value that's unlikely to be set already.
-        // SAFETY: tests in the same module may race; we only assert
-        // on the variant produced, not the inner string, so a
-        // concurrent unset is observationally equivalent to "not set".
+        // SAFETY: #[serial] serializes every env-mutating test in this binary.
         unsafe {
             std::env::set_var("WAYLAND_DISPLAY", "wayland-test");
         }

--- a/crates/wcore-cli/src/init.rs
+++ b/crates/wcore-cli/src/init.rs
@@ -331,6 +331,7 @@ pub fn print_summary(outcome: &InitOutcome) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
     use std::path::Path;
     use tempfile::TempDir;
 
@@ -408,10 +409,11 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn placeholder_used_when_no_model_anywhere() {
         // Save + unset WAYLAND_MODEL for this test.
         let saved = std::env::var("WAYLAND_MODEL").ok();
-        // SAFETY: tests run single-threaded by default for this assertion.
+        // SAFETY: #[serial] serializes every env-mutating test in this binary.
         unsafe {
             std::env::remove_var("WAYLAND_MODEL");
         }
@@ -420,7 +422,7 @@ mod tests {
         let body = std::fs::read_to_string(tmp.path().join(".wayland/config.toml")).unwrap();
         assert!(body.contains(PLACEHOLDER_MODEL));
         if let Some(v) = saved {
-            // SAFETY: same.
+            // SAFETY: #[serial] serializes every env-mutating test in this binary.
             unsafe {
                 std::env::set_var("WAYLAND_MODEL", v);
             }

--- a/crates/wcore-cli/src/tui/commands/mod.rs
+++ b/crates/wcore-cli/src/tui/commands/mod.rs
@@ -541,6 +541,7 @@ fn damerau_levenshtein(a: &str, b: &str) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
 
     // ── damerau_levenshtein ────────────────────────────────────────────
 
@@ -873,14 +874,15 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn theme_light_arg_resolves_to_the_light_palette() {
         use crate::tui::theme::Theme;
         // `Theme::for_mode` resolves the palette by terminal capability
         // (truecolor RGB vs 256-indexed vs `Reset` under NO_COLOR). This test
         // verifies the mode→palette MAPPING, not capability detection, so pin
         // truecolor + clear NO_COLOR for a deterministic result in CI's clean
-        // env (no COLORTERM/TTY). SAFETY: nextest isolates each test in its
-        // own process; the write cannot race another test.
+        // env (no COLORTERM/TTY).
+        // SAFETY: #[serial] serializes every env-mutating test in this binary.
         unsafe {
             std::env::remove_var("NO_COLOR");
             std::env::set_var("COLORTERM", "truecolor");

--- a/crates/wcore-cli/src/tui/frecency.rs
+++ b/crates/wcore-cli/src/tui/frecency.rs
@@ -152,6 +152,7 @@ fn now_secs() -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
 
     /// Build a store with explicit `(hits, last_used)` entries, bypassing
     /// `record` so tests can place an entry at a chosen age.
@@ -217,15 +218,16 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn save_then_load_round_trips_the_store() {
         // Redirect the config dir at process scope so `store_path`
         // resolves into a temp dir for this test.
         let tmp = tempfile::tempdir().expect("temp dir");
-        // SAFETY: single-threaded test; WAYLAND_HOME is the canonical
-        // hermetic override resolved by `wayland_config_dir()` (F-010,
-        // #270). It works uniformly on every platform — unlike
-        // XDG_CONFIG_HOME, which `dirs::config_dir()` ignores on
-        // macOS/Windows.
+        // SAFETY: #[serial] serializes every env-mutating test in this binary.
+        // WAYLAND_HOME is the canonical hermetic override resolved by
+        // `wayland_config_dir()` (F-010, #270). It works uniformly on every
+        // platform — unlike XDG_CONFIG_HOME, which `dirs::config_dir()`
+        // ignores on macOS/Windows.
         unsafe {
             std::env::set_var("WAYLAND_HOME", tmp.path());
         }

--- a/crates/wcore-cli/src/tui/surfaces/config.rs
+++ b/crates/wcore-cli/src/tui/surfaces/config.rs
@@ -3376,6 +3376,7 @@ mod tests {
     use ratatui::Terminal;
     use ratatui::backend::TestBackend;
     use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+    use serial_test::serial;
 
     /// A key event with no modifiers.
     fn key(code: KeyCode) -> KeyEvent {
@@ -3962,6 +3963,7 @@ mod tests {
     // ── esc saves an unsaved change ─────────────────────────────────────
 
     #[test]
+    #[serial]
     fn esc_saves_an_unsaved_toggle() {
         // `esc` over a dirty overview SAVES the edit and stays on the surface
         // (the footer's "saves & closes" contract). Reverting on esc was the
@@ -4060,6 +4062,7 @@ mod tests {
     // ── detail pane save promotes the baseline ──────────────────────────
 
     #[test]
+    #[serial]
     fn detail_pane_enter_saves_the_change() {
         // The detail-pane `⏎` runs a real save through `patch_global_config`,
         // whose path resolves via process-global `WAYLAND_HOME`. Hermetic via
@@ -4273,6 +4276,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn expert_commit_renders_new_value_and_persists() {
         // `⏎` commits: the new value must render (buffer gone) AND land in
         // `[providers.<active>].compat` on disk. Hermetic via WAYLAND_HOME.
@@ -4340,6 +4344,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn overview_esc_saves_pending_toggle_instead_of_reverting() {
         // Regression: toggling Long-term memory then pressing `esc` must SAVE
         // the edit (persist + advance baseline + signal a live rebind) and
@@ -4446,6 +4451,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn tools_row_space_toggles_and_persists_auto_approve() {
         // S5: the Tools row's `space` flips `[tools] auto_approve`; `esc` saves
         // it to disk. Hermetic via WAYLAND_HOME under the shared env lock.
@@ -4490,6 +4496,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn wallet_row_edits_and_persists_budget_cap() {
         // S5: the Wallet row opens a dollar editor on `⏎`; committing then
         // saving persists `[budget] max_cost_usd`.
@@ -4622,6 +4629,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn egress_allowlist_add_persists_to_security() {
         // Add an entry, then `esc` saves the collection to `[security]
         // egress_allow` on disk. Hermetic via WAYLAND_HOME under the env lock.
@@ -4660,6 +4668,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn failover_toggle_and_fallback_chain_persist_to_provider_chain() {
         // Enabling failover then adding a fallback model persists both
         // `[provider_chain] enabled` and `fallback_models` on a single save.
@@ -4850,6 +4859,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn advanced_traces_toggle_persists_to_observability() {
         // S6: the Advanced Structured-traces toggle flips `[observability]`
         // and `esc` saves it. Hermetic via WAYLAND_HOME under the env lock.
@@ -4890,6 +4900,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn advanced_credential_backend_radio_cycles_and_persists() {
         // S6: the credential-store radio cycles plaintext↔keyring and persists
         // to `[storage.credentials] backend`.

--- a/crates/wcore-cli/src/tui/surfaces/diagnostics.rs
+++ b/crates/wcore-cli/src/tui/surfaces/diagnostics.rs
@@ -2042,6 +2042,7 @@ mod tests {
     use super::*;
     use crate::tui::app::App;
     use crate::tui::theme::Theme;
+    use serial_test::serial;
 
     fn key(code: KeyCode) -> KeyEvent {
         KeyEvent::new(code, KeyModifiers::NONE)
@@ -3132,6 +3133,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn doctor_shows_yellow_when_key_unset() {
         // With no provider keys set, every provider row must render as
         // Yellow with the "no key" detail string. The brand-yellow `▲`
@@ -3179,6 +3181,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn doctor_provider_health_times_out_at_5s() {
         // A wedged provider must NOT stall /doctor. We point
         // `ANTHROPIC_API_BASE` at a TCP listener that accepts and never

--- a/crates/wcore-cli/src/tui/surfaces/onboarding.rs
+++ b/crates/wcore-cli/src/tui/surfaces/onboarding.rs
@@ -1729,6 +1729,7 @@ mod tests {
     use ratatui::Terminal;
     use ratatui::backend::TestBackend;
     use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+    use serial_test::serial;
 
     fn key(code: KeyCode) -> KeyEvent {
         KeyEvent::new(code, KeyModifiers::NONE)
@@ -2487,10 +2488,11 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn short_path_collapses_the_home_directory() {
         // The Ready card shortens a path under $HOME to a leading `~` so
         // it wraps cleanly — it never cuts a path mid-string.
-        // SAFETY: single-threaded test, env restored immediately after.
+        // SAFETY: #[serial] serializes every env-mutating test in this binary.
         let prev = std::env::var_os("HOME");
         unsafe { std::env::set_var("HOME", "/Users/sean") };
         let shortened = short_path(std::path::Path::new(

--- a/crates/wcore-cli/src/tui/theme.rs
+++ b/crates/wcore-cli/src/tui/theme.rs
@@ -377,6 +377,7 @@ impl Theme {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
     use std::sync::Mutex;
 
     /// Serializes the two tests that mutate process-global env vars
@@ -469,15 +470,15 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn for_mode_resolves_light_dark_auto() {
         let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         // `for_mode` branches on truecolor (hearth* vs hearth*_256) and on
         // NO_COLOR, both process-global. Force COLORTERM=truecolor and clear
         // NO_COLOR so the assertions are deterministic regardless of host.
         //
-        // SAFETY: single-threaded test body; env mutations are paired and
-        // restored at the end. This and `detect_honors_the_no_color_env_var`
-        // are the only tests in this module touching these vars.
+        // SAFETY: #[serial] serializes every env-mutating test in this binary.
+        // Env mutations are paired and restored at the end.
         let prior_colorterm = std::env::var_os("COLORTERM");
         let prior_no_color = std::env::var_os("NO_COLOR");
         let prior_fgbg = std::env::var_os("COLORFGBG");
@@ -541,6 +542,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn detect_honors_the_no_color_env_var() {
         // `detect()` is the single entry point the live TUI must call so
         // `NO_COLOR` is respected at runtime. With the var set to a
@@ -553,10 +555,8 @@ mod tests {
         // `COLORTERM=truecolor` for the fall-through assertions to be
         // deterministic regardless of host environment.
         //
-        // SAFETY: `set_var`/`remove_var` are process-global. The `ENV_LOCK`
-        // guard serializes this test against `for_mode_resolves_light_dark_auto`
-        // (the only other env-mutating test in this module), so there is no
-        // concurrent reader/writer racing inside this binary.
+        // SAFETY: #[serial] serializes every env-mutating test in this binary.
+        // The `ENV_LOCK` guard is kept as belt-and-suspenders redundancy.
         let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let prior_colorterm = std::env::var_os("COLORTERM");
         unsafe { std::env::set_var("COLORTERM", "truecolor") };

--- a/crates/wcore-cli/src/tui/theme_detect.rs
+++ b/crates/wcore-cli/src/tui/theme_detect.rs
@@ -63,6 +63,7 @@ pub fn detect_light_mode() -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
 
     #[test]
     fn colorfgbg_light_vs_dark() {
@@ -97,13 +98,12 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn detect_light_mode_reads_colorfgbg_then_falls_back_to_dark() {
-        // `detect_light_mode` reads process-global env. This is the only
-        // test in this module that sets COLORFGBG/TERM_PROGRAM, so there is
-        // no concurrent reader to race with inside this binary.
+        // `detect_light_mode` reads process-global env; set/remove are paired
+        // and the prior values are restored at the end.
         //
-        // SAFETY: single-threaded test body; set/remove are paired and the
-        // prior values are restored at the end.
+        // SAFETY: #[serial] serializes every env-mutating test in this binary.
         let prior_fgbg = std::env::var_os("COLORFGBG");
         let prior_tp = std::env::var_os("TERM_PROGRAM");
 

--- a/crates/wcore-cli/tests/harness_regression.rs
+++ b/crates/wcore-cli/tests/harness_regression.rs
@@ -36,6 +36,7 @@ use std::process::{Command, Output};
 use std::time::{Duration, Instant};
 
 use serde_json::Value;
+use serial_test::serial;
 use tempfile::TempDir;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::Command as AsyncCommand;
@@ -1002,11 +1003,12 @@ async fn r010_openrouter_url_no_double_v1() {
 // log message edits while still catching the absence of the log entirely.
 
 #[tokio::test]
+#[serial]
 async fn r011_channels_auto_register_logs() {
     // Ensure RUST_LOG=info so the child binary emits tracing output.
     // The runner inherits env from the test process, so setting it here
     // propagates to the spawned engine binary.
-    // Safety: test-only, single-threaded nextest run per crate convention.
+    // SAFETY: #[serial] serializes every env-mutating test in this binary.
     unsafe { std::env::set_var("RUST_LOG", "info") };
 
     let scenario = Scenario::new("r011_channels_auto_register_logs", Category::Coverage)
@@ -1070,10 +1072,11 @@ async fn r011_channels_auto_register_logs() {
 //      appear in stderr — FAIL if none match (closes the silent-pass).
 
 #[tokio::test]
+#[serial]
 async fn r012_honcho_fallback_on_no_key() {
     // Remove HONCHO_API_KEY from this process so the child inherits the
     // absence and the local-backend fallback path fires.
-    // Safety: test-only env mutation; nextest isolates each test process.
+    // SAFETY: #[serial] serializes every env-mutating test in this binary.
     unsafe { std::env::remove_var("HONCHO_API_KEY") };
     unsafe { std::env::set_var("RUST_LOG", "info") };
 

--- a/crates/wcore-cli/tests/memory_show_test.rs
+++ b/crates/wcore-cli/tests/memory_show_test.rs
@@ -16,6 +16,7 @@
 
 use std::fs;
 
+use serial_test::serial;
 use tempfile::TempDir;
 use uuid::Uuid;
 
@@ -65,6 +66,7 @@ async fn fixture_with_session_data(session_id: &str) -> (TempDir, TempDir) {
 }
 
 #[tokio::test(flavor = "current_thread")]
+#[serial]
 async fn memory_show_renders_project_procedures_and_session() {
     let session = "test-session-m3-4";
     let (project, memory_root) = fixture_with_session_data(session).await;


### PR DESCRIPTION
## What

Final PR in the env-race `#[serial]` sweep. Converges every env-mutating test
in `wcore-cli` onto the default `serial_test` group so concurrent tests in the
single lib test binary cannot race on process-global environment variables.

All `#[cfg(test)] mod tests` across a crate's `src/*.rs` compile into ONE lib
test binary and run on a thread pool. `serial_test`'s default `#[serial]` only
serializes against other default-group serial tests — NOT against a plain
`#[test]`, a named `#[serial(name)]` group, or a bespoke `Mutex` guard. This PR
reconciles the crate's three bespoke mutexes onto the default group (the mutexes
are kept as redundant belt-and-suspenders):

- `ENV_LOCK` — `src/tui/theme.rs`
- `DIAG_ENV_LOCK` / `EnvBatch` — `src/tui/surfaces/diagnostics.rs`
- `EXPERT_ENV_LOCK` — `src/tui/surfaces/config.rs`

## Change (test-only, additive)

- 24 tests across 12 files gain the default `#[serial]`.
- `crash_sentinel.rs`: normalize a named `#[serial(env)]` group to the default
  `#[serial]` (a named group does not serialize against the default group — this
  was the concrete race hole).
- Stale `// SAFETY:` comments claiming single-threaded / nextest-process-isolation
  / unique-var safety corrected to reference the `#[serial]` serialization.
- All bespoke mutexes/guards (`ENV_LOCK`, `DIAG_ENV_LOCK`, `EXPERT_ENV_LOCK`,
  `EnvGuard`) preserved.
- Import discipline: bare `#[serial]` with `use serial_test::serial;` where an
  unconditional user exists; no import trap introduced.

No production code paths touched.

## Verification (build box, warm 1.95.0 toolchain)

- `cargo clippy -p wcore-cli --all-targets -- -D warnings` — clean.
- `cargo test -p wcore-cli --lib` — 1578 passed / 0 failed.
- `cargo test -p wcore-cli --tests` — pass.

Adversarially reviewed (verdict SHIP): an independent reviewer enumerated all
env-mutation sites from scratch (134 grep hits → distinct tests), confirmed
every enclosing test carries default `#[serial]` (incl. ~35 already converged in
prior PRs), no plain-`#[test]` env mutator, no named group remaining, no
mutex-only-without-serial, no import trap, no `fn`-signature mangling, test-only.
