### PR TITLE
fix(tui): anchor stale test clock; avoid Windows Instant underflow

### DIFF
--- a/crates/wcore-cli/src/tui/agents/stale.rs
+++ b/crates/wcore-cli/src/tui/agents/stale.rs
@@ -55,10 +55,22 @@ mod tests {
         }
     }
 
+    /// A Windows-safe base "now" for tests that fabricate an OLDER timestamp by
+    /// subtracting a `Duration`. On a freshly-booted Windows CI runner
+    /// `Instant::now()` can be smaller than the offsets these tests subtract, and
+    /// `Instant - Duration` PANICS on underflow (std `time.rs:445`) — the
+    /// intermittent `CI (Array)` failure (fails only when runner uptime < the
+    /// subtracted offset). Anchoring the base well ahead keeps every
+    /// `base - <offset>` positive; `duration_since` is unaffected because the
+    /// base and the fabricated event shift together, preserving the intended age.
+    fn test_now() -> Instant {
+        Instant::now() + Duration::from_secs(2 * 3600)
+    }
+
     #[test]
     fn running_agent_within_threshold_is_not_stale_v093() {
         let mut app = App::default();
-        let t0 = Instant::now();
+        let t0 = test_now();
         app.session
             .sub_agents
             .push(mk_agent("a", SubAgentStatus::Running));
@@ -71,7 +83,7 @@ mod tests {
     #[test]
     fn running_agent_past_threshold_is_stale_v093() {
         let mut app = App::default();
-        let t0 = Instant::now();
+        let t0 = test_now();
         app.session
             .sub_agents
             .push(mk_agent("a", SubAgentStatus::Running));
@@ -84,7 +96,7 @@ mod tests {
     #[test]
     fn done_agent_with_old_event_is_not_stale_v093() {
         let mut app = App::default();
-        let t0 = Instant::now();
+        let t0 = test_now();
         // Done agent with a very old last-event must NOT be counted.
         app.session
             .sub_agents
@@ -97,7 +109,7 @@ mod tests {
     #[test]
     fn failed_agent_with_old_event_is_not_stale_v093() {
         let mut app = App::default();
-        let t0 = Instant::now();
+        let t0 = test_now();
         app.session
             .sub_agents
             .push(mk_agent("a", SubAgentStatus::Failed));
@@ -120,7 +132,7 @@ mod tests {
     #[test]
     fn check_counts_multiple_stale_agents_v093() {
         let mut app = App::default();
-        let t0 = Instant::now();
+        let t0 = test_now();
         // Two stale Running agents.
         app.session
             .sub_agents
@@ -154,7 +166,7 @@ mod tests {
     #[test]
     fn stateless_repeated_check_returns_running_total_not_delta_v093() {
         let mut app = App::default();
-        let t0 = Instant::now();
+        let t0 = test_now();
         app.session
             .sub_agents
             .push(mk_agent("a", SubAgentStatus::Running));


### PR DESCRIPTION
## Problem

`CI (Array)` (the Windows leg) intermittently fails in `tui::agents::stale` tests. On a freshly-booted Windows CI runner `Instant::now()` can be smaller than the offsets these tests subtract to fabricate an *older* event timestamp, and `Instant - Duration` **panics on underflow** (std `time.rs:445`). The failure is deterministic by runner uptime — it fires only when uptime < the subtracted offset (up to 1h), which is why higher-uptime runners (e.g. #220) passed.

## Fix

Test-only. A `test_now()` helper anchors the base clock 2h ahead:

```rust
fn test_now() -> Instant { Instant::now() + Duration::from_secs(2 * 3600) }
```

Every `base - <offset>` now stays positive. `duration_since` semantics are unchanged because the base and the fabricated event shift together, preserving the intended age. The one call site with no subtraction (`check(&app, Instant::now())`) is left as-is.

## Verification

Hetzner nextest, all 7 stale tests green:

```
Summary  7 tests run: 7 passed, 1781 skipped
```

`cargo fmt` clean; no residual bare `Instant::now() - Duration` in the file.

Unblocks #223 (and any Windows-gated PR hitting the same class). Other `Instant - Duration` sites in UI code subtract only 5–10s / 500ms — far too small to underflow on any realistic runner age — so they are out of scope here.