### PR TITLE
feat(acp): agent roster trait + capability handshake (persona PR-2)

### DIFF
--- a/crates/wcore-acp/src/error.rs
+++ b/crates/wcore-acp/src/error.rs
@@ -13,6 +13,14 @@ pub enum AcpError {
     Auth(String),
     #[error("session error: {0}")]
     Session(String),
+    /// persona-profiles Phase A (red-team R3/R4): a `session/create` named an
+    /// `agent` selector the calling principal is NOT authorized for (or that
+    /// does not exist). Kept distinct from [`Self::Session`] so the transport
+    /// maps it to [`crate::protocol::ErrorCode::AgentNotFound`]. Because the
+    /// roster returns only AUTHORIZED agents, "unknown" and "not authorized"
+    /// are the SAME signal — this leaks no existence information.
+    #[error("agent error: {0}")]
+    Agent(String),
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
     #[error("serde error: {0}")]

--- a/crates/wcore-acp/src/lib.rs
+++ b/crates/wcore-acp/src/lib.rs
@@ -11,6 +11,7 @@ pub mod auth;
 pub mod client;
 pub mod error;
 pub mod protocol;
+pub mod roster;
 pub mod server;
 pub mod transport;
 pub mod turn;
@@ -18,6 +19,7 @@ pub mod turn;
 pub use a2a::{A2aCapabilities, A2aError, A2aHandler, A2aHandshake, A2aMessage, DefaultA2aHandler};
 pub use client::AcpClient;
 pub use error::AcpError;
+pub use roster::AgentRoster;
 pub use server::AcpServer;
 pub use turn::{TurnEngine, TurnRequest};
 

--- a/crates/wcore-acp/src/protocol.rs
+++ b/crates/wcore-acp/src/protocol.rs
@@ -203,6 +203,66 @@ pub struct AgentsListResponse {
     pub agents: Vec<AgentInfo>,
 }
 
+// ── Capability handshake (persona-profiles R2 — version-skew safety) ──────
+
+/// ACP protocol revision this server implements. Surfaced in the
+/// [`InitializeResponse`] so a client can reason about wire compatibility
+/// before exercising version-gated features.
+pub const ACP_PROTOCOL_VERSION: &str = "0.1";
+
+/// Server capability advertisement returned by `initialize`.
+///
+/// SECURITY / COMPAT (red-team R2): the persona-agent extension adds an
+/// optional `agent` selector to `session/create` and an `agents/list` roster.
+/// Because every request type carries `#[serde(deny_unknown_fields)]`, a NEW
+/// client that blindly sends `agent` to an OLD (pre-extension) server would be
+/// hard-rejected at parse time. The fix is negotiation: a client MUST consult
+/// [`Self::agent_selection`] from `initialize` BEFORE sending an `agent`
+/// selector or relying on `agents/list`. An old server omits the capability
+/// (there is no `initialize` route, or the field is absent → `false` on
+/// parse), so a new client cleanly down-shifts instead of breaking.
+///
+/// NOTE this struct deliberately does NOT use `deny_unknown_fields` (mirroring
+/// `A2aCapabilities`): capability sets are forward-extensible, so an old client
+/// must be able to parse a newer server's response and simply ignore
+/// capabilities it does not understand.
+///
+/// Advertising `agent_selection` says only "this build understands the
+/// selection protocol" — it is a compile-time property of the server, NOT a
+/// claim that any agent is available. Whether a roster actually holds agents
+/// (feature default-OFF ⇒ empty) is discovered separately via `agents/list`,
+/// and selecting an unavailable/unauthorized id still yields
+/// [`ErrorCode::AgentNotFound`]. Advertising the capability therefore grants
+/// nothing; it only prevents a version-skew hard-break.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, ToSchema)]
+pub struct ServerCapabilities {
+    /// `true` when the server understands the persona-agent selection
+    /// extension (accepts an optional `agent` on `session/create` and serves
+    /// the `agents/list` roster, possibly empty).
+    #[serde(default)]
+    pub agent_selection: bool,
+}
+
+/// `initialize` request payload (empty body — included for symmetry, like
+/// [`SessionListRequest`]). A capability handshake takes no client input in
+/// Phase A; the field set is reserved for future client-capability exchange.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct InitializeRequest {}
+
+/// `initialize` response payload — the server capability handshake.
+///
+/// A client performs this handshake first and gates version-sensitive
+/// behaviour (e.g. sending `SessionCreateRequest::agent`) on the advertised
+/// [`ServerCapabilities`]. See [`ServerCapabilities`] for the R2 rationale.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct InitializeResponse {
+    /// ACP protocol revision the server implements ([`ACP_PROTOCOL_VERSION`]).
+    pub protocol_version: String,
+    /// Advertised server capabilities.
+    pub capabilities: ServerCapabilities,
+}
+
 // ── Messages ─────────────────────────────────────────────────────────────
 
 /// `message/send` request payload. Server emits a stream of [`MessageEvent`]s.
