### PR TITLE
fix(read): apply diff-resend on all routes, not just client (#182)

### DIFF
--- a/crates/wcore-agent/src/bootstrap.rs
+++ b/crates/wcore-agent/src/bootstrap.rs
@@ -351,11 +351,13 @@ impl AgentBootstrap {
             let cache = Arc::new(std::sync::RwLock::new(
                 wcore_tools::file_cache::FileStateCache::new(&self.config.file_cache),
             ));
-            // Token-opt (diff-resend): enable client-side diff answers only on
-            // routes that optimize client-side. Router-optimized routes leave
-            // this off and send full reads. Set once here from the resolved
+            // Token-opt: enable OUTPUT-dedup (identical-tool-result backrefs)
+            // only on client-optimized routes; router-optimized routes defer
+            // output/wire dedup to the server. Set once here from the resolved
             // compat (config is moved into the engine below, so it must happen
-            // before construction).
+            // before construction). NOTE (#182): this no longer gates the read
+            // diff-resend — that is a context reduction the server can't do for
+            // us, so it runs on every route (see wcore-tools `read.rs`).
             if let Ok(mut c) = cache.write() {
                 c.set_optimize_reads(self.config.compat.input_optimization() == "client");
             }

--- a/crates/wcore-tools/src/file_cache.rs
+++ b/crates/wcore-tools/src/file_cache.rs
@@ -43,11 +43,12 @@ pub struct FileStateCache {
     entries: LruCache<PathBuf, FileState>,
     max_size_bytes: usize,
     current_size_bytes: usize,
-    /// Token-opt (diff-resend): whether re-reads on this route may be answered
-    /// with a line diff instead of full content. Set once from the resolved
-    /// `ProviderCompat.input_optimization()` (`"client"` → true). Router-side
-    /// optimization leaves this false so the engine sends full reads and defers
-    /// to the server.
+    /// Token-opt: whether OUTPUT-dedup ([`Self::output_backref`]) is enabled for
+    /// this route. Set once from `ProviderCompat.input_optimization()` (`"client"`
+    /// → true); router-optimized routes leave it false and defer output/wire
+    /// dedup to the server. NOTE (#182): this no longer gates the read
+    /// diff-resend — that is a context reduction the server can't do for us, so it
+    /// applies on every route (see `read.rs`).
     optimize_reads: bool,
     /// Token-opt (diff-resend): monotonically bumped by the engine whenever a
     /// compaction pass (autocompact OR microcompact) runs. A cached read is only
@@ -126,13 +127,14 @@ impl FileStateCache {
         None
     }
 
-    /// Token-opt: enable/disable diff-resend for this cache's route. Called once
-    /// at bootstrap from the resolved provider compat.
+    /// Token-opt: enable/disable OUTPUT-dedup ([`Self::output_backref`]) for this
+    /// cache's route. Called once at bootstrap from the resolved provider compat.
+    /// (Read diff-resend is no longer gated on this — see #182.)
     pub fn set_optimize_reads(&mut self, enabled: bool) {
         self.optimize_reads = enabled;
     }
 
-    /// Token-opt: whether diff-resend is enabled for this route.
+    /// Token-opt: whether OUTPUT-dedup is enabled for this route.
     pub fn optimize_reads(&self) -> bool {
         self.optimize_reads
     }

--- a/crates/wcore-tools/src/read.rs
+++ b/crates/wcore-tools/src/read.rs
@@ -318,8 +318,18 @@ impl Tool for ReadTool {
         // not stubbing) capture a base for a possible diff. See `execute()` for
         // the `ReadResult` guard rationale.
         //
-        // `diff_base` is only populated when a diff would be SOUND to emit:
-        //   * the route opted into client-side optimization (`optimize_reads`),
+        // `diff_base` is only populated when a diff would be SOUND to emit.
+        //
+        // #182: this is deliberately NOT gated on the route's `optimize_reads`
+        // flag. Diff-resend shrinks THIS agent's own context — it is model-facing
+        // ("apply this diff to your previous Read") — so it applies on every
+        // route, exactly like the always-on unchanged-stub below. `optimize_reads`
+        // (== `input_optimization == "client"`) governs OUTPUT-side opts and
+        // wire/billing input dedup, which a server-side router (flux-router,
+        // openrouter, …) does upstream; but a router cannot shrink this process's
+        // context window, so on router routes a mid-turn re-read of a changed file
+        // was re-injecting the FULL file (the #182 bloat). The soundness guards
+        // below still hold on all routes:
         //   * this is a full read (offset/limit None) matching the cached window,
         //   * the caller is the main agent (`source_agent` is None) — the cache is
         //     process-wide across sub-agents, so a sibling's read must never seed
@@ -327,7 +337,9 @@ impl Tool for ReadTool {
         //   * the base is a `ReadResult` (something the model actually saw), and
         //   * the base is still visible: the compaction generation has not moved
         //     since it was cached, so the diff's reference content has not been
-        //     collapsed/cleared out of the transcript.
+        //     collapsed/cleared out of the transcript,
+        //   * and `build_read_diff` verifies the diff reconstructs the current
+        //     content byte-for-byte before it is ever emitted.
         let is_full_read = offset.is_none() && limit.is_none();
         let single_agent = ctx.source_agent.is_none();
         let mut diff_base: Option<String> = None;
@@ -342,7 +354,6 @@ impl Tool for ReadTool {
             && let (Some(cache_arc), Some(current_mtime)) = (&self.file_cache, mtime_ms)
             && let Ok(mut cache) = cache_arc.write()
         {
-            let optimize_reads = cache.optimize_reads();
             current_gen = cache.compaction_generation();
             if let Some(cached) = cache.get(path) {
                 let matches_window = cached.offset == offset && cached.limit == limit;
@@ -368,8 +379,7 @@ impl Tool for ReadTool {
                         is_error: false,
                     };
                 }
-                if optimize_reads
-                    && is_full_read
+                if is_full_read
                     && single_agent
                     && matches_window
                     && cached.provenance == Provenance::ReadResult
@@ -888,8 +898,13 @@ mod tests {
         );
     }
 
+    /// #182: diff-resend is a context reduction, so it applies on EVERY route —
+    /// including router-optimized ones (`optimize_reads` false). A server-side
+    /// router optimizes the wire/billing but cannot shrink THIS process's
+    /// context, so a mid-turn re-read of an externally-changed file must diff,
+    /// not re-inject the full file (the exact bloat #182 reported on flux-router).
     #[tokio::test]
-    async fn route_disabled_returns_full_content_not_diff() {
+    async fn router_route_still_diffs_changed_reread() {
         let dir = tempdir().unwrap();
         let file = write_lines(dir.path(), "big.txt", 60, "ORIGINAL");
 
@@ -899,15 +914,23 @@ mod tests {
         let ctx = ctx_main();
         let input = json!({ "file_path": file.to_str().unwrap() });
 
-        tool.execute_with_ctx(input.clone(), &ctx).await;
+        let r1 = tool.execute_with_ctx(input.clone(), &ctx).await;
+        assert!(!r1.content.contains(DIFF_RESEND_HEADER));
         std::thread::sleep(std::time::Duration::from_millis(50));
         let _ = write_lines(dir.path(), "big.txt", 60, "PATCHED");
 
         let r2 = tool.execute_with_ctx(input, &ctx).await;
-        assert!(!r2.content.contains(DIFF_RESEND_HEADER));
+        assert!(!r2.is_error);
+        assert!(
+            r2.content.contains(DIFF_RESEND_HEADER),
+            "#182: a router route must ALSO diff a changed re-read, got: {}",
+            r2.content
+        );
         assert!(r2.content.contains("PATCHED"));
-        // Full content has every line numbered.
-        assert!(r2.content.contains("line 59"));
+        assert!(
+            r2.content.len() < r1.content.len(),
+            "diff must be smaller than the full content"
+        );
     }
 
     #[tokio::test]

--- a/crates/wcore-tools/src/read_diff.rs
+++ b/crates/wcore-tools/src/read_diff.rs
@@ -42,8 +42,8 @@ pub fn strip_line_numbers(numbered: &str) -> Vec<String> {
 
 /// Longest-common-subsequence line diff. Returns the ordered edit script that
 /// turns `base` into `cur`. O(n*m) time/space — bounded by the 100 KB Read
-/// result cap, and only ever run on a route that opted into client-side
-/// optimization.
+/// result cap. Runs on every route (diff-resend is no longer route-gated; see
+/// #182), subject to the caller's soundness guards in `read.rs`.
 fn diff_ops(base: &[String], cur: &[String]) -> Vec<Op> {
     let n = base.len();
     let m = cur.len();


### PR DESCRIPTION
Fixes **#182** — mid-turn external file edits force full re-reads (120x in one customer audit; the largest context-bloat source besides raw conversation length).

## Root cause
The Read tool's **diff-resend** — answering a re-read of a *changed* file with only the changed lines + a model-facing `DIFF_RESEND_HEADER` ("apply this diff to your previous Read") — already existed and is byte-exact verified (`build_read_diff` reconstructs the current content before emitting). But it was gated behind `cache.optimize_reads()` (= `ProviderCompat.input_optimization() == "client"`), i.e. **disabled on router routes** (flux-router / openrouter / sakana). On those routes a changed file fell through to full content — the #182 bloat.

## Fix
Decouple diff-resend from the route gate. Diff-resend shrinks **this process's context window** (it's model-facing); a server-side router optimizes wire/billing but cannot do that for us — so it belongs on every route, exactly like the **already-always-on unchanged-stub**. All soundness guards are kept: full-read only, single-agent, exact-window match, `ReadResult` provenance, compaction-generation match, and byte-exact reconstruction. `optimize_reads` now gates only output-dedup (`output_backref`); output-side opts (terseness, stop-sequences) stay correctly router-gated.

## Verification
- Hetzner **nextest -p wcore-tools 1120/1120** — new `router_route_still_diffs_changed_reread` asserts a router-route cache now diffs a changed re-read; existing client-route + sub-agent-guard tests still pass. `clippy` clean, `fmt` clean.
- **Adversarial cross-audit: SHIP.** Verified the load-bearing question: `FluxRouterProvider`/`OpenRouterProvider`/`SakanaProvider` are thin pass-throughs to `OpenAIProvider` that serialize tool-result content **verbatim** — no server-side read reconstruction keyed on full content, so forwarding a diff instead is safe. No other test/invariant depends on router-routes-get-full-content. Fixed two stale comments it flagged.

Cross-lane note: this changes what the model *behind flux-router* receives on a re-read (a diff). The audit confirms flux-router is transparent to tool-result content, so no flux-specific breakage — flagging for flux/desktop awareness regardless.