### PR TITLE
feat(acp): bind selected persona to the session engine (persona PR-4)

### DIFF
--- a/crates/wcore-acp/src/server.rs
+++ b/crates/wcore-acp/src/server.rs
@@ -365,6 +365,12 @@ impl HttpHandler for AcpServer {
             req.tools
         };
 
+        // persona-profiles PR-4': carry the session's AUTHORIZED persona-agent id
+        // into the turn so the engine bridge can apply that persona's overlay.
+        // Read from the session record (NOT from the request body) — a per-message
+        // body can never smuggle in a persona that was not authorized at create.
+        let agent = self.session_agent(&req.session_id).await;
+
         match &self.turn_engine {
             Some(engine) => {
                 engine
@@ -372,6 +378,7 @@ impl HttpHandler for AcpServer {
                         session_id: req.session_id,
                         text: req.text,
                         tools,
+                        agent,
                     })
                     .await
             }

--- a/crates/wcore-acp/src/turn.rs
+++ b/crates/wcore-acp/src/turn.rs
@@ -65,6 +65,20 @@ pub struct TurnRequest {
     /// session's configured allowlist (or the engine's full registry when
     /// the session record carries none).
     pub tools: Vec<ToolDefinition>,
+    /// persona-profiles PR-4' — the AUTHORIZED persona-agent id this session was
+    /// created with (`None` = no persona: the engine behaves exactly as before).
+    ///
+    /// Only the opaque ID travels here. The persona's `system_prompt`/`model`/
+    /// `allowed_tools` live in the CLI layer's manifest and are resolved THERE —
+    /// deliberately never carried through `wcore-acp`, so the transport crate
+    /// stays free of identity sources and a prompt/capability can never be
+    /// serialized onto the wire.
+    ///
+    /// The id was validated against the authorized roster at `session/create`
+    /// (unknown/unauthorized ⇒ `AgentNotFound`), so an engine bridge may treat a
+    /// `Some(id)` here as already-authorized — but it MUST still resolve it
+    /// through the same authorized set (fail closed) rather than trusting it.
+    pub agent: Option<String>,
 }
 
 /// Turns one user prompt into a stream of [`MessageEvent`]s.
@@ -181,6 +195,7 @@ mod tests {
             session_id: "s1".to_string(),
             text: "go".to_string(),
             tools: Vec::new(),
+            agent: None,
         };
         let frames: Vec<MessageEvent> = Arc::new(engine)
             .run_turn(req)
@@ -221,6 +236,7 @@ mod tests {
             session_id: "s1".to_string(),
             text: "go".to_string(),
             tools: Vec::new(),
+            agent: None,
         };
         let frames: Vec<MessageEvent> = Arc::new(engine)
             .run_turn(req)

--- a/crates/wcore-acp/tests/approval_gate.rs
+++ b/crates/wcore-acp/tests/approval_gate.rs
@@ -58,6 +58,7 @@ fn turn_req() -> TurnRequest {
         session_id: "s1".to_string(),
         text: "write the probe".to_string(),
         tools: Vec::new(),
+        agent: None,
     }
 }
 