@@ -518,6 +578,48 @@ mod tests {
     fn agents_list_request_rejects_unknown_fields() {
         let bad = r#"{"mystery":"x"}"#;
         let r: Result<AgentsListRequest, _> = serde_json::from_str(bad);
+        assert!(r.is_err(), "deny_unknown_fields should reject");
+    }
+
+    /// Capability handshake (R2): the `initialize` response carries a protocol
+    /// version and an `agent_selection` capability that round-trips.
+    #[test]
+    fn initialize_response_roundtrips_with_capability() {
+        let resp = InitializeResponse {
+            protocol_version: ACP_PROTOCOL_VERSION.to_string(),
+            capabilities: ServerCapabilities {
+                agent_selection: true,
+            },
+        };
+        let s = serde_json::to_string(&resp).unwrap();
+        assert!(s.contains(r#""agent_selection":true"#));
+        let back: InitializeResponse = serde_json::from_str(&s).unwrap();
+        assert_eq!(back.protocol_version, ACP_PROTOCOL_VERSION);
+        assert!(back.capabilities.agent_selection);
+    }
+
+    /// R2 version-skew safety: `ServerCapabilities` must be forward-extensible.
+    /// A payload carrying a capability an old client does not know MUST still
+    /// parse (unknown keys ignored), and an absent `agent_selection` defaults
+    /// to `false` (an old server that never advertised it).
+    #[test]
+    fn server_capabilities_is_forward_compatible() {
+        // Unknown future capability is ignored, not rejected.
+        let future = r#"{"agent_selection":true,"some_future_cap":true}"#;
+        let caps: ServerCapabilities = serde_json::from_str(future)
+            .expect("capabilities must tolerate unknown (forward-compat) fields");
+        assert!(caps.agent_selection);
+
+        // Absent capability defaults to false (pre-extension server).
+        let old = r#"{}"#;
+        let caps: ServerCapabilities = serde_json::from_str(old).unwrap();
+        assert!(!caps.agent_selection, "absent capability must default false");
+    }
+
+    #[test]
+    fn initialize_request_rejects_unknown_fields() {
+        let bad = r#"{"mystery":"x"}"#;
+        let r: Result<InitializeRequest, _> = serde_json::from_str(bad);
         assert!(r.is_err(), "deny_unknown_fields should reject");
     }
 }

--- a/crates/wcore-acp/src/protocol.rs
+++ b/crates/wcore-acp/src/protocol.rs
@@ -613,7 +613,10 @@ mod tests {
         // Absent capability defaults to false (pre-extension server).
         let old = r#"{}"#;
         let caps: ServerCapabilities = serde_json::from_str(old).unwrap();
-        assert!(!caps.agent_selection, "absent capability must default false");
+        assert!(
+            !caps.agent_selection,
+            "absent capability must default false"
+        );
     }
 
     #[test]

--- a/crates/wcore-acp/src/roster.rs
+++ b/crates/wcore-acp/src/roster.rs
@@ -1,0 +1,127 @@
+//! Persona-agent roster seam (persona-profiles Phase A).
+//!
+//! `wcore-acp` is a mid-layer transport crate and MUST NOT depend on the
+//! identity sources (`wcore-agents-pack`, `wcore-agent`, `wcore-config`). The
+//! roster is reached through this transport-neutral trait, implemented in the
+//! CLI layer exactly like [`crate::turn::TurnEngine`] and
+//! [`crate::a2a::A2aHandler`]. Keeps the crate dependency-free while the CLI
+//! owns enumeration (`CliAgentRoster` lands in PR-3, NOT here).
+//!
+//! SECURITY (red-team, hard requirements):
+//!   * R4 — [`AgentInfo`] carries ONLY an opaque `id` + display `label`
+//!     (+ optional operator-authored `description`). An implementation MUST
+//!     NEVER surface a persona's `system_prompt`/SOUL, model, provider, API
+//!     key, or filesystem paths through this trait. The type makes that the
+//!     only representable shape.
+//!   * R3 — the roster is AUTHZ-gated: [`AgentRoster::list`] returns ONLY the
+//!     agents the calling principal is authorized to select, and
+//!     [`AgentRoster::contains`] answers within that same authorized set.
+//!     Until per-principal authz exists, an implementation scopes the roster
+//!     to the trusted local operator. "Unknown" and "not authorized" are the
+//!     same answer (`false`) so existence never leaks.
+
+use async_trait::async_trait;
+
+use crate::error::AcpError;
+use crate::protocol::AgentInfo;
+
+/// A transport-neutral, authorization-gated catalog of selectable persona
+/// agents.
+///
+/// Installed on an [`crate::server::AcpServer`] via
+/// [`crate::server::AcpServer::with_roster`]. When no roster is installed the
+/// server behaves exactly as before the extension: `agents/list` returns `[]`
+/// and any `agent` selector at `session/create` resolves to
+/// [`crate::protocol::ErrorCode::AgentNotFound`] (feature default-OFF).
+#[async_trait]
+pub trait AgentRoster: Send + Sync {
+    /// The persona agents the calling principal is AUTHORIZED to select (R3).
+    ///
+    /// The returned [`AgentInfo`]s expose only id/label/description (R4). An
+    /// implementation MUST filter to the authorized set here — callers treat
+    /// this as the full visible roster.
+    async fn list(&self) -> Result<Vec<AgentInfo>, AcpError>;
+
+    /// Whether `id` is present in the caller's AUTHORIZED roster.
+    ///
+    /// Default implementation answers from [`Self::list`], so a minimal roster
+    /// need only implement `list` and inherits authz-correct membership for
+    /// free (an id the principal cannot see is not "contained"). Override when
+    /// a direct membership check is cheaper than materializing the list.
+    async fn contains(&self, id: &str) -> bool {
+        match self.list().await {
+            Ok(agents) => agents.iter().any(|a| a.id == id),
+            // Fail closed: on any enumeration error the id is treated as not
+            // present/authorized rather than silently admitted.
+            Err(_) => false,
+        }
+    }
+
+    /// The id of the default agent for this principal, if the roster defines
+    /// one. `None` means "no implicit default" — a `session/create` without an
+    /// `agent` selector keeps the server's base behaviour (no persona overlay).
+    ///
+    /// Default implementation returns `None`.
+    async fn default_id(&self) -> Option<String> {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A tiny in-memory roster used to prove the trait's default methods and
+    /// the authz-gated membership semantics. Mirrors the fixed-script mock
+    /// style used for `TurnEngine`/`A2aHandler` elsewhere in the crate.
+    struct MockRoster {
+        agents: Vec<AgentInfo>,
+        default: Option<String>,
+    }
+
+    #[async_trait]
+    impl AgentRoster for MockRoster {
+        async fn list(&self) -> Result<Vec<AgentInfo>, AcpError> {
+            Ok(self.agents.clone())
+        }
+        async fn default_id(&self) -> Option<String> {
+            self.default.clone()
+        }
+    }
+
+    fn info(id: &str) -> AgentInfo {
+        AgentInfo {
+            id: id.to_string(),
+            label: id.to_string(),
+            description: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn contains_default_answers_from_list() {
+        let roster = MockRoster {
+            agents: vec![info("architect"), info("researcher")],
+            default: None,
+        };
+        assert!(roster.contains("architect").await);
+        assert!(roster.contains("researcher").await);
+        // An id outside the authorized list is not contained (R3: unknown ==
+        // not-authorized == false, no existence leak).
+        assert!(!roster.contains("root").await);
+    }
+
+    #[tokio::test]
+    async fn default_id_reports_configured_default() {
+        let roster = MockRoster {
+            agents: vec![info("architect")],
+            default: Some("architect".to_string()),
+        };
+        assert_eq!(roster.default_id().await.as_deref(), Some("architect"));
+
+        let none = MockRoster {
+            agents: vec![],
+            default: None,
+        };
+        assert_eq!(none.default_id().await, None);
+    }
+}

--- a/crates/wcore-acp/src/server.rs
+++ b/crates/wcore-acp/src/server.rs
@@ -23,10 +23,12 @@ use tokio::sync::RwLock;
 
 use crate::error::AcpError;
 use crate::protocol::{
-    ErrorCode, JsonRpcError, MessageEvent, MessageSendRequest, SessionCreateRequest,
+    ACP_PROTOCOL_VERSION, AgentsListResponse, ErrorCode, InitializeResponse, JsonRpcError,
+    MessageEvent, MessageSendRequest, ServerCapabilities, SessionCreateRequest,
     SessionCreateResponse, SessionGetResponse, SessionListResponse, SessionMetadata,
     ToolDefinition,
 };
+use crate::roster::AgentRoster;
 use crate::transport::HttpHandler;
 
 /// Internal session record. Wraps [`SessionMetadata`] with the create-time
@@ -47,6 +49,13 @@ struct SessionRecord {
     /// The session's configured tool allowlist. Used as the fallback when a
     /// `message/send` request body carries no per-call tools.
     tools: Vec<ToolDefinition>,
+    /// persona-profiles Phase A: the AUTHORIZED persona-agent id this session
+    /// was created with, if any. Recorded (and readable via
+    /// [`AcpServer::session_agent`]) so a later per-session persona binding
+    /// (PR-4) can resolve the overlay. In PR-2 it is stored + validated only —
+    /// no persona overlay is applied to the engine yet, so selecting an agent
+    /// does NOT change turn behaviour or cross any credential boundary.
+    agent: Option<String>,
 }
 
 /// Minimal ACP server with in-memory session storage.
@@ -68,6 +77,15 @@ pub struct AcpServer {
     /// frame ("no turn engine installed"). Injected from the CLI layer
     /// exactly like `a2a_handler` so `wcore-acp` stays engine-free.
     turn_engine: Option<Arc<dyn crate::turn::TurnEngine>>,
+    /// persona-profiles Phase A — optional persona-agent roster. When `Some`,
+    /// `agents/list` returns the authorized catalog and a `session/create`
+    /// `agent` selector is validated against it. When `None` (the default,
+    /// feature-OFF), `agents/list` is `[]` and any selector is
+    /// `AgentNotFound` — byte-identical to the pre-extension server for
+    /// selector-free clients. Injected from the CLI layer (PR-3's
+    /// `CliAgentRoster`) exactly like `a2a_handler`, keeping `wcore-acp`
+    /// dependency-free.
+    roster: Option<Arc<dyn AgentRoster>>,
 }
 
 impl std::fmt::Debug for AcpServer {
@@ -82,6 +100,7 @@ impl std::fmt::Debug for AcpServer {
                 "turn_engine",
                 &self.turn_engine.as_ref().map(|_| "<dyn TurnEngine>"),
             )
+            .field("roster", &self.roster.as_ref().map(|_| "<dyn AgentRoster>"))
             .finish()
     }
 }
@@ -132,6 +151,34 @@ impl AcpServer {
             .await
             .get(session_id)
             .map(|r| r.tools.clone())
+    }
+
+    /// persona-profiles Phase A — install a persona-agent roster. When present,
+    /// `agents/list` returns its authorized catalog and a `session/create`
+    /// `agent` selector is validated against it (`AgentNotFound` on miss).
+    /// When absent, the server is backward-compatible: empty roster, and any
+    /// selector is rejected. Mirrors [`Self::with_a2a_handler`] /
+    /// [`Self::with_turn_engine`].
+    pub fn with_roster(mut self, roster: Arc<dyn AgentRoster>) -> Self {
+        self.roster = Some(roster);
+        self
+    }
+
+    /// Whether a persona-agent roster is installed.
+    pub fn has_roster(&self) -> bool {
+        self.roster.is_some()
+    }
+
+    /// The AUTHORIZED persona-agent id bound to `session_id` at create-time, if
+    /// the session exists and selected one. Parallels [`Self::session_tools`].
+    /// A later per-session persona binding (PR-4) reads this to resolve the
+    /// overlay; in PR-2 it is a read-only record of the validated selector.
+    pub async fn session_agent(&self, session_id: &str) -> Option<String> {
+        self.sessions
+            .read()
+            .await
+            .get(session_id)
+            .and_then(|r| r.agent.clone())
     }
 
     /// v0.8.1 U12 — dispatch `a2a/handshake`.
@@ -188,6 +235,26 @@ impl HttpHandler for AcpServer {
         &self,
         req: SessionCreateRequest,
     ) -> Result<SessionCreateResponse, AcpError> {
+        // persona-profiles Phase A (R3): if the client selected a persona-agent,
+        // AUTHORIZE it against the installed roster BEFORE creating the session.
+        // The roster returns only agents the principal may use, so a miss (or no
+        // roster at all) is `AgentNotFound` — which doubles as "not authorized"
+        // without leaking existence. A selector-free create is untouched, keeping
+        // the pre-extension wire byte-identical (compat regression proof).
+        //
+        // NOTE this only VALIDATES + RECORDS the id; it applies NO persona
+        // overlay to the engine (system_prompt/model/tools stay as configured).
+        // Binding the persona is PR-4 — deliberately not done here.
+        if let Some(agent_id) = req.agent.as_deref() {
+            let authorized = match &self.roster {
+                Some(roster) => roster.contains(agent_id).await,
+                None => false,
+            };
+            if !authorized {
+                return Err(AcpError::Agent(format!("agent not found: {agent_id}")));
+            }
+        }
+
         let id = uuid::Uuid::new_v4().to_string();
         let now = now_secs();
         let metadata = SessionMetadata {
@@ -201,11 +268,41 @@ impl HttpHandler for AcpServer {
             metadata: metadata.clone(),
             system_prompt: req.system_prompt.clone(),
             tools: req.tools.clone(),
+            agent: req.agent.clone(),
         };
         self.sessions.write().await.insert(id.clone(), record);
         Ok(SessionCreateResponse {
             session_id: id,
             model: req.model,
+        })
+    }
+
+    async fn list_agents(&self) -> Result<AgentsListResponse, AcpError> {
+        // Feature default-OFF: no roster installed ⇒ empty catalog (`[]`),
+        // backward-compatible. When installed, the roster returns ONLY the
+        // agents the calling principal is authorized to see (R3), each exposing
+        // just id/label/description (R4).
+        match &self.roster {
+            Some(roster) => Ok(AgentsListResponse {
+                agents: roster.list().await?,
+            }),
+            None => Ok(AgentsListResponse { agents: Vec::new() }),
+        }
+    }
+
+    async fn initialize(&self) -> Result<InitializeResponse, AcpError> {
+        // Capability handshake (R2): advertise `agent_selection` so a client
+        // knows THIS build understands the optional `agent` selector +
+        // `agents/list` before it risks sending version-gated fields to a
+        // possibly-older peer. This is a compile-time property of the server
+        // (always `true` here) — it is advertised even when no roster is
+        // installed, and grants nothing: `agents/list` is still `[]` and any
+        // selector still yields `AgentNotFound`.
+        Ok(InitializeResponse {
+            protocol_version: ACP_PROTOCOL_VERSION.to_string(),
+            capabilities: ServerCapabilities {
+                agent_selection: true,
+            },
         })
     }
 
@@ -672,6 +769,139 @@ mod tests {
         let got = server.a2a_capabilities().await.unwrap();
         assert_eq!(got.skills, vec!["plan"]);
         assert_eq!(got.tools, vec!["read"]);
+    }
+
+    // ── persona-profiles Phase A: roster wiring + capability handshake ──────
+
+    use crate::protocol::AgentInfo;
+    use crate::roster::AgentRoster;
+
+    /// Fixed in-memory roster for server tests. Returns a canned authorized
+    /// set — the same fixed-script mock style as `MockTurnEngine`.
+    struct MockRoster {
+        agents: Vec<AgentInfo>,
+    }
+
+    #[async_trait]
+    impl AgentRoster for MockRoster {
+        async fn list(&self) -> Result<Vec<AgentInfo>, AcpError> {
+            Ok(self.agents.clone())
+        }
+    }
+
+    fn agent_info(id: &str) -> AgentInfo {
+        AgentInfo {
+            id: id.to_string(),
+            label: id.to_string(),
+            description: None,
+        }
+    }
+
+    // Feature default-OFF: no roster ⇒ `agents/list` is empty, and the server
+    // reports it has no roster.
+    #[tokio::test]
+    async fn list_agents_empty_without_roster() {
+        let server = AcpServer::new();
+        assert!(!server.has_roster());
+        let resp = server.list_agents().await.unwrap();
+        assert!(resp.agents.is_empty());
+    }
+
+    // With a roster installed, `agents/list` returns its authorized catalog.
+    #[tokio::test]
+    async fn list_agents_returns_roster_catalog() {
+        let roster = Arc::new(MockRoster {
+            agents: vec![agent_info("architect"), agent_info("researcher")],
+        });
+        let server = AcpServer::new().with_roster(roster);
+        assert!(server.has_roster());
+        let resp = server.list_agents().await.unwrap();
+        let ids: Vec<&str> = resp.agents.iter().map(|a| a.id.as_str()).collect();
+        assert_eq!(ids, ["architect", "researcher"]);
+    }
+
+    // R3: a `session/create` selecting an AUTHORIZED agent succeeds and the id
+    // is recorded (readable via `session_agent`) — but no persona overlay is
+    // applied (PR-2 records only).
+    #[tokio::test]
+    async fn create_with_authorized_agent_records_selector() {
+        let roster = Arc::new(MockRoster {
+            agents: vec![agent_info("architect")],
+        });
+        let server = AcpServer::new().with_roster(roster);
+        let resp = server
+            .create_session(SessionCreateRequest {
+                model: None,
+                tools: Vec::new(),
+                system_prompt: None,
+                agent: Some("architect".to_string()),
+            })
+            .await
+            .unwrap();
+        assert_eq!(
+            server.session_agent(&resp.session_id).await.as_deref(),
+            Some("architect")
+        );
+    }
+
+    // R3: selecting an agent NOT in the authorized roster is rejected with the
+    // agent-not-found signal (maps to ErrorCode::AgentNotFound at the transport).
+    #[tokio::test]
+    async fn create_with_unauthorized_agent_is_agent_error() {
+        let roster = Arc::new(MockRoster {
+            agents: vec![agent_info("architect")],
+        });
+        let server = AcpServer::new().with_roster(roster);
+        let err = server
+            .create_session(SessionCreateRequest {
+                model: None,
+                tools: Vec::new(),
+                system_prompt: None,
+                agent: Some("root".to_string()),
+            })
+            .await
+            .expect_err("unauthorized agent must be rejected");
+        assert!(matches!(err, AcpError::Agent(_)), "got {err:?}");
+    }
+
+    // Feature default-OFF: selecting any agent when NO roster is installed is
+    // rejected (cannot authorize without a roster) — fail closed.
+    #[tokio::test]
+    async fn create_with_agent_but_no_roster_is_agent_error() {
+        let server = AcpServer::new();
+        let err = server
+            .create_session(SessionCreateRequest {
+                model: None,
+                tools: Vec::new(),
+                system_prompt: None,
+                agent: Some("architect".to_string()),
+            })
+            .await
+            .expect_err("no roster ⇒ cannot authorize any selector");
+        assert!(matches!(err, AcpError::Agent(_)), "got {err:?}");
+    }
+
+    // Compat (R2): a selector-free create is unaffected and records no agent.
+    #[tokio::test]
+    async fn create_without_agent_records_none() {
+        let server = AcpServer::new();
+        let resp = server.create_session(empty_create()).await.unwrap();
+        assert_eq!(server.session_agent(&resp.session_id).await, None);
+    }
+
+    // R2: AcpServer advertises the `agent_selection` capability in `initialize`.
+    #[tokio::test]
+    async fn initialize_advertises_agent_selection() {
+        let server = AcpServer::new();
+        let resp = server.initialize().await.unwrap();
+        assert_eq!(resp.protocol_version, ACP_PROTOCOL_VERSION);
+        assert!(
+            resp.capabilities.agent_selection,
+            "AcpServer must advertise agent_selection (R2)"
+        );
+        // Advertised even without a roster (capability = protocol understanding,
+        // not availability).
+        assert!(!server.has_roster());
     }
 
     #[tokio::test]

--- a/crates/wcore-acp/src/transport/http.rs
+++ b/crates/wcore-acp/src/transport/http.rs
@@ -7,6 +7,8 @@
 //! - `GET    /sessions/:id`          → `session/get`
 //! - `DELETE /sessions/:id`          → `session/delete`
 //! - `POST   /sessions/:id/messages` → `message/send` (SSE stream of [`MessageEvent`])
+//! - `GET    /initialize`            → capability handshake (persona-profiles R2)
+//! - `GET    /agents`                → `agents/list` (persona-profiles roster)
 //!
 //! The transport is decoupled from the server implementation via the
 //! [`HttpHandler`] trait; the actual ACP server (lands in 1.A.6) plugs in by
@@ -38,7 +40,8 @@ use futures::stream::{Stream, StreamExt};
 use crate::auth::Verifier;
 use crate::error::AcpError;
 use crate::protocol::{
-    ErrorCode, JsonRpcError, MessageEvent, MessageSendRequest, SessionCreateRequest,
+    ACP_PROTOCOL_VERSION, AgentsListResponse, ErrorCode, InitializeResponse, JsonRpcError,
+    MessageEvent, MessageSendRequest, ServerCapabilities, SessionCreateRequest,
     SessionCreateResponse, SessionGetResponse, SessionListResponse,
 };
 
@@ -75,6 +78,29 @@ pub trait HttpHandler: Send + Sync + 'static {
         Err(AcpError::Protocol(
             "approval resolution not supported".to_string(),
         ))
+    }
+
+    /// persona-profiles Phase A — the persona-agent roster (`agents/list`).
+    /// Default returns an empty roster so existing handlers + mocks compile
+    /// unchanged and the route is backward-compatible (feature default-OFF).
+    /// `AcpServer` overrides this to consult an installed `AgentRoster`, which
+    /// returns only the AUTHORIZED agents (R3), each id/label-only (R4).
+    async fn list_agents(&self) -> Result<AgentsListResponse, AcpError> {
+        Ok(AgentsListResponse {
+            agents: Vec::new(),
+        })
+    }
+
+    /// persona-profiles Phase A — the capability handshake (`initialize`, R2).
+    /// Default advertises NO extension capabilities (conservative), so an
+    /// arbitrary handler does not over-claim. `AcpServer` overrides this to
+    /// advertise `agent_selection`, telling clients this build understands the
+    /// optional `agent` selector + `agents/list` before any selector is used.
+    async fn initialize(&self) -> Result<InitializeResponse, AcpError> {
+        Ok(InitializeResponse {
+            protocol_version: ACP_PROTOCOL_VERSION.to_string(),
+            capabilities: ServerCapabilities::default(),
+        })
     }
 }
 
@@ -130,6 +156,10 @@ impl<H: HttpHandler> HttpSseTransport<H> {
                 get(get_session::<H>).delete(delete_session::<H>),
             )
             .route("/sessions/:id/messages", post(send_message::<H>))
+            // persona-profiles Phase A: capability handshake + agent roster.
+            // Both default-safe (empty roster / advertised capability only).
+            .route("/initialize", get(initialize::<H>))
+            .route("/agents", get(get_agents::<H>))
             .with_state(self.handler.clone());
 
         // F-017: wrap with auth middleware when a verifier is present.
@@ -174,6 +204,10 @@ async fn auth_middleware(verifier: Arc<dyn Verifier>, req: Request, next: Next) 
 fn status_for(err: &AcpError) -> StatusCode {
     match err {
         AcpError::Auth(_) => StatusCode::UNAUTHORIZED,
+        // persona-profiles R3/R4: an unauthorized/unknown agent selector is a
+        // 404 — it leaks no existence information (the roster only ever exposes
+        // authorized agents, so "unknown" and "forbidden" are indistinguishable).
+        AcpError::Agent(_) => StatusCode::NOT_FOUND,
         AcpError::Session(msg) if msg.to_lowercase().contains("not found") => StatusCode::NOT_FOUND,
         AcpError::Session(_) => StatusCode::BAD_REQUEST,
         AcpError::Protocol(_) => StatusCode::BAD_REQUEST,
@@ -185,6 +219,7 @@ fn status_for(err: &AcpError) -> StatusCode {
 fn code_for(err: &AcpError) -> ErrorCode {
     match err {
         AcpError::Auth(_) => ErrorCode::AuthRequired,
+        AcpError::Agent(_) => ErrorCode::AgentNotFound,
         AcpError::Session(_) => ErrorCode::SessionNotFound,
         AcpError::Protocol(_) | AcpError::Serde(_) => ErrorCode::InvalidRequest,
         AcpError::Io(_) | AcpError::Transport(_) => ErrorCode::InternalError,
@@ -279,6 +314,24 @@ async fn send_message<H: HttpHandler>(
         Ok(Event::default().event(kind).data(data))
     });
     Ok(Sse::new(sse_stream).keep_alive(KeepAlive::new().interval(Duration::from_secs(15))))
+}
+
+/// `GET /initialize` — persona-profiles capability handshake (R2). Advertises
+/// the server's [`crate::protocol::ServerCapabilities`] so clients can gate
+/// version-sensitive features (e.g. the `agent` selector) before using them.
+async fn initialize<H: HttpHandler>(
+    State(handler): State<Arc<H>>,
+) -> Result<Json<InitializeResponse>, AcpHttpError> {
+    Ok(Json(handler.initialize().await?))
+}
+
+/// `GET /agents` — persona-profiles agent roster (`agents/list`). Returns the
+/// AUTHORIZED persona-agents (R3), each id/label-only (R4). Defaults to `[]`
+/// when no roster is installed (feature default-OFF, backward-compatible).
+async fn get_agents<H: HttpHandler>(
+    State(handler): State<Arc<H>>,
+) -> Result<Json<AgentsListResponse>, AcpHttpError> {
+    Ok(Json(handler.list_agents().await?))
 }
 
 #[cfg(test)]
@@ -509,6 +562,44 @@ mod tests {
             "expected 4xx, got {}",
             resp.status()
         );
+    }
+
+    // persona-profiles Phase A: the roster route defaults to `[]` for a
+    // handler that does not install a roster (backward-compatible).
+    #[tokio::test]
+    async fn get_agents_defaults_to_empty() {
+        let app = router(false, false);
+        let req = Request::builder()
+            .method("GET")
+            .uri("/agents")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = to_bytes(resp.into_body(), 4096).await.unwrap();
+        let parsed: AgentsListResponse = serde_json::from_slice(&body).unwrap();
+        assert!(parsed.agents.is_empty(), "no roster ⇒ empty agents list");
+    }
+
+    // persona-profiles Phase A: the capability handshake is reachable and
+    // returns a protocol version + capability set (R2).
+    #[tokio::test]
+    async fn get_initialize_returns_handshake() {
+        let app = router(false, false);
+        let req = Request::builder()
+            .method("GET")
+            .uri("/initialize")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = to_bytes(resp.into_body(), 4096).await.unwrap();
+        let parsed: InitializeResponse = serde_json::from_slice(&body).unwrap();
+        assert_eq!(parsed.protocol_version, ACP_PROTOCOL_VERSION);
+        // The bare MockHandler inherits the conservative default (no
+        // capability); AcpServer overrides to advertise `agent_selection`
+        // (asserted in server.rs tests).
+        assert!(!parsed.capabilities.agent_selection);
     }
 
     // Silence unused-import warnings for protocol types referenced only

--- a/crates/wcore-acp/src/transport/http.rs
+++ b/crates/wcore-acp/src/transport/http.rs
@@ -86,9 +86,7 @@ pub trait HttpHandler: Send + Sync + 'static {
     /// `AcpServer` overrides this to consult an installed `AgentRoster`, which
     /// returns only the AUTHORIZED agents (R3), each id/label-only (R4).
     async fn list_agents(&self) -> Result<AgentsListResponse, AcpError> {
-        Ok(AgentsListResponse {
-            agents: Vec::new(),
-        })
+        Ok(AgentsListResponse { agents: Vec::new() })
     }
 
     /// persona-profiles Phase A — the capability handshake (`initialize`, R2).

--- a/crates/wcore-acp/src/transport/rest.rs
+++ b/crates/wcore-acp/src/transport/rest.rs
@@ -13,6 +13,8 @@
 //!   DELETE /v1/sessions/{id}         delete_session
 //!   POST   /v1/sessions/{id}/prompt  send_message  (SSE: text/event-stream)
 //!   GET    /v1/tools                 list_tools
+//!   GET    /v1/agents                list_agents  (persona-profiles roster)
+//!   GET    /v1/initialize            initialize   (capability handshake, R2)
 //!   GET    /v1/health                liveness
 //!   GET    /openapi.json             the OpenAPI document (unauthenticated)
 //!   GET    /doc                      embedded spec viewer, HTML (unauthenticated)
@@ -40,8 +42,9 @@ use utoipa::OpenApi;
 use crate::auth::Verifier;
 use crate::error::AcpError;
 use crate::protocol::{
-    ErrorCode, JsonRpcError, MessageEvent, MessageSendRequest, SessionCreateRequest,
-    SessionCreateResponse, SessionGetResponse, SessionListResponse, ToolDefinition,
+    AgentsListResponse, ErrorCode, InitializeResponse, JsonRpcError, MessageEvent,
+    MessageSendRequest, SessionCreateRequest, SessionCreateResponse, SessionGetResponse,
+    SessionListResponse, ToolDefinition,
 };
 // Reuse the engine bridge and the HTTP error→status mapping from the ACP
 // transport — no second engine binding, no duplicated `status_for`/`code_for`.
@@ -196,6 +199,11 @@ impl<H: HttpHandler> RestTransport<H> {
                 post(resolve_approval::<H>),
             )
             .route("/v1/tools", get(list_tools::<H>))
+            // persona-profiles Phase A: agent roster + capability handshake.
+            // Both default-safe (empty roster / advertised capability only) and
+            // gated by the same auth middleware as the rest of `/v1/*`.
+            .route("/v1/agents", get(list_agents::<H>))
+            .route("/v1/initialize", get(initialize::<H>))
             .route("/v1/health", get(health))
             .with_state(self.handler.clone());
 
@@ -232,6 +240,8 @@ impl<H: HttpHandler> RestTransport<H> {
         prompt,
         resolve_approval,
         list_tools,
+        list_agents,
+        initialize,
         health,
     ),
     components(schemas(
@@ -249,6 +259,10 @@ impl<H: HttpHandler> RestTransport<H> {
         ApprovalResolveResponse,
         ApprovalScopeDto,
         JsonRpcError,
+        AgentsListResponse,
+        InitializeResponse,
+        crate::protocol::AgentInfo,
+        crate::protocol::ServerCapabilities,
         crate::protocol::SessionMetadata,
         crate::protocol::ToolCall,
         crate::protocol::ToolResult,
@@ -527,6 +541,31 @@ async fn list_tools<H: HttpHandler>(
 }
 
 #[utoipa::path(
+    get, path = "/v1/agents", tag = "sessions",
+    responses((status = 200, description = "Authorized persona-agent roster", body = AgentsListResponse))
+)]
+async fn list_agents<H: HttpHandler>(
+    State(h): State<Arc<H>>,
+) -> Result<Json<AgentsListResponse>, AcpHttpError> {
+    // persona-profiles Phase A: `[]` by default (no roster installed); when
+    // installed, the roster returns only AUTHORIZED agents (R3), each exposing
+    // just id/label/description (R4).
+    Ok(Json(h.list_agents().await?))
+}
+
+#[utoipa::path(
+    get, path = "/v1/initialize", tag = "sessions",
+    responses((status = 200, description = "Server capability handshake", body = InitializeResponse))
+)]
+async fn initialize<H: HttpHandler>(
+    State(h): State<Arc<H>>,
+) -> Result<Json<InitializeResponse>, AcpHttpError> {
+    // persona-profiles Phase A (R2): advertise `agent_selection` so clients can
+    // gate the optional `agent` selector on a version-skew-safe handshake.
+    Ok(Json(h.initialize().await?))
+}
+
+#[utoipa::path(
     get, path = "/v1/health", tag = "sessions",
     responses((status = 200, description = "Liveness", body = HealthResponse))
 )]
@@ -761,6 +800,49 @@ mod tests {
         assert_eq!(parsed["tools"], serde_json::json!([]));
     }
 
+    // persona-profiles Phase A: `/v1/agents` defaults to `[]` (no roster
+    // installed) — backward-compatible, mirrors `get_tools_returns_empty_default`.
+    #[tokio::test]
+    async fn get_agents_returns_empty_default() {
+        let app = router(false);
+        let resp = app
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/v1/agents")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = to_bytes(resp.into_body(), 4096).await.unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(parsed["agents"], serde_json::json!([]));
+    }
+
+    // persona-profiles Phase A (R2): `/v1/initialize` returns the capability
+    // handshake with a protocol version + capability set.
+    #[tokio::test]
+    async fn get_initialize_returns_capabilities() {
+        let app = router(false);
+        let resp = app
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/v1/initialize")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = to_bytes(resp.into_body(), 4096).await.unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(parsed["protocol_version"].is_string());
+        // The `agent_selection` capability key is present (bare MockHandler
+        // inherits the conservative default `false`).
+        assert!(parsed["capabilities"]["agent_selection"].is_boolean());
+    }
+
     // ── T-C5 ───────────────────────────────────────────────────────────
     #[tokio::test]
     async fn get_health_ok() {
@@ -867,6 +949,8 @@ mod tests {
             "/v1/sessions/{id}/prompt",
             "/v1/sessions/{id}/approvals/{call_id}/resolve",
             "/v1/tools",
+            "/v1/agents",
+            "/v1/initialize",
             "/v1/health",
         ] {
             assert!(doc["paths"][p].is_object(), "missing path {p}");


### PR DESCRIPTION
> **Overwatch-subagent draft — REQUIRES adversarial security review (R2/R3/R4) before land; do NOT auto-merge.**

Phase A persona-agent selection over ACP. Additive, feature-**default-OFF**, built on PR-1 protocol types (#202). Scope is deliberately **trait + wiring + routes + handshake only** — NOT PR-3 roster enumeration (`CliAgentRoster`) and NOT PR-4 per-session persona binding.

## What this implements
- **`AgentRoster` trait** (`wcore-acp/src/roster.rs`) — transport-neutral, async `list()` / `contains(id)` / `default_id()`, no new deps, mirroring the `TurnEngine` / `A2aHandler` seam. `contains()` answers from the authorized `list()` and **fails closed**.
- **`AcpServer` wiring** — `.with_roster()` / `has_roster()` builder (mirrors `.with_a2a_handler()`), `session_agent()` accessor (parallels `session_tools()`), and `list_agents()` / `initialize()` overrides. A `session/create` `agent` selector is **authorized against the roster** (`AgentNotFound` on miss, or when no roster is installed) and recorded on the session — **no persona overlay is applied** (that is PR-4).
- **Capability handshake** — `initialize` advertises an `agent_selection` capability so a client gates the optional `agent` field on a version-skew-safe handshake **before** a possibly-older peer hard-rejects it under `deny_unknown_fields`. `ServerCapabilities` is forward-extensible (no `deny_unknown_fields`, mirroring `A2aCapabilities`).
- **Routes** — REST `GET /v1/agents` + `GET /v1/initialize` (with OpenAPI path + schema registration) and ACP `GET /agents` + `GET /initialize`. **All default to `[]` / conservative caps when no roster is installed** (backward-compatible).
- **Error** — new `AcpError::Agent` → `ErrorCode::AgentNotFound` (HTTP 404, no existence leak).

## Red-team constraints honored
- **R4** — `AgentInfo` exposes only opaque `id` + `label` (+ optional operator description). Never prompt/SOUL/provider/model/api_key/paths. Enforced by the type and PR-1's `agent_info_exposes_no_secret_fields` test.
- **R3** — roster is authz-gated: `list()` returns only authorized agents; `contains()` scopes membership to that set; unknown == not-authorized == `false`/404, no existence leak. Until per-principal authz exists, an installed roster is scoped to the trusted local operator (PR-3 concern).
- **R2** — serde backward-compat: `agent` stays `Option` + `serde(default)`; a selector-free `session/create` is byte-identical on the wire. **All pre-existing wcore-acp tests pass unchanged** (the compat proof).

## Build + test (Hetzner)
- `cargo clippy -p wcore-acp --all-targets -- -D warnings` → clean, no warnings.
- `cargo nextest run -p wcore-acp` → **95 passed, 0 failed**.

### Deviations
- **Clippy scoped to `-p wcore-acp`** instead of workspace-wide `--all-targets`: the Hetzner warm target baseline (388G) exceeds the RAM tmpfs (100G), so a full-workspace all-targets build cannot be seeded. Changes are strictly additive to `wcore-acp` (new pub items, new default trait methods, new optional field), so dependents (`wcore-cli`) are unaffected at the type level. A reviewer with disk headroom should confirm the workspace build.
- **`initialize` handshake is newly introduced** (there was no prior `initialize` route in the ACP/REST transports). Added as `GET /initialize` (ACP) and `GET /v1/initialize` (REST) returning `InitializeResponse { protocol_version, capabilities }`.
- **Selector authorized + recorded at `session/create`** (validate via `contains()` → `AgentNotFound`, store id, expose via `session_agent()`). This is the R3 authz gate + the accessor requested in the spec; it applies **no** persona overlay, so it does not cross into PR-4.