### PR TITLE
feat(acp): stamp per-turn turn_id on terminal Done/Error frames (#787)

### DIFF
--- a/crates/wcore-acp/src/client.rs
+++ b/crates/wcore-acp/src/client.rs
@@ -274,6 +274,7 @@ mod tests {
         {
             Ok(futures::stream::iter(vec![MessageEvent::Done {
                 stop_reason: "end_turn".to_string(),
+                turn_id: String::new(),
             }])
             .boxed())
         }

--- a/crates/wcore-acp/src/protocol.rs
+++ b/crates/wcore-acp/src/protocol.rs
@@ -325,9 +325,24 @@ pub enum MessageEvent {
     },
     Done {
         stop_reason: String,
+        /// #787: stable per-turn correlation id (the turn's `msg_id` uuid — a
+        /// `uuid::Uuid::new_v4()` minted once per turn). Lets a host dedup a
+        /// terminal frame per turn: a re-wake straggler carries the PRIOR
+        /// turn's id, so it is distinguishable from the new turn's terminal.
+        /// Empty only on server-level frames that carry no turn context (e.g.
+        /// "no turn engine installed"). `#[serde(default)]` so a newer client
+        /// can still parse an older server that omits it.
+        #[serde(default, skip_serializing_if = "String::is_empty")]
+        turn_id: String,
     },
     Error {
         error: JsonRpcError,
+        /// #787: stable per-turn correlation id — see [`MessageEvent::Done`].
+        /// Carried here precisely because the error/synthetic-terminal path is
+        /// the duplicate-terminal case a host dedups (`agent_run_id` is `None`
+        /// there, `msg_id` is not).
+        #[serde(default, skip_serializing_if = "String::is_empty")]
+        turn_id: String,
     },
 }
 

--- a/crates/wcore-acp/src/server.rs
+++ b/crates/wcore-acp/src/server.rs
@@ -392,6 +392,9 @@ impl HttpHandler for AcpServer {
                         message: "no turn engine installed".to_string(),
                         data: None,
                     },
+                    // #787: a server-level frame with no turn context — there is
+                    // no per-turn id to stamp (no engine ran).
+                    turn_id: String::new(),
                 };
                 Ok(stream::iter(vec![ev]).boxed())
             }
@@ -541,7 +544,7 @@ mod tests {
             .unwrap();
         let first = s.next().await.expect("one event");
         match first {
-            MessageEvent::Error { error } => {
+            MessageEvent::Error { error, .. } => {
                 assert_eq!(error.message, "no turn engine installed");
                 assert_eq!(error.code, ErrorCode::InternalError.code());
             }
@@ -564,6 +567,7 @@ mod tests {
             },
             MessageEvent::Done {
                 stop_reason: "end_turn".to_string(),
+                turn_id: String::new(),
             },
         ]));
         let server = AcpServer::new().with_turn_engine(engine.clone());
@@ -583,7 +587,7 @@ mod tests {
             other => panic!("expected TextDelta, got {other:?}"),
         }
         match s.next().await.expect("terminal") {
-            MessageEvent::Done { stop_reason } => assert_eq!(stop_reason, "end_turn"),
+            MessageEvent::Done { stop_reason, .. } => assert_eq!(stop_reason, "end_turn"),
             other => panic!("expected Done, got {other:?}"),
         }
         assert!(s.next().await.is_none());
@@ -615,6 +619,7 @@ mod tests {
         }];
         let engine = Arc::new(MockTurnEngine::new(vec![MessageEvent::Done {
             stop_reason: "end_turn".to_string(),
+            turn_id: String::new(),
         }]));
         let server = AcpServer::new().with_turn_engine(engine.clone());
         let resp = server
@@ -666,6 +671,7 @@ mod tests {
         };
         let engine = Arc::new(MockTurnEngine::new(vec![MessageEvent::Done {
             stop_reason: "end_turn".to_string(),
+            turn_id: String::new(),
         }]));
         let server = AcpServer::new().with_turn_engine(engine.clone());
         let resp = server

