### PR TITLE
feat(cli): add migrate hermes importer for named profiles (#228)

### DIFF
--- a/crates/wcore-cli/Cargo.toml
+++ b/crates/wcore-cli/Cargo.toml
@@ -189,6 +189,8 @@ toml.workspace = true
 url.workspace = true
 regex.workspace = true
 serde.workspace = true
+# `serde_yaml` parses Hermes `config.yaml` for the `migrate` importer (#228).
+serde_yaml.workspace = true
 thiserror.workspace = true
 dirs.workspace = true
 reqwest = { workspace = true, features = ["blocking"], optional = true }

--- a/crates/wcore-cli/src/lib.rs
+++ b/crates/wcore-cli/src/lib.rs
@@ -122,6 +122,9 @@ pub mod auth;
 // active-pointer access stays in `wcore_config::profile` (D2 single-reader lint).
 pub mod profile;
 
+// CLI surface: `wayland-core migrate` — import Hermes/OpenClaw setups (#228).
+pub mod migrate;
+
 // CLI surface: `wayland-core image` — FluxRouter image generation
 // (`POST /v1/images/generations`). Lives in the lib so credential
 // resolution + path numbering are unit-testable.

--- a/crates/wcore-cli/src/main.rs
+++ b/crates/wcore-cli/src/main.rs
@@ -559,6 +559,11 @@ enum TopCmd {
         #[command(subcommand)]
         cmd: wcore_cli::profile::ProfileCmd,
     },
+    /// Import an existing agent setup (Hermes) into wayland-core profiles.
+    Migrate {
+        #[command(subcommand)]
+        cmd: wcore_cli::migrate::MigrateCmd,
+    },
 }
 
 /// F-089: `models` sub-subcommands.
@@ -1150,6 +1155,14 @@ async fn run() -> anyhow::Result<ExitCode> {
                 Ok(()) => Ok(ExitCode::SUCCESS),
                 Err(e) => {
                     eprintln!("wayland-core profile: {e:#}");
+                    Ok(ExitCode::FAILURE)
+                }
+            },
+            // `migrate::run` is synchronous — no `.await` (mirrors `TopCmd::Profile`).
+            TopCmd::Migrate { cmd } => match wcore_cli::migrate::run(cmd) {
+                Ok(()) => Ok(ExitCode::SUCCESS),
+                Err(e) => {
+                    eprintln!("wayland-core migrate: {e:#}");
                     Ok(ExitCode::FAILURE)
                 }
             },

