### PR TITLE
test(signal): unique tempdir fixes fetch_media cross-run collision

### DIFF
--- a/crates/wcore-channel-signal/Cargo.toml
+++ b/crates/wcore-channel-signal/Cargo.toml
@@ -19,3 +19,4 @@ wcore-channels = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time", "io-util", "sync"] }
+tempfile.workspace = true

--- a/crates/wcore-channel-signal/src/lib.rs
+++ b/crates/wcore-channel-signal/src/lib.rs
@@ -402,12 +402,15 @@ mod tests {
 
     #[tokio::test]
     async fn fetch_media_reads_local_attachment_by_id() {
-        let dir = std::env::temp_dir().join("wcore_signal_fetch_media_test");
-        std::fs::create_dir_all(&dir).unwrap();
+        // Per-process unique tempdir (auto-removed on drop). A fixed shared
+        // /tmp path collides across concurrent workspace runs — one run's
+        // cleanup deletes another's fixture (#191).
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dir = tmp.path();
         std::fs::write(dir.join("att-id-1"), b"SIGBYTES").unwrap();
 
         let mut config = cfg();
-        config.attachments_dir = Some(dir.clone());
+        config.attachments_dir = Some(dir.to_path_buf());
         let ch = SignalChannel::new("t", config);
 
         let att = wcore_channels::event::Attachment {
@@ -416,8 +419,7 @@ mod tests {
         };
         let bytes = ch.fetch_media(&att).await.unwrap();
         assert_eq!(bytes, b"SIGBYTES");
-
-        let _ = std::fs::remove_file(dir.join("att-id-1"));
+        // No manual cleanup: `tmp` (TempDir) removes the directory on drop.
     }
 
     #[tokio::test]


### PR DESCRIPTION
Fixes #191.

`fetch_media_reads_local_attachment_by_id` used a fixed shared path `std::env::temp_dir().join("wcore_signal_fetch_media_test")`. Two concurrent workspace-suite runs on one machine collide: one run's `remove_file` cleanup deletes the other's fixture (found during #190; same class as the uid_store/offset_store fix there).

Switch to `tempfile::TempDir` (unique per-process, auto-removed on drop) and add the `tempfile` dev-dependency. Test-only; no production paths.

Verified on Hetzner (1.95.0): `cargo clippy -p wcore-channel-signal --all-targets -- -D warnings` clean; `cargo test -p wcore-channel-signal` = 41 passed / 0 failed (incl. `fetch_media_reads_local_attachment_by_id`).