--- a/crates/wcore-acp/src/transport/http.rs
+++ b/crates/wcore-acp/src/transport/http.rs
@@ -401,6 +401,7 @@ mod tests {
                 MessageEvent::TextDelta { text: "hi".into() },
                 MessageEvent::Done {
                     stop_reason: "end_turn".into(),
+                    turn_id: String::new(),
                 },
             ];
             Ok(Box::pin(stream::iter(events)))

--- a/crates/wcore-acp/src/transport/rest.rs
+++ b/crates/wcore-acp/src/transport/rest.rs
@@ -649,6 +649,7 @@ mod tests {
                 MessageEvent::TextDelta { text: "hi".into() },
                 MessageEvent::Done {
                     stop_reason: "end_turn".into(),
+                    turn_id: String::new(),
                 },
             ];
             Ok(Box::pin(stream::iter(events)))

--- a/crates/wcore-acp/src/turn.rs
+++ b/crates/wcore-acp/src/turn.rs
@@ -188,6 +188,7 @@ mod tests {
                 },
                 MessageEvent::Done {
                     stop_reason: "end_turn".to_string(),
+                    turn_id: String::new(),
                 },
             ],
         };
@@ -215,7 +216,7 @@ mod tests {
             .count();
         assert_eq!(terminals, 1, "exactly one terminal frame");
         match frames.last().expect("last frame") {
-            MessageEvent::Done { stop_reason } => assert_eq!(stop_reason, "end_turn"),
+            MessageEvent::Done { stop_reason, .. } => assert_eq!(stop_reason, "end_turn"),
             other => panic!("expected Done last, got {other:?}"),
         }
     }
@@ -230,6 +231,7 @@ mod tests {
                     message: "boom".to_string(),
                     data: None,
                 },
+                turn_id: String::new(),
             }],
         };
         let req = TurnRequest {

--- a/crates/wcore-acp/tests/approval_gate.rs
+++ b/crates/wcore-acp/tests/approval_gate.rs
@@ -87,6 +87,7 @@ async fn mutating_tool_emits_approval_required_before_result() {
             },
             MessageEvent::Done {
                 stop_reason: "end_turn".to_string(),
+                turn_id: String::new(),
             },
         ],
     };
@@ -163,6 +164,7 @@ async fn force_posture_emits_bare_tool_call_without_gate() {
             },
             MessageEvent::Done {
                 stop_reason: "end_turn".to_string(),
+                turn_id: String::new(),
             },
         ],
     };

--- a/crates/wcore-acp/tests/rest_roundtrip.rs
+++ b/crates/wcore-acp/tests/rest_roundtrip.rs
@@ -74,6 +74,7 @@ impl HttpHandler for MockHandler {
             MessageEvent::TextDelta { text: "hi".into() },
             MessageEvent::Done {
                 stop_reason: "end_turn".into(),
+                turn_id: String::new(),
             },
         ];
         Ok(Box::pin(stream::iter(events)))

--- a/crates/wcore-cli/src/acp_engine.rs
+++ b/crates/wcore-cli/src/acp_engine.rs
@@ -398,6 +398,15 @@ struct ProtocolToMessageStream {
     /// `(name, input)` by `call_id` so the gate frame projects a faithful
     /// `ToolCall`. The map is bounded by the in-flight tool calls of one turn.
     pending_calls: HashMap<String, (String, serde_json::Value)>,
+    /// #787: the turn's `msg_id`, stashed from the first frame that carries it
+    /// (every ACP turn opens with `StreamStart { msg_id }`). Used as the
+    /// terminal frame's `turn_id` when the terminal `ProtocolEvent::Error`
+    /// itself carries `msg_id: None` — the in-band `emit_error` path
+    /// (`ChannelSink::emit_error`) has no msg_id in its trait signature and
+    /// hardcodes `None`, yet it is a terminal frame the host must be able to
+    /// dedup. Without this stash that (common, retryable-provider-error)
+    /// terminal would ship `turn_id = ""` and collapse the dedup key.
+    turn_id: String,
 }
 
 impl ProtocolToMessageStream {
@@ -406,6 +415,17 @@ impl ProtocolToMessageStream {
             rx,
             done: false,
             pending_calls: HashMap::new(),
+            turn_id: String::new(),
+        }
+    }
+
+    /// #787: remember the turn's `msg_id` from the first non-empty frame that
+    /// carries one (all frames of a turn share the same id). Used as the
+    /// fallback `turn_id` for a terminal `Error` frame whose own `msg_id` is
+    /// `None` (the in-band `emit_error` path).
+    fn stash_turn_id(&mut self, msg_id: &str) {
+        if self.turn_id.is_empty() && !msg_id.is_empty() {
+            self.turn_id = msg_id.to_string();
         }
     }
 
