### PR TITLE
feat(acp): serve an isolated profile via `acp serve --profile`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9350,6 +9350,7 @@ dependencies = [
  "chrono",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "toml",

--- a/crates/wcore-cli/src/acp.rs
+++ b/crates/wcore-cli/src/acp.rs
@@ -9,6 +9,7 @@
 //! would all be orphans.
 
 use std::net::SocketAddr;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use clap::{Args, Subcommand};
@@ -86,6 +87,87 @@ pub struct AcpServeArgs {
     /// overlay prompt/model/tools only, never credentials.
     #[arg(long)]
     pub enable_agent_selection: bool,
+
+    /// Serve as an ISOLATED PROFILE — the profile's own home (credentials,
+    /// `.env`, memory, skills, SOUL), and its provider/model from that home's
+    /// own `config.toml`.
+    ///
+    /// This is the supervisor/router spawn primitive: one `acp serve --profile
+    /// <name>` child process PER profile, each with its own `WAYLAND_HOME`, is
+    /// how per-profile identity stays isolated. N profiles are NEVER served
+    /// from one process — that would share this process's global
+    /// `WAYLAND_HOME` / credential / egress singletons across identities.
+    ///
+    /// The home is materialized at process entry by
+    /// `profile::activate_for_launch()` (which scans raw argv, so it sees this
+    /// flag) and becomes `WAYLAND_HOME`. `Config::resolve` then reads that
+    /// home's own `config.toml` for provider/model — so nothing is routed into
+    /// the config-file `[profiles.<name>]` OVERLAY, which is a distinct
+    /// mechanism whose missing-table case hard-errors.
+    ///
+    /// FAILS CLOSED: if the profile is unknown, has no home on disk, or
+    /// disagrees with an explicitly-set `WAYLAND_HOME`, the server refuses to
+    /// start rather than silently falling through to the SHARED DEFAULT home
+    /// and cross-writing another profile's credentials and memory.
+    ///
+    /// `--profile` also works in the GLOBAL position (`wayland-core --profile X
+    /// acp serve`); both positions are validated. This field exists so clap
+    /// accepts and documents the subcommand form — the guard itself reads the
+    /// name from raw argv (see `serve`), which is the single source of truth
+    /// `activate_for_launch` also uses, so the two cannot disagree.
+    #[arg(long, value_name = "NAME")]
+    pub profile: Option<String>,
+}
+
+/// Resolve `--profile` to the isolated home the process is ACTUALLY bound to,
+/// refusing every case where the two could disagree.
+///
+/// `profile::activate_for_launch()` already ran at process entry and either set
+/// `WAYLAND_HOME` to the profile's home, or — when the name is invalid or the
+/// home does not exist — WARNED and fell through to the shared default home.
+/// That fall-through is tolerable for interactive CLI use but NOT for a host
+/// protocol: an ACP server told to serve profile `work` while actually writing
+/// the default home would cross-write another identity's credentials and
+/// memory. This is the same contract `json_stream_profile_guard` (main.rs)
+/// enforces for `--json-stream`; ACP is the same class of surface.
+///
+/// Returns the resolved home on success, or a loud error string to refuse with.
+fn resolve_profile_home(name: &str) -> Result<PathBuf, String> {
+    let dir = wcore_config::profile::profile_dir(name)
+        .map_err(|e| format!("refusing to serve ACP with an invalid --profile {name:?}: {e}"))?;
+
+    if !dir.is_dir() {
+        return Err(format!(
+            "refusing to serve ACP with --profile {name:?}: no profile home at {}. \
+             Without it the server would fall through to the SHARED DEFAULT home and \
+             cross-write another profile's credentials and memory. Create it with \
+             `wayland-core profile create {name}`.",
+            dir.display()
+        ));
+    }
+
+    // `WAYLAND_HOME` is the single source of truth after activation, and an
+    // explicit one always WINS over `--profile` (profile.rs resolution order).
+    // So if it points somewhere else, the flag is a lie about the identity this
+    // process actually serves — refuse rather than serve the wrong home.
+    if let Some(home) = std::env::var_os("WAYLAND_HOME") {
+        let home = PathBuf::from(home);
+        let same = match (home.canonicalize(), dir.canonicalize()) {
+            (Ok(a), Ok(b)) => a == b,
+            _ => home == dir,
+        };
+        if !same {
+            return Err(format!(
+                "refusing to serve ACP: --profile {name:?} resolves to {} but WAYLAND_HOME is {}. \
+                 An explicit WAYLAND_HOME wins over --profile, so this server would serve one \
+                 profile's identity under another's name. Unset one of them.",
+                dir.display(),
+                home.display()
+            ));
+        }
+    }
+
+    Ok(dir)
 }
 
 #[derive(Args, Debug)]
@@ -129,6 +211,47 @@ pub async fn run(args: AcpArgs) -> anyhow::Result<()> {
 const ACP_SERVER_KEY_ACCOUNT: &str = "acp-server-key";
 
 async fn serve(args: AcpServeArgs) -> anyhow::Result<()> {
+    // Bind the isolated profile FIRST — before the bind address is parsed, before
+    // the server's API key is loaded-or-GENERATED into the keychain, before the
+    // config is resolved, and before the egress policy is installed. A refused
+    // profile must have ZERO side effects: if this ran later, `--profile ghost`
+    // (a name with no home) would fall through to the SHARED DEFAULT home, mint
+    // and persist a fresh server key there, and only then refuse. Fails closed —
+    // see `resolve_profile_home`.
+    //
+    // We read the requested profile from RAW ARGV (`requested_profile_from_argv`),
+    // NOT `args.profile`. `--profile` is accepted in two clap positions — global
+    // (`wayland-core --profile X acp serve`) and subcommand (`... acp serve
+    // --profile X`) — and `activate_for_launch` (which binds WAYLAND_HOME at
+    // process entry) honors BOTH via the same argv scan. Reading only the
+    // subcommand field would leave the global position unguarded: activation
+    // would fall through to the default home while this guard saw `None` and
+    // waved it past — serving one identity while writing another's. One argv
+    // source keeps the guard and activation in lockstep by construction.
+    if let Some(name) = wcore_config::profile::requested_profile_from_argv() {
+        let home = resolve_profile_home(&name).map_err(|e| anyhow::anyhow!("{e}"))?;
+        eprintln!(
+            "wayland-core acp: serving isolated profile {name:?} (home {})",
+            home.display()
+        );
+    } else if let Some(unbound) =
+        wcore_config::profile::launch_outcome().and_then(|o| o.unbound_selection)
+    {
+        // No `--profile` flag, but activation selected a profile via the `active`
+        // pointer (`wayland-core profile use <name>`) whose home is absent — so it
+        // fell through to the SHARED DEFAULT home. The flag guard above can't see
+        // this (there is no flag); reason on activation's RESULT instead. Fail
+        // closed: serving now would expose the default identity's credentials and
+        // memory under the selected profile's name. Same class as the flag path.
+        return Err(anyhow::anyhow!(
+            "refusing to serve ACP: the active profile {unbound:?} was selected but has no home \
+             on disk, so this process fell through to the SHARED DEFAULT home. Serving would \
+             expose the default identity's credentials and memory under {unbound:?}. Recreate it \
+             (`wayland-core profile create {unbound}`) or clear the selection \
+             (`wayland-core profile use default`)."
+        ));
+    }
+
     let addr: SocketAddr = args
         .bind
         .parse()
@@ -180,6 +303,15 @@ async fn serve(args: AcpServeArgs) -> anyhow::Result<()> {
         max_tokens: None,
         max_turns: None,
         system_prompt: None,
+        // NOT the profile name. `CliArgs.profile` selects a config-file
+        // `[profiles.<name>]` OVERLAY table — a DIFFERENT mechanism from an
+        // isolated-home profile, and a missing table is a hard error. An
+        // isolated profile carries its provider/model/keys through its OWN
+        // `config.toml`, which `Config::resolve` already reads because
+        // `wayland_config_dir()` honors the `WAYLAND_HOME` that
+        // `activate_for_launch` set from `--profile`. So the overlay is both
+        // redundant here and a footgun (it would abort every profile that
+        // hasn't had a `[profiles.<name>]` table hand-authored).
         profile: None,
         auto_approve: false,
         project_dir: None,
@@ -411,8 +543,113 @@ async fn request(args: AcpRequestArgs) -> anyhow::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
     use std::time::Duration;
     use tokio::net::TcpListener;
+
+    /// Point `profiles_root()` at a scratch dir and clear any inherited
+    /// `WAYLAND_HOME`. Mutates process-global env, hence `#[serial]` on every
+    /// test that calls it.
+    fn with_profiles_root(dir: &std::path::Path) {
+        // SAFETY: these tests are `#[serial]`, so no other test thread is
+        // observing the environment while we mutate it.
+        unsafe {
+            std::env::set_var("WAYLAND_PROFILES_ROOT", dir);
+            std::env::remove_var("WAYLAND_HOME");
+        }
+    }
+
+    fn clear_profile_env() {
+        // SAFETY: as above — serialized.
+        unsafe {
+            std::env::remove_var("WAYLAND_PROFILES_ROOT");
+            std::env::remove_var("WAYLAND_HOME");
+        }
+    }
+
+    /// The happy path: a profile whose home exists resolves to that home.
+    #[test]
+    #[serial]
+    fn existing_profile_resolves_to_its_own_home() {
+        let tmp = tempfile::tempdir().unwrap();
+        with_profiles_root(tmp.path());
+        std::fs::create_dir_all(tmp.path().join("work")).unwrap();
+
+        let home = resolve_profile_home("work").expect("an existing profile resolves");
+        assert_eq!(home, tmp.path().join("work"));
+        clear_profile_env();
+    }
+
+    /// THE CORE GUARD: a profile with no home on disk must REFUSE, not fall
+    /// through to the shared default home. Falling through is what
+    /// cross-writes another identity's credentials and memory.
+    #[test]
+    #[serial]
+    fn missing_profile_home_refuses_instead_of_using_the_default_home() {
+        let tmp = tempfile::tempdir().unwrap();
+        with_profiles_root(tmp.path());
+
+        let err = resolve_profile_home("ghost").expect_err("a missing home must refuse");
+        assert!(
+            err.contains("no profile home"),
+            "the refusal must name the cause; got: {err}"
+        );
+        clear_profile_env();
+    }
+
+    /// An explicit `WAYLAND_HOME` WINS over `--profile` (profile.rs resolution
+    /// order), so a disagreement means the server would serve one identity
+    /// under another's name. Refuse.
+    #[test]
+    #[serial]
+    fn wayland_home_disagreeing_with_the_profile_refuses() {
+        let tmp = tempfile::tempdir().unwrap();
+        with_profiles_root(tmp.path());
+        std::fs::create_dir_all(tmp.path().join("work")).unwrap();
+        let other = tmp.path().join("somewhere-else");
+        std::fs::create_dir_all(&other).unwrap();
+        // SAFETY: serialized.
+        unsafe { std::env::set_var("WAYLAND_HOME", &other) };
+
+        let err = resolve_profile_home("work").expect_err("a mismatched home must refuse");
+        assert!(
+            err.contains("WAYLAND_HOME"),
+            "the refusal must name the conflict; got: {err}"
+        );
+        clear_profile_env();
+    }
+
+    /// The agreeing case is NOT a conflict: activation sets `WAYLAND_HOME` to
+    /// exactly the profile's home, which is the normal supervisor spawn.
+    #[test]
+    #[serial]
+    fn wayland_home_agreeing_with_the_profile_is_accepted() {
+        let tmp = tempfile::tempdir().unwrap();
+        with_profiles_root(tmp.path());
+        let home = tmp.path().join("work");
+        std::fs::create_dir_all(&home).unwrap();
+        // SAFETY: serialized.
+        unsafe { std::env::set_var("WAYLAND_HOME", &home) };
+
+        let got = resolve_profile_home("work").expect("an agreeing home is the normal spawn");
+        assert_eq!(got, home);
+        clear_profile_env();
+    }
+
+    /// A hostile name must never be joined onto the profiles root.
+    #[test]
+    #[serial]
+    fn traversal_name_is_rejected_by_validation() {
+        let tmp = tempfile::tempdir().unwrap();
+        with_profiles_root(tmp.path());
+
+        let err = resolve_profile_home("../../etc").expect_err("traversal must be rejected");
+        assert!(
+            err.contains("invalid --profile"),
+            "the refusal must name it invalid; got: {err}"
+        );
+        clear_profile_env();
+    }
 
     /// End-to-end smoke: `serve` on an ephemeral port, then drive
     /// each `Request` op against it, asserting basic shape.

--- a/crates/wcore-config/src/profile.rs
+++ b/crates/wcore-config/src/profile.rs
@@ -225,20 +225,47 @@ fn profile_flag_from_args(args: impl Iterator<Item = String>) -> Option<String> 
 /// before `load_wayland_env_file()` and before any thread (or the Tokio
 /// runtime) is spawned.
 pub fn activate_for_launch() {
-    activate_for_launch_impl(std::env::args());
+    let outcome = activate_for_launch_impl(std::env::args());
+    // First-wins; `main()` calls this exactly once at process entry.
+    let _ = LAUNCH_OUTCOME.set(outcome);
+}
+
+/// What [`activate_for_launch`] did with the profile selection — recorded so a
+/// host guard can reason about the RESULT of activation WITHOUT re-reading the
+/// `active` pointer (the D2 single-reader discipline forbids reading it outside
+/// this module; re-reading it deep in the stack is the exact corruption bug).
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct LaunchOutcome {
+    /// A profile was selected — via `--profile` OR the `active` pointer — but
+    /// its home did not exist (or the name was invalid), so activation WARNED
+    /// and fell through to the shared default home. `Some(name)` is the identity
+    /// that was asked for and NOT bound. A host protocol must refuse rather than
+    /// serve the default home's credentials/memory under that name.
+    pub unbound_selection: Option<String>,
+}
+
+static LAUNCH_OUTCOME: std::sync::OnceLock<LaunchOutcome> = std::sync::OnceLock::new();
+
+/// The recorded outcome of this process's launch-time profile activation, or
+/// `None` if [`activate_for_launch`] has not run (e.g. a unit test that never
+/// entered `main`). See [`LaunchOutcome`].
+#[must_use]
+pub fn launch_outcome() -> Option<LaunchOutcome> {
+    LAUNCH_OUTCOME.get().cloned()
 }
 
 /// Testable core of [`activate_for_launch`] — argv is injected so tests can
 /// exercise the `--profile` path without mutating the real process arguments.
-fn activate_for_launch_impl(args: impl Iterator<Item = String>) {
-    // 1. Explicit WAYLAND_HOME wins — never override it.
+fn activate_for_launch_impl(args: impl Iterator<Item = String>) -> LaunchOutcome {
+    // 1. Explicit WAYLAND_HOME wins — never override it. An explicit home is an
+    //    unambiguous binding, so nothing is left unbound.
     if std::env::var_os("WAYLAND_HOME").is_some() {
-        return;
+        return LaunchOutcome::default();
     }
 
     // 2. --profile on argv, else 3. the active pointer.
     let Some(name) = profile_flag_from_args(args).or_else(read_active_pointer) else {
-        return;
+        return LaunchOutcome::default();
     };
 
     match profile_dir(&name) {
@@ -246,17 +273,39 @@ fn activate_for_launch_impl(args: impl Iterator<Item = String>) {
             // SAFETY: single-threaded at process entry (see the doc comment and
             // the `main()` call site). No other thread can observe the env race.
             unsafe { std::env::set_var("WAYLAND_HOME", &dir) };
+            LaunchOutcome::default()
         }
         Ok(dir) => {
             eprintln!(
                 "warning: profile {name:?} not found at {} — using the default home",
                 dir.display()
             );
+            LaunchOutcome {
+                unbound_selection: Some(name),
+            }
         }
         Err(e) => {
             eprintln!("warning: ignoring invalid profile selection: {e}");
+            LaunchOutcome {
+                unbound_selection: Some(name),
+            }
         }
     }
+}
+
+/// The profile name requested on THIS process's command line, if any —
+/// `--profile <name>` / `--profile=<name>` in either the global or a
+/// subcommand position (a raw-argv scan, stopping at `--`, so a literal
+/// `--profile` inside a user prompt is never mistaken for the flag).
+///
+/// This is the SAME source [`activate_for_launch`] resolves the home from, so a
+/// host guard that validates "am I actually bound to the profile I was asked
+/// for?" and the activation that binds it cannot disagree — they read one
+/// signal. Returns `None` when no `--profile` was given (an isolated home bound
+/// purely via an explicit `WAYLAND_HOME`, or the default home).
+#[must_use]
+pub fn requested_profile_from_argv() -> Option<String> {
+    profile_flag_from_args(std::env::args())
 }
 
 // ===========================================================================
@@ -896,6 +945,20 @@ mod tests {
         assert_eq!(profile_flag_from_args(argv(&["--profile"])), None);
         // A trailing --profile with no value resolves to None (falls through).
         assert_eq!(profile_flag_from_args(argv(&["wcore", "--profile"])), None);
+        // Position-independence: the flag is found the same whether it precedes
+        // the subcommand (global) or follows it. A host guard reading this must
+        // catch BOTH — reading only the parsed subcommand field leaves the
+        // global position unguarded.
+        assert_eq!(
+            profile_flag_from_args(argv(&["wcore", "--profile", "work", "acp", "serve"])),
+            Some("work".to_string()),
+            "global position (before the subcommand)"
+        );
+        assert_eq!(
+            profile_flag_from_args(argv(&["wcore", "acp", "serve", "--profile", "work"])),
+            Some("work".to_string()),
+            "subcommand position (after the subcommand)"
+        );
     }
 
     #[test]
@@ -973,9 +1036,11 @@ mod tests {
             ("WAYLAND_PROFILES_ROOT", Some(root.path().to_str().unwrap())),
             ("WAYLAND_HOME", None),
         ]);
-        activate_for_launch_impl(argv(&["wcore", "--profile", "ghost"]));
-        // Missing profile dir → warn + fall through; WAYLAND_HOME stays unset.
+        let outcome = activate_for_launch_impl(argv(&["wcore", "--profile", "ghost"]));
+        // Missing profile dir → warn + fall through; WAYLAND_HOME stays unset...
         assert_eq!(std::env::var_os("WAYLAND_HOME"), None);
+        // ...and the outcome records the unbound selection so a host can refuse.
+        assert_eq!(outcome.unbound_selection.as_deref(), Some("ghost"));
     }
 
     #[test]
@@ -986,8 +1051,56 @@ mod tests {
             ("WAYLAND_PROFILES_ROOT", Some(root.path().to_str().unwrap())),
             ("WAYLAND_HOME", None),
         ]);
-        activate_for_launch_impl(argv(&["wcore", "--profile", "../escape"]));
+        let outcome = activate_for_launch_impl(argv(&["wcore", "--profile", "../escape"]));
         assert_eq!(std::env::var_os("WAYLAND_HOME"), None);
+        assert_eq!(outcome.unbound_selection.as_deref(), Some("../escape"));
+    }
+
+    /// The pointer path is a first-class selection source, so its missing-home
+    /// fall-through must ALSO be recorded — this is the fail-open a flag-only
+    /// guard misses (`wayland-core profile use X` then a bare launch when X's
+    /// home is gone).
+    #[test]
+    #[serial]
+    fn activate_records_unbound_selection_from_the_active_pointer() {
+        let root = tempdir().unwrap();
+        let _g = EnvGuard::set(&[
+            ("WAYLAND_PROFILES_ROOT", Some(root.path().to_str().unwrap())),
+            ("WAYLAND_HOME", None),
+        ]);
+        // Realistic scenario: `profile use work` while work existed, then work's
+        // home is deleted → the pointer is now stale. (The writer refuses a
+        // non-existent home, so create → point → delete.)
+        std::fs::create_dir_all(root.path().join("work")).unwrap();
+        set_active_profile("work").unwrap();
+        std::fs::remove_dir_all(root.path().join("work")).unwrap();
+
+        // No --profile flag; selection comes from the (now stale) pointer.
+        let outcome = activate_for_launch_impl(argv(&["wcore"]));
+        assert_eq!(std::env::var_os("WAYLAND_HOME"), None);
+        assert_eq!(
+            outcome.unbound_selection.as_deref(),
+            Some("work"),
+            "a pointer-selected missing home must be recorded, not silently ignored"
+        );
+    }
+
+    /// A cleanly bound profile (home exists) leaves nothing unbound.
+    #[test]
+    #[serial]
+    fn activate_bound_profile_records_no_unbound_selection() {
+        let root = tempdir().unwrap();
+        let _g = EnvGuard::set(&[
+            ("WAYLAND_PROFILES_ROOT", Some(root.path().to_str().unwrap())),
+            ("WAYLAND_HOME", None),
+        ]);
+        std::fs::create_dir_all(root.path().join("work")).unwrap();
+        let outcome = activate_for_launch_impl(argv(&["wcore", "--profile", "work"]));
+        assert_eq!(
+            std::env::var_os("WAYLAND_HOME"),
+            Some(root.path().join("work").into_os_string())
+        );
+        assert_eq!(outcome.unbound_selection, None);
     }
 
     // --- Phase 2 management helpers ----------------------------------------


### PR DESCRIPTION
The supervisor/router **spawn primitive** (prereq for PR-7): one `acp serve --profile <name>`
child process per profile, each bound to that profile's own `WAYLAND_HOME` — own credentials,
`.env`, memory, skills, SOUL. N profiles are **never** served from one process (the home /
credential / egress singletons are process-global — sharing them across identities bleeds creds).

## What it does
- `profile::activate_for_launch()` already materializes the home at process entry (raw-argv scan,
  so it sees `--profile` in either flag position). `Config::resolve` then reads **that home's own
  `config.toml`** because `wayland_config_dir()` honors `WAYLAND_HOME` — so a profile's
  provider/model/keys already apply with no overlay.
- New fail-closed guard `resolve_profile_home`: refuses to start when the profile name is invalid,
  its home is absent, or an explicit `WAYLAND_HOME` disagrees with the flag. Same contract
  `json_stream_profile_guard` enforces for `--json-stream`.

## Two things this deliberately does NOT do (both were bugs in the first draft, caught in review)
1. **Does not route the name into `CliArgs.profile`.** That selects a config-file `[profiles.<name>]`
   OVERLAY table — a *different* mechanism whose missing-table case is a **hard error**. Routing it in
   aborted every isolated profile lacking a hand-authored overlay (`Config::resolve: Profile 'X' not
   found in config`). The isolated home carries provider/model via its own `config.toml`, so the
   overlay is redundant here. Reverted to `profile: None`.
2. **Guards BOTH flag positions.** `--profile` is accepted globally (`wayland-core --profile X acp
   serve`) and at the subcommand (`... acp serve --profile X`); `activate_for_launch` honors both.
   The guard reads the name from raw argv (new `requested_profile_from_argv`) — the same source
   activation uses — so neither position is fail-open. It runs FIRST in `serve()`, before the bind
   parse / server-key keychain load / config resolve / egress install, so a refused profile has
   **zero side effects**.

## Verification (Linux, Hetzner) — including LIVE binary repro
- clippy `--all-targets -D warnings` clean; `wcore-cli` 1607/1607; `wcore-config` 426/426; fmt clean.
- Live binary (the same method review used to prove the original bugs):
  - `acp serve --profile work` (home exists, no overlay table) → passes guard **and** config-resolve
    (previously aborted `Profile 'work' not found in config`).
  - `--profile ghost` in **global** position → **refuses** (previously fell through to default home).
  - `--profile ghost` in **subcommand** position → refuses.

## Known limitation (for PR-7, not this PR)
The ACP server's own API key is one keychain entry (`acp-server-key`) shared across profiles, so
profile-server auth is process-global. Not a credential bleed (provider creds load per-home after the
guard), but the supervisor/router should namespace or front this. Tracked for PR-7.