### PR TITLE
feat(acp): profile supervisor router, one process per profile (PR-7)

### DIFF
--- a/crates/wcore-acp/src/client.rs
+++ b/crates/wcore-acp/src/client.rs
@@ -42,6 +42,10 @@ pub struct AcpClient {
     http: HttpClient,
     base_url: String,
     bearer: Option<String>,
+    /// persona-profiles PR-7 — `X-API-Key` sent on every request. This is the
+    /// auth an `acp serve` server enforces (`SimpleKeyVerifier`), so the profile
+    /// SUPERVISOR uses it to talk to a child it spawned with a known key.
+    api_key: Option<String>,
 }
 
 impl AcpClient {
@@ -56,6 +60,7 @@ impl AcpClient {
             http,
             base_url: base_url.into().trim_end_matches('/').to_string(),
             bearer: None,
+            api_key: None,
         })
     }
 
@@ -65,10 +70,23 @@ impl AcpClient {
         self
     }
 
+    /// persona-profiles PR-7 — attach an ACP server API key, sent as the
+    /// `X-API-Key` header the `acp serve` `SimpleKeyVerifier` enforces. Builder.
+    pub fn with_api_key(mut self, key: impl Into<String>) -> Self {
+        self.api_key = Some(key.into());
+        self
+    }
+
     fn maybe_auth(
         &self,
         req: wcore_egress::EgressRequestBuilder,
     ) -> wcore_egress::EgressRequestBuilder {
+        // X-API-Key (server auth) and bearer are independent; apply whichever is
+        // configured. The supervisor uses X-API-Key to reach a child server.
+        let req = match &self.api_key {
+            Some(k) => req.header("X-API-Key", k),
+            None => req,
+        };
         match &self.bearer {
             Some(t) => req.bearer_auth(t),
             None => req,

--- a/crates/wcore-acp/src/lib.rs
+++ b/crates/wcore-acp/src/lib.rs
@@ -12,6 +12,7 @@ pub mod client;
 pub mod error;
 pub mod protocol;
 pub mod roster;
+pub mod router;
 pub mod server;
 pub mod transport;
 pub mod turn;
@@ -20,6 +21,7 @@ pub use a2a::{A2aCapabilities, A2aError, A2aHandler, A2aHandshake, A2aMessage, D
 pub use client::AcpClient;
 pub use error::AcpError;
 pub use roster::AgentRoster;
+pub use router::ProfileRouter;
 pub use server::AcpServer;
 pub use turn::{TurnEngine, TurnRequest};
 

--- a/crates/wcore-acp/src/router.rs
+++ b/crates/wcore-acp/src/router.rs
@@ -1,0 +1,94 @@
+//! Profile-supervisor seam for the ACP transports (persona-profiles PR-7).
+//!
+//! `wcore-acp` is a mid-layer transport crate and MUST NOT depend on the
+//! process/spawn machinery, the profile store, or an ACP client pool. The
+//! supervisor is reached through this transport-neutral trait, implemented in
+//! `wcore-cli` exactly like [`crate::turn::TurnEngine`], [`crate::a2a::A2aHandler`]
+//! and [`crate::roster::AgentRoster`]. Keeps the crate dependency-free while the
+//! CLI layer owns process lifecycle.
+//!
+//! # What this is (and the invariant it enforces)
+//!
+//! An in-process persona overlay (PR-4') and a per-PROFILE agent are two
+//! DIFFERENT mechanisms. A persona shares this process's single
+//! credential/home identity; a `profile:<name>` agent is a SEPARATE PROCESS
+//! (`wcore acp serve --profile <name>`) with its OWN `WAYLAND_HOME` ⇒ own
+//! keys/.env/memory/SOUL. One profile per process is the ONLY safe topology —
+//! N profiles in one address space is the credential-bleed the red-team
+//! rejected (shared `WAYLAND_HOME`/`*_API_KEY`/egress globals). The router
+//! therefore never resolves a profile to an in-process overlay; it spawns/routes
+//! to that profile's child.
+//!
+//! # Hard requirements on any implementation
+//!   * **One child = one profile = one identity.** Never multiplex profiles.
+//!   * **Fail closed.** An invalid/absent profile ([`crate::error::AcpError`]
+//!     from `profile_dir`, or a missing home dir) MUST error — NEVER fall
+//!     through to this process's default home (that is the cross-write
+//!     corruption `json_stream_profile_guard` exists to prevent).
+//!   * **No secrets cross the wire.** The router routes JSON-RPC to a localhost
+//!     child; a profile's home path, model, provider, or key is never surfaced
+//!     through [`crate::protocol::AgentInfo`] (that stays id + label only, R4).
+//!   * **Authz-gated + default-OFF.** The server only consults a router for a
+//!     session whose create-time `agent` was AUTHORIZED by the roster, and only
+//!     when the operator enabled the supervisor feature.
+
+use std::pin::Pin;
+
+use async_trait::async_trait;
+use futures::stream::Stream;
+
+use crate::error::AcpError;
+use crate::protocol::{MessageEvent, MessageSendRequest, SessionCreateRequest, SessionGetResponse};
+
+/// A transport-neutral supervisor that fans ACP sessions whose agent is a
+/// `profile:<name>` selector out to a per-profile child process.
+///
+/// Installed on an [`crate::server::AcpServer`] via
+/// [`crate::server::AcpServer::with_profile_router`]. When no router is
+/// installed, a `profile:` agent is simply unreachable: the roster does not
+/// enumerate profiles (feature default-OFF), so `session/create` never
+/// authorizes one, and the server behaves exactly as before the extension.
+///
+/// The server dispatches to the router by branching on the session's
+/// create-time-stored `agent` (never the per-message body), so an authorized
+/// profile binding cannot be smuggled in per message.
+#[async_trait]
+pub trait ProfileRouter: Send + Sync {
+    /// Establish routing for a newly created session whose `agent` is a
+    /// `profile:<name>` selector: spawn (or reuse) the child process for that
+    /// profile and open a child session mapped to the parent `session_id`.
+    ///
+    /// `agent` is the FULL selector as authorized at create-time (e.g.
+    /// `"profile:work"`); the implementation strips the `profile:` prefix.
+    /// `req` is the originating create request (model/tools/system_prompt) —
+    /// forwarded to the child's own `session/create`.
+    ///
+    /// FAIL CLOSED: on an invalid/absent profile, or a child that fails to
+    /// spawn/handshake, return `Err` — the server then discards the parent
+    /// session record, so a failed bind never leaves a dangling session that
+    /// could later fall through to the default identity.
+    async fn open(
+        &self,
+        session_id: &str,
+        agent: &str,
+        req: &SessionCreateRequest,
+    ) -> Result<(), AcpError>;
+
+    /// Forward a message to the child session mapped to `req.session_id` and
+    /// stream the child's response back. The returned stream MUST end with
+    /// exactly one terminal [`MessageEvent`] (`Done` or `Error`) — a transport
+    /// or child-death failure mid-stream is surfaced as a terminal `Error`
+    /// frame, not a dropped stream. An `Err` here is reserved for failures
+    /// BEFORE a stream exists (e.g. unknown session).
+    async fn send(
+        &self,
+        req: MessageSendRequest,
+    ) -> Result<Pin<Box<dyn Stream<Item = MessageEvent> + Send>>, AcpError>;
+
+    /// Fetch metadata for the child session mapped to `session_id`.
+    async fn get(&self, session_id: &str) -> Result<SessionGetResponse, AcpError>;
+
+    /// Tear down the child session mapped to `session_id`. The implementation
+    /// reaps the child process when its last session is deleted.
+    async fn delete(&self, session_id: &str) -> Result<(), AcpError>;
+}

--- a/crates/wcore-acp/src/server.rs
+++ b/crates/wcore-acp/src/server.rs
@@ -394,10 +394,10 @@ impl HttpHandler for AcpServer {
         // persona-profiles PR-7: reap the per-profile child session mapped to
         // this session (the router tears the child process down when its last
         // session goes away). Non-profile sessions have no child — nothing to do.
-        if Self::is_profile_agent(record.agent.as_deref()) {
-            if let Some(router) = &self.router {
-                router.delete(&session_id).await?;
-            }
+        if Self::is_profile_agent(record.agent.as_deref())
+            && let Some(router) = &self.router
+        {
+            router.delete(&session_id).await?;
         }
         Ok(())
     }
@@ -1069,7 +1069,7 @@ mod tests {
         );
         assert_eq!(
             router.sent.lock().unwrap().as_slice(),
-            &[resp.session_id.clone()]
+            std::slice::from_ref(&resp.session_id)
         );
 
         server

--- a/crates/wcore-acp/src/server.rs
+++ b/crates/wcore-acp/src/server.rs
@@ -86,6 +86,16 @@ pub struct AcpServer {
     /// `CliAgentRoster`) exactly like `a2a_handler`, keeping `wcore-acp`
     /// dependency-free.
     roster: Option<Arc<dyn AgentRoster>>,
+    /// persona-profiles PR-7 — optional profile SUPERVISOR/ROUTER. When `Some`,
+    /// a session whose create-time `agent` is a `profile:<name>` selector is
+    /// routed to a per-profile child process (one process per profile — its own
+    /// `WAYLAND_HOME`/keys/memory) instead of the in-process `turn_engine`. When
+    /// `None` (the default, feature-OFF), the roster enumerates no profiles, so
+    /// `session/create` never authorizes one and nothing reaches this path —
+    /// byte-identical to the pre-extension server. Injected from the CLI layer
+    /// (where process spawn + the ACP client pool live), keeping `wcore-acp`
+    /// process-machinery-free.
+    router: Option<Arc<dyn crate::router::ProfileRouter>>,
 }
 
 impl std::fmt::Debug for AcpServer {
@@ -101,6 +111,10 @@ impl std::fmt::Debug for AcpServer {
                 &self.turn_engine.as_ref().map(|_| "<dyn TurnEngine>"),
             )
             .field("roster", &self.roster.as_ref().map(|_| "<dyn AgentRoster>"))
+            .field(
+                "router",
+                &self.router.as_ref().map(|_| "<dyn ProfileRouter>"),
+            )
             .finish()
     }
 }
@@ -167,6 +181,28 @@ impl AcpServer {
     /// Whether a persona-agent roster is installed.
     pub fn has_roster(&self) -> bool {
         self.roster.is_some()
+    }
+
+    /// persona-profiles PR-7 — install the profile supervisor/router. When
+    /// present, a session created with a `profile:<name>` agent is routed to a
+    /// per-profile child process instead of the in-process turn engine. When
+    /// absent, no profile is enumerable/authorizable, so nothing reaches the
+    /// router. Mirrors [`Self::with_turn_engine`] / [`Self::with_roster`].
+    pub fn with_profile_router(mut self, router: Arc<dyn crate::router::ProfileRouter>) -> Self {
+        self.router = Some(router);
+        self
+    }
+
+    /// Whether a profile supervisor/router is installed.
+    pub fn has_profile_router(&self) -> bool {
+        self.router.is_some()
+    }
+
+    /// persona-profiles PR-7 — whether an agent selector names a per-PROFILE
+    /// agent (routed to its own child process) rather than an in-process
+    /// persona overlay. `profile:` is the wire prefix of a profile-agent id.
+    fn is_profile_agent(agent: Option<&str>) -> bool {
+        agent.is_some_and(|a| a.starts_with("profile:"))
     }
 
     /// The AUTHORIZED persona-agent id bound to `session_id` at create-time, if
@@ -271,6 +307,27 @@ impl HttpHandler for AcpServer {
             agent: req.agent.clone(),
         };
         self.sessions.write().await.insert(id.clone(), record);
+
+        // persona-profiles PR-7: a `profile:<name>` agent routes to a per-PROFILE
+        // CHILD process (its own WAYLAND_HOME/identity). Spawn/open it now and map
+        // this parent session to the child. FAIL CLOSED — on any error discard the
+        // just-inserted parent record, so a failed bind never leaves a session
+        // that could later fall through to this process's default identity.
+        if Self::is_profile_agent(req.agent.as_deref()) {
+            let agent_id = req.agent.as_deref().unwrap_or_default();
+            let opened = match &self.router {
+                Some(router) => router.open(&id, agent_id, &req).await,
+                // Authorized as a profile agent but no supervisor is installed —
+                // a misconfiguration. Fail closed rather than silently serving
+                // the default identity under the profile's name.
+                None => Err(AcpError::Agent(format!("agent not found: {agent_id}"))),
+            };
+            if let Err(e) = opened {
+                self.sessions.write().await.remove(&id);
+                return Err(e);
+            }
+        }
+
         Ok(SessionCreateResponse {
             session_id: id,
             model: req.model,
@@ -328,14 +385,21 @@ impl HttpHandler for AcpServer {
     }
 
     async fn delete_session(&self, session_id: String) -> Result<(), AcpError> {
-        let mut guard = self.sessions.write().await;
-        if guard.remove(&session_id).is_some() {
-            Ok(())
-        } else {
-            Err(AcpError::Session(format!(
+        let removed = self.sessions.write().await.remove(&session_id);
+        let Some(record) = removed else {
+            return Err(AcpError::Session(format!(
                 "session not found: {session_id}"
-            )))
+            )));
+        };
+        // persona-profiles PR-7: reap the per-profile child session mapped to
+        // this session (the router tears the child process down when its last
+        // session goes away). Non-profile sessions have no child — nothing to do.
+        if Self::is_profile_agent(record.agent.as_deref()) {
+            if let Some(router) = &self.router {
+                router.delete(&session_id).await?;
+            }
         }
+        Ok(())
     }
 
     async fn send_message(
@@ -370,6 +434,28 @@ impl HttpHandler for AcpServer {
         // Read from the session record (NOT from the request body) — a per-message
         // body can never smuggle in a persona that was not authorized at create.
         let agent = self.session_agent(&req.session_id).await;
+
+        // persona-profiles PR-7: a `profile:<name>` session is served by its own
+        // child process — forward the message to that child instead of the
+        // in-process turn engine. The persona/tools overlay is the CHILD's
+        // concern (it runs under the profile's own home/config).
+        if Self::is_profile_agent(agent.as_deref()) {
+            return match &self.router {
+                Some(router) => {
+                    router
+                        .send(MessageSendRequest {
+                            session_id: req.session_id,
+                            text: req.text,
+                            tools,
+                        })
+                        .await
+                }
+                None => Err(AcpError::Session(format!(
+                    "session {} is bound to a profile agent but no supervisor is installed",
+                    req.session_id
+                ))),
+            };
+        }
 
         match &self.turn_engine {
             Some(engine) => {
@@ -875,6 +961,177 @@ mod tests {
             .await
             .expect_err("unauthorized agent must be rejected");
         assert!(matches!(err, AcpError::Agent(_)), "got {err:?}");
+    }
+
+    // ── persona-profiles PR-7: profile supervisor/router dispatch ───────────
+
+    use crate::router::ProfileRouter;
+
+    /// A mock supervisor that records routed calls WITHOUT spawning a real
+    /// child — proves `AcpServer` dispatches a `profile:` session to the router
+    /// (and a non-profile session to the engine), and fails closed on open error.
+    #[derive(Default)]
+    struct MockProfileRouter {
+        opened: std::sync::Mutex<Vec<(String, String)>>,
+        sent: std::sync::Mutex<Vec<String>>,
+        deleted: std::sync::Mutex<Vec<String>>,
+        fail_open: bool,
+    }
+
+    #[async_trait]
+    impl ProfileRouter for MockProfileRouter {
+        async fn open(
+            &self,
+            session_id: &str,
+            agent: &str,
+            _req: &SessionCreateRequest,
+        ) -> Result<(), AcpError> {
+            if self.fail_open {
+                return Err(AcpError::Agent(format!("cannot open {agent}")));
+            }
+            self.opened
+                .lock()
+                .unwrap()
+                .push((session_id.to_string(), agent.to_string()));
+            Ok(())
+        }
+        async fn send(
+            &self,
+            req: MessageSendRequest,
+        ) -> Result<Pin<Box<dyn Stream<Item = MessageEvent> + Send>>, AcpError> {
+            self.sent.lock().unwrap().push(req.session_id.clone());
+            let ev = MessageEvent::Done {
+                stop_reason: "end_turn".to_string(),
+                turn_id: req.session_id,
+            };
+            Ok(stream::iter(vec![ev]).boxed())
+        }
+        async fn get(&self, session_id: &str) -> Result<SessionGetResponse, AcpError> {
+            Err(AcpError::Session(format!("no child for {session_id}")))
+        }
+        async fn delete(&self, session_id: &str) -> Result<(), AcpError> {
+            self.deleted.lock().unwrap().push(session_id.to_string());
+            Ok(())
+        }
+    }
+
+    // A `profile:<name>` session is opened on the router at create, forwarded to
+    // it on send, and reaped on delete — NEVER the in-process engine.
+    #[tokio::test]
+    async fn profile_agent_routes_to_supervisor_not_engine() {
+        let roster = Arc::new(MockRoster {
+            agents: vec![agent_info("profile:work")],
+        });
+        let router = Arc::new(MockProfileRouter::default());
+        // An engine is installed but must NOT run for a profile session — its
+        // script is a marker we assert never reaches the caller.
+        let engine = Arc::new(MockTurnEngine::new(vec![MessageEvent::Error {
+            error: JsonRpcError {
+                code: -1,
+                message: "ENGINE-MUST-NOT-RUN".to_string(),
+                data: None,
+            },
+            turn_id: String::new(),
+        }]));
+        let server = AcpServer::new()
+            .with_roster(roster)
+            .with_turn_engine(engine)
+            .with_profile_router(router.clone());
+
+        let resp = server
+            .create_session(SessionCreateRequest {
+                model: None,
+                tools: Vec::new(),
+                system_prompt: None,
+                agent: Some("profile:work".to_string()),
+            })
+            .await
+            .unwrap();
+        assert_eq!(
+            router.opened.lock().unwrap().as_slice(),
+            &[(resp.session_id.clone(), "profile:work".to_string())],
+            "create must open the child on the router"
+        );
+
+        let s = server
+            .send_message(MessageSendRequest {
+                session_id: resp.session_id.clone(),
+                text: "hi".to_string(),
+                tools: Vec::new(),
+            })
+            .await
+            .unwrap();
+        let frames: Vec<MessageEvent> = s.collect().await;
+        // Routed to the child (a clean Done), NOT the engine's error marker.
+        assert!(
+            matches!(frames.last(), Some(MessageEvent::Done { .. })),
+            "got {frames:?}"
+        );
+        assert_eq!(
+            router.sent.lock().unwrap().as_slice(),
+            &[resp.session_id.clone()]
+        );
+
+        server
+            .delete_session(resp.session_id.clone())
+            .await
+            .unwrap();
+        assert_eq!(
+            router.deleted.lock().unwrap().as_slice(),
+            &[resp.session_id]
+        );
+    }
+
+    // FAIL CLOSED: a child that cannot open fails the create AND leaves no
+    // dangling parent session (which could later fall through to the default).
+    #[tokio::test]
+    async fn profile_open_failure_fails_closed_with_no_dangling_session() {
+        let roster = Arc::new(MockRoster {
+            agents: vec![agent_info("profile:ghost")],
+        });
+        let router = Arc::new(MockProfileRouter {
+            fail_open: true,
+            ..Default::default()
+        });
+        let server = AcpServer::new()
+            .with_roster(roster)
+            .with_profile_router(router);
+        let err = server
+            .create_session(SessionCreateRequest {
+                model: None,
+                tools: Vec::new(),
+                system_prompt: None,
+                agent: Some("profile:ghost".to_string()),
+            })
+            .await
+            .expect_err("a child that cannot open must fail the create");
+        assert!(matches!(err, AcpError::Agent(_)), "got {err:?}");
+        assert_eq!(
+            server.session_count().await,
+            0,
+            "no dangling session after a failed profile bind"
+        );
+    }
+
+    // FAIL CLOSED: a profile agent authorized but NO supervisor installed must
+    // error — never serve this process's default identity under the profile name.
+    #[tokio::test]
+    async fn profile_agent_without_router_fails_closed() {
+        let roster = Arc::new(MockRoster {
+            agents: vec![agent_info("profile:work")],
+        });
+        let server = AcpServer::new().with_roster(roster);
+        let err = server
+            .create_session(SessionCreateRequest {
+                model: None,
+                tools: Vec::new(),
+                system_prompt: None,
+                agent: Some("profile:work".to_string()),
+            })
+            .await
+            .expect_err("profile agent with no supervisor must fail closed");
+        assert!(matches!(err, AcpError::Agent(_)), "got {err:?}");
+        assert_eq!(server.session_count().await, 0);
     }
 
     // Feature default-OFF: selecting any agent when NO roster is installed is

--- a/crates/wcore-cli/src/acp.rs
+++ b/crates/wcore-cli/src/acp.rs
@@ -117,6 +117,22 @@ pub struct AcpServeArgs {
     /// `activate_for_launch` also uses, so the two cannot disagree.
     #[arg(long, value_name = "NAME")]
     pub profile: Option<String>,
+
+    /// persona-profiles PR-7 — enable the profile SUPERVISOR/ROUTER. When set,
+    /// isolated profiles are enumerated as `profile:<name>` agents, and a
+    /// `session/create` selecting one spawns a DEDICATED child process
+    /// (`acp serve --profile <name>`) with that profile's own `WAYLAND_HOME` /
+    /// credentials and routes the session to it. One process PER profile — N
+    /// profiles are NEVER multiplexed into this process (that would share this
+    /// process's credential / egress singletons across identities).
+    ///
+    /// This is DISTINCT from `--profile` (which makes THIS process serve one
+    /// profile) and from `--enable-agent-selection` (in-process personas that
+    /// share this identity). FAILS CLOSED: selecting an unknown profile is
+    /// `AgentNotFound` and spawns no child. Default-OFF: without it, no profile
+    /// is enumerated or routable and the server behaves byte-identically.
+    #[arg(long)]
+    pub enable_profile_router: bool,
 }
 
 /// Resolve `--profile` to the isolated home the process is ACTUALLY bound to,
@@ -364,14 +380,32 @@ async fn serve(args: AcpServeArgs) -> anyhow::Result<()> {
     // overlay). Sharing the instance is the invariant that makes "what you may
     // select" and "what may be applied to your engine" the same set — two rosters
     // could drift and become an authz bypass.
-    let roster = if args.enable_agent_selection {
-        let r = crate::acp_roster::CliAgentRoster::from_trusted_sources();
-        eprintln!(
-            "wayland-core acp: persona-agent selection ENABLED — {} trusted agent(s) \
-             selectable (AgentPack + global operator YAML; project manifests and \
-             isolated profiles are never enumerated).",
-            r.len()
-        );
+    //
+    // PR-7: the profile SUPERVISOR shares this same roster — enabling it
+    // enumerates `profile:<name>` agents so `session/create` can AUTHORIZE a
+    // profile selector, which the installed `ProfileRouter` then spawns/routes
+    // to a dedicated child. A roster is built when EITHER feature is on.
+    let roster = if args.enable_agent_selection || args.enable_profile_router {
+        let mut r = crate::acp_roster::CliAgentRoster::from_trusted_sources();
+        if args.enable_agent_selection {
+            eprintln!(
+                "wayland-core acp: persona-agent selection ENABLED — {} trusted agent(s) \
+                 selectable (AgentPack + global operator YAML; project manifests and \
+                 isolated profiles are never enumerated as in-process personas).",
+                r.len()
+            );
+        }
+        if args.enable_profile_router {
+            let profiles = wcore_config::profile::list_profiles();
+            let n = profiles.len();
+            r = r.with_profiles(profiles);
+            eprintln!(
+                "wayland-core acp: profile SUPERVISOR/ROUTER ENABLED — {n} isolated \
+                 profile(s) selectable as profile:<name>; each spawns a dedicated child \
+                 process with its own WAYLAND_HOME/credentials (one process per profile, \
+                 fail-closed on unknown profiles)."
+            );
+        }
         Some(Arc::new(r))
     } else {
         None
@@ -392,6 +426,15 @@ async fn serve(args: AcpServeArgs) -> anyhow::Result<()> {
         .with_turn_engine(turn_engine);
     if let Some(r) = roster {
         acp_server = acp_server.with_roster(r);
+    }
+    // PR-7: install the profile supervisor. It re-invokes THIS binary as
+    // `acp serve --profile <name>` per selected profile and routes that
+    // session to the child. Only reachable for a `profile:` agent the roster
+    // above authorized (default-OFF ⇒ no profile is ever authorized).
+    if args.enable_profile_router {
+        let router = crate::profile_router::CliProfileRouter::new()
+            .map_err(|e| anyhow::anyhow!("failed to init profile supervisor: {e}"))?;
+        acp_server = acp_server.with_profile_router(Arc::new(router));
     }
     let server = Arc::new(acp_server);
 

--- a/crates/wcore-cli/src/acp.rs
+++ b/crates/wcore-cli/src/acp.rs
@@ -261,31 +261,40 @@ async fn serve(args: AcpServeArgs) -> anyhow::Result<()> {
     // We try to load an existing key from the keychain first; if absent
     // (first run), we generate a new one, persist it, and print it to stderr
     // exactly once. The key is 32 random bytes, hex-encoded → 64 chars.
-    let api_key = match wcore_config::keychain::get_secret(
-        wcore_acp::auth::KEYCHAIN_SERVICE,
-        ACP_SERVER_KEY_ACCOUNT,
-    ) {
+    // persona-profiles PR-7: when the profile SUPERVISOR spawns this process as
+    // a per-profile CHILD, it injects a pre-generated server key via
+    // WAYLAND_ACP_SERVER_KEY so the parent's AcpClient can authenticate to us
+    // (X-API-Key) WITHOUT scraping our stderr for a keychain-generated key. The
+    // env var is readable only by this child process (and root); children bind
+    // localhost ephemeral ports. Takes precedence over the keychain path below.
+    let api_key = match std::env::var("WAYLAND_ACP_SERVER_KEY") {
         Ok(k) if !k.is_empty() => k,
-        _ => {
-            // First run: generate a fresh key.
-            let random_bytes: [u8; 32] = {
-                let mut buf = [0u8; 32];
-                // Use uuid's rng (already in the workspace) for portability.
-                let id = uuid::Uuid::new_v4();
-                let id2 = uuid::Uuid::new_v4();
-                buf[..16].copy_from_slice(id.as_bytes());
-                buf[16..].copy_from_slice(id2.as_bytes());
-                buf
-            };
-            let key: String = random_bytes.iter().map(|b| format!("{:02x}", b)).collect();
-            store_api_key(ACP_SERVER_KEY_ACCOUNT, &key)
-                .map_err(|e| anyhow::anyhow!("keychain store failed: {e}"))?;
-            eprintln!(
-                "wayland-core acp: generated API key (first run) — \
+        _ => match wcore_config::keychain::get_secret(
+            wcore_acp::auth::KEYCHAIN_SERVICE,
+            ACP_SERVER_KEY_ACCOUNT,
+        ) {
+            Ok(k) if !k.is_empty() => k,
+            _ => {
+                // First run: generate a fresh key.
+                let random_bytes: [u8; 32] = {
+                    let mut buf = [0u8; 32];
+                    // Use uuid's rng (already in the workspace) for portability.
+                    let id = uuid::Uuid::new_v4();
+                    let id2 = uuid::Uuid::new_v4();
+                    buf[..16].copy_from_slice(id.as_bytes());
+                    buf[16..].copy_from_slice(id2.as_bytes());
+                    buf
+                };
+                let key: String = random_bytes.iter().map(|b| format!("{:02x}", b)).collect();
+                store_api_key(ACP_SERVER_KEY_ACCOUNT, &key)
+                    .map_err(|e| anyhow::anyhow!("keychain store failed: {e}"))?;
+                eprintln!(
+                    "wayland-core acp: generated API key (first run) — \
                  pass as X-API-Key header:\n  {key}"
-            );
-            key
-        }
+                );
+                key
+            }
+        },
     };
 
     // Resolve a runtime Config for the engine. Provider/model/api-key flags

--- a/crates/wcore-cli/src/acp_roster.rs
+++ b/crates/wcore-cli/src/acp_roster.rs
@@ -58,8 +58,29 @@ use wcore_agent::agents::registry::{AgentRegistry, AgentSource};
 use wcore_agents_pack::AgentPack;
 use wcore_plugin_api::agent_manifest::AgentManifest;
 
+/// A roster entry — either an in-process PERSONA (an overlay applied to THIS
+/// process's single identity) or a `profile:<name>` AGENT (a separate process
+/// with its own credential home, reached via the supervisor/router; PR-7).
+///
+/// Modelling both kinds explicitly is a fail-open guard: a `profile:` id is
+/// enumerable + selectable (so the supervisor may route it) but
+/// [`CliAgentRoster::resolve`] returns `None` for it, so it can NEVER apply an
+/// in-process persona overlay to this engine. Collapsing the two — treating a
+/// profile id as a persona that happens to resolve to the default identity —
+/// is exactly the fail-open the design forbids.
+#[derive(Debug, Clone)]
+enum RosterEntry {
+    /// A trusted persona (AgentPack or operator global YAML). Resolvable to an
+    /// overlay server-side.
+    Persona(AgentManifest),
+    /// An isolated profile, enumerated as `profile:<name>`. Routed to a child
+    /// process by the supervisor; NEVER resolvable to an in-process overlay.
+    Profile(String),
+}
+
 /// Authorization-gated roster of TRUSTED persona agents (AgentPack + the
-/// operator's global agent YAML). See the module docs for the trust model.
+/// operator's global agent YAML) and — when the profile supervisor is enabled
+/// (PR-7) — `profile:<name>` agents. See the module docs for the trust model.
 #[derive(Debug, Clone, Default)]
 pub struct CliAgentRoster {
     /// THE authorized set — the single source of truth, keyed by id (BTreeMap ⇒
@@ -75,7 +96,7 @@ pub struct CliAgentRoster {
     ///
     /// The manifest NEVER leaves this crate: only [`Self::to_info`]'s wire-safe
     /// projection is handed to `wcore-acp`.
-    by_id: BTreeMap<String, AgentManifest>,
+    by_id: BTreeMap<String, RosterEntry>,
 }
 
 impl CliAgentRoster {
@@ -95,11 +116,11 @@ impl CliAgentRoster {
     /// project-supplied agents dir could be threaded in.
     pub fn from_pack_and_global_dir(global_agents_dir: &Path) -> Self {
         // BTreeMap ⇒ deterministic, sorted-by-id output.
-        let mut by_id: BTreeMap<String, AgentManifest> = BTreeMap::new();
+        let mut by_id: BTreeMap<String, RosterEntry> = BTreeMap::new();
 
         // 1. Compiled-in personas (trusted by construction).
         for manifest in AgentPack::list() {
-            by_id.insert(manifest.name.clone(), manifest);
+            by_id.insert(manifest.name.clone(), RosterEntry::Persona(manifest));
         }
 
         // 2. Operator-authored global YAML. Loaded through the registry so we
@@ -121,11 +142,30 @@ impl CliAgentRoster {
                 // built-in: it is the more specific, operator-authored source.
                 // Both sides are TRUSTED, so this is not an escalation path (a
                 // project source is never in this map at all).
-                by_id.insert(manifest.name.clone(), manifest);
+                by_id.insert(manifest.name.clone(), RosterEntry::Persona(manifest));
             }
         }
 
         Self { by_id }
+    }
+
+    /// persona-profiles PR-7 — add `profile:<name>` entries (isolated-profile
+    /// agents). Only called when `--enable-profile-router` is set, so profile
+    /// enumeration stays behind the feature flag.
+    ///
+    /// A Profile entry is enumerable + selectable (it authorizes
+    /// `session/create.agent = "profile:<name>"` so the SUPERVISOR may spawn +
+    /// route to that profile's child) but is NEVER resolvable to an in-process
+    /// overlay: [`Self::resolve`] returns `None` for it. That is the fail-open
+    /// guard — a `profile:` id can never apply a system_prompt/model overlay to
+    /// THIS process's engine; it only ever routes out to a dedicated child.
+    #[must_use]
+    pub fn with_profiles(mut self, names: Vec<String>) -> Self {
+        for name in names {
+            let id = format!("profile:{name}");
+            self.by_id.insert(id, RosterEntry::Profile(name));
+        }
+        self
     }
 
     /// persona-profiles PR-4' — resolve an AUTHORIZED id to its persona overlay
@@ -140,7 +180,24 @@ impl CliAgentRoster {
     /// and NO overlay is ever applied. There is deliberately no second lookup
     /// path (a divergent resolver is exactly how an authz bypass is born).
     pub fn resolve(&self, id: &str) -> Option<AgentManifest> {
-        self.by_id.get(id).cloned()
+        match self.by_id.get(id) {
+            Some(RosterEntry::Persona(m)) => Some(m.clone()),
+            // A `profile:<name>` id is deliberately NOT resolvable to an
+            // in-process overlay — it routes to a dedicated child (PR-7). This
+            // is the fail-open guard.
+            Some(RosterEntry::Profile(_)) | None => None,
+        }
+    }
+
+    /// persona-profiles PR-7 — resolve a `profile:<name>` id to its profile
+    /// name for the supervisor/router. `None` for personas and unknown ids,
+    /// mirroring [`Self::resolve`]'s single-map, fail-closed discipline (what is
+    /// not enumerated as a Profile is not routable).
+    pub fn resolve_profile(&self, id: &str) -> Option<String> {
+        match self.by_id.get(id) {
+            Some(RosterEntry::Profile(name)) => Some(name.clone()),
+            Some(RosterEntry::Persona(_)) | None => None,
+        }
     }
 
     /// The ONE manifest → wire mapping. R4: drops `system_prompt`, `model`,
@@ -154,6 +211,20 @@ impl CliAgentRoster {
                 None
             } else {
                 Some(manifest.description.clone())
+            },
+        }
+    }
+
+    /// Project any roster entry to its wire-safe [`AgentInfo`]. A Profile
+    /// surfaces ONLY as `id = "profile:<name>"`, `label = <name>` — never its
+    /// home path/model/key (R4: the credential boundary never crosses the wire).
+    fn entry_to_info(entry: &RosterEntry) -> AgentInfo {
+        match entry {
+            RosterEntry::Persona(m) => Self::to_info(m),
+            RosterEntry::Profile(name) => AgentInfo {
+                id: format!("profile:{name}"),
+                label: name.clone(),
+                description: None,
             },
         }
     }
@@ -172,10 +243,11 @@ impl CliAgentRoster {
 #[async_trait]
 impl AgentRoster for CliAgentRoster {
     async fn list(&self) -> Result<Vec<AgentInfo>, AcpError> {
-        // Projected from the SAME map `resolve()` reads ⇒ what is enumerable is
-        // exactly what is selectable is exactly what is resolvable. R4: only the
-        // wire-safe projection escapes; the manifest never does.
-        Ok(self.by_id.values().map(Self::to_info).collect())
+        // Projected from the SAME map `resolve()`/`resolve_profile()` read ⇒
+        // what is enumerable is exactly what is selectable is exactly what is
+        // resolvable/routable. R4: only the wire-safe projection escapes; the
+        // manifest (and any profile home) never does.
+        Ok(self.by_id.values().map(Self::entry_to_info).collect())
     }
     // `contains` uses the trait default, which answers from `list` — so the
     // authz gate applied above governs selector admission too (R3). No override:
@@ -374,5 +446,82 @@ mod tests {
                 "{id} must not resolve to an overlay"
             );
         }
+    }
+
+    /// PR-7 fail-open guard: a `profile:<name>` is enumerable + selectable (the
+    /// supervisor may route it) yet NEVER resolvable to an in-process overlay.
+    /// It resolves only via `resolve_profile` (to a routable name).
+    #[tokio::test]
+    async fn profiles_enumerate_and_route_but_never_overlay() {
+        let dir = tempfile::tempdir().unwrap();
+        let roster = CliAgentRoster::from_pack_and_global_dir(dir.path())
+            .with_profiles(vec!["work".into(), "home".into()]);
+
+        // Enumerated as `profile:<name>`, label = name, no capability fields.
+        let listed = roster.list().await.unwrap();
+        let work = listed
+            .iter()
+            .find(|a| a.id == "profile:work")
+            .expect("profile:work must be enumerated");
+        assert_eq!(work.label, "work");
+        assert_eq!(work.description, None);
+
+        // Selectable — authorizes the supervisor route.
+        assert!(roster.contains("profile:work").await);
+        // But NEVER resolvable to an in-process persona overlay (fail-open guard).
+        assert!(
+            roster.resolve("profile:work").is_none(),
+            "a profile must never resolve to an in-process overlay"
+        );
+        // The router-facing resolver DOES see it (routable name).
+        assert_eq!(
+            roster.resolve_profile("profile:work").as_deref(),
+            Some("work")
+        );
+        assert_eq!(
+            roster.resolve_profile("profile:home").as_deref(),
+            Some("home")
+        );
+        // A persona is not a profile; an unknown id is neither.
+        assert!(roster.resolve_profile("nonexistent").is_none());
+        assert!(roster.resolve_profile("").is_none());
+    }
+
+    /// R4: even a profile's wire projection carries no home path/model/key — the
+    /// credential boundary never crosses the wire.
+    #[tokio::test]
+    async fn profile_info_carries_no_secrets() {
+        let dir = tempfile::tempdir().unwrap();
+        let roster =
+            CliAgentRoster::from_pack_and_global_dir(dir.path()).with_profiles(vec!["work".into()]);
+        let listed = roster.list().await.unwrap();
+        let work = listed.iter().find(|a| a.id == "profile:work").unwrap();
+        let json = serde_json::to_string(work).unwrap();
+        // Only the opaque id + label; no home path, model, or key material.
+        assert!(json.contains("profile:work"));
+        for leaked in [
+            "WAYLAND_HOME",
+            "/home/",
+            "api_key",
+            "system_prompt",
+            "model",
+        ] {
+            assert!(
+                !json.contains(leaked),
+                "profile AgentInfo leaked {leaked}: {json}"
+            );
+        }
+    }
+
+    /// Default-OFF: without `with_profiles`, no profile is enumerated or
+    /// selectable — byte-identical to the pre-PR-7 roster.
+    #[tokio::test]
+    async fn profiles_absent_without_with_profiles() {
+        let dir = tempfile::tempdir().unwrap();
+        let roster = CliAgentRoster::from_pack_and_global_dir(dir.path());
+        assert!(!roster.contains("profile:work").await);
+        assert!(roster.resolve_profile("profile:work").is_none());
+        let listed = roster.list().await.unwrap();
+        assert!(listed.iter().all(|a| !a.id.starts_with("profile:")));
     }
 }

--- a/crates/wcore-cli/src/lib.rs
+++ b/crates/wcore-cli/src/lib.rs
@@ -25,6 +25,12 @@ pub mod acp_engine;
 // alongside the other injected bridges.
 pub mod acp_roster;
 
+// persona-profiles PR-7: the CLI-layer `ProfileRouter` impl — the profile
+// SUPERVISOR. `wcore-acp` owns the transport-neutral router seam but must not
+// depend on process/spawn machinery or the profile store, so the one-process-
+// per-profile spawn/health-check/route/reap lifecycle lives here.
+pub mod profile_router;
+
 // v0.7.0 Task 3.B.2: `agent` subcommand — five flag-driven CRUD ops
 // (create / list / show / edit / delete) wrapping the
 // `wcore_agents_pack::factory` user-agent surface. Lives in the lib so

--- a/crates/wcore-cli/src/main.rs
+++ b/crates/wcore-cli/src/main.rs
@@ -880,6 +880,11 @@ async fn run() -> anyhow::Result<ExitCode> {
             // Best-effort: remove the sentinel so the next restart
             // doesn't falsely report a crash.
             let _ = std::fs::remove_file(&sentinel_path_for_sig);
+            // PR-7: reap any live per-profile supervisor children before exit.
+            // std::process::exit bypasses Drop, so the router's Drop-based
+            // reaping never runs on a signal — without this, SIGTERM/SIGINT/
+            // SIGHUP orphans every credential-bearing `acp serve --profile` child.
+            wcore_cli::profile_router::reap_all_children_blocking();
             std::process::exit(0);
         });
     }
@@ -899,6 +904,10 @@ async fn run() -> anyhow::Result<ExitCode> {
             // before a hard kill.
             let _ = tokio::signal::ctrl_c().await;
             let _ = std::fs::remove_file(&sentinel_path_for_sig);
+            // PR-7: reap live per-profile children before exit (exit bypasses
+            // Drop). Without this, a Ctrl+C / TerminateProcess orphans every
+            // credential-bearing `acp serve --profile` child.
+            wcore_cli::profile_router::reap_all_children_blocking();
             std::process::exit(0);
         });
     }

--- a/crates/wcore-cli/src/profile_router.rs
+++ b/crates/wcore-cli/src/profile_router.rs
@@ -1,0 +1,691 @@
+//! `CliProfileRouter` — the wcore-cli implementation of
+//! [`wcore_acp::router::ProfileRouter`] (persona-profiles PR-7).
+//!
+//! An in-process persona overlay (PR-4') and a `profile:<name>` agent are two
+//! DIFFERENT mechanisms. A persona shares this process's single credential/home
+//! identity; a profile is a SEPARATE PROCESS (`wcore acp serve --profile
+//! <name>`) with its OWN `WAYLAND_HOME` ⇒ own keys/.env/memory/SOUL. One
+//! profile per process is the ONLY safe topology — N profiles in one address
+//! space is the credential-bleed the red-team rejected (shared
+//! `WAYLAND_HOME`/`*_API_KEY`/egress singletons). This router therefore never
+//! resolves a profile to an in-process overlay; it spawns/routes to that
+//! profile's dedicated child and forwards JSON-RPC over a localhost loopback.
+//!
+//! # Invariants carried from the design (06-supervisor-seams) + review hardening
+//!   * **One child = one profile = one identity.** Never multiplex profiles.
+//!   * **No inherited credentials.** A child is spawned with a CLEARED
+//!     environment (only a credential-free allowlist is passed through), so its
+//!     `*_API_KEY`/`.env` identity comes SOLELY from its own `WAYLAND_HOME` — a
+//!     `*_API_KEY` present in the supervisor's own env can't shadow it.
+//!   * **Fail closed.** An invalid/absent profile ([`profile_dir`] error or a
+//!     missing home dir) returns [`AcpError::Agent`] (⇒ `AgentNotFound`) — the
+//!     child is NEVER spawned and we NEVER fall through to the default home.
+//!   * **No half-up children.** A spawned child that fails its health-check is
+//!     killed + reaped before the error returns.
+//!   * **Per-child key.** Each child gets a fresh random `X-API-Key` injected
+//!     via `WAYLAND_ACP_SERVER_KEY`; one operator key is never shared.
+//!   * **Signal-safe reaping.** Live children are held in a process-global
+//!     registry so the signal handler (which `std::process::exit`s, bypassing
+//!     `Drop`) can reap every child — no orphaned credential-bearing processes.
+//!   * **Bounded.** Concurrent children are capped.
+
+use std::collections::HashMap;
+use std::net::TcpListener;
+use std::path::{Path, PathBuf};
+use std::pin::Pin;
+use std::process::{Child as ProcChild, Command, Stdio};
+use std::sync::Mutex as StdMutex;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use futures::stream::{self, Stream, StreamExt};
+use tokio::sync::Mutex;
+
+use wcore_acp::client::AcpClient;
+use wcore_acp::error::AcpError;
+use wcore_acp::protocol::{
+    ErrorCode, JsonRpcError, MessageEvent, MessageSendRequest, SessionCreateRequest,
+    SessionGetResponse,
+};
+use wcore_acp::router::ProfileRouter;
+
+/// Max concurrent per-profile children. A ceiling so a hostile/buggy client
+/// cannot fork-bomb the host by opening unbounded distinct profiles.
+const DEFAULT_MAX_CHILDREN: usize = 16;
+
+/// Health-check poll interval for a freshly spawned child.
+const HEALTH_POLL_INTERVAL: Duration = Duration::from_millis(100);
+/// Health-check attempts before giving up (⇒ ~5s budget) and reaping the child.
+const HEALTH_POLL_ATTEMPTS: usize = 50;
+
+/// Environment variables passed through to a spawned child. This is an
+/// ALLOWLIST: the child is spawned with a cleared environment and only these
+/// (credential-FREE) vars are re-added. Any `*_API_KEY`/token in the
+/// supervisor's own environment is therefore NEVER inherited — a child's
+/// provider credentials come solely from its own `WAYLAND_HOME`. Adding a var
+/// here must be a deliberate, non-secret choice.
+#[cfg(unix)]
+const ENV_PASSTHROUGH: &[&str] = &[
+    // process basics + external-tool resolution
+    "PATH",
+    "HOME",
+    "USER",
+    "LOGNAME",
+    "SHELL",
+    "TERM",
+    "TMPDIR",
+    "TZ",
+    // locale (avoid encoding breakage)
+    "LANG",
+    "LANGUAGE",
+    "LC_ALL",
+    "LC_CTYPE",
+    // XDG base dirs (the `dirs` crate consults these on Linux)
+    "XDG_CONFIG_HOME",
+    "XDG_DATA_HOME",
+    "XDG_CACHE_HOME",
+    "XDG_RUNTIME_DIR",
+    // TLS trust roots (HTTPS to providers on distros that set these)
+    "SSL_CERT_FILE",
+    "SSL_CERT_DIR",
+    // diagnostics
+    "RUST_BACKTRACE",
+    "RUST_LOG",
+    // REQUIRED: the child's profile_dir(name) must resolve to the SAME root we
+    // pass as WAYLAND_HOME, or its resolve_profile_home guard refuses to start.
+    "WAYLAND_PROFILES_ROOT",
+];
+#[cfg(windows)]
+const ENV_PASSTHROUGH: &[&str] = &[
+    "PATH",
+    "PATHEXT",
+    "SystemRoot",
+    "SystemDrive",
+    "windir",
+    "ComSpec",
+    "USERPROFILE",
+    "HOMEDRIVE",
+    "HOMEPATH",
+    "TEMP",
+    "TMP",
+    "APPDATA",
+    "LOCALAPPDATA",
+    "PROGRAMDATA",
+    "NUMBER_OF_PROCESSORS",
+    "PROCESSOR_ARCHITECTURE",
+    "SSL_CERT_FILE",
+    "SSL_CERT_DIR",
+    "RUST_BACKTRACE",
+    "RUST_LOG",
+    "WAYLAND_PROFILES_ROOT",
+];
+
+/// Process-global registry of live per-profile child processes, keyed by pid.
+///
+/// This is the SINGLE owner of the OS `Child` handles so BOTH the async router
+/// (normal per-session reap) AND the synchronous process signal handler can reap
+/// them. The signal handler (`main.rs`) calls `std::process::exit(0)`, which
+/// bypasses every `Drop`; without a sync-reachable registry, a SIGTERM/SIGINT/
+/// SIGHUP would orphan every credential-bearing child. A plain `std::sync::Mutex`
+/// (not the tokio one) so it is lockable from the non-async signal path.
+static LIVE_CHILDREN: StdMutex<Option<HashMap<u32, ProcChild>>> = StdMutex::new(None);
+
+/// Move a spawned child into the global registry; returns its pid.
+fn register_child(child: ProcChild) -> u32 {
+    let pid = child.id();
+    let mut g = LIVE_CHILDREN.lock().unwrap_or_else(|e| e.into_inner());
+    g.get_or_insert_with(HashMap::new).insert(pid, child);
+    pid
+}
+
+/// Whether the registered child for `pid` has already exited (fast-fail during
+/// health-check). Treats an unregistered pid as gone.
+fn child_exited(pid: u32) -> bool {
+    let mut g = LIVE_CHILDREN.lock().unwrap_or_else(|e| e.into_inner());
+    match g.as_mut().and_then(|m| m.get_mut(&pid)) {
+        Some(child) => matches!(child.try_wait(), Ok(Some(_))),
+        None => true,
+    }
+}
+
+/// Kill + wait the registered child with `pid` (normal per-session reap or
+/// half-up cleanup). Best-effort, idempotent.
+fn reap_child(pid: u32) {
+    let mut g = LIVE_CHILDREN.lock().unwrap_or_else(|e| e.into_inner());
+    if let Some(map) = g.as_mut()
+        && let Some(mut child) = map.remove(&pid)
+    {
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+}
+
+/// Kill + wait EVERY live profile child. Signal-safe (synchronous, `std` mutex).
+///
+/// Call this from the process signal handler BEFORE `std::process::exit(0)` so a
+/// normal shutdown (SIGTERM/SIGINT/SIGHUP, Windows Ctrl+C) never orphans a
+/// credential-bearing `acp serve --profile` child. Idempotent.
+pub fn reap_all_children_blocking() {
+    let mut g = LIVE_CHILDREN.lock().unwrap_or_else(|e| e.into_inner());
+    if let Some(map) = g.as_mut() {
+        for (_pid, mut child) in map.drain() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
+}
+
+/// Supervisor that fans `profile:<name>` ACP sessions out to a dedicated child
+/// process per profile. Installed on an
+/// [`wcore_acp::server::AcpServer`](wcore_acp::server::AcpServer) via
+/// `with_profile_router`.
+pub struct CliProfileRouter {
+    /// This binary — re-invoked as `acp serve --profile <name>` per child.
+    exe: PathBuf,
+    /// Concurrent-child ceiling.
+    max_children: usize,
+    /// Router bookkeeping. The tokio mutex is held across spawn + health-check
+    /// (the double-spawn guard) but RELEASED before per-session network round
+    /// trips (`create_session`/`delete_session`) so one profile's I/O can't
+    /// starve another's session open/close.
+    inner: Mutex<Inner>,
+}
+
+#[derive(Default)]
+struct Inner {
+    /// profile name -> its child's bookkeeping.
+    children: HashMap<String, ChildMeta>,
+    /// parent session id -> the child it routes to.
+    routes: HashMap<String, Route>,
+}
+
+/// Where a parent session is mapped inside a child.
+struct Route {
+    profile: String,
+    child_session_id: String,
+}
+
+/// Per-profile child bookkeeping. The OS `Child` handle itself lives in
+/// [`LIVE_CHILDREN`]; here we keep only the pid + client + counters.
+struct ChildMeta {
+    pid: u32,
+    /// Client bound to the child's loopback port + injected key.
+    client: AcpClient,
+    /// Parent sessions currently routed here.
+    sessions: usize,
+    /// In-flight `open()` calls that have committed to this child but not yet
+    /// recorded a session (they released the lock to await `create_session`).
+    /// A child is reaped only when `sessions == 0 && opening == 0`, so a
+    /// concurrent open can't have its just-spawned child reaped out from under it.
+    opening: usize,
+}
+
+impl Drop for Inner {
+    fn drop(&mut self) {
+        // Fallback reap for a clean shutdown that DOES run destructors. The
+        // signal path can't rely on this (std::process::exit skips Drop) — it
+        // calls reap_all_children_blocking() instead.
+        for (_name, meta) in self.children.drain() {
+            reap_child(meta.pid);
+        }
+    }
+}
+
+impl CliProfileRouter {
+    /// Build a router that re-invokes the current binary for each child.
+    pub fn new() -> Result<Self, AcpError> {
+        let exe = std::env::current_exe()
+            .map_err(|e| AcpError::Transport(format!("cannot resolve current binary: {e}")))?;
+        Ok(Self {
+            exe,
+            max_children: DEFAULT_MAX_CHILDREN,
+            inner: Mutex::new(Inner::default()),
+        })
+    }
+
+    /// Override the concurrent-child cap (min 1). Builder.
+    pub fn with_max_children(mut self, n: usize) -> Self {
+        self.max_children = n.max(1);
+        self
+    }
+
+    /// Spawn a fresh `acp serve --profile <name>` child bound to a loopback
+    /// ephemeral port with a per-child injected key and a CLEARED environment.
+    /// Registers the child in [`LIVE_CHILDREN`] and returns its bookkeeping.
+    /// Does NOT health-check or register in `Inner` — the caller does.
+    fn spawn_child(&self, name: &str, dir: &Path) -> Result<ChildMeta, AcpError> {
+        // Free port: bind :0, read the port, then DROP the listener before the
+        // child binds it (avoids parsing the child's stderr for its port).
+        let port = {
+            let l = TcpListener::bind("127.0.0.1:0")
+                .map_err(|e| AcpError::Transport(format!("alloc loopback port: {e}")))?;
+            l.local_addr()
+                .map_err(|e| AcpError::Transport(format!("read loopback port: {e}")))?
+                .port()
+        };
+        // Per-child API key (never shared across identities): 64 hex chars.
+        let key = random_hex_key();
+        // Per-child append log under the temp dir, keyed by the unique port.
+        let log_path = std::env::temp_dir().join(format!("wayland-acp-profile-{name}-{port}.log"));
+        let log = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&log_path)
+            .map_err(|e| {
+                AcpError::Transport(format!("open child log {}: {e}", log_path.display()))
+            })?;
+        let log2 = log
+            .try_clone()
+            .map_err(|e| AcpError::Transport(format!("clone child log handle: {e}")))?;
+
+        let bind = format!("127.0.0.1:{port}");
+        let mut cmd = Command::new(&self.exe);
+        // CRITICAL (credential isolation): clear the environment and re-add ONLY
+        // the credential-free allowlist. A `*_API_KEY` in the supervisor's own
+        // env (loaded from its home's `.env` at startup, or exported in the
+        // launching shell) must NOT be inherited — the child's `.env` is
+        // load-if-absent, so an inherited key would silently shadow the profile's
+        // own identity. Clearing makes the child's WAYLAND_HOME the sole source.
+        cmd.env_clear();
+        for k in ENV_PASSTHROUGH {
+            if let Some(v) = std::env::var_os(k) {
+                cmd.env(k, v);
+            }
+        }
+        // Pass BOTH --profile and WAYLAND_HOME=profile_dir(name): they AGREE
+        // (same dir the child derives), and the child's resolve_profile_home
+        // guard refuses to start if they ever disagree — a second fail-closed line.
+        cmd.args(["acp", "serve", "--profile", name, "--bind", &bind])
+            .env("WAYLAND_ACP_SERVER_KEY", &key)
+            .env("WAYLAND_HOME", dir)
+            .stdin(Stdio::null())
+            .stdout(Stdio::from(log))
+            .stderr(Stdio::from(log2));
+        #[cfg(unix)]
+        {
+            use std::os::unix::process::CommandExt as _;
+            // process_group(0) calls setsid() in the child — its own group,
+            // detached from our controlling terminal.
+            cmd.process_group(0);
+        }
+        let proc = cmd
+            .spawn()
+            .map_err(|e| AcpError::Transport(format!("spawn profile child {name:?}: {e}")))?;
+
+        let base = format!("http://127.0.0.1:{port}");
+        let client = AcpClient::new(base)?.with_api_key(key);
+        let pid = register_child(proc);
+        Ok(ChildMeta {
+            pid,
+            client,
+            sessions: 0,
+            opening: 0,
+        })
+    }
+
+    /// Poll a freshly spawned child until its ACP server answers (also verifies
+    /// the injected key handshake) or the budget expires. On expiry the caller
+    /// reaps the child — we never leave a half-up child registered.
+    async fn health_check(pid: u32, client: &AcpClient, name: &str) -> Result<(), AcpError> {
+        for _ in 0..HEALTH_POLL_ATTEMPTS {
+            if child_exited(pid) {
+                return Err(AcpError::Transport(format!(
+                    "profile child {name:?} exited during startup"
+                )));
+            }
+            if client.list_sessions().await.is_ok() {
+                return Ok(());
+            }
+            tokio::time::sleep(HEALTH_POLL_INTERVAL).await;
+        }
+        Err(AcpError::Transport(format!(
+            "profile child {name:?} did not become healthy within budget"
+        )))
+    }
+}
+
+#[async_trait]
+impl ProfileRouter for CliProfileRouter {
+    async fn open(
+        &self,
+        session_id: &str,
+        agent: &str,
+        req: &SessionCreateRequest,
+    ) -> Result<(), AcpError> {
+        // A non-`profile:` selector reaching the router is a server-side bug;
+        // fail closed (AgentNotFound) rather than guess an identity.
+        let name = agent
+            .strip_prefix("profile:")
+            .ok_or_else(|| AcpError::Agent(format!("not a profile selector: {agent}")))?;
+
+        // FAIL CLOSED: an invalid name or a missing home dir is AgentNotFound —
+        // the child is never spawned and we never touch the default home.
+        let dir = wcore_config::profile::profile_dir(name)
+            .map_err(|e| AcpError::Agent(format!("agent not found: profile:{name} ({e})")))?;
+        if !dir.is_dir() {
+            return Err(AcpError::Agent(format!("agent not found: profile:{name}")));
+        }
+
+        // Phase 1 (LOCKED): ensure a healthy child exists and claim an in-flight
+        // `open` on it. The double-spawn guard holds the lock across spawn +
+        // health-check so two concurrent opens for the SAME new profile can't
+        // both spawn (the second blocks, then reuses).
+        let client = {
+            let mut inner = self.inner.lock().await;
+            if !inner.children.contains_key(name) {
+                if inner.children.len() >= self.max_children {
+                    return Err(AcpError::Transport(format!(
+                        "profile-router child cap ({}) reached; refusing to spawn {name:?}",
+                        self.max_children
+                    )));
+                }
+                let meta = self.spawn_child(name, &dir)?;
+                let pid = meta.pid;
+                let client = meta.client.clone();
+                if let Err(e) = Self::health_check(pid, &client, name).await {
+                    reap_child(pid); // never leave a half-up child
+                    return Err(e);
+                }
+                inner.children.insert(name.to_string(), meta);
+            }
+            let meta = inner
+                .children
+                .get_mut(name)
+                .expect("child present after get-or-spawn");
+            meta.opening += 1; // pin the child against reap while we create below
+            meta.client.clone()
+        };
+
+        // Phase 2 (UNLOCKED): open the child session over the network. `agent:
+        // None` to the child — the child IS the profile, it does not re-route.
+        let created = client
+            .create_session(SessionCreateRequest {
+                model: req.model.clone(),
+                tools: req.tools.clone(),
+                system_prompt: req.system_prompt.clone(),
+                agent: None,
+            })
+            .await;
+
+        // Phase 3 (LOCKED): release the open pin, then record the route (success)
+        // or reap the child if it is now wholly unused (failure).
+        let mut inner = self.inner.lock().await;
+        let child_session_id = match created {
+            Ok(resp) => resp.session_id,
+            Err(e) => {
+                let mut reap = None;
+                if let Some(meta) = inner.children.get_mut(name) {
+                    meta.opening = meta.opening.saturating_sub(1);
+                    if meta.sessions == 0 && meta.opening == 0 {
+                        reap = Some(meta.pid);
+                    }
+                }
+                if let Some(pid) = reap {
+                    inner.children.remove(name);
+                    reap_child(pid);
+                }
+                return Err(e);
+            }
+        };
+        match inner.children.get_mut(name) {
+            Some(meta) => {
+                meta.opening = meta.opening.saturating_sub(1);
+                meta.sessions += 1;
+            }
+            None => {
+                // The child vanished between phase 1 and here — tear down the
+                // orphaned child session we just opened rather than leak it.
+                let _ = client.delete_session(&child_session_id).await;
+                return Err(AcpError::Transport(format!(
+                    "profile child {name:?} vanished during open"
+                )));
+            }
+        }
+        inner.routes.insert(
+            session_id.to_string(),
+            Route {
+                profile: name.to_string(),
+                child_session_id,
+            },
+        );
+        Ok(())
+    }
+
+    async fn send(
+        &self,
+        req: MessageSendRequest,
+    ) -> Result<Pin<Box<dyn Stream<Item = MessageEvent> + Send>>, AcpError> {
+        // Resolve the route + clone the child client, then RELEASE the lock
+        // before streaming — a long-lived turn must not hold the router mutex.
+        let (client, child_session_id) = {
+            let inner = self.inner.lock().await;
+            let route = inner.routes.get(&req.session_id).ok_or_else(|| {
+                AcpError::Session(format!("no profile route for session {}", req.session_id))
+            })?;
+            let child = inner.children.get(&route.profile).ok_or_else(|| {
+                AcpError::Session(format!("profile child gone for session {}", req.session_id))
+            })?;
+            (child.client.clone(), route.child_session_id.clone())
+        };
+
+        let upstream = client
+            .send_message(MessageSendRequest {
+                session_id: child_session_id,
+                text: req.text,
+                tools: req.tools,
+            })
+            .await?;
+
+        // Adapt `Result<MessageEvent, AcpError>` -> `MessageEvent`. The trait
+        // requires EXACTLY ONE terminal frame (`Done`|`Error`): we pass the
+        // child's frames through and FUSE right after its first terminal; a
+        // mid-stream error, OR the child's stream ending WITHOUT a terminal,
+        // both synthesize one terminal `Error` (never a silent drop that would
+        // hang the caller waiting for completion).
+        // State is `(inner_stream, done)`. `done` is set true after we yield a
+        // terminal frame (the child's own, or a synthesized one), so the next
+        // poll returns `None` and the adapted stream ends with exactly one
+        // terminal — never a silent drop, never a re-poll of an exhausted stream.
+        let adapted = stream::unfold((upstream, false), |(mut s, done)| async move {
+            if done {
+                return None;
+            }
+            match s.next().await {
+                Some(Ok(ev)) => {
+                    let terminal =
+                        matches!(ev, MessageEvent::Done { .. } | MessageEvent::Error { .. });
+                    Some((ev, (s, terminal)))
+                }
+                Some(Err(e)) => Some((
+                    terminal_error(format!("profile child stream error: {e}")),
+                    (s, true),
+                )),
+                None => Some((
+                    terminal_error("profile child stream ended without a terminal frame".into()),
+                    (s, true),
+                )),
+            }
+        });
+        Ok(Box::pin(adapted))
+    }
+
+    async fn get(&self, session_id: &str) -> Result<SessionGetResponse, AcpError> {
+        let (client, child_session_id) = {
+            let inner = self.inner.lock().await;
+            let route = inner.routes.get(session_id).ok_or_else(|| {
+                AcpError::Session(format!("no profile route for session {session_id}"))
+            })?;
+            let child = inner.children.get(&route.profile).ok_or_else(|| {
+                AcpError::Session(format!("profile child gone for session {session_id}"))
+            })?;
+            (child.client.clone(), route.child_session_id.clone())
+        };
+        client.get_session(&child_session_id).await
+    }
+
+    async fn delete(&self, session_id: &str) -> Result<(), AcpError> {
+        // Phase 1 (LOCKED): drop the route, capture the child client + target.
+        let (client, child_session_id, profile) = {
+            let mut inner = self.inner.lock().await;
+            // Idempotent: no route ⇒ nothing to tear down (server already removed
+            // its own record). Not an error.
+            let Some(route) = inner.routes.remove(session_id) else {
+                return Ok(());
+            };
+            match inner.children.get(&route.profile) {
+                Some(meta) => (
+                    meta.client.clone(),
+                    route.child_session_id.clone(),
+                    route.profile,
+                ),
+                None => return Ok(()), // child already gone
+            }
+        };
+
+        // Phase 2 (UNLOCKED): delete the child session over the network.
+        let _ = client.delete_session(&child_session_id).await;
+
+        // Phase 3 (LOCKED): decrement and reap when this profile's child has no
+        // sessions AND no in-flight opens.
+        let mut inner = self.inner.lock().await;
+        let mut reap = None;
+        if let Some(meta) = inner.children.get_mut(&profile) {
+            meta.sessions = meta.sessions.saturating_sub(1);
+            if meta.sessions == 0 && meta.opening == 0 {
+                reap = Some(meta.pid);
+            }
+        }
+        if let Some(pid) = reap {
+            inner.children.remove(&profile);
+            reap_child(pid);
+        }
+        Ok(())
+    }
+}
+
+/// One terminal `Error` frame for the send adapter (empty turn_id — a
+/// transport-level failure has no forwarded turn context).
+fn terminal_error(message: String) -> MessageEvent {
+    MessageEvent::Error {
+        error: JsonRpcError {
+            code: ErrorCode::InternalError.code(),
+            message,
+            data: None,
+        },
+        turn_id: String::new(),
+    }
+}
+
+/// 32 random bytes (two v4 UUIDs) hex-encoded to 64 chars — same shape as the
+/// `acp serve` first-run key so a child accepts it as its `X-API-Key`.
+fn random_hex_key() -> String {
+    let a = uuid::Uuid::new_v4();
+    let b = uuid::Uuid::new_v4();
+    let mut buf = [0u8; 32];
+    buf[..16].copy_from_slice(a.as_bytes());
+    buf[16..].copy_from_slice(b.as_bytes());
+    buf.iter().map(|x| format!("{x:02x}")).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn req() -> SessionCreateRequest {
+        SessionCreateRequest {
+            model: None,
+            tools: Vec::new(),
+            system_prompt: None,
+            agent: None,
+        }
+    }
+
+    /// FAIL CLOSED: an unknown profile (no home dir) errors as AgentNotFound and
+    /// spawns NO child — never falls through to a default identity.
+    #[tokio::test]
+    async fn open_unknown_profile_fails_closed_no_child() {
+        let router = CliProfileRouter::new().unwrap();
+        let err = router
+            .open(
+                "sess-1",
+                "profile:definitely-not-a-real-profile-xyz",
+                &req(),
+            )
+            .await
+            .expect_err("unknown profile must fail");
+        assert!(matches!(err, AcpError::Agent(_)), "got {err:?}");
+        assert_eq!(
+            router.inner.lock().await.children.len(),
+            0,
+            "no child may be spawned for an unknown profile"
+        );
+    }
+
+    /// A non-`profile:` selector reaching the router is rejected (server bug —
+    /// fail closed rather than guess an identity).
+    #[tokio::test]
+    async fn open_non_profile_selector_is_rejected() {
+        let router = CliProfileRouter::new().unwrap();
+        let err = router
+            .open("s", "persona:researcher", &req())
+            .await
+            .expect_err("non-profile selector must fail");
+        assert!(matches!(err, AcpError::Agent(_)), "got {err:?}");
+    }
+
+    /// Sending to an unmapped session errors (no silent default routing).
+    #[tokio::test]
+    async fn send_unknown_session_errors() {
+        let router = CliProfileRouter::new().unwrap();
+        // The Ok arm is a boxed `dyn Stream` (no Debug), so match rather than
+        // `expect_err` (which would need Debug on the Ok type).
+        match router
+            .send(MessageSendRequest {
+                session_id: "nope".into(),
+                text: "hi".into(),
+                tools: Vec::new(),
+            })
+            .await
+        {
+            Err(AcpError::Session(_)) => {}
+            Err(other) => panic!("expected a Session error, got {other:?}"),
+            Ok(_) => panic!("expected an error for an unknown session, got a stream"),
+        }
+    }
+
+    /// Deleting an unmapped session is a no-op success (idempotent teardown).
+    #[tokio::test]
+    async fn delete_unknown_session_is_ok() {
+        let router = CliProfileRouter::new().unwrap();
+        assert!(router.delete("nope").await.is_ok());
+    }
+
+    /// Two distinct keys never collide and are the right shape (64 lc hex).
+    #[test]
+    fn random_hex_key_is_64_hex_and_unique() {
+        let a = random_hex_key();
+        let b = random_hex_key();
+        assert_eq!(a.len(), 64);
+        assert!(
+            a.chars()
+                .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase())
+        );
+        assert_ne!(a, b);
+    }
+
+    /// The env allowlist must never carry a credential-shaped variable — that
+    /// would reintroduce the cross-identity bleed `env_clear` exists to close.
+    #[test]
+    fn env_passthrough_carries_no_credentials() {
+        for k in ENV_PASSTHROUGH {
+            let up = k.to_ascii_uppercase();
+            assert!(
+                !up.contains("API_KEY")
+                    && !up.contains("TOKEN")
+                    && !up.contains("SECRET")
+                    && !up.contains("PASSWORD"),
+                "credential-shaped var {k:?} must not be in the passthrough allowlist"
+            );
+        }
+    }
+}

--- a/crates/wcore-cli/src/profile_router.rs
+++ b/crates/wcore-cli/src/profile_router.rs
@@ -35,6 +35,7 @@ use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::process::{Child as ProcChild, Command, Stdio};
 use std::sync::Mutex as StdMutex;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -88,6 +89,17 @@ const ENV_PASSTHROUGH: &[&str] = &[
     // TLS trust roots (HTTPS to providers on distros that set these)
     "SSL_CERT_FILE",
     "SSL_CERT_DIR",
+    // Outbound proxy config. reqwest reads these from the env; without them a
+    // child in a proxied/corporate network can't reach any LLM provider after
+    // env_clear. Shared infrastructure config, not a per-identity secret.
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "ALL_PROXY",
+    "NO_PROXY",
+    "http_proxy",
+    "https_proxy",
+    "all_proxy",
+    "no_proxy",
     // diagnostics
     "RUST_BACKTRACE",
     "RUST_LOG",
@@ -115,6 +127,15 @@ const ENV_PASSTHROUGH: &[&str] = &[
     "PROCESSOR_ARCHITECTURE",
     "SSL_CERT_FILE",
     "SSL_CERT_DIR",
+    // Outbound proxy config (see the unix list) — infra, not a secret.
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "ALL_PROXY",
+    "NO_PROXY",
+    "http_proxy",
+    "https_proxy",
+    "all_proxy",
+    "no_proxy",
     "RUST_BACKTRACE",
     "RUST_LOG",
     "WAYLAND_PROFILES_ROOT",
@@ -130,10 +151,26 @@ const ENV_PASSTHROUGH: &[&str] = &[
 /// (not the tokio one) so it is lockable from the non-async signal path.
 static LIVE_CHILDREN: StdMutex<Option<HashMap<u32, ProcChild>>> = StdMutex::new(None);
 
+/// Set once a shutdown reap has begun. Checked by `register_child` UNDER the
+/// `LIVE_CHILDREN` lock so a child spawned in the narrow window between
+/// `reap_all_children_blocking`'s drain and `std::process::exit(0)` is killed
+/// immediately instead of being orphaned past process exit.
+static SHUTTING_DOWN: AtomicBool = AtomicBool::new(false);
+
 /// Move a spawned child into the global registry; returns its pid.
-fn register_child(child: ProcChild) -> u32 {
+///
+/// If a shutdown reap has already started, the child is killed + reaped here
+/// instead of registered (it would otherwise outlive the exiting supervisor).
+/// The returned pid then refers to a dead process, so the caller's health-check
+/// fails and `open()` fails closed — no orphan, no half-up child.
+fn register_child(mut child: ProcChild) -> u32 {
     let pid = child.id();
     let mut g = LIVE_CHILDREN.lock().unwrap_or_else(|e| e.into_inner());
+    if SHUTTING_DOWN.load(Ordering::SeqCst) {
+        let _ = child.kill();
+        let _ = child.wait();
+        return pid;
+    }
     g.get_or_insert_with(HashMap::new).insert(pid, child);
     pid
 }
@@ -166,6 +203,10 @@ fn reap_child(pid: u32) {
 /// normal shutdown (SIGTERM/SIGINT/SIGHUP, Windows Ctrl+C) never orphans a
 /// credential-bearing `acp serve --profile` child. Idempotent.
 pub fn reap_all_children_blocking() {
+    // Set BEFORE taking the lock so any `register_child` that acquires the lock
+    // afterwards observes the shutdown and self-reaps its child (closing the
+    // spawn-after-drain orphan window).
+    SHUTTING_DOWN.store(true, Ordering::SeqCst);
     let mut g = LIVE_CHILDREN.lock().unwrap_or_else(|e| e.into_inner());
     if let Some(map) = g.as_mut() {
         for (_pid, mut child) in map.drain() {
@@ -685,6 +726,19 @@ mod tests {
                     && !up.contains("SECRET")
                     && !up.contains("PASSWORD"),
                 "credential-shaped var {k:?} must not be in the passthrough allowlist"
+            );
+        }
+    }
+
+    /// Proxy config MUST pass through — else a child in a proxied/corporate
+    /// network can't reach any LLM provider after env_clear (a real regression
+    /// the verify review caught). Lock it in so a refactor can't silently drop it.
+    #[test]
+    fn env_passthrough_includes_proxy_vars() {
+        for want in ["HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "ALL_PROXY"] {
+            assert!(
+                ENV_PASSTHROUGH.contains(&want),
+                "proxy var {want:?} must be in the passthrough allowlist"
             );
         }
     }


### PR DESCRIPTION
## persona-profiles PR-7 — profile SUPERVISOR/ROUTER (one process per profile)

Lands the final persona-parity deliverable as **one feature-flagged, default-OFF PR**: an
ACP supervisor that serves each isolated profile as its **own dedicated child process**
(`wayland-core acp serve --profile <name>`), never multiplexed in-process.

### Why one process per profile
A profile is a **credential boundary** — its own `WAYLAND_HOME` ⇒ own keys/`.env`/memory/SOUL.
Serving N profiles from one address space would share this process's `WAYLAND_HOME` / `*_API_KEY`
/ egress singletons across identities (the credential-bleed the red-team rejected). So a
`profile:<name>` agent is routed to a separate child; a persona overlay (PR-4') stays in-process.

### What's in it
- **`ProfileRouter` trait** (`wcore-acp/src/router.rs`, engine-free) + `AcpServer` fail-closed
  dispatch keyed on the create-time-stored `agent` (never the per-message body). *(inc 1)*
- **`AcpClient` X-API-Key** + `serve()` `WAYLAND_ACP_SERVER_KEY` env-injection so the parent
  reaches a child it spawned with a known key (no stderr-scraping). *(inc 2a)*
- **`CliProfileRouter`** (`wcore-cli/src/profile_router.rs`) — the supervisor: spawns
  `acp serve --profile X --bind 127.0.0.1:<ephemeral>` with a **per-child random key** +
  `WAYLAND_HOME=profile_dir(X)`, **health-checks** (kill+err on timeout — never a half-up child),
  pools an `AcpClient` per child, maps parent↔child sessions, and **reaps** the child (SIGKILL+wait)
  when its last session is deleted (and any survivors on `Drop`). Concurrent children are **capped**;
  the async mutex is held across spawn+health-check so concurrent opens can't double-spawn. *(inc 2b)*
- **`RosterEntry{Persona|Profile}`** enum + `--enable-profile-router` flag + `serve()` wiring.
  A `profile:` id is enumerable + selectable (so the supervisor may route it) but **never**
  resolvable to an in-process overlay (`resolve()` → None) — the fail-open guard the design requires. *(inc 2c)*

### Hard invariants (all enforced + tested)
- One child = one profile = one identity; N profiles are never multiplexed.
- Fail closed: unknown/absent profile ⇒ `AgentNotFound`, **no child spawned, never the default home**.
- No secrets on the wire: `AgentInfo` is id+label only; a profile's home/model/key never crosses.
- Authz-gated + **default-OFF**: without the flag no profile is enumerated → byte-identical server.
- Per-child key; children reaped; concurrent children bounded.

### Verification
- **1877/1877** nextest (`-p wcore-acp -p wcore-cli`) on Linux — +8 new tests (router fail-closed /
  non-profile-rejection / unknown-session / idempotent-delete / key-shape; roster profile
  enumerate-route-never-overlay / no-secrets / default-off) + the 3 inc-1 dispatch tests.
- **LIVE binary repro** on Linux (real `wayland-core` process): `agents/list` enumerates `profile:alpha`
  → `session/create` spawns a child with an **isolated `WAYLAND_HOME`** → `message/send` routes to it
  → `delete` **reaps** it → `profile:ghost` ⇒ **404 + no child**. (see PR comment for the transcript)
- `cargo clippy` clean, `cargo fmt` clean.

Closes the persona-parity gate. Default-OFF ⇒ zero behavior change until an operator opts in.