--- a/crates/wcore-agent/src/bootstrap.rs
+++ b/crates/wcore-agent/src/bootstrap.rs
@@ -171,6 +171,13 @@ pub struct AgentBootstrap {
     /// shell tools. `None` (the default, and always the case for the local
     /// CLI / TUI / json-stream engines) leaves the full toolset intact.
     channel_tool_posture: Option<crate::channel_tools::ChannelToolScope>,
+    /// persona-profiles PR-4' — restrict this engine's toolset to a persona's
+    /// declared `allowed_tools`. `None` (every pre-existing caller) leaves the
+    /// toolset untouched. Applied with the SAME `registry.retain` mechanism the
+    /// channel posture uses, so a persona can only ever NARROW the toolset —
+    /// never widen it, and never grant auto-approval (that is
+    /// `[tools] allow_list`, a different and deliberately untouched knob).
+    persona_tool_allowlist: Option<Vec<String>>,
     /// wayland#551 — skip the config-declared MCP `connect_all` during
     /// build so slow/hung servers cannot gate boot. The caller owns
     /// connecting them afterwards (json-stream does it in the background
@@ -202,6 +209,7 @@ impl AgentBootstrap {
             without_channels: false,
             enable_inbound_dispatch: false,
             channel_tool_posture: None,
+            persona_tool_allowlist: None,
             defer_config_mcp: false,
             active_assistant: None,
         }
@@ -241,6 +249,22 @@ impl AgentBootstrap {
     /// [`crate::channel_tools::apply_posture`].
     pub fn channel_tool_posture(mut self, scope: crate::channel_tools::ChannelToolScope) -> Self {
         self.channel_tool_posture = Some(scope);
+        self
+    }
+
+    /// persona-profiles PR-4' — restrict the toolset to a persona's declared
+    /// `allowed_tools` (from its `AgentManifest`). An EMPTY list is treated as
+    /// "no restriction declared" and leaves the toolset intact.
+    ///
+    /// This can only NARROW the registry (it is a `retain`), so a persona can
+    /// never gain a tool the engine would not otherwise have. It deliberately
+    /// does NOT touch `[tools] allow_list` — that is the AUTO-APPROVE list, and
+    /// mapping a persona's capability list onto it would silently auto-approve
+    /// destructive tools (Bash/Write) instead of merely making them available.
+    pub fn tool_allowlist(mut self, allowed: Vec<String>) -> Self {
+        if !allowed.is_empty() {
+            self.persona_tool_allowlist = Some(allowed);
+        }
         self
     }
 
@@ -2129,6 +2153,20 @@ impl AgentBootstrap {
                 posture = ?scope.posture,
                 sandbox_enforces_read_deny = enforces,
                 "channel engine tool posture applied"
+            );
+        }
+
+        // persona-profiles PR-4' — narrow the toolset to the selected persona's
+        // declared `allowed_tools`. Same `retain` mechanism as the channel
+        // posture above, and applied AFTER it so a persona composes with (and can
+        // only further narrow) any posture already in force — it can never
+        // re-widen a restricted channel engine.
+        if let Some(allowed) = &self.persona_tool_allowlist {
+            registry.retain(|t| allowed.iter().any(|a| a == t.name()));
+            tracing::info!(
+                target: "wcore_agent::bootstrap",
+                allowed = ?allowed,
+                "persona tool allowlist applied"
             );
         }
 

--- a/crates/wcore-cli/src/acp.rs
+++ b/crates/wcore-cli/src/acp.rs
@@ -213,29 +213,44 @@ async fn serve(args: AcpServeArgs) -> anyhow::Result<()> {
             args.bind
         );
     }