--- a/crates/wcore-cli/src/migrate/hermes.rs
+++ b/crates/wcore-cli/src/migrate/hermes.rs
@@ -1,0 +1,425 @@
+//! Hermes → wayland-core source loader + mappers (issue #228).
+//!
+//! Reads a Hermes home (`~/.hermes` by default) and turns each
+//! `profiles/<name>/` into a wayland-core [`ProfilePlan`]. Pure reconnaissance
+//! of the source tree — nothing here writes to disk; the apply step in
+//! [`super::apply_plan`] is the only writer.
+//!
+//! On-disk formats consumed (verified against a real Hermes install):
+//!   - `profiles/<name>/config.yaml` — a `model:` block
+//!     (`default` / `provider` / `base_url` / `api_mode`) and an optional
+//!     `mcp_servers:` map.
+//!   - `profiles/<name>/.env` — dotenv, provider-named keys (`<PROVIDER>_API_KEY`).
+//!   - `profiles/<name>/{skills/,SOUL.md,memories/}` — counted for the deferred
+//!     inventory, not imported in this slice.
+
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+use serde::Deserialize;
+use wcore_config::config::{McpServerConfig, ProfileConfig, TransportType};
+
+use super::{Deferred, MigrationPlan, ProfilePlan};
+
+/// Resolve and validate the Hermes home to import from.
+pub fn detect_home(explicit: Option<&Path>) -> Result<PathBuf> {
+    let home = match explicit {
+        Some(p) => p.to_path_buf(),
+        None => dirs::home_dir()
+            .context("cannot resolve the home directory to locate ~/.hermes")?
+            .join(".hermes"),
+    };
+    let profiles = home.join("profiles");
+    if !profiles.is_dir() {
+        bail!(
+            "no Hermes profiles found — expected a directory at {}",
+            profiles.display()
+        );
+    }
+    Ok(home)
+}
+
+/// Walk `<home>/profiles/*` and build the full migration plan.
+pub fn build_plan(home: &Path, include_credentials: bool) -> Result<MigrationPlan> {
+    let profiles_dir = home.join("profiles");
+    let existing_profiles = existing_profile_names();
+    let existing_mcp = existing_mcp_names();
+
+    let mut entries: Vec<PathBuf> = std::fs::read_dir(&profiles_dir)
+        .with_context(|| format!("reading {}", profiles_dir.display()))?
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| p.is_dir())
+        .collect();
+    entries.sort();
+
+    let mut profiles = Vec::new();
+    let mut mcp_servers: BTreeMap<String, McpServerConfig> = BTreeMap::new();
+    let mut mcp_conflicts: Vec<String> = Vec::new();
+    let mut deferred = Deferred::default();
+    let mut warnings = Vec::new();
+
+    for dir in entries {
+        let name = match dir.file_name().and_then(|n| n.to_str()) {
+            Some(n) => n.to_string(),
+            None => continue,
+        };
+        let cfg_path = dir.join("config.yaml");
+        if !cfg_path.is_file() {
+            warnings.push(format!("profile {name:?}: no config.yaml — skipped"));
+            continue;
+        }
+        let hermes =
+            parse_config(&cfg_path).with_context(|| format!("parsing {}", cfg_path.display()))?;
+
+        let (provider, model) = map_model(&hermes.model);
+        let mut config = ProfileConfig {
+            provider,
+            model,
+            base_url: hermes.model.base_url.clone(),
+            ..Default::default()
+        };
+
+        // MCP servers: add new ones globally, reference all by name.
+        let mut refs: Vec<String> = Vec::new();
+        for (srv_name, srv) in hermes.mcp_servers.unwrap_or_default() {
+            if existing_mcp.contains(&srv_name) {
+                if !mcp_conflicts.contains(&srv_name) {
+                    mcp_conflicts.push(srv_name.clone());
+                }
+            } else {
+                mcp_servers
+                    .entry(srv_name.clone())
+                    .or_insert_with(|| map_mcp(&srv));
+            }
+            refs.push(srv_name);
+        }
+        refs.sort();
+        refs.dedup();
+        if !refs.is_empty() {
+            config.mcp_servers = Some(refs.clone());
+        }
+
+        // Credentials (value read only when it may be written; name always
+        // recorded for the preview).
+        let mut credential_env_var = None;
+        let mut has_credential = false;
+        let env_path = dir.join(".env");
+        if env_path.is_file() {
+            let env = parse_dotenv(&env_path).unwrap_or_default();
+            if let Some((var, value)) = pick_provider_key(&env, config.provider.as_deref()) {
+                has_credential = true;
+                credential_env_var = Some(var);
+                if include_credentials {
+                    config.api_key = Some(value);
+                }
+            }
+        }
+
+        // Deferred inventory.
+        deferred.skills += count_subdirs(&dir.join("skills"));
+        if dir.join("SOUL.md").is_file() {
+            deferred.personas += 1;
+        }
+        deferred.memory_files += count_memory_notes(&dir.join("memories"));
+
+        profiles.push(ProfilePlan {
+            conflict: existing_profiles.contains(&name),
+            name,
+            config,
+            has_credential,
+            credential_env_var,
+            mcp_refs: refs,
+        });
+    }
+
+    if profiles.is_empty() {
+        bail!(
+            "no importable Hermes profiles under {}",
+            profiles_dir.display()
+        );
+    }
+
+    mcp_conflicts.sort();
+    mcp_conflicts.dedup();
+    Ok(MigrationPlan {
+        source: "hermes",
+        source_home: home.to_path_buf(),
+        profiles,
+        mcp_servers,
+        mcp_conflicts,
+        deferred,
+        warnings,
+    })
+}
+
+// --- Hermes source schema (permissive; unknown keys ignored) ---
+
+#[derive(Debug, Deserialize, Default)]
+struct HermesConfig {
+    #[serde(default)]
+    model: HermesModel,
+    #[serde(default)]
+    mcp_servers: Option<HashMap<String, HermesMcpServer>>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct HermesModel {
+    default: Option<String>,
+    provider: Option<String>,
+    base_url: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct HermesMcpServer {
+    command: Option<String>,
+    args: Option<Vec<String>>,
+    env: Option<HashMap<String, String>>,
+    url: Option<String>,
+    headers: Option<HashMap<String, String>>,
+    transport: Option<String>,
+}
+
+fn parse_config(path: &Path) -> Result<HermesConfig> {
+    let raw = std::fs::read_to_string(path)?;
+    let cfg: HermesConfig = serde_yaml::from_str(&raw)?;
+    Ok(cfg)
+}
+
+/// Map the Hermes `model:` block to `(provider, model)`. A leading
+/// `<provider>/` prefix on the model id is stripped when it matches the
+/// declared provider (Hermes stores e.g. `deepseek/deepseek-v4-pro` +
+/// `provider: deepseek`; wayland-core wants the bare `deepseek-v4-pro`).
+fn map_model(m: &HermesModel) -> (Option<String>, Option<String>) {
+    let provider = m.provider.clone();
+    let model = m.default.clone().map(|d| {
+        if let Some(p) = &provider
+            && let Some(rest) = d.strip_prefix(&format!("{p}/"))
+        {
+            return rest.to_string();
+        }
+        d
+    });
+    (provider, model)
+}
+
+fn map_mcp(s: &HermesMcpServer) -> McpServerConfig {
+    let transport = match s.transport.as_deref() {
+        Some("sse") => TransportType::Sse,
+        Some("http" | "streamable-http" | "streamable_http") => TransportType::StreamableHttp,
+        Some("stdio") => TransportType::Stdio,
+        // No explicit transport: URL-only ⇒ HTTP, otherwise stdio.
+        _ if s.url.is_some() && s.command.is_none() => TransportType::StreamableHttp,
+        _ => TransportType::Stdio,
+    };
+    McpServerConfig {
+        transport,
+        command: s.command.clone(),
+        args: s.args.clone(),
+        env: s.env.clone(),
+        url: s.url.clone(),
+        headers: s.headers.clone(),
+        deferred: None,
+        allow_local: false,
+        only_for_assistant: None,
+    }
+}
+
+/// Minimal dotenv reader: `KEY=VALUE`, `#` comments and blank lines skipped, an
+/// optional `export ` prefix stripped, and a single layer of matching quotes
+/// removed. Good enough for the provider-key case; not a full dotenv parser.
+fn parse_dotenv(path: &Path) -> Result<HashMap<String, String>> {
+    let raw = std::fs::read_to_string(path)?;
+    let mut map = HashMap::new();
+    for line in raw.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let line = line.strip_prefix("export ").unwrap_or(line);
+        let Some((key, val)) = line.split_once('=') else {
+            continue;
+        };
+        let key = key.trim();
+        if key.is_empty() {
+            continue;
+        }
+        let mut val = val.trim();
+        if val.len() >= 2
+            && ((val.starts_with('"') && val.ends_with('"'))
+                || (val.starts_with('\'') && val.ends_with('\'')))
+        {
+            val = &val[1..val.len() - 1];
+        }
+        map.insert(key.to_string(), val.to_string());
+    }
+    Ok(map)
+}
+
+/// Choose the provider API key from a profile's `.env`. Prefers the
+/// provider-named `<PROVIDER>_API_KEY`; otherwise falls back to the
+/// lexicographically-first `*_API_KEY` so the choice is deterministic.
+fn pick_provider_key(
+    env: &HashMap<String, String>,
+    provider: Option<&str>,
+) -> Option<(String, String)> {
+    if let Some(p) = provider {
+        let want = format!("{}_API_KEY", p.to_ascii_uppercase());
+        if let Some(v) = env.get(&want) {
+            return Some((want, v.clone()));
+        }
+    }
+    let mut candidates: Vec<(&String, &String)> = env
+        .iter()
+        .filter(|(k, _)| k.ends_with("_API_KEY"))
+        .collect();
+    candidates.sort_by(|a, b| a.0.cmp(b.0));
+    candidates
+        .first()
+        .map(|(k, v)| ((*k).clone(), (*v).clone()))
+}
+
+fn count_subdirs(dir: &Path) -> usize {
+    std::fs::read_dir(dir)
+        .map(|rd| {
+            rd.filter_map(|e| e.ok())
+                .filter(|e| e.path().is_dir())
+                .count()
+        })
+        .unwrap_or(0)
+}
+
+/// Count `*.md` memory notes, excluding the `MEMORY.md` entrypoint (mirrors the
+/// `wcore-memory` legacy importer's exclusion).
+fn count_memory_notes(dir: &Path) -> usize {
+    std::fs::read_dir(dir)
+        .map(|rd| {
+            rd.filter_map(|e| e.ok())
+                .filter(|e| {
+                    e.path().extension().and_then(|x| x.to_str()) == Some("md")
+                        && e.file_name() != "MEMORY.md"
+                })
+                .count()
+        })
+        .unwrap_or(0)
+}
+
+fn existing_profile_names() -> HashSet<String> {
+    wcore_config::config::global_profiles()
+        .into_iter()
+        .map(|(name, _, _)| name)
+        .collect()
+}
+
+/// Read the `[mcp.servers]` names already present in the global `config.toml`.
+/// Best-effort and read-only: any missing file or parse error yields an empty
+/// set (the apply step never clobbers an existing server regardless).
+fn existing_mcp_names() -> HashSet<String> {
+    #[derive(Deserialize, Default)]
+    struct Probe {
+        #[serde(default)]
+        mcp: McpProbe,
+    }
+    #[derive(Deserialize, Default)]
+    struct McpProbe {
+        #[serde(default)]
+        servers: HashMap<String, toml::Value>,
+    }
+
+    let path = wcore_config::config::global_config_path();
+    let Ok(raw) = std::fs::read_to_string(path) else {
+        return HashSet::new();
+    };
+    toml::from_str::<Probe>(&raw)
+        .map(|p| p.mcp.servers.into_keys().collect())
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn map_model_strips_matching_provider_prefix() {
+        let m = HermesModel {
+            default: Some("deepseek/deepseek-v4-pro".into()),
+            provider: Some("deepseek".into()),
+            base_url: Some("https://api.deepseek.com/v1".into()),
+        };
+        let (provider, model) = map_model(&m);
+        assert_eq!(provider.as_deref(), Some("deepseek"));
+        assert_eq!(model.as_deref(), Some("deepseek-v4-pro"));
+    }
+
+    #[test]
+    fn map_model_keeps_id_when_prefix_does_not_match() {
+        let m = HermesModel {
+            default: Some("anthropic/claude".into()),
+            provider: Some("openrouter".into()),
+            base_url: None,
+        };
+        let (provider, model) = map_model(&m);
+        assert_eq!(provider.as_deref(), Some("openrouter"));
+        // Prefix belongs to a different provider — must NOT be stripped.
+        assert_eq!(model.as_deref(), Some("anthropic/claude"));
+    }
+
+    #[test]
+    fn dotenv_parses_export_quotes_and_comments() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join(".env");
+        std::fs::write(
+            &p,
+            "# comment\nexport DEEPSEEK_API_KEY=\"sk-abc\"\nOPENAI_API_KEY=sk-plain\n\nBROKEN\n",
+        )
+        .unwrap();
+        let env = parse_dotenv(&p).unwrap();
+        assert_eq!(env.get("DEEPSEEK_API_KEY").unwrap(), "sk-abc");
+        assert_eq!(env.get("OPENAI_API_KEY").unwrap(), "sk-plain");
+        assert!(!env.contains_key("BROKEN"));
+    }
+
+    #[test]
+    fn pick_provider_key_prefers_provider_named_var() {
+        let mut env = HashMap::new();
+        env.insert("OPENAI_API_KEY".to_string(), "openai".to_string());
+        env.insert("DEEPSEEK_API_KEY".to_string(), "deepseek".to_string());
+        let (var, val) = pick_provider_key(&env, Some("deepseek")).unwrap();
+        assert_eq!(var, "DEEPSEEK_API_KEY");
+        assert_eq!(val, "deepseek");
+    }
+
+    #[test]
+    fn pick_provider_key_falls_back_deterministically() {
+        let mut env = HashMap::new();
+        env.insert("OPENAI_API_KEY".to_string(), "b".to_string());
+        env.insert("ANTHROPIC_API_KEY".to_string(), "a".to_string());
+        // Provider not present as its own var ⇒ lexicographically-first *_API_KEY.
+        let (var, _) = pick_provider_key(&env, Some("deepseek")).unwrap();
+        assert_eq!(var, "ANTHROPIC_API_KEY");
+    }
+
+    #[test]
+    fn map_mcp_infers_transport() {
+        let stdio = HermesMcpServer {
+            command: Some("srv".into()),
+            ..Default::default()
+        };
+        assert_eq!(map_mcp(&stdio).transport, TransportType::Stdio);
+
+        let http = HermesMcpServer {
+            url: Some("https://example.com/mcp".into()),
+            ..Default::default()
+        };
+        assert_eq!(map_mcp(&http).transport, TransportType::StreamableHttp);
+    }
+
+    #[test]
+    fn parse_config_ignores_unknown_keys_and_null_mcp() {
+        let yaml = "model:\n  default: deepseek/x\n  provider: deepseek\n  api_mode: chat_completions\nmcp_servers:\nterminal:\n  foo: bar\n";
+        let cfg: HermesConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(cfg.model.provider.as_deref(), Some("deepseek"));
+        assert!(cfg.mcp_servers.unwrap_or_default().is_empty());
+    }
+}

