### PR TITLE
fix(exec): cross-platform command execution — unbreak Windows (#754)

### DIFF
--- a/crates/wcore-sandbox/src/backends/appcontainer.rs
+++ b/crates/wcore-sandbox/src/backends/appcontainer.rs
@@ -139,6 +139,51 @@ impl ProbeCache {
     }
 }
 
+/// Collapse concurrent cold availability probes into a single real probe
+/// (FerroxLabs/wayland#754).
+///
+/// The probe cache alone does not stop a stampede: when the cache is cold, N
+/// concurrent callers all miss it *before* any records a verdict, so each runs
+/// its OWN probe. On Windows those parallel AppContainer spawns contend on the
+/// shared per-PID profile and mostly fail, and every failure is cached as
+/// `UnavailableUntil(now + neg_ttl)` — so `default_for_platform()` returns
+/// `FailClosedBackend` and refuses EVERY command for the whole TTL window.
+///
+/// This helper gates the slow (probe) path so only the first cold arrival
+/// spawns; the rest block on `gate` and then observe that arrival's verdict via
+/// the double-checked cache read. Split out of `is_available` (which is
+/// Windows-only) so the concurrency contract is unit-testable on every platform
+/// with a counting closure standing in for the real Win32 probe. The gate is
+/// held only across a cold probe, so warm calls stay lock-free on the fast path.
+#[cfg(any(windows, test))]
+fn probe_single_flight(
+    cache: &std::sync::Mutex<ProbeCache>,
+    gate: &std::sync::Mutex<()>,
+    neg_ttl: Duration,
+    probe: impl FnOnce() -> bool,
+) -> bool {
+    // Fast path: a cached verdict needs neither a probe nor the gate.
+    {
+        let g = cache.lock().expect("probe cache poisoned");
+        if let Some(cached) = g.cached(Instant::now()) {
+            return cached;
+        }
+    }
+    // Slow path: serialize, then re-check the cache under the gate so only the
+    // first arrival probes and the rest reuse its verdict.
+    let _gate = gate.lock().expect("probe gate poisoned");
+    {
+        let g = cache.lock().expect("probe cache poisoned");
+        if let Some(cached) = g.cached(Instant::now()) {
+            return cached;
+        }
+    }
+    let result = probe();
+    let mut g = cache.lock().expect("probe cache poisoned");
+    g.record(result, Instant::now(), neg_ttl);
+    result
+}
+
 #[cfg(test)]
 mod probe_cache_tests {
     use super::{Duration, Instant, ProbeCache};
@@ -193,6 +238,51 @@ mod probe_cache_tests {
         // A later successful probe upgrades to sticky-available.
         c.record(true, t0 + Duration::from_secs(31), Duration::from_secs(30));
         assert_eq!(c.cached(t0 + Duration::from_secs(3600)), Some(true));
+    }
+
+    /// Regression for FerroxLabs/wayland#754: concurrent cold callers must NOT
+    /// each run the real probe. Before the single-flight gate, N parallel
+    /// `is_available()` callers all missed the cold cache and each launched its
+    /// own AppContainer spawn; on Windows those contended and failed, poisoning
+    /// the negative cache so every command was refused by `FailClosedBackend`.
+    /// With the gate, the probe runs exactly once and every caller observes the
+    /// same verdict. Without the gate this asserts >1 and fails.
+    #[test]
+    fn single_flight_runs_probe_once_under_concurrency() {
+        use super::probe_single_flight;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::{Arc, Barrier, Mutex};
+
+        let cache = Arc::new(Mutex::new(ProbeCache::new()));
+        let gate = Arc::new(Mutex::new(()));
+        let probe_calls = Arc::new(AtomicUsize::new(0));
+        let n = 32usize;
+        let barrier = Arc::new(Barrier::new(n));
+
+        let mut handles = Vec::with_capacity(n);
+        for _ in 0..n {
+            let cache = Arc::clone(&cache);
+            let gate = Arc::clone(&gate);
+            let probe_calls = Arc::clone(&probe_calls);
+            let barrier = Arc::clone(&barrier);
+            handles.push(std::thread::spawn(move || {
+                // Release all threads at once to maximize the cold-cache race.
+                barrier.wait();
+                probe_single_flight(&cache, &gate, Duration::from_secs(30), || {
+                    probe_calls.fetch_add(1, Ordering::SeqCst);
+                    // Widen the window a real Win32 probe would occupy.
+                    std::thread::sleep(Duration::from_millis(5));
+                    true
+                })
+            }));
+        }
+        let all_available = handles.into_iter().all(|h| h.join().unwrap());
+        assert!(all_available, "every caller must observe the Available verdict");
+        assert_eq!(
+            probe_calls.load(Ordering::SeqCst),
+            1,
+            "the real probe must run exactly once despite {n} concurrent cold callers (#754)"
+        );
     }
 }
 