@@ -413,8 +433,21 @@ impl ProtocolToMessageStream {
     /// `None` to swallow the event; sets `done` when the frame is terminal.
     fn project(&mut self, ev: ProtocolEvent) -> Option<MessageEvent> {
         match ev {
-            ProtocolEvent::TextDelta { text, .. } => Some(MessageEvent::TextDelta { text }),
-            ProtocolEvent::Thinking { text, .. } => Some(MessageEvent::Thinking { text }),
+            ProtocolEvent::StreamStart { msg_id } => {
+                // #787: the guaranteed-first frame of every ACP turn — stash its
+                // id so a later terminal Error with msg_id: None can still stamp
+                // the right turn_id. Swallowed (no MessageEvent analogue).
+                self.stash_turn_id(&msg_id);
+                None
+            }
+            ProtocolEvent::TextDelta { text, msg_id } => {
+                self.stash_turn_id(&msg_id);
+                Some(MessageEvent::TextDelta { text })
+            }
+            ProtocolEvent::Thinking { text, msg_id, .. } => {
+                self.stash_turn_id(&msg_id);
+                Some(MessageEvent::Thinking { text })
+            }
             ProtocolEvent::ToolRequest { call_id, tool, .. } => {
                 // D012: remember the call so the matching `ApprovalRequired`
                 // (synthesized by the relay's `ChannelEmitter`) can project a
@@ -461,13 +494,19 @@ impl ProtocolToMessageStream {
                     is_error: true,
                 },
             }),
-            ProtocolEvent::StreamEnd { finish_reason, .. } => {
+            ProtocolEvent::StreamEnd {
+                msg_id,
+                finish_reason,
+                ..
+            } => {
                 self.done = true;
                 Some(MessageEvent::Done {
                     stop_reason: stop_reason_str(finish_reason).to_string(),
+                    // #787: stamp the per-turn id so the host can dedup terminals.
+                    turn_id: msg_id,
                 })
             }
-            ProtocolEvent::Error { error, .. } => {
+            ProtocolEvent::Error { msg_id, error, .. } => {
                 self.done = true;
                 Some(MessageEvent::Error {
                     error: JsonRpcError {
@@ -477,6 +516,14 @@ impl ProtocolToMessageStream {
                         // inspect it.
                         data: Some(serde_json::json!({ "retryable": error.retryable })),
                     },
+                    // #787: the error terminal is exactly the duplicate-terminal
+                    // case the host dedups. Prefer the frame's own msg_id, but
+                    // the in-band `emit_error` path (ChannelSink::emit_error)
+                    // has no msg_id in its trait signature and relays
+                    // `msg_id: None` — fall back to the id stashed from the
+                    // turn's StreamStart so this (common, retryable) terminal
+                    // still carries a stable turn_id.
+                    turn_id: msg_id.unwrap_or_else(|| self.turn_id.clone()),
                 })
             }
             // D012 (P0 security): surface the approval gate to REST/SSE/ACP
@@ -512,9 +559,10 @@ impl ProtocolToMessageStream {
                     resume_token,
                 })
             }
-            // StreamStart / ToolRunning / ToolChunk / Suspend / ApprovalResume /
-            // Info / traces / costs etc. have no faithful ACP `MessageEvent`
-            // analogue — swallow them.
+            // ToolRunning / ToolChunk / Suspend / ApprovalResume / Info /
+            // traces / costs etc. have no faithful ACP `MessageEvent` analogue —
+            // swallow them. (StreamStart is handled explicitly above so its
+            // msg_id can seed the turn_id stash before it is swallowed.)
             _ => None,
         }
     }
@@ -685,7 +733,7 @@ impl EngineSession {
         while let Some(ev) = stream.next().await {
             match ev {
                 MessageEvent::TextDelta { text } => reply.push_str(&text),
-                MessageEvent::Error { error } => return Err(error.message),
+                MessageEvent::Error { error, .. } => return Err(error.message),
                 MessageEvent::Done { .. } => break,
                 // Thinking / tool frames are not part of the A2A reply text.
                 _ => {}
@@ -1200,7 +1248,7 @@ mod tests {
             other => panic!("expected ToolResult, got {other:?}"),
         }
         match &out[3] {
-            MessageEvent::Done { stop_reason } => assert_eq!(stop_reason, "max_tokens"),
+            MessageEvent::Done { stop_reason, .. } => assert_eq!(stop_reason, "max_tokens"),
             other => panic!("expected Done, got {other:?}"),
         }
     }
@@ -1456,12 +1504,76 @@ mod tests {
         let out = project_all(events).await;
         assert_eq!(out.len(), 1);
         match &out[0] {
-            MessageEvent::Error { error } => {
+            MessageEvent::Error { error, turn_id } => {
                 assert_eq!(error.message, "kaboom");
                 assert_eq!(error.code, ErrorCode::ToolFailed.code());
                 assert_eq!(
                     error.data.as_ref().unwrap().get("retryable").unwrap(),
                     &serde_json::Value::Bool(true)
+                );
+                // #787: the source ProtocolEvent::Error carried msg_id "m" →
+                // it must be stamped as the terminal frame's turn_id.
+                assert_eq!(turn_id, "m");
+            }
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn projection_stamps_turn_id_from_stream_end_msg_id() {
+        // #787: the terminal Done frame must carry the turn's msg_id as
+        // turn_id so a host can dedup terminals per turn (a re-wake straggler
+        // then carries the PRIOR turn's id, distinct from the new turn's).
+        let events = vec![ProtocolEvent::StreamEnd {
+            msg_id: "turn-xyz".into(),
+            finish_reason: FinishReason::Stop,
+            usage: None,
+            usage_delta: None,
+            agent_run_id: None,
+        }];
+        let out = project_all(events).await;
+        assert_eq!(out.len(), 1);
+        match &out[0] {
+            MessageEvent::Done {
+                stop_reason,
+                turn_id,
+            } => {
+                assert_eq!(stop_reason, "end_turn");
+                assert_eq!(turn_id, "turn-xyz");
+            }
+            other => panic!("expected Done, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn projection_stamps_turn_id_on_in_band_error_from_stream_start() {
+        // #787 regression: the in-band emit_error path (ChannelSink::emit_error)
+        // relays ProtocolEvent::Error { msg_id: None } — yet it is a TERMINAL
+        // frame the host must dedup. The turn's id, stashed from the opening
+        // StreamStart, must be stamped as turn_id; otherwise the dedup key
+        // collapses to `${conv}#` for every retryable provider error (the exact
+        // case #787 targets). Without the stash this asserts turn_id == "".
+        let events = vec![
+            ProtocolEvent::StreamStart {
+                msg_id: "turn-abc".into(),
+            },
+            ProtocolEvent::Error {
+                msg_id: None,
+                error: wcore_protocol::events::ErrorInfo {
+                    code: "provider_error".into(),
+                    message: "upstream 503".into(),
+                    retryable: true,
+                },
+            },
+        ];
+        let out = project_all(events).await;
+        // StreamStart is swallowed; only the terminal Error projects.
+        assert_eq!(out.len(), 1);
+        match &out[0] {
+            MessageEvent::Error { turn_id, .. } => {
+                assert_eq!(
+                    turn_id, "turn-abc",
+                    "in-band error must inherit the turn's StreamStart id"
                 );
             }
             other => panic!("expected Error, got {other:?}"),

--- a/crates/wcore-cli/tests/acp_engine_turn.rs
+++ b/crates/wcore-cli/tests/acp_engine_turn.rs
@@ -110,7 +110,7 @@ async fn acp_turn_streams_text_then_done() {
         "exactly one terminal frame; frames: {frames:?}"
     );
     match frames.last().expect("a terminal frame") {
-        MessageEvent::Done { stop_reason } => assert_eq!(stop_reason, "end_turn"),
+        MessageEvent::Done { stop_reason, .. } => assert_eq!(stop_reason, "end_turn"),
         other => panic!("expected a clean Done last, got {other:?}"),
     }
 }


### PR DESCRIPTION
## What

Adds a stable per-turn `turn_id: String` to the ACP terminal frames `MessageEvent::Done` and `MessageEvent::Error`, stamped from the turn's `msg_id` (the per-turn `uuid::Uuid::new_v4()`). This is the **core half of #787** (`FerroxLabs/wayland`): the desktop dedups duplicate terminal `responseStream` frames on `${conversation}#${turnId}`, but wayland-core's terminal frames carried no turn id, so a re-wake straggler could not be told apart from a fresh turn's terminal.

Contract ACKed by the desktop lane on #787 (2026-07-11): `turn_id` snake_case on the wire, value = the `msg_id` uuid, safe to land independently (until the desktop consumption follow-up lands, the desktop simply ignores the new field).

## How

- `crates/wcore-acp/src/protocol.rs` — add `turn_id: String` to `Done` and `Error` (`#[serde(default, skip_serializing_if = "String::is_empty")]`, matching the sibling `resume_token` field). `MessageEvent` has no `deny_unknown_fields`, so this is back-compatible in both directions (old host / new server ignores it; new host / old server defaults it to empty).
- `crates/wcore-cli/src/acp_engine.rs` — stamp `turn_id` in the `ProtocolEvent` → `MessageEvent` projection: `StreamEnd.msg_id` → `Done.turn_id`; `Error.msg_id` → `Error.turn_id`.

### Adversarial review caught a real hole (fixed here)

The in-band `emit_error` path (`ChannelSink::emit_error`) relays `ProtocolEvent::Error { msg_id: None }` — the `OutputSink::emit_error(msg, retryable)` trait carries no `msg_id`. Since the projection treats **any** `Error` as terminal, a retryable provider error (the most common error terminal, and precisely the case #787 targets) would otherwise ship `turn_id = ""` and collapse the dedup key to `${conv}#`. Fix: `ProtocolToMessageStream` stashes the turn's id from the opening `StreamStart { msg_id }` (belt-and-braces from `TextDelta`/`Thinking`) and the `Error` arm falls back to that stash when its own `msg_id` is `None`. Server-level frames that genuinely have no turn context (e.g. "no turn engine installed") remain empty by design.

## Testing

Verified on the Linux build box (nextest, `-p wcore-acp -p wcore-cli`): **1863/1863 passed**; `clippy --all-targets -- -D warnings` clean; `cargo fmt --check` clean.

New/updated tests:
- `projection_stamps_turn_id_from_stream_end_msg_id` — `StreamEnd.msg_id` → `Done.turn_id`.
- `projection_stamps_turn_id_on_in_band_error_from_stream_start` — regression for the fix above: `StreamStart{msg_id:"t"}` then `Error{msg_id:None}` ⇒ `turn_id == "t"`.
- `projection_maps_error_frame_with_retryable_data` — extended to assert the stamped id.

Closes the core half of #787 (desktop consumption follow-up tracked separately on that issue).
