### PR TITLE
test(telegram): unique channel names isolate longpoll offset stores

### DIFF
--- a/crates/wcore-channel-telegram/src/lib.rs
+++ b/crates/wcore-channel-telegram/src/lib.rs
@@ -714,7 +714,12 @@ mod tests {
             .await;
 
         let creds = InMemoryCreds::with_token("telegram.test.bot_token", TEST_TOKEN);
-        let mut ch = TelegramChannel::with_api_base("test", cfg(), creds, server.url());
+        // Unique channel name → unique offset-store file, so this test's offset
+        // watermark can't collide with another telegram test under the shared
+        // process-wide WAYLAND_HOME (`cargo test` runs the whole crate's tests
+        // in ONE process; the pid-unique WAYLAND_HOME is then shared by all of
+        // them, and offset_store keys only on the channel name — #210).
+        let mut ch = TelegramChannel::with_api_base("longpoll-ingest", cfg(), creds, server.url());
         ch.start().await.unwrap();
 
         // Wait until the long-poll task has pushed the message.
@@ -770,7 +775,9 @@ mod tests {
             .await;
 
         let creds = InMemoryCreds::with_token("telegram.test.bot_token", TEST_TOKEN);
-        let mut ch = TelegramChannel::with_api_base("test", cfg(), creds, server.url());
+        // Unique channel name → unique offset-store file, isolated from the
+        // other longpoll test under the shared process WAYLAND_HOME (#210).
+        let mut ch = TelegramChannel::with_api_base("longpoll-advance", cfg(), creds, server.url());
         ch.start().await.unwrap();
 
         // Wait until we see the second call hit with offset=43.


### PR DESCRIPTION
Fixes #210.

Under `cargo test --workspace` the whole crate's tests run in ONE process, so the pid-unique `WAYLAND_HOME` that `cfg()` sets (via `Once`) is shared by all of them. `offset_store` keys its state file only on the channel name, so the two long-poll tests — both using channel `"test"` — shared a single offset file. When one advanced the getUpdates watermark, the other's first `getUpdates` no longer matched the `offset=0` mock → `expected a MessageReceived event` (the 2/64 Linux failures; timing-masked on macOS, and green under nextest since it isolates one process per test).

Give each offset-writing test a unique channel name (`longpoll-ingest` / `longpoll-advance`) → unique offset file → no cross-test collision. Test-only.

Verified on Hetzner (1.95.0): `cargo clippy -p wcore-channel-telegram --all-targets -- -D warnings` clean; `cargo test -p wcore-channel-telegram` = **64/64 on 4 consecutive runs** (previously flaked 1–2/64).