@@ -881,6 +971,32 @@ mod windows_impl {
         CACHE.get_or_init(|| Mutex::new(ProbeCache::new()))
     }
 
+    /// Single-flight gate for the availability probe (FerroxLabs/wayland#754).
+    ///
+    /// The probe cache alone does NOT prevent a stampede: when the cache is
+    /// cold, N concurrent `is_available()` callers all miss it *before* any of
+    /// them records a verdict, so each launches its OWN real AppContainer spawn
+    /// at the same instant. On Windows those parallel spawns contend on the
+    /// shared per-PID AppContainer profile / profile-service RPC and most of
+    /// them FAIL — and every failure is written into the cache as
+    /// `UnavailableUntil(now + NEGATIVE_PROBE_TTL)`, so for the next 30s
+    /// `default_for_platform()` returns `FailClosedBackend` and EVERY tool
+    /// command is refused ("sandbox UNAVAILABLE … refusing to run"). The agent
+    /// reads that as a failed command and retries, which the user sees as every
+    /// shell command timing out / returning empty / looping.
+    ///
+    /// This gate serializes the SLOW (probe) path so only the first cold caller
+    /// actually spawns; the rest block briefly, then observe its verdict via the
+    /// double-checked cache read in `is_available()`. A single serial probe is
+    /// reliable (it is exactly the serial path every non-concurrent command
+    /// already takes), so the cache warms to `Available` (sticky) and all later
+    /// calls take the lock-free fast path. Held only across the cold probe, so it
+    /// adds no steady-state contention.
+    fn probe_gate() -> &'static Mutex<()> {
+        static GATE: OnceLock<Mutex<()>> = OnceLock::new();
+        GATE.get_or_init(|| Mutex::new(()))
+    }
+
     #[async_trait]
     impl SandboxBackend for AppContainerBackend {
         fn name(&self) -> &'static str {
@@ -907,17 +1023,16 @@ mod windows_impl {
         /// [`probe_appcontainer_available`], so a stalled Win32 setup call can
         /// cost at most one guarded probe per TTL window.
         fn is_available(&self) -> bool {
-            let cache = probe_cache();
-            {
-                let g = cache.lock().expect("probe cache poisoned");
-                if let Some(cached) = g.cached(Instant::now()) {
-                    return cached;
-                }
-            }
-            let result = probe_appcontainer_available();
-            let mut g = cache.lock().expect("probe cache poisoned");
-            g.record(result, Instant::now(), NEGATIVE_PROBE_TTL);
-            result
+            // Single-flight the probe so concurrent cold callers collapse onto
+            // ONE real AppContainer spawn instead of stampeding it (#754). The
+            // logic lives in a platform-independent helper so it is unit-tested
+            // on every target; here it is driven by the real Win32 probe.
+            super::probe_single_flight(
+                probe_cache(),
+                probe_gate(),
+                NEGATIVE_PROBE_TTL,
+                probe_appcontainer_available,
+            )
         }
 
         fn enforces_read_deny(&self) -> bool {

--- a/crates/wcore-sandbox/src/backends/appcontainer.rs
+++ b/crates/wcore-sandbox/src/backends/appcontainer.rs
@@ -171,6 +171,10 @@ fn probe_single_flight(
     }
     // Slow path: serialize, then re-check the cache under the gate so only the
     // first arrival probes and the rest reuse its verdict.
+    // The gate stays un-poisonable in practice: the real Win32 FFI runs on the
+    // detached `appcontainer-probe` thread, so a panic there surfaces here as a
+    // `RecvTimeoutError::Disconnected` → `false` return, never an unwind through
+    // this caller — a caller-thread unwind cannot poison the gate and wedge it.
     let _gate = gate.lock().expect("probe gate poisoned");
     {
         let g = cache.lock().expect("probe cache poisoned");
@@ -284,6 +288,75 @@ mod probe_cache_tests {
             "the real probe must run exactly once despite {n} concurrent cold callers (#754)"
         );
     }
+
+    /// Fail-closed counterpart to the test above (FerroxLabs/wayland#754): the
+    /// single-flight fix must NOT weaken fail-closed under concurrency. When the
+    /// (one) probe reports the sandbox UNAVAILABLE, N concurrent cold callers
+    /// must still (a) run the probe exactly once — no stampede, (b) EVERY caller
+    /// observe `false` (→ `FailClosedBackend`, never a silent unsandboxed
+    /// fallback), and (c) leave the cache holding the negative `UnavailableUntil`
+    /// verdict so later calls within the TTL reuse it instead of re-probing.
+    #[test]
+    fn single_flight_fails_closed_once_under_concurrency() {
+        use super::probe_single_flight;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::{Arc, Barrier, Mutex};
+
+        let cache = Arc::new(Mutex::new(ProbeCache::new()));
+        let gate = Arc::new(Mutex::new(()));
+        let probe_calls = Arc::new(AtomicUsize::new(0));
+        let n = 32usize;
+        let ttl = Duration::from_secs(30);
+        let barrier = Arc::new(Barrier::new(n));
+
+        let mut handles = Vec::with_capacity(n);
+        for _ in 0..n {
+            let cache = Arc::clone(&cache);
+            let gate = Arc::clone(&gate);
+            let probe_calls = Arc::clone(&probe_calls);
+            let barrier = Arc::clone(&barrier);
+            handles.push(std::thread::spawn(move || {
+                barrier.wait();
+                probe_single_flight(&cache, &gate, ttl, || {
+                    probe_calls.fetch_add(1, Ordering::SeqCst);
+                    // Widen the window a real Win32 probe would occupy.
+                    std::thread::sleep(Duration::from_millis(5));
+                    false // sandbox UNAVAILABLE — must fail closed
+                })
+            }));
+        }
+        // (b) every caller observes the fail-closed verdict (none saw Available).
+        let any_available = handles.into_iter().any(|h| h.join().unwrap());
+        assert!(
+            !any_available,
+            "every caller must observe the UNAVAILABLE verdict (fail closed)"
+        );
+        // (a) no stampede: the failing probe ran exactly once.
+        assert_eq!(
+            probe_calls.load(Ordering::SeqCst),
+            1,
+            "the failing probe must run exactly once despite {n} concurrent cold callers (#754)"
+        );
+        // (c) the cache holds the negative verdict (UnavailableUntil), reused
+        // within the TTL — an Unknown/uncached verdict would surface as `None`.
+        assert_eq!(
+            cache.lock().unwrap().cached(Instant::now()),
+            Some(false),
+            "a concurrent fail-closed probe must cache UnavailableUntil, not leave the cache cold"
+        );
+        // …and a follow-up caller reuses that verdict WITHOUT re-probing: this
+        // closure would flip the result to Available if it ran, so it must not.
+        let reused = probe_single_flight(&cache, &gate, ttl, || {
+            probe_calls.fetch_add(1, Ordering::SeqCst);
+            true
+        });
+        assert!(!reused, "cached fail-closed verdict must be reused, not re-probed");
+        assert_eq!(
+            probe_calls.load(Ordering::SeqCst),
+            1,
+            "cached UnavailableUntil must be reused within the TTL — no re-probe"
+        );
+    }
 }
 
 #[cfg(windows)]
@@ -301,7 +374,7 @@ mod windows_impl {
     use std::ptr;
     use std::sync::mpsc;
     use std::sync::{Mutex, OnceLock};
-    use std::time::{Duration, Instant};
+    use std::time::Duration;
     use windows_sys::Win32::Foundation::{
         CloseHandle, ERROR_ALREADY_EXISTS, GetLastError, HANDLE, INVALID_HANDLE_VALUE,
         WAIT_OBJECT_0, WAIT_TIMEOUT,

--- a/crates/wcore-sandbox/src/backends/appcontainer.rs
+++ b/crates/wcore-sandbox/src/backends/appcontainer.rs
@@ -281,7 +281,10 @@ mod probe_cache_tests {
             }));
         }
         let all_available = handles.into_iter().all(|h| h.join().unwrap());
-        assert!(all_available, "every caller must observe the Available verdict");
+        assert!(
+            all_available,
+            "every caller must observe the Available verdict"
+        );
         assert_eq!(
             probe_calls.load(Ordering::SeqCst),
             1,
@@ -350,7 +353,10 @@ mod probe_cache_tests {
             probe_calls.fetch_add(1, Ordering::SeqCst);
             true
         });
-        assert!(!reused, "cached fail-closed verdict must be reused, not re-probed");
+        assert!(
+            !reused,
+            "cached fail-closed verdict must be reused, not re-probed"
+        );
         assert_eq!(
             probe_calls.load(Ordering::SeqCst),
             1,


### PR DESCRIPTION
> ## ⚠️ REQUIRES ADVERSARIAL REVIEW + WINDOWS RUNTIME VERIFICATION BEFORE LAND — DO **NOT** AUTO-MERGE
> This changes the Windows sandbox-selection path. It has been validated on real
> Windows 11 (see evidence below), but a human reviewer must (a) adversarially
> review the single-flight logic for lock ordering / poisoning regressions and
> (b) re-confirm the runtime repro on Windows before this lands. **Do not land
> via the auto-merge gate.**

## Summary

On Windows, **every** Bash/PowerShell command the agent runs could suddenly
start timing out / returning empty / looping — the C1 desktop-release blocker
tracked in #754. Root cause is a **cold-cache probe stampede** in the Windows
AppContainer sandbox's availability check, which poisons the negative-probe
cache and routes every command to `FailClosedBackend` ("sandbox UNAVAILABLE …
refusing to run") for 30 seconds at a time.

This was **not** a bug in the spawn / pipe-drain / timeout machinery — those are
correct and verified working on real Windows (see "What is NOT the bug"). It is
a **concurrency** bug in backend *selection*.

## Root cause (file:line)

`crates/wcore-sandbox/src/backends/appcontainer.rs` — `AppContainerBackend::is_available()`.

The Bash tool selects its backend on every invocation via
`default_for_platform()` → `appc.is_available()`
(`crates/wcore-tools/src/bash.rs:542` and the ctx/streaming variants). On
Windows, `is_available()` runs a **real** `cmd.exe /c exit 0` spawn through the
entire AppContainer pipeline (`probe_appcontainer_available`), then caches the
verdict.

The cache alone does **not** prevent a stampede. When the process-global cache
is cold, N concurrent callers all take the fast-path miss **before** any of them
records a verdict, so **each one launches its own AppContainer spawn at the same
instant**:

```
fn is_available(&self) -> bool {
    { let g = cache.lock()…; if let Some(c) = g.cached(now) { return c; } } // all N miss
    let result = probe_appcontainer_available();   // ← all N probe concurrently
    …g.record(result, now, NEGATIVE_PROBE_TTL);     // ← failures cached for 30s
}
```

On Windows those parallel spawns contend on the **shared per-PID AppContainer
profile** (`WCoreSandbox-<pid>`, intentionally leaked/reused) and the
profile-service RPC, and most of them fail. Each failure is written as
`ProbeVerdict::UnavailableUntil(now + NEGATIVE_PROBE_TTL)` (30s). For that whole
window `default_for_platform()` (`crates/wcore-sandbox/src/lib.rs:398-406`)
finds `is_available() == false` and falls through to `unsandboxed_fallback()` →
**`FailClosedBackend`**, whose `execute()` refuses every command. The agent sees
a failed tool call, retries, and the user experiences "every shell command times
out / returns empty / runs away and loops."

### Why Windows-only
- **Linux**: `BubblewrapBackend::is_available()` is `which::which("bwrap").is_some()` — a pure PATH lookup that cannot fail under concurrency.
- **macOS**: `SandboxExecBackend`'s probe has no per-process profile to contend on.
- **Windows**: is the only backend whose availability probe is an expensive, stateful, per-PID-profile **real spawn** — not concurrency-safe.

### Why model-dependent (explains #552 exactly)
Models that emit **parallel** tool calls in one turn (e.g. Fable 5) hit the
cold-cache stampede and poison the cache. Models that **serialize** tool calls
(e.g. Flux) let the first probe warm the cache to sticky `Available` before the
second call ever runs — hence "switching to Flux fixes it, same workspace, same
prompt, same everything."

## The fix

Single-flight the availability probe (`+126 / -11`, one file). Concurrent cold
callers now collapse onto **one** real spawn and share its verdict via a
double-checked cache read behind a dedicated gate; the winner warms the cache to
sticky `Available` and everyone else (and all later calls) take the lock-free
fast path. A single serial probe is reliable — it is exactly the path every
non-concurrent command already takes.

The single-flight logic is extracted into a platform-independent helper
(`probe_single_flight`, `#[cfg(any(windows, test))]`) so the concurrency
contract is unit-tested on **every** target with a counting closure standing in
for the real Win32 probe. Follows the crate's existing `cfg(windows)` /
`cfg(any(windows, test))` conventions; no behavior change on Linux/macOS.

## Evidence — real Windows 11 (NT 10.0.26200, cargo 1.95), before/after

Reproduced and fixed on real hardware with a repro that fires 24 concurrent
`cmd /C echo` commands through `default_for_platform()` (mirrors the desktop
app's parallel tool calls):

| | Result |
|---|---|
| **BEFORE** (origin/main) | `REPRO5 concurrent: ok=1 bad=23` (and on a second run `ok=0 bad=24`) — 23–24 of 24 commands refused: `ERR: sandbox UNAVAILABLE … refusing to run with host permissions` |
| **AFTER** (this branch) | `REPRO5 concurrent: ok=24 bad=0 elapsed=87ms` — all commands succeed |

Also on real Windows, **serial** exec was already fine both before and after
(proving the spawn/pipe/timeout path is not the bug): single `cmd /C echo`
26 ms; workspace-DACL path 804 ms; streaming 128 KB output 124 ms; all 32
`wcore-tools` `BashTool` unit tests pass; the live AppContainer `echo`/large-
output tests pass.

New cross-platform regression test passes on Windows and Linux:
`backends::appcontainer::probe_cache_tests::single_flight_runs_probe_once_under_concurrency`
(32 concurrent cold callers ⇒ the probe closure runs **exactly once**; without
the gate it runs N times and the test fails).

## Evidence — Linux (Hetzner)

- `cargo clippy -p wcore-sandbox --all-targets -- -D warnings` → **clean, exit 0**.
- `cargo nextest run -p wcore-sandbox` → **54 passed, 2 skipped, 0 failed** (incl. the new single-flight test).

## What is NOT the bug (ruled out on real Windows)

The classic Windows-hostile patterns were all already handled correctly and
verified live: concurrent pipe draining (#520), job-tree reap before drain
(#100), the probe wall-clock bound (#125), PowerShell→cmd fallback (#413), the
shell selector (#197), DLL-not-found diagnostics (#324). Serial `echo hi`
returns in tens of milliseconds. The failure only manifests under **concurrent**
backend selection.

## Windows runtime verification recipe (for the reviewer)

On a Windows host with the Rust toolchain (key-auth SSH to the box works
non-interactively):

```powershell
git clone https://github.com/FerroxLabs/wayland-core.git wl754; cd wl754
git checkout fix/exec-windows-probe-singleflight
# 1) Cross-platform regression test (must pass; fails on origin/main without the gate):
cargo test -p wcore-sandbox --lib single_flight_runs_probe_once_under_concurrency -- --nocapture
# 2) Concurrency smoke via the public API — fire many parallel commands through
#    default_for_platform(); on origin/main most return the FailClosed refusal,
#    on this branch all return exit 0 with their echoed output. (Harness: a
#    tokio multi_thread test spawning ~24 `cmd /C echo` through
#    backend.execute(); see the PR discussion for the exact repro file used.)
$env:WAYLAND_SANDBOX_LIVE_WINDOWS=1; cargo test -p wcore-sandbox echo_runs_live -- --nocapture
```

Full desktop-app confirmation: build the Windows binary, load a repo workspace,
select a model that issues **parallel** tool calls (e.g. Fable 5), and run
several shell commands in one turn — they should return promptly instead of all
timing out / refusing.

## Issues closed

Closes #754, #756, #287, #305, #503, #552.

---
Base: `origin/main` @ `3887bcf`. One-file change. No dependency or public-API
changes.