-    let turn_engine = Arc::new(
-        crate::acp_engine::EngineTurnEngine::new(config.clone(), cwd.clone())
-            .force_tools(args.allow_all_tools),
-    );
-    let a2a = Arc::new(crate::acp_engine::EngineA2aHandler::new(
-        agent_id, config, cwd,
-    ));
-    // persona-profiles Phase A (PR-3'): install the trusted persona-agent roster
-    // ONLY when the operator opts in. Feature default-OFF — with no roster
-    // installed the server keeps its pre-persona behaviour exactly (empty
-    // `agents/list`, `AgentNotFound` for any selector).
-    let mut acp_server = AcpServer::new()
-        .with_a2a_handler(a2a)
-        .with_turn_engine(turn_engine);
-    if args.enable_agent_selection {
-        let roster = crate::acp_roster::CliAgentRoster::from_trusted_sources();
+    // persona-profiles Phase A: build the trusted persona-agent roster ONLY when
+    // the operator opts in. Feature default-OFF — with no roster the server keeps
+    // its pre-persona behaviour exactly (empty `agents/list`, `AgentNotFound` for
+    // any selector, and no persona is resolvable by the engine).
+    //
+    // ONE roster instance is shared by the server (which AUTHORIZES a selector at
+    // session/create) and the turn engine (which RESOLVES that id to the persona
+    // overlay). Sharing the instance is the invariant that makes "what you may
+    // select" and "what may be applied to your engine" the same set — two rosters
+    // could drift and become an authz bypass.
+    let roster = if args.enable_agent_selection {
+        let r = crate::acp_roster::CliAgentRoster::from_trusted_sources();
         eprintln!(
             "wayland-core acp: persona-agent selection ENABLED — {} trusted agent(s) \
              selectable (AgentPack + global operator YAML; project manifests and \
              isolated profiles are never enumerated).",
-            roster.len()
+            r.len()
         );
-        acp_server = acp_server.with_roster(Arc::new(roster));
+        Some(Arc::new(r))
+    } else {
+        None
+    };
+
+    let mut engine = crate::acp_engine::EngineTurnEngine::new(config.clone(), cwd.clone())
+        .force_tools(args.allow_all_tools);
+    if let Some(r) = &roster {
+        engine = engine.with_roster(Arc::clone(r));
+    }
+    let turn_engine = Arc::new(engine);
+
+    let a2a = Arc::new(crate::acp_engine::EngineA2aHandler::new(
+        agent_id, config, cwd,
+    ));
+    let mut acp_server = AcpServer::new()
+        .with_a2a_handler(a2a)
+        .with_turn_engine(turn_engine);
+    if let Some(r) = roster {
+        acp_server = acp_server.with_roster(r);
     }
     let server = Arc::new(acp_server);
 

--- a/crates/wcore-cli/src/acp_engine.rs
+++ b/crates/wcore-cli/src/acp_engine.rs
@@ -718,6 +718,15 @@ pub struct EngineTurnEngine {
     /// client-bound approval channel is a tracked follow-up). When on, the
     /// API key is root-equivalent and the operator opted into that.
     force_tools: bool,
+    /// persona-profiles PR-4' — the SAME authorized roster the ACP server is
+    /// wired with. Resolves a session's selected persona id to its overlay
+    /// (system_prompt / model / max_turns / allowed_tools).
+    ///
+    /// It MUST be the same `CliAgentRoster` instance the server authorizes
+    /// against, so "what you may select" and "what may be applied to your engine"
+    /// cannot drift apart. `None` (no `--enable-agent-selection`) ⇒ no persona is
+    /// ever resolvable and the engine behaves exactly as before.
+    roster: Option<Arc<crate::acp_roster::CliAgentRoster>>,
 }
 
 impl EngineTurnEngine {
@@ -731,6 +740,7 @@ impl EngineTurnEngine {
             sessions: Arc::new(AsyncMutex::new(HashMap::new())),
             provider: None,
             force_tools: false,
+            roster: None,
         }
     }
 
@@ -741,6 +751,47 @@ impl EngineTurnEngine {
     pub fn force_tools(mut self, on: bool) -> Self {
         self.force_tools = on;
         self
+    }
+
+    /// persona-profiles PR-4' — install the authorized persona roster (the SAME
+    /// instance the `AcpServer` is given) so a session's selected persona can be
+    /// resolved to its overlay. Without this, no persona is resolvable.
+    pub fn with_roster(mut self, roster: Arc<crate::acp_roster::CliAgentRoster>) -> Self {
+        self.roster = Some(roster);
+        self
+    }
+
+    /// persona-profiles PR-4' — the engine inputs for a session's persona.
+    ///
+    /// Returns the (possibly overlaid) [`Config`] plus the persona's declared
+    /// tool allowlist. When `agent` is `None`, or no roster is installed, or the
+    /// id does not resolve in the AUTHORIZED set (fail closed), this is exactly
+    /// the base config with no allowlist — byte-identical to pre-persona
+    /// behaviour.
+    ///
+    /// The overlay is PROMPT / MODEL / LIMITS only. It deliberately does not
+    /// touch `WAYLAND_HOME`, API keys, or the egress policy: those are
+    /// process-global credential identity, and swapping them per session is the
+    /// credential-bleed the design forbids. True per-profile isolation is the
+    /// supervisor (one process per profile), not this overlay.
+    fn engine_inputs_for(&self, agent: Option<&str>) -> (Config, Vec<String>) {
+        let Some(manifest) = agent
+            .and_then(|id| self.roster.as_ref().map(|r| (id, r)))
+            .and_then(|(id, r)| r.resolve(id))
+        else {
+            return (self.config.clone(), Vec::new());
+        };
+
+        let mut config = self.config.clone();
+        config.system_prompt = Some(manifest.system_prompt.clone());
+        if let Some(model) = manifest.model.clone() {
+            config.model = model;
+        }
+        if let Some(max_turns) = manifest.max_turns {
+            // AgentManifest carries u32; Config carries usize.
+            config.max_turns = Some(max_turns as usize);
+        }
+        (config, manifest.allowed_tools.clone())
     }
 
     /// Test/embedding seam: build a turn engine with a pre-created provider,
@@ -757,6 +808,10 @@ impl EngineTurnEngine {
             cwd,
             sessions: Arc::new(AsyncMutex::new(HashMap::new())),
             provider: Some(provider),
+            // No persona roster on the embedding/test seam: personas are an
+            // operator-enabled ACP-serve feature, so a hermetic engine resolves
+            // no persona (fail closed).
+            roster: None,
             // Embedding/test seam: the caller is in-process and trusted, so
             // tools auto-approve (hermetic turn tests drive real tool flow).
             force_tools: true,
@@ -765,7 +820,21 @@ impl EngineTurnEngine {
 
     /// Fetch (or build + cache) the `EngineSession` for `session_id`. One
     /// engine per session preserves conversation history across turns.
-    async fn session_for(&self, session_id: &str) -> Result<Arc<EngineSession>, AcpError> {
+    ///
+    /// persona-profiles PR-4': `agent` is the session's AUTHORIZED persona id (or
+    /// `None`). The persona is bound at BUILD time — the engine cached for this
+    /// session id is constructed WITH that persona's overlay. This is load-bearing:
+    /// the pool is keyed by session id and a session's persona is fixed for its
+    /// lifetime, so a cached engine always carries the persona it was created
+    /// with, and two sessions with different personas get different engines. (If
+    /// the overlay were applied per-turn instead, the first session to build an
+    /// engine would silently impose its persona on every later session — an
+    /// identity/security bug.)
+    async fn session_for(
+        &self,
+        session_id: &str,
+        agent: Option<&str>,
+    ) -> Result<Arc<EngineSession>, AcpError> {
         {
             let pool = self.sessions.lock().await;
             if let Some(existing) = pool.get(session_id) {
@@ -802,8 +871,14 @@ impl EngineTurnEngine {
             approval_manager.set_mode(wcore_protocol::commands::SessionMode::Force);
         }
 
+        // persona-profiles PR-4': resolve this session's persona (if any) to its
+        // config overlay + declared tool allowlist. Fails CLOSED — an id that is
+        // not in the authorized roster yields the base config and no allowlist.
+        let (session_config, persona_tools) = self.engine_inputs_for(agent);
+
         let output: Arc<dyn OutputSink> = Arc::new(RelaySink::new(relay.clone()));
-        let mut bootstrap = AgentBootstrap::new(self.config.clone(), self.cwd.clone(), output);
+        let mut bootstrap = AgentBootstrap::new(session_config.clone(), self.cwd.clone(), output)
+            .tool_allowlist(persona_tools);
         if let Some(provider) = &self.provider {
             bootstrap = bootstrap.provider(provider.clone());
         }
@@ -813,7 +888,7 @@ impl EngineTurnEngine {
             .map_err(|e| AcpError::Protocol(format!("engine bootstrap failed: {e}")))?;
         let mut engine = result.engine;
 
-        let provider_name = self.config.provider_label.clone();
+        let provider_name = session_config.provider_label.clone();
         engine
             .init_session(&provider_name, &self.cwd, Some(session_id))
             .map_err(|e| AcpError::Protocol(format!("engine init_session failed: {e}")))?;
@@ -848,7 +923,10 @@ impl TurnEngine for EngineTurnEngine {
         // applied to the engine build in this MVP (documented follow-up); the
         // engine's full registry is the faithful default.
         let _ = &req.tools;
-        let session = self.session_for(&req.session_id).await?;
+        // persona-profiles PR-4': bind THIS session's authorized persona (None = none).
+        let session = self
+            .session_for(&req.session_id, req.agent.as_deref())
+            .await?;
         let msg_id = uuid::Uuid::new_v4().to_string();
         Ok(session.run_turn(req.text, msg_id).await)
     }
@@ -962,7 +1040,8 @@ impl EngineA2aHandler {
     /// session keyed on the agent id (the first build wins) and reads its
     /// registered tools.
     async fn tool_catalog(&self) -> Vec<String> {
-        match self.inner.session_for(&self.agent_id).await {
+        // A2A federation carries no ACP persona selector — no overlay.
+        match self.inner.session_for(&self.agent_id, None).await {
             Ok(session) => session.tool_names(),
             Err(_) => Vec::new(),
         }
@@ -1011,7 +1090,7 @@ impl A2aHandler for EngineA2aHandler {
         };
         let session = self
             .inner
-            .session_for(&session_id)
+            .session_for(&session_id, None)
             .await
             .map_err(|e| A2aError::HandlerError(e.to_string()))?;
         let msg_id = uuid::Uuid::new_v4().to_string();
@@ -1688,6 +1767,133 @@ mod tests {
         assert!(
             matches!(err, AcpError::Session(_)),
             "re-resolving a consumed gate is idempotent not-found, got {err:?}"
+        );
+    }
+
+    // ── persona-profiles PR-4': per-session persona overlay ───────────────
+    //
+    // The security decision lives in `engine_inputs_for`: it alone decides
+    // whether a persona overlay is applied and what it contains. These pin it.
+
+    fn persona_roster(dir: &std::path::Path) -> Arc<crate::acp_roster::CliAgentRoster> {
+        Arc::new(crate::acp_roster::CliAgentRoster::from_pack_and_global_dir(
+            dir,
+        ))
+    }
+
+    fn write_persona(dir: &std::path::Path, name: &str, prompt: &str, model: &str, tools: &[&str]) {
+        std::fs::create_dir_all(dir).unwrap();
+        let tools_yaml: String = tools.iter().map(|t| format!("  - {t}\n")).collect();
+        std::fs::write(
+            dir.join(format!("{name}.yaml")),
+            format!(
+                "name: {name}\ndescription: d\nsystem_prompt: \"{prompt}\"\nmodel: {model}\nallowed_tools:\n{tools_yaml}"
+            ),
+        )
+        .unwrap();
+    }
+
+    /// No persona selected ⇒ base config, no allowlist: byte-identical to the
+    /// pre-persona engine.
+    #[test]
+    fn no_agent_leaves_the_engine_inputs_untouched() {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = EngineTurnEngine::new(placeholder_config(), ".".to_string())
+            .with_roster(persona_roster(dir.path()));
+        let (cfg, tools) = engine.engine_inputs_for(None);
+        assert_eq!(cfg.system_prompt, placeholder_config().system_prompt);
+        assert_eq!(cfg.model, placeholder_config().model);
+        assert!(tools.is_empty());
+    }
+
+    /// FAIL CLOSED: an id outside the AUTHORIZED roster applies no overlay. A
+    /// hostile/unknown id can never inject a system_prompt into an engine.
+    #[test]
+    fn unauthorized_agent_applies_no_overlay() {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = EngineTurnEngine::new(placeholder_config(), ".".to_string())
+            .with_roster(persona_roster(dir.path()));
+        let (cfg, tools) = engine.engine_inputs_for(Some("not-in-the-roster"));
+        assert_eq!(cfg.system_prompt, placeholder_config().system_prompt);
+        assert!(tools.is_empty());
+    }
+
+    /// Feature default-OFF: with NO roster installed even a real pack id is inert.
+    #[test]
+    fn no_roster_installed_means_no_persona_is_resolvable() {
+        let engine = EngineTurnEngine::new(placeholder_config(), ".".to_string());
+        let (cfg, tools) = engine.engine_inputs_for(Some("architect"));
+        assert_eq!(cfg.system_prompt, placeholder_config().system_prompt);
+        assert!(tools.is_empty());
+    }
+
+    /// A selected persona overlays prompt + model and carries its declared
+    /// tool allowlist through to the bootstrap.
+    #[test]
+    fn selected_persona_overlays_prompt_model_and_tools() {
+        let dir = tempfile::tempdir().unwrap();
+        write_persona(
+            dir.path(),
+            "opsbot",
+            "YOU ARE OPS",
+            "test-model-x",
+            &["Read", "Grep"],
+        );
+        let engine = EngineTurnEngine::new(placeholder_config(), ".".to_string())
+            .with_roster(persona_roster(dir.path()));
+        let (cfg, tools) = engine.engine_inputs_for(Some("opsbot"));
+        assert_eq!(cfg.system_prompt.as_deref(), Some("YOU ARE OPS"));
+        assert_eq!(cfg.model, "test-model-x");
+        assert_eq!(tools, vec!["Read".to_string(), "Grep".to_string()]);
+    }
+
+    /// THE landmine test. Two sessions selecting DIFFERENT personas must never
+    /// share an overlay. The engine pool is keyed by session id and the persona
+    /// is bound at engine-BUILD time, so each session's inputs are independent —
+    /// if the overlay were computed once and reused, the first session would
+    /// silently impose its persona on every later one (identity/security bug).
+    #[test]
+    fn two_personas_never_share_an_overlay() {
+        let dir = tempfile::tempdir().unwrap();
+        write_persona(dir.path(), "alpha", "I AM ALPHA", "model-a", &["Read"]);
+        write_persona(dir.path(), "beta", "I AM BETA", "model-b", &["Grep"]);
+        let engine = EngineTurnEngine::new(placeholder_config(), ".".to_string())
+            .with_roster(persona_roster(dir.path()));
+
+        let (a, a_tools) = engine.engine_inputs_for(Some("alpha"));
+        let (b, b_tools) = engine.engine_inputs_for(Some("beta"));
+
+        assert_eq!(a.system_prompt.as_deref(), Some("I AM ALPHA"));
+        assert_eq!(b.system_prompt.as_deref(), Some("I AM BETA"));
+        assert_ne!(a.system_prompt, b.system_prompt);
+        assert_ne!(a.model, b.model);
+        assert_eq!(a_tools, vec!["Read".to_string()]);
+        assert_eq!(b_tools, vec!["Grep".to_string()]);
+    }
+
+    /// The overlay is PROMPT/MODEL/LIMITS only — it must NEVER re-point the
+    /// process's credential identity. Swapping creds per session is exactly the
+    /// credential-bleed the design forbids (true per-profile isolation is the
+    /// supervisor: one process per profile).
+    #[test]
+    fn persona_overlay_never_touches_credential_identity() {
+        let dir = tempfile::tempdir().unwrap();
+        write_persona(dir.path(), "opsbot", "ops", "m", &["Read"]);
+        let engine = EngineTurnEngine::new(placeholder_config(), ".".to_string())
+            .with_roster(persona_roster(dir.path()));
+        let base = placeholder_config();
+        let (cfg, _) = engine.engine_inputs_for(Some("opsbot"));
+        assert_eq!(
+            cfg.api_key, base.api_key,
+            "persona must not swap the API key"
+        );
+        assert_eq!(
+            cfg.provider_label, base.provider_label,
+            "persona must not swap the provider identity"
+        );
+        assert_eq!(
+            cfg.base_url, base.base_url,
+            "persona must not repoint the provider endpoint"
         );
     }
 }

--- a/crates/wcore-cli/src/acp_roster.rs
+++ b/crates/wcore-cli/src/acp_roster.rs
@@ -62,10 +62,20 @@ use wcore_plugin_api::agent_manifest::AgentManifest;
 /// operator's global agent YAML). See the module docs for the trust model.
 #[derive(Debug, Clone, Default)]
 pub struct CliAgentRoster {
-    /// Precomputed authorized set, keyed by id for stable ordering. Snapshotted
-    /// at construction: enumeration is a startup concern, and a fixed snapshot
-    /// means a mid-session filesystem change cannot silently widen the roster.
-    agents: Vec<AgentInfo>,
+    /// THE authorized set — the single source of truth, keyed by id (BTreeMap ⇒
+    /// deterministic, sorted enumeration). Snapshotted at construction: a
+    /// mid-session filesystem change cannot silently widen the roster.
+    ///
+    /// The full [`AgentManifest`] is retained (not just the wire-safe
+    /// [`AgentInfo`]) because PR-4' must resolve a selected id to that persona's
+    /// overlay (system_prompt/model/allowed_tools) SERVER-SIDE. Storing both
+    /// views in one map is deliberate: `list()`, `contains()` and `resolve()` all
+    /// answer from THIS map, so an id that is not enumerable/selectable can never
+    /// be resolved to an overlay (fail closed — no divergence to bypass).
+    ///
+    /// The manifest NEVER leaves this crate: only [`Self::to_info`]'s wire-safe
+    /// projection is handed to `wcore-acp`.
+    by_id: BTreeMap<String, AgentManifest>,
 }
 
 impl CliAgentRoster {
@@ -85,12 +95,11 @@ impl CliAgentRoster {
     /// project-supplied agents dir could be threaded in.
     pub fn from_pack_and_global_dir(global_agents_dir: &Path) -> Self {
         // BTreeMap ⇒ deterministic, sorted-by-id output.
-        let mut by_id: BTreeMap<String, AgentInfo> = BTreeMap::new();
+        let mut by_id: BTreeMap<String, AgentManifest> = BTreeMap::new();
 
         // 1. Compiled-in personas (trusted by construction).
         for manifest in AgentPack::list() {
-            let info = Self::to_info(&manifest);
-            by_id.insert(info.id.clone(), info);
+            by_id.insert(manifest.name.clone(), manifest);
         }
 
         // 2. Operator-authored global YAML. Loaded through the registry so we
@@ -108,16 +117,30 @@ impl CliAgentRoster {
                 continue;
             }
             if let Some(manifest) = registry.get(&name) {
-                let info = Self::to_info(&manifest);
                 // Operator's own YAML intentionally overrides a same-named
                 // built-in: it is the more specific, operator-authored source.
-                by_id.insert(info.id.clone(), info);
+                // Both sides are TRUSTED, so this is not an escalation path (a
+                // project source is never in this map at all).
+                by_id.insert(manifest.name.clone(), manifest);
             }
         }
 
-        Self {
-            agents: by_id.into_values().collect(),
-        }
+        Self { by_id }
+    }
+
+    /// persona-profiles PR-4' — resolve an AUTHORIZED id to its persona overlay
+    /// (system_prompt / model / allowed_tools / max_turns).
+    ///
+    /// SERVER-SIDE ONLY. The returned [`AgentManifest`] must never be serialized
+    /// or handed to `wcore-acp` — only [`Self::to_info`]'s projection crosses the
+    /// wire (R4).
+    ///
+    /// FAIL CLOSED: this reads the SAME `by_id` map that `list()`/`contains()`
+    /// answer from, so an id that is not enumerable/selectable resolves to `None`
+    /// and NO overlay is ever applied. There is deliberately no second lookup
+    /// path (a divergent resolver is exactly how an authz bypass is born).
+    pub fn resolve(&self, id: &str) -> Option<AgentManifest> {
+        self.by_id.get(id).cloned()
     }
 
     /// The ONE manifest → wire mapping. R4: drops `system_prompt`, `model`,
@@ -137,19 +160,22 @@ impl CliAgentRoster {
 
     /// Number of authorized agents (tests + observability).
     pub fn len(&self) -> usize {
-        self.agents.len()
+        self.by_id.len()
     }
 
     /// Whether the authorized roster is empty.
     pub fn is_empty(&self) -> bool {
-        self.agents.is_empty()
+        self.by_id.is_empty()
     }
 }
 
 #[async_trait]
 impl AgentRoster for CliAgentRoster {
     async fn list(&self) -> Result<Vec<AgentInfo>, AcpError> {
-        Ok(self.agents.clone())
+        // Projected from the SAME map `resolve()` reads ⇒ what is enumerable is
+        // exactly what is selectable is exactly what is resolvable. R4: only the
+        // wire-safe projection escapes; the manifest never does.
+        Ok(self.by_id.values().map(Self::to_info).collect())
     }
     // `contains` uses the trait default, which answers from `list` — so the
     // authz gate applied above governs selector admission too (R3). No override:
@@ -178,11 +204,11 @@ mod tests {
         assert!(!pack_names.is_empty(), "AgentPack should ship personas");
         for name in &pack_names {
             assert!(
-                roster.agents.iter().any(|a| &a.id == name),
+                roster.by_id.contains_key(name),
                 "AgentPack persona {name} missing from roster"
             );
         }
-        assert!(roster.agents.iter().all(|a| !a.id.is_empty()));
+        assert!(roster.by_id.keys().all(|id| !id.is_empty()));
     }
 
     /// Operator-authored global YAML is enumerated alongside the pack.
@@ -193,11 +219,13 @@ mod tests {
         let roster = CliAgentRoster::from_pack_and_global_dir(dir.path());
 
         let ops = roster
-            .agents
-            .iter()
-            .find(|a| a.id == "opsbot")
+            .resolve("opsbot")
             .expect("global operator agent should be enumerated");
-        assert_eq!(ops.description.as_deref(), Some("desc for opsbot"));
+        assert_eq!(ops.description, "desc for opsbot");
+        assert_eq!(
+            CliAgentRoster::to_info(&ops).description.as_deref(),
+            Some("desc for opsbot")
+        );
     }
 
     /// SECURITY (untrusted project content): an agent manifest sitting in a
@@ -215,18 +243,24 @@ mod tests {
         let roster = CliAgentRoster::from_pack_and_global_dir(global.path());
 
         assert!(
-            roster.agents.iter().any(|a| a.id == "trusted-global"),
+            roster.by_id.contains_key("trusted-global"),
             "trusted global agent should be present"
         );
         assert!(
-            !roster.agents.iter().any(|a| a.id == "evil-project"),
+            !roster.by_id.contains_key("evil-project"),
             "project-supplied agent MUST NOT be enumerated"
         );
-        // And it is not admissible as a selector either (R3: unknown == not
-        // authorized == false, via the trait's `contains` default).
+        // Not admissible as a selector either (R3: unknown == not authorized ==
+        // false, via the trait's `contains` default).
         assert!(
             !roster.contains("evil-project").await,
             "project-supplied agent MUST NOT be selectable"
+        );
+        // PR-4' fail-closed: and it can NEVER be resolved to a persona overlay,
+        // so its attacker-controlled system_prompt can never reach an engine.
+        assert!(
+            roster.resolve("evil-project").is_none(),
+            "project-supplied agent MUST NOT resolve to an overlay"
         );
     }
 
@@ -292,14 +326,15 @@ mod tests {
 
     /// Deterministic, sorted output — a roster that reorders per call would make
     /// clients' agent lists flap.
-    #[test]
-    fn roster_is_sorted_and_deduped() {
+    #[tokio::test]
+    async fn roster_is_sorted_and_deduped() {
         let dir = tempfile::tempdir().unwrap();
         write_agent_yaml(dir.path(), "zzz-last", "z");
         write_agent_yaml(dir.path(), "aaa-first", "a");
         let roster = CliAgentRoster::from_pack_and_global_dir(dir.path());
 
-        let ids: Vec<&str> = roster.agents.iter().map(|a| a.id.as_str()).collect();
+        let listed = roster.list().await.unwrap();
+        let ids: Vec<&str> = listed.iter().map(|a| a.id.as_str()).collect();
         let mut sorted = ids.clone();
         sorted.sort_unstable();
         assert_eq!(ids, sorted, "roster must be sorted by id");
@@ -307,5 +342,37 @@ mod tests {
         let mut uniq = ids.clone();
         uniq.dedup();
         assert_eq!(ids.len(), uniq.len(), "roster must not contain duplicates");
+    }
+
+    /// PR-4' core invariant: what is ENUMERABLE == what is SELECTABLE == what is
+    /// RESOLVABLE. Any divergence between these three is an authz bypass (an id
+    /// you cannot see but can still bind a persona from, or vice-versa).
+    #[tokio::test]
+    async fn list_contains_and_resolve_never_diverge() {
+        let dir = tempfile::tempdir().unwrap();
+        write_agent_yaml(dir.path(), "opsbot", "ops");
+        let roster = CliAgentRoster::from_pack_and_global_dir(dir.path());
+
+        for info in roster.list().await.unwrap() {
+            assert!(
+                roster.contains(&info.id).await,
+                "listed agent {} must be selectable",
+                info.id
+            );
+            assert!(
+                roster.resolve(&info.id).is_some(),
+                "listed agent {} must be resolvable",
+                info.id
+            );
+        }
+        // And the converse: an id that is not listed is neither selectable nor
+        // resolvable (fail closed).
+        for id in ["", "nope", "../escape", "OPSBOT"] {
+            assert!(!roster.contains(id).await, "{id} must not be selectable");
+            assert!(
+                roster.resolve(id).is_none(),
+                "{id} must not resolve to an overlay"
+            );
+        }
     }
 }

--- a/crates/wcore-cli/tests/acp_engine_turn.rs
+++ b/crates/wcore-cli/tests/acp_engine_turn.rs
@@ -81,6 +81,7 @@ async fn acp_turn_streams_text_then_done() {
             session_id: "11111111-2222-3333-4444-aaaaaaaaaaaa".to_string(),
             text: "say hi".to_string(),
             tools: Vec::new(),
+            agent: None,
         })
         .await
         .expect("run_turn establishes a stream");


### PR DESCRIPTION
Fourth step of the persona-profiles stack (follows #202 types, #206 roster trait, #213 enumeration).
Makes a selected persona actually *do something*: the agent chosen at `session/create` overlays the
engine inputs for that session — **one engine, one profile**, no in-process multi-tenancy.

## Design (the safe seam)
- ONE `Arc<CliAgentRoster>` is shared by both the server (which **authorizes** the selector) and the
  engine (which **resolves** the overlay) — so list/contains/resolve cannot disagree.
- Persona is read from the **session record**, not the request body (`server.rs` `send_message`), so a
  turn cannot smuggle a different persona than the one authorized at session creation.
- Persona is bound at engine **BUILD** time (`session_for`), not per turn. The engine pool is keyed by
  session id; a per-turn overlay would let the first session silently impose its persona on later ones.
  Pinned by `two_personas_never_share_an_overlay`.
- Single decision point (`engine_inputs_for`): unknown/unauthorized id ⇒ **no overlay at all** (fail closed).

## Three traps this deliberately avoids
1. **`config.tools.allow_list` is the AUTO-APPROVE list, not a registration allowlist** (`config.rs`
   `default_allow_list`: "anything that writes/executes is NOT in this list and still gates"). Mapping a
   persona's `allowed_tools` onto it — the obvious wiring — would **auto-approve Bash/Write** for any
   persona that declares them. We do not touch it.
2. All 13 AgentPack personas *do* declare `allowed_tools`, so "fail closed on non-empty" would have made
   every persona unselectable. The list is honored properly instead.
3. The correct seam already existed: `AgentBootstrap` restricts tools via `registry.retain(...)`. New
   sibling `tool_allowlist()` runs at the same site, **after** channel posture — so it can only NARROW,
   never re-widen a restricted engine. Empty list = no restriction.

## Security (red-team)
- Overlay touches `system_prompt` / `model` / `max_turns` / tool allowlist ONLY. Provider + credential
  resolution branch on `config.provider`/`api_key`/`base_url` and **never** on `config.model`, so the
  model overlay cannot bleed credentials (`persona_overlay_never_touches_credential_identity`).
- Still default-OFF behind `--enable-agent-selection`; no roster ⇒ nothing resolvable.

## Tests (6 new)
`no_agent_leaves_the_engine_inputs_untouched`, `unauthorized_agent_applies_no_overlay`,
`no_roster_installed_means_no_persona_is_resolvable`, `selected_persona_overlays_prompt_model_and_tools`,
`two_personas_never_share_an_overlay`, `persona_overlay_never_touches_credential_identity`.

## Verification (Linux, Hetzner)
`clippy --all-targets -- -D warnings` clean; wcore-acp 91/91; wcore-cli 1602/1602; persona suite 29/29
by name; `cargo fmt --check` clean. Re-verified on the post-#213 main base.