--- a/crates/wcore-cli/src/migrate/mod.rs
+++ b/crates/wcore-cli/src/migrate/mod.rs
@@ -1,0 +1,409 @@
+//! CLI surface: `wayland-core migrate` — import an existing agent setup from
+//! another tool into wayland-core's named profiles (issue #228).
+//!
+//! First slice is **Hermes-first** (see [`hermes`]): a Hermes profile
+//! (`~/.hermes/profiles/<name>/`) maps ~1:1 onto a wayland-core named profile
+//! (`[profiles.<name>]` in `config.toml`) — provider, model, base URL, the MCP
+//! servers it references, and (opt-in) its provider API key.
+//!
+//! The importer follows the same discipline as the existing `legacy_import`
+//! precedent in `wcore-memory`: it is **non-destructive** (never writes to the
+//! source tree), **idempotent** (a profile whose name already exists is skipped
+//! unless `--overwrite`), and reports exactly what it did. The flow is
+//! detect → plan (preview) → confirm → apply, and `--dry-run` stops after the
+//! preview.
+//!
+//! Skills, personas (`SOUL.md`), and long-term memory are detected and counted
+//! in the preview but are NOT written in this slice — they are tracked for a
+//! follow-up rather than silently dropped.
+
+use std::collections::BTreeMap;
+use std::io::{IsTerminal, Write};
+use std::path::PathBuf;
+
+use anyhow::{Result, bail};
+use clap::{Args, Subcommand};
+use wcore_config::config::{McpServerConfig, ProfileConfig, patch_global_config};
+
+pub mod hermes;
+
+/// `wayland-core migrate <source>` subcommands.
+#[derive(Subcommand, Debug)]
+pub enum MigrateCmd {
+    /// Import Hermes profiles (`~/.hermes/profiles/*`) into wayland-core.
+    Hermes(HermesArgs),
+}
+
+/// Options for `migrate hermes`.
+#[derive(Args, Debug)]
+pub struct HermesArgs {
+    /// Hermes home to import from (default: `~/.hermes`).
+    #[arg(long)]
+    pub home: Option<PathBuf>,
+    /// Show what would be imported and exit without writing anything.
+    #[arg(long)]
+    pub dry_run: bool,
+    /// Apply without the interactive confirmation prompt.
+    #[arg(long)]
+    pub yes: bool,
+    /// Also import provider API keys. Keys are written into `config.toml`
+    /// (created `0600`). Off by default — secrets are never migrated silently.
+    #[arg(long)]
+    pub include_credentials: bool,
+    /// Overwrite wayland-core profiles whose name already exists.
+    #[arg(long)]
+    pub overwrite: bool,
+}
+
+/// One wayland-core profile to be created from a source profile.
+#[derive(Debug)]
+pub struct ProfilePlan {
+    /// Profile name (the `[profiles.<name>]` key).
+    pub name: String,
+    /// The mapped profile config. `api_key` is populated only when the caller
+    /// asked to include credentials AND a provider key was found.
+    pub config: ProfileConfig,
+    /// A provider API key was found in the source `.env` (regardless of whether
+    /// it will actually be written).
+    pub has_credential: bool,
+    /// The env var name the key came from — for the preview, never its value.
+    pub credential_env_var: Option<String>,
+    /// MCP server names this profile references.
+    pub mcp_refs: Vec<String>,
+    /// A wayland-core profile with this name already exists.
+    pub conflict: bool,
+}
+
+/// Source artifacts detected but intentionally NOT imported in this slice.
+#[derive(Debug, Default)]
+pub struct Deferred {
+    /// Skill directories found across the imported profiles.
+    pub skills: usize,
+    /// `SOUL.md` persona files found.
+    pub personas: usize,
+    /// Memory notes (`memories/*.md`, excluding the `MEMORY.md` entrypoint).
+    pub memory_files: usize,
+}
+
+/// The full set of changes an import would make.
+#[derive(Debug)]
+pub struct MigrationPlan {
+    /// Source tool name, e.g. `"hermes"`.
+    pub source: &'static str,
+    /// Resolved source home the plan was built from.
+    pub source_home: PathBuf,
+    /// Profiles to import (including ones flagged as conflicts).
+    pub profiles: Vec<ProfilePlan>,
+    /// New MCP server definitions to add, keyed by server name. Names already
+    /// present in `config.toml` are excluded here and listed in
+    /// [`MigrationPlan::mcp_conflicts`] instead.
+    pub mcp_servers: BTreeMap<String, McpServerConfig>,
+    /// MCP server names already present in `config.toml` (left untouched).
+    pub mcp_conflicts: Vec<String>,
+    /// Detected-but-deferred artifacts.
+    pub deferred: Deferred,
+    /// Non-fatal notes surfaced during planning.
+    pub warnings: Vec<String>,
+}
+
+impl MigrationPlan {
+    /// True when applying the plan would change nothing (every profile is a
+    /// conflict that will be skipped, and there are no new MCP servers).
+    fn is_empty(&self, overwrite: bool) -> bool {
+        let no_profiles = self.profiles.iter().all(|p| p.conflict) && !overwrite;
+        no_profiles && self.mcp_servers.is_empty()
+    }
+}
+
+/// Summary of what an apply actually wrote.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct MigrationReport {
+    pub profiles_added: usize,
+    pub profiles_skipped: usize,
+    pub mcp_added: usize,
+    pub credentials_written: usize,
+}
+
+/// Entry point for `wayland-core migrate`.
+pub fn run(cmd: MigrateCmd) -> Result<()> {
+    match cmd {
+        MigrateCmd::Hermes(args) => run_hermes(args),
+    }
+}
+
+fn run_hermes(args: HermesArgs) -> Result<()> {
+    let home = hermes::detect_home(args.home.as_deref())?;
+    let plan = hermes::build_plan(&home, args.include_credentials)?;
+
+    render_plan(&plan, args.include_credentials, args.overwrite);
+
+    if plan.is_empty(args.overwrite) {
+        println!("\nNothing to import — every profile already exists.");
+        return Ok(());
+    }
+    if args.dry_run {
+        println!("\nDry run — no changes written.");
+        return Ok(());
+    }
+    if !confirm(args.yes)? {
+        println!("Aborted — no changes written.");
+        return Ok(());
+    }
+
+    let report = apply_plan(&plan, args.include_credentials, args.overwrite)?;
+    print_report(&report, &plan);
+    Ok(())
+}
+
+/// Apply the plan to `config.toml` via the atomic partial writer.
+///
+/// A new profile is inserted whole. An EXISTING profile is only touched when
+/// `overwrite` is set, and then it is **merged, not replaced**: the
+/// importer-managed fields (provider, model, base URL, MCP refs) are refreshed
+/// from the source, but a stored `api_key` is never wiped — it is replaced only
+/// when this run both imports credentials AND actually found a new one — and
+/// hand-added fields (`max_tokens`, `max_turns`, `extends`, `compat`) are left
+/// intact. This keeps a previously-imported secret from silently vanishing on a
+/// re-sync. MCP servers are always left untouched when the name collides.
+fn apply_plan(
+    plan: &MigrationPlan,
+    include_credentials: bool,
+    overwrite: bool,
+) -> Result<MigrationReport> {
+    let selected: Vec<&ProfilePlan> = plan
+        .profiles
+        .iter()
+        .filter(|p| overwrite || !p.conflict)
+        .collect();
+
+    let credentials_written = if include_credentials {
+        selected
+            .iter()
+            .filter(|p| p.config.api_key.is_some())
+            .count()
+    } else {
+        0
+    };
+    let report = MigrationReport {
+        profiles_added: selected.len(),
+        profiles_skipped: plan.profiles.len() - selected.len(),
+        mcp_added: plan.mcp_servers.len(),
+        credentials_written,
+    };
+
+    patch_global_config(|f| {
+        for pp in &selected {
+            let incoming = &pp.config;
+            match f.profiles.get_mut(&pp.name) {
+                // Existing + `--overwrite`: merge, preserving secret & manual fields.
+                Some(existing) if overwrite => {
+                    existing.provider = incoming.provider.clone();
+                    existing.model = incoming.model.clone();
+                    existing.base_url = incoming.base_url.clone();
+                    existing.mcp_servers = incoming.mcp_servers.clone();
+                    if include_credentials && incoming.api_key.is_some() {
+                        existing.api_key = incoming.api_key.clone();
+                    }
+                }
+                // Existing without `--overwrite` (created between plan and
+                // apply): leave it untouched — fail-safe skip.
+                Some(_) => {}
+                // Fresh profile.
+                None => {
+                    let mut cfg = incoming.clone();
+                    if !include_credentials {
+                        cfg.api_key = None;
+                    }
+                    f.profiles.insert(pp.name.clone(), cfg);
+                }
+            }
+        }
+        for (name, def) in &plan.mcp_servers {
+            f.mcp
+                .servers
+                .entry(name.clone())
+                .or_insert_with(|| def.clone());
+        }
+    })?;
+
+    Ok(report)
+}
+
+/// Prompt for confirmation. `--yes` skips it. A non-interactive stdin without
+/// `--yes` is refused (fail-closed) rather than applied silently.
+fn confirm(yes: bool) -> Result<bool> {
+    if yes {
+        return Ok(true);
+    }
+    if !std::io::stdin().is_terminal() {
+        bail!("refusing to apply without confirmation; re-run with --yes");
+    }
+    print!("Apply these changes? [y/N] ");
+    std::io::stdout().flush().ok();
+    let mut line = String::new();
+    std::io::stdin().read_line(&mut line)?;
+    Ok(matches!(
+        line.trim().to_ascii_lowercase().as_str(),
+        "y" | "yes"
+    ))
+}
+
+fn render_plan(plan: &MigrationPlan, include_credentials: bool, overwrite: bool) {
+    println!("Migration plan: {} → wayland-core", plan.source);
+    println!("Source: {}", plan.source_home.display());
+    println!("\nProfiles ({}):", plan.profiles.len());
+    for p in &plan.profiles {
+        let flag = match (p.conflict, overwrite) {
+            (true, false) => "  [already exists — skipped unless --overwrite]",
+            (true, true) => {
+                "  [already exists — will be updated; existing credential & manual settings preserved]"
+            }
+            (false, _) => "",
+        };
+        println!("  • {}{}", p.name, flag);
+        println!(
+            "      provider={} model={}",
+            p.config.provider.as_deref().unwrap_or("?"),
+            p.config.model.as_deref().unwrap_or("?"),
+        );
+        if let Some(url) = &p.config.base_url {
+            println!("      base_url={url}");
+        }
+        if !p.mcp_refs.is_empty() {
+            println!("      mcp: {}", p.mcp_refs.join(", "));
+        }
+        if let Some(var) = &p.credential_env_var {
+            if include_credentials {
+                println!("      credential: {var} → config.toml (0600)");
+            } else {
+                println!(
+                    "      credential: {var} found — NOT imported (pass --include-credentials)"
+                );
+            }
+        }
+    }
+
+    if !plan.mcp_servers.is_empty() {
+        let names: Vec<&str> = plan.mcp_servers.keys().map(String::as_str).collect();
+        println!(
+            "\nMCP servers to add ({}): {}",
+            names.len(),
+            names.join(", ")
+        );
+    }
+    if !plan.mcp_conflicts.is_empty() {
+        println!(
+            "MCP servers already present (left untouched): {}",
+            plan.mcp_conflicts.join(", ")
+        );
+    }
+
+    let d = &plan.deferred;
+    if d.skills + d.personas + d.memory_files > 0 {
+        println!("\nDetected but NOT imported in this pass (tracked for a follow-up):");
+        if d.skills > 0 {
+            println!(
+                "  • {} skill director{}",
+                d.skills,
+                plural(d.skills, "y", "ies")
+            );
+        }
+        if d.personas > 0 {
+            println!(
+                "  • {} SOUL.md persona file{}",
+                d.personas,
+                plural(d.personas, "", "s")
+            );
+        }
+        if d.memory_files > 0 {
+            println!(
+                "  • {} memory note{}",
+                d.memory_files,
+                plural(d.memory_files, "", "s")
+            );
+        }
+    }
+    for w in &plan.warnings {
+        println!("  ! {w}");
+    }
+}
+
+fn print_report(report: &MigrationReport, plan: &MigrationPlan) {
+    println!(
+        "\nImported {} profile{} ({} skipped), {} MCP server{}, {} credential{}.",
+        report.profiles_added,
+        plural(report.profiles_added, "", "s"),
+        report.profiles_skipped,
+        report.mcp_added,
+        plural(report.mcp_added, "", "s"),
+        report.credentials_written,
+        plural(report.credentials_written, "", "s"),
+    );
+    let _ = plan;
+}
+
+fn plural(n: usize, one: &'static str, many: &'static str) -> &'static str {
+    if n == 1 { one } else { many }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn profile(name: &str, conflict: bool) -> ProfilePlan {
+        ProfilePlan {
+            name: name.into(),
+            config: ProfileConfig::default(),
+            has_credential: false,
+            credential_env_var: None,
+            mcp_refs: Vec::new(),
+            conflict,
+        }
+    }
+
+    fn plan_with(profiles: Vec<ProfilePlan>) -> MigrationPlan {
+        MigrationPlan {
+            source: "hermes",
+            source_home: PathBuf::from("/tmp/hermes"),
+            profiles,
+            mcp_servers: BTreeMap::new(),
+            mcp_conflicts: Vec::new(),
+            deferred: Deferred::default(),
+            warnings: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn is_empty_when_all_profiles_conflict_and_no_overwrite() {
+        let plan = plan_with(vec![profile("a", true), profile("b", true)]);
+        assert!(plan.is_empty(false));
+        // With --overwrite the conflicting profiles are writable again.
+        assert!(!plan.is_empty(true));
+    }
+
+    #[test]
+    fn is_empty_false_when_a_fresh_profile_exists() {
+        let plan = plan_with(vec![profile("a", true), profile("b", false)]);
+        assert!(!plan.is_empty(false));
+    }
+
+    #[test]
+    fn is_empty_false_when_only_new_mcp_servers() {
+        let mut plan = plan_with(vec![profile("a", true)]);
+        plan.mcp_servers.insert(
+            "srv".into(),
+            McpServerConfig {
+                transport: wcore_config::config::TransportType::Stdio,
+                command: Some("x".into()),
+                args: None,
+                env: None,
+                url: None,
+                headers: None,
+                deferred: None,
+                allow_local: false,
+                only_for_assistant: None,
+            },
+        );
+        assert!(!plan.is_empty(false));
+    }
+}

--- a/crates/wcore-cli/tests/migrate_hermes.rs
+++ b/crates/wcore-cli/tests/migrate_hermes.rs
@@ -1,0 +1,257 @@
+//! Integration tests for `wayland-core migrate hermes` (issue #228).
+//!
+//! Drives the public importer against a fixture Hermes home with `WAYLAND_HOME`
+//! pointed at a tempdir, then reads back the written `config.toml`. Serialized
+//! because the importer resolves `config.toml` through the process-global
+//! `WAYLAND_HOME` env var (same discipline as the `profile` CLI tests — avoids
+//! the env-race class that #192/#196 fenced).
+
+use std::path::{Path, PathBuf};
+
+use serial_test::serial;
+use tempfile::TempDir;
+use wcore_cli::migrate::{self, HermesArgs, MigrateCmd};
+
+/// RAII env guard restoring prior values on drop.
+struct EnvGuard(Vec<(&'static str, Option<std::ffi::OsString>)>);
+impl EnvGuard {
+    fn set(pairs: &[(&'static str, Option<&str>)]) -> Self {
+        let saved = pairs
+            .iter()
+            .map(|(k, v)| {
+                let prev = std::env::var_os(k);
+                match v {
+                    Some(val) => unsafe { std::env::set_var(k, val) },
+                    None => unsafe { std::env::remove_var(k) },
+                }
+                (*k, prev)
+            })
+            .collect();
+        Self(saved)
+    }
+}
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        for (k, prev) in &self.0 {
+            match prev {
+                Some(v) => unsafe { std::env::set_var(k, v) },
+                None => unsafe { std::env::remove_var(k) },
+            }
+        }
+    }
+}
+
+/// A tempdir `WAYLAND_HOME` (so `config.toml` resolves there) with `XDG_DATA_HOME`
+/// cleared so it can't shadow the override on Linux.
+fn rooted() -> (EnvGuard, TempDir) {
+    let home = tempfile::tempdir().unwrap();
+    let g = EnvGuard::set(&[
+        ("WAYLAND_HOME", Some(home.path().to_str().unwrap())),
+        ("XDG_DATA_HOME", None),
+    ]);
+    (g, home)
+}
+
+/// Build a fixture Hermes home with two profiles: `alpha` (full: model + mcp +
+/// key + persona + skill) and `beta` (bare model only).
+fn fixture_hermes() -> TempDir {
+    let dir = tempfile::tempdir().unwrap();
+    let alpha = dir.path().join("profiles/alpha");
+    std::fs::create_dir_all(alpha.join("skills/foo")).unwrap();
+    std::fs::create_dir_all(alpha.join("memories")).unwrap();
+    std::fs::write(
+        alpha.join("config.yaml"),
+        "model:\n  default: deepseek/deepseek-v4-pro\n  provider: deepseek\n  base_url: https://api.deepseek.com/v1\n  api_mode: chat_completions\nmcp_servers:\n  ijfw-memory:\n    command: /usr/bin/ijfw-memory\n    args: []\n    env:\n      PATH: /usr/bin\nterminal:\n  ignored: true\n",
+    )
+    .unwrap();
+    std::fs::write(alpha.join(".env"), "DEEPSEEK_API_KEY=sk-secret-alpha\n").unwrap();
+    std::fs::write(alpha.join("SOUL.md"), "You are alpha.").unwrap();
+    std::fs::write(
+        alpha.join("skills/foo/SKILL.md"),
+        "---\nname: foo\n---\nbody",
+    )
+    .unwrap();
+    std::fs::write(alpha.join("memories/note.md"), "a memory").unwrap();
+    std::fs::write(alpha.join("memories/MEMORY.md"), "entrypoint").unwrap();
+
+    let beta = dir.path().join("profiles/beta");
+    std::fs::create_dir_all(&beta).unwrap();
+    std::fs::write(
+        beta.join("config.yaml"),
+        "model:\n  default: claude-opus\n  provider: anthropic\n",
+    )
+    .unwrap();
+    dir
+}
+
+fn config_toml(home: &Path) -> String {
+    std::fs::read_to_string(home.join("config.toml")).unwrap_or_default()
+}
+
+fn hermes_args(home: &Path, include_credentials: bool, overwrite: bool) -> HermesArgs {
+    HermesArgs {
+        home: Some(home.to_path_buf()),
+        dry_run: false,
+        yes: true,
+        include_credentials,
+        overwrite,
+    }
+}
+
+#[test]
+#[serial]
+fn build_plan_maps_hermes_profiles() {
+    let _g = rooted().0; // isolate global_profiles() reads
+    let hermes = fixture_hermes();
+    let plan = migrate::hermes::build_plan(hermes.path(), false).unwrap();
+
+    assert_eq!(plan.source, "hermes");
+    assert_eq!(plan.profiles.len(), 2, "alpha + beta");
+
+    // Sorted: alpha first.
+    let alpha = &plan.profiles[0];
+    assert_eq!(alpha.name, "alpha");
+    assert_eq!(alpha.config.provider.as_deref(), Some("deepseek"));
+    // "deepseek/" prefix stripped against the matching provider.
+    assert_eq!(alpha.config.model.as_deref(), Some("deepseek-v4-pro"));
+    assert_eq!(
+        alpha.config.base_url.as_deref(),
+        Some("https://api.deepseek.com/v1")
+    );
+    assert_eq!(alpha.mcp_refs, vec!["ijfw-memory".to_string()]);
+    assert!(alpha.has_credential);
+    assert_eq!(
+        alpha.credential_env_var.as_deref(),
+        Some("DEEPSEEK_API_KEY")
+    );
+    // include_credentials=false ⇒ the value is NOT loaded into the plan.
+    assert!(alpha.config.api_key.is_none());
+
+    // New MCP server captured globally.
+    assert!(plan.mcp_servers.contains_key("ijfw-memory"));
+    let srv = &plan.mcp_servers["ijfw-memory"];
+    assert_eq!(srv.command.as_deref(), Some("/usr/bin/ijfw-memory"));
+
+    // Deferred inventory counted, not imported.
+    assert_eq!(plan.deferred.skills, 1);
+    assert_eq!(plan.deferred.personas, 1);
+    assert_eq!(plan.deferred.memory_files, 1, "MEMORY.md excluded");
+
+    let beta = &plan.profiles[1];
+    assert_eq!(beta.name, "beta");
+    assert_eq!(beta.config.provider.as_deref(), Some("anthropic"));
+    assert!(!beta.has_credential);
+}
+
+#[test]
+#[serial]
+fn apply_writes_profiles_and_mcp_without_secrets_by_default() {
+    let (_g, home) = rooted();
+    let hermes = fixture_hermes();
+
+    migrate::run(MigrateCmd::Hermes(hermes_args(hermes.path(), false, false))).unwrap();
+
+    let names: Vec<String> = wcore_config::config::global_profiles()
+        .into_iter()
+        .map(|(n, _, _)| n)
+        .collect();
+    assert!(names.contains(&"alpha".to_string()));
+    assert!(names.contains(&"beta".to_string()));
+
+    let toml = config_toml(home.path());
+    assert!(toml.contains("[profiles.alpha]"));
+    assert!(toml.contains("deepseek-v4-pro"));
+    assert!(toml.contains("[mcp.servers.ijfw-memory]"));
+    // No credentials imported by default.
+    assert!(
+        !toml.contains("sk-secret-alpha"),
+        "default import must not write the API key"
+    );
+    assert!(!toml.contains("api_key"));
+}
+
+#[test]
+#[serial]
+fn include_credentials_writes_key_and_overwrite_replaces() {
+    let (_g, home) = rooted();
+    let hermes = fixture_hermes();
+
+    // First import without secrets.
+    migrate::run(MigrateCmd::Hermes(hermes_args(hermes.path(), false, false))).unwrap();
+    assert!(!config_toml(home.path()).contains("sk-secret-alpha"));
+
+    // Re-run WITH credentials + overwrite ⇒ key now present.
+    migrate::run(MigrateCmd::Hermes(hermes_args(hermes.path(), true, true))).unwrap();
+    let toml = config_toml(home.path());
+    assert!(
+        toml.contains("sk-secret-alpha"),
+        "--include-credentials must write the API key"
+    );
+}
+
+#[test]
+#[serial]
+fn overwrite_without_credentials_preserves_secret_and_manual_fields() {
+    let (_g, home) = rooted();
+    let hermes = fixture_hermes();
+
+    // Import WITH credentials → the api_key is stored.
+    migrate::run(MigrateCmd::Hermes(hermes_args(hermes.path(), true, false))).unwrap();
+    assert!(config_toml(home.path()).contains("sk-secret-alpha"));
+
+    // Hand-add an importer-UNmanaged field to the imported profile.
+    wcore_config::config::patch_global_config(|f| {
+        if let Some(p) = f.profiles.get_mut("alpha") {
+            p.max_tokens = Some(4096);
+        }
+    })
+    .unwrap();
+
+    // Re-sync WITHOUT --include-credentials but WITH --overwrite. This must
+    // refresh the managed fields WITHOUT wiping the stored secret or the
+    // hand-added field (the #228 cross-audit BLOCKER).
+    migrate::run(MigrateCmd::Hermes(hermes_args(hermes.path(), false, true))).unwrap();
+
+    let toml = config_toml(home.path());
+    assert!(
+        toml.contains("sk-secret-alpha"),
+        "overwrite without --include-credentials must preserve the stored api_key"
+    );
+    assert!(
+        toml.contains("4096"),
+        "hand-added max_tokens must survive an overwrite"
+    );
+    // Importer-managed field still present.
+    assert!(toml.contains("deepseek-v4-pro"));
+}
+
+#[test]
+#[serial]
+fn import_is_idempotent_without_overwrite() {
+    let (_g, home) = rooted();
+    let hermes = fixture_hermes();
+
+    migrate::run(MigrateCmd::Hermes(hermes_args(hermes.path(), false, false))).unwrap();
+    let first = config_toml(home.path());
+
+    // Second run without --overwrite is a no-op (existing profiles skipped) and
+    // must not error or duplicate entries.
+    migrate::run(MigrateCmd::Hermes(hermes_args(hermes.path(), false, false))).unwrap();
+    let second = config_toml(home.path());
+
+    assert_eq!(
+        first, second,
+        "re-import without --overwrite must not change config"
+    );
+    // Exactly one alpha table.
+    assert_eq!(second.matches("[profiles.alpha]").count(), 1);
+}
+
+#[test]
+#[serial]
+fn missing_hermes_home_errors() {
+    let _g = rooted().0;
+    let missing: PathBuf = tempfile::tempdir().unwrap().path().join("nope");
+    let err = migrate::hermes::detect_home(Some(&missing)).unwrap_err();
+    assert!(err.to_string().contains("no Hermes profiles"));
+}


### PR DESCRIPTION
## What

First slice of the **#228 migration engine**: a `wayland-core migrate hermes` subcommand that imports an existing Hermes setup (`~/.hermes/profiles/*`) into wayland-core named profiles. Flow: **detect → plan/preview → confirm → apply** (`--dry-run` stops after the preview).

Grounded against a real local Hermes install (not inference).

## Mapping

| Hermes | wayland-core |
|---|---|
| `profiles/<name>/config.yaml` → `model` block (default/provider/base_url) | `[profiles.<name>]` `ProfileConfig` (provider/model/base_url; a matching `<provider>/` prefix is stripped from the model id) |
| `mcp_servers` map | `[mcp.servers.*]` + the profile's `mcp_servers` refs |
| `.env` provider key (`<PROVIDER>_API_KEY`) | inline `api_key` — **only with `--include-credentials`** |

## Safety

- **Non-destructive** to the Hermes source (read-only).
- **Idempotent**: an existing profile is skipped unless `--overwrite`; re-runs never duplicate or corrupt entries. Colliding MCP servers are never clobbered.
- **Secrets**: never migrated by default, never printed in the preview (name only), and a non-interactive apply **fails closed** without `--yes`.
- **Merge on `--overwrite`** (not blind replace): managed fields (provider/model/base_url/mcp) refresh, but a previously-stored `api_key` and hand-added fields (`max_tokens`/`extends`/`compat`) are preserved. *(This closed a secret-loss BLOCKER found in adversarial review.)*

## Deferred (reported, not dropped)

Skills, personas (`SOUL.md`), and long-term memory are detected and **counted in the preview** but not written in this slice — tracked for a follow-up. **OpenClaw** import is the next slice.

## Tests

11 unit + 7 integration tests. Full `wcore-cli` suite green on the build box (1796 passed); clippy clean.

Closes the Hermes portion of #228 (wayland/#228).