### PR TITLE
feat(proving-ground): M1 harness + provenance & detection tests (#53)

### DIFF
--- a/crates/wcore-cli/build.rs
+++ b/crates/wcore-cli/build.rs
@@ -1,0 +1,24 @@
+use std::process::Command;
+
+fn main() {
+    let sha = Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .unwrap_or_else(|| "unknown".into());
+    println!("cargo:rustc-env=WAYLAND_SOURCE_SHA={sha}");
+
+    // Resolve the real HEAD path (works for both normal repos and worktrees).
+    let git_dir = std::process::Command::new("git")
+        .args(["rev-parse", "--git-dir"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .unwrap_or_default();
+    if !git_dir.is_empty() {
+        println!("cargo:rerun-if-changed={git_dir}/HEAD");
+    }
+}

--- a/crates/wcore-cli/src/main.rs
+++ b/crates/wcore-cli/src/main.rs
@@ -312,6 +312,12 @@ struct Cli {
     #[arg(long)]
     config_path: bool,
 
+    /// Print build provenance (version + embedded source git SHA) and exit.
+    /// Catches the stale-build class: the SHA must match the HEAD the binary
+    /// was compiled from. Used by the build-provenance integration test.
+    #[arg(long)]
+    build_info: bool,
+
     /// Print skill directory paths and exit
     #[arg(long)]
     skills_path: bool,
@@ -1166,6 +1172,16 @@ async fn run() -> anyhow::Result<ExitCode> {
     // touching config files, OAuth, or the engine bootstrap.
     if cli.doctor {
         return Ok(doctor::run(cli.probe_mcp).await);
+    }
+
+    // Handle --build-info: print version + embedded source SHA and exit.
+    if cli.build_info {
+        println!(
+            "wayland-core {} (source {})",
+            env!("CARGO_PKG_VERSION"),
+            env!("WAYLAND_SOURCE_SHA")
+        );
+        return Ok(ExitCode::SUCCESS);
     }
 
     // Handle --config-path

--- a/crates/wcore-cli/tests/build_provenance.rs
+++ b/crates/wcore-cli/tests/build_provenance.rs
@@ -1,0 +1,101 @@
+//! Build-provenance invariant (Known Bug #4).
+//!
+//! Dual-mode design:
+//!
+//! - **Default (local dev):** asserts the binary's embedded source SHA is an
+//!   ancestor of the current repo HEAD (`git merge-base --is-ancestor`).  This
+//!   is green after the common "build → commit → run tests" sequence because
+//!   the build SHA is simply an older point in the same lineage.  The invariant
+//!   still catches foreign or corrupt builds (SHA not in repo history at all).
+//!
+//! - **Strict (CI / overnight / fresh-build gate):** when `CI` or
+//!   `PROVING_GROUND_STRICT_PROVENANCE` is set, also asserts the embedded SHA
+//!   equals the current HEAD exactly.  This is only correct where the binary
+//!   is guaranteed to have been freshly built at HEAD (e.g. `cargo build`
+//!   immediately before `cargo nextest run` in the same CI job).
+//!
+//! Why not always strict?  In local dev the workflow is: build → work →
+//! commit → run tests.  After the commit HEAD advances but the binary's baked
+//! SHA doesn't change (Cargo's `rerun-if-changed` guards don't re-trigger on a
+//! plain `git commit`).  Requiring `embedded == HEAD` would red-fail on every
+//! commit-after-build, which is noise, not signal.
+
+#[test]
+fn binary_matches_repo_head() {
+    // ── 1. Resolve git HEAD ───────────────────────────────────────────────
+    let Ok(head_out) = std::process::Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+    else {
+        // git not available — skip; provenance check is only meaningful where git exists
+        return;
+    };
+    if !head_out.status.success() {
+        // not a git repo (box gate, tarball build) — skip
+        return;
+    }
+    let head = String::from_utf8_lossy(&head_out.stdout).trim().to_string();
+    if head.is_empty() {
+        return;
+    }
+
+    // ── 2. Extract embedded SHA from `wayland-core --build-info` ─────────
+    let info_out = std::process::Command::new(env!("CARGO_BIN_EXE_wayland-core"))
+        .arg("--build-info")
+        .output()
+        .unwrap();
+    let info = String::from_utf8_lossy(&info_out.stdout);
+
+    // Parse the "(source <sha>)" token.
+    let embedded_sha = info
+        .split_whitespace()
+        .skip_while(|t| *t != "(source")
+        .nth(1)
+        .map(|t| t.trim_end_matches(')').to_string())
+        .unwrap_or_default();
+
+    assert!(
+        !embedded_sha.is_empty() && embedded_sha != "unknown",
+        "binary did not emit a real source SHA in --build-info output: {info:?}"
+    );
+
+    // ── 3. Default mode: embedded SHA must be an ancestor of HEAD ─────────
+    //
+    // `git merge-base --is-ancestor A B` exits 0 iff A is an ancestor of B
+    // (or A == B).  This passes when the binary was built at HEAD or any
+    // earlier commit in the same lineage.
+    let ancestor_status = std::process::Command::new("git")
+        .args(["merge-base", "--is-ancestor", &embedded_sha, &head])
+        .status();
+
+    match ancestor_status {
+        Ok(s) if s.success() => {} // ancestor check passed — fall through to strict
+        Ok(_) => {
+            panic!(
+                "binary source {embedded_sha} is not reachable from HEAD \
+                 {head} — foreign or corrupt build"
+            );
+        }
+        Err(e) => {
+            panic!("git merge-base --is-ancestor failed: {e}");
+        }
+    }
+
+    // ── 4. Strict mode: embedded SHA must equal HEAD exactly ──────────────
+    //
+    // Enabled when CI or PROVING_GROUND_STRICT_PROVENANCE is set (any
+    // non-empty value).  Only safe in environments where the binary is
+    // freshly built at HEAD immediately before the test run.
+    let strict = std::env::var("CI").map(|v| !v.is_empty()).unwrap_or(false)
+        || std::env::var("PROVING_GROUND_STRICT_PROVENANCE")
+            .map(|v| !v.is_empty())
+            .unwrap_or(false);
+
+    if strict {
+        assert_eq!(
+            embedded_sha, head,
+            "STRICT: binary source {embedded_sha} != HEAD {head} \
+             (stale build — rebuild required)"
+        );
+    }
+}

--- a/crates/wcore-cli/tests/proving_ground.rs
+++ b/crates/wcore-cli/tests/proving_ground.rs
@@ -1,0 +1,235 @@
+//! Proving Ground integration tests — deterministic cell runner.
+//!
+//! Each test is a `Cell` that declares its config state, terminal shape,
+//! and a script closure that drives the PTY. `run_cell` materializes the
+//! config, launches the binary, runs the script, captures a `RunRecord`,
+//! and cleans up the tempdir.
+//!
+//! The whole harness is PTY-driven and therefore Unix-only — gate the entire
+//! test crate so it compiles to an empty binary on Windows (the
+//! `support::proving_ground` module is itself `#[cfg(unix)]`, so a file-scope
+//! `use` of it would otherwise fail to resolve on Windows).
+#![cfg(unix)]
+
+#[path = "support/mod.rs"]
+mod support;
+
+use std::time::Duration;
+
+use support::proving_ground::invariants;
+use support::proving_ground::record::{self, RunRecord};
+use support::proving_ground::{
+    CANONICAL_REVEAL_KEYS, Cell, ConfigState, Session, TermShape, run_cell,
+};
+
+const SECS_10: Duration = Duration::from_secs(10);
+
+#[cfg(unix)]
+#[test]
+fn run_cell_captures_a_runrecord_for_a_clean_boot() {
+    let cell = Cell {
+        name: "clean-boot",
+        config: ConfigState::ConfiguredOpenAi, // writes a minimal config so it boots to Workspace
+        term: TermShape::default(),
+        script: |pty, _s| {
+            pty.wait_for(
+                |t| t.contains("Workspace"),
+                std::time::Duration::from_secs(10),
+                "workspace",
+            );
+        },
+    };
+    let rec = run_cell(&cell);
+    assert!(
+        !rec.dirty_death,
+        "clean boot must not leave a dirty-death sentinel"
+    );
+    assert!(rec.final_screen.contains("Workspace"));
+}
+
+#[cfg(unix)]
+#[test]
+fn onboarding_persists_across_relaunch() {
+    let session = Session::new();
+    ConfigState::EnvKeysOnly.materialize(session.home()); // OPENAI_API_KEY in child env, no config.toml
+
+    // First launch: connect the detected env key (press '1'), complete the flow.
+    let mut p1 = session.launch();
+    p1.wait_for(
+        |t| t.contains("Detected in your environment"),
+        SECS_10,
+        "onboarding",
+    );
+    p1.send(b"1"); // connect OpenAI (offline) -> AddMore ("Keys saved")
+    // Env keys connect without a network round-trip and land on AddMore; the
+    // single detected key means the cursor defaults to "Continue".
+    p1.wait_for(|t| t.contains("Keys saved"), SECS_10, "keys-saved");
+    p1.send(b"\r"); // AddMore: Continue -> Name ("Almost done")
+    p1.wait_for(|t| t.contains("Almost done"), SECS_10, "name-step");
+    p1.send(b"\r"); // Name: finish -> Ready
+    p1.wait_for(|t| t.contains("Ready"), SECS_10, "ready");
+    p1.send(b"\r"); // finish -> Workspace
+
+    // Item 4: snapshot screen BEFORE quit so final_screen reflects the UI state.
+    let final_screen_p1 = record::redact(&p1.screen_text());
+    p1.quit();
+    let rec1 = RunRecord::capture_post_quit(session.home(), &mut p1, final_screen_p1);
+
+    // config.toml MUST now exist with the provider.
+    let cfg = std::fs::read_to_string(session.home().join("config.toml")).unwrap_or_default();
+    assert!(
+        cfg.contains("openai"),
+        "connect must persist a provider to config.toml"
+    );
+
+    // Second launch (same home): MUST land on Workspace, not Onboarding.
+    let mut p2 = session.launch();
+    p2.wait_for(
+        |t| t.contains("Workspace") && !t.contains("connect a provider to begin"),
+        SECS_10,
+        "workspace-not-onboarding",
+    );
+    let final_screen_p2 = record::redact(&p2.screen_text());
+    p2.quit();
+    let rec2 = RunRecord::capture_post_quit(session.home(), &mut p2, final_screen_p2);
+
+    // Item 4: wire the config_persists invariant.
+    invariants::config_persists(&[rec1, rec2]).unwrap();
+}
+
+#[cfg(unix)]
+#[test]
+fn connect_all_env_keys_persists_across_relaunch() {
+    let session = Session::new();
+    ConfigState::MultiEnvKeys.materialize(session.home()); // OPENAI + ANTHROPIC keys in env, no config.toml
+
+    // First launch: connect all detected env keys at once (press 'a').
+    let mut p1 = session.launch();
+    p1.wait_for(
+        |t| t.contains("Detected in your environment"),
+        SECS_10,
+        "onboarding",
+    );
+    p1.send(b"a"); // connect all env keys
+    // 'a' routes to Step::Name which renders "What should I call you?"
+    p1.wait_for(
+        |t| t.contains("What should I call you?"),
+        SECS_10,
+        "name-step",
+    );
+    p1.send(b"\r"); // accept default name → finish_with_config → Ready step
+    // Wait for Ready, then press ⏎ to enter the Workspace so quit() can
+    // send the palette /exit command cleanly (it requires the Workspace surface).
+    p1.wait_for(
+        |t| t.contains("Press") && t.contains("workspace"),
+        SECS_10,
+        "ready-step",
+    );
+    p1.send(b"\r"); // advance to Workspace
+    p1.wait_for(
+        |t| t.contains("Workspace") && !t.contains("connect a provider to begin"),
+        SECS_10,
+        "workspace-after-onboarding",
+    );
+
+    let final_screen_p1 = record::redact(&p1.screen_text());
+    p1.quit();
+    let rec1 = RunRecord::capture_post_quit(session.home(), &mut p1, final_screen_p1);
+
+    assert!(
+        !rec1.dirty_death,
+        "first launch must exit cleanly (no force-kill sentinel)"
+    );
+
+    // config.toml MUST now exist with BOTH provider slugs — proves the full
+    // multi-provider config was written, not just the single-provider stub
+    // that connect_all_env_keys persists as an early mid-flow checkpoint.
+    let cfg = std::fs::read_to_string(session.home().join("config.toml")).unwrap_or_default();
+    assert!(
+        cfg.contains("openai"),
+        "connect-all must write openai to config.toml; got: {cfg}"
+    );
+    assert!(
+        cfg.contains("anthropic"),
+        "connect-all must write anthropic to config.toml; got: {cfg}"
+    );
+
+    // Second launch (same home): MUST land on Workspace, not Onboarding.
+    let mut p2 = session.launch();
+    p2.wait_for(
+        |t| t.contains("Workspace") && !t.contains("connect a provider to begin"),
+        SECS_10,
+        "workspace-not-onboarding",
+    );
+    let final_screen_p2 = record::redact(&p2.screen_text());
+    p2.quit();
+    let rec2 = RunRecord::capture_post_quit(session.home(), &mut p2, final_screen_p2);
+
+    // Wire the config_persists invariant.
+    invariants::config_persists(&[rec1, rec2]).unwrap();
+}
+
+#[cfg(unix)]
+#[test]
+fn same_cell_yields_same_verdicts_twice() {
+    let cell = Cell {
+        name: "replay-determinism",
+        config: ConfigState::ConfiguredOpenAi,
+        term: TermShape::default(),
+        script: |pty, _s| {
+            pty.wait_for(
+                |t| t.contains("Workspace"),
+                std::time::Duration::from_secs(10),
+                "workspace",
+            );
+        },
+    };
+    let a = run_cell(&cell);
+    let b = run_cell(&cell);
+    assert_eq!(
+        a.dirty_death, b.dirty_death,
+        "dirty_death verdict must be stable across runs"
+    );
+    assert_eq!(
+        a.final_screen.contains("Workspace"),
+        b.final_screen.contains("Workspace"),
+        "Workspace-reached verdict must be stable across runs"
+    );
+    assert_eq!(
+        a.config_toml.is_some(),
+        b.config_toml.is_some(),
+        "config-present verdict must be stable across runs"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn doctor_content_reachable_at_short_height() {
+    let session = Session::new();
+    ConfigState::ConfiguredOpenAi.materialize(session.home());
+    // 24-row height forces overflow: the /doctor report spans SYSTEM ·
+    // PROVIDERS · CONFIG · TOOLS · MCP SERVERS · CHANNELS · DISCOVERED ·
+    // RECENT ERRORS · TOKEN BUDGET — more than 24 lines — so TOKENS is
+    // below the fold without scrolling.
+    let mut p = session.launch_sized(TermShape {
+        rows: 24,
+        cols: 100,
+    });
+    p.wait_for(|t| t.contains("Workspace"), SECS_10, "workspace");
+    p.send(b"/doctor\r");
+    p.wait_for(|t| t.contains("SYSTEM"), SECS_10, "doctor");
+    // The TOKEN BUDGET section must be reachable via the canonical reveal keys.
+    let reached = support::proving_ground::reach_text(
+        &mut p,
+        "TOKEN BUDGET",
+        CANONICAL_REVEAL_KEYS,
+        Duration::from_millis(300),
+    );
+    assert!(
+        reached,
+        "/doctor must scroll to its TOKEN BUDGET section at 24-row height"
+    );
+    // Wire the content_reachable invariant.
+    invariants::content_reachable("TOKEN BUDGET", reached);
+    p.quit();
+}

--- a/crates/wcore-cli/tests/support/mod.rs
+++ b/crates/wcore-cli/tests/support/mod.rs
@@ -3,3 +3,7 @@
 //! Included from integration test files via `#[path = "support/mod.rs"] mod support;`.
 
 pub mod mock_llm;
+pub mod pty;
+
+#[cfg(unix)]
+pub mod proving_ground;

--- a/crates/wcore-cli/tests/support/proving_ground/invariants.rs
+++ b/crates/wcore-cli/tests/support/proving_ground/invariants.rs
@@ -1,0 +1,122 @@
+//! Reusable invariant checkers for Proving Ground cells.
+//!
+//! Each function takes a slice of `RunRecord`s (one per launch of a
+//! `Session`) and returns `Ok(())` when the invariant holds or
+//! `Err(String)` with a human-readable failure message when it does not.
+//!
+//! Invariants are composable: a cell can assert several of them in
+//! sequence so the diagnostic message points at the specific violation.
+
+use super::record::RunRecord;
+
+/// Assert that a scroll/reveal key sequence was able to bring `target` into
+/// view.
+///
+/// `reached` is the result of [`super::reach_text`] — `true` if the target
+/// appeared on screen after sending the reveal keys, `false` if it never did.
+///
+/// This is a thin wrapper so invariant failures report the target label and a
+/// consistent message rather than a bare `assert!` with no context.
+///
+/// # Panics
+///
+/// Panics when `reached` is `false`, with a message naming the target.
+pub fn content_reachable(target: &str, reached: bool) {
+    assert!(
+        reached,
+        "content_reachable: '{target}' was not found on screen after sending \
+         the canonical reveal keys — the surface may not be scrollable"
+    );
+}
+
+/// Assert that after a connect run, a relaunch record lands on Workspace.
+///
+/// Specifically checks:
+/// 1. At least two records are present (`records[0]` = connect run,
+///    `records[1]` = relaunch run).
+/// 2. The connect run's `config_toml` is `Some` and contains a provider
+///    slug, confirming that onboarding wrote the selection to disk.
+/// 3. The relaunch run's `final_screen` contains "Workspace" and does NOT
+///    contain "connect a provider to begin" — the onboarding subtitle —
+///    confirming the binary booted to Workspace rather than re-entering
+///    onboarding.
+pub fn config_persists(records: &[RunRecord]) -> Result<(), String> {
+    if records.len() < 2 {
+        return Err(format!(
+            "config_persists requires at least 2 records (connect + relaunch), \
+             got {}",
+            records.len()
+        ));
+    }
+
+    let connect_rec = &records[0];
+    let relaunch_rec = &records[1];
+
+    // The connect run must have written a config.toml with a provider.
+    match &connect_rec.config_toml {
+        None => {
+            return Err(
+                "connect run: config.toml was not written — onboarding must persist \
+                 the provider choice to disk before the user quits"
+                    .to_string(),
+            );
+        }
+        Some(toml) if toml.trim().is_empty() => {
+            return Err(
+                "connect run: config.toml exists but is empty — expected at least \
+                 a [default] provider entry"
+                    .to_string(),
+            );
+        }
+        Some(toml) => {
+            // A minimal config must contain at least one provider slug.
+            // We do not prescribe which slug — any known provider name is
+            // sufficient evidence that onboarding made a choice.
+            let known_slugs = [
+                "anthropic",
+                "openai",
+                "openrouter",
+                "gemini",
+                "groq",
+                "xai",
+                "mistral",
+                "deepseek",
+                "fireworks",
+                "together",
+                "cerebras",
+                "perplexity",
+                "moonshot",
+                "ollama",
+            ];
+            let has_provider = known_slugs.iter().any(|slug| toml.contains(slug));
+            if !has_provider {
+                return Err(format!(
+                    "connect run: config.toml does not contain a known provider slug.\n\
+                     config.toml contents:\n{toml}"
+                ));
+            }
+        }
+    }
+
+    // The relaunch run must boot to Workspace, not Onboarding.
+    if !relaunch_rec.final_screen.contains("Workspace") {
+        return Err(format!(
+            "relaunch: final screen does not contain 'Workspace' — binary may \
+             have re-entered onboarding.\nfinal screen:\n{}",
+            relaunch_rec.final_screen
+        ));
+    }
+    if relaunch_rec
+        .final_screen
+        .contains("connect a provider to begin")
+    {
+        return Err(format!(
+            "relaunch: final screen contains the onboarding subtitle \
+             'connect a provider to begin' — binary re-entered onboarding \
+             instead of landing on Workspace.\nfinal screen:\n{}",
+            relaunch_rec.final_screen
+        ));
+    }
+
+    Ok(())
+}

--- a/crates/wcore-cli/tests/support/proving_ground/mod.rs
+++ b/crates/wcore-cli/tests/support/proving_ground/mod.rs
@@ -1,0 +1,351 @@
+//! Proving Ground harness — `Session`, `Cell`, `run_cell`, `ConfigState`,
+//! `TermShape`, and `RunRecord`.
+//!
+//! This module is the foundation scaffold: many public items exist for later
+//! Tasks 3 and 4 and are not yet used in Task 2's single test.
+#![allow(dead_code)]
+//!
+//! # Design
+//!
+//! A *cell* is the unit of test work: it declares its config state, its
+//! terminal shape, and a script closure that drives the PTY.  `run_cell`
+//! materializes the config, boots the binary in a throw-away tempdir, runs
+//! the script, captures a `RunRecord`, and cleans up.
+//!
+//! The harness is Unix-only (`portable_pty` cannot surface stdout in
+//! headless GHA runners on Windows — see `pty.rs`).
+
+#[cfg(unix)]
+pub use super::pty::Pty;
+#[allow(unused_imports)]
+// Re-exported for non-PTY (headless / json-stream) spawns only.
+// The PTY path (`Pty::spawn_with_env`) does its own STRIPPED_PROVIDER_ENV
+// strip directly; `harden_child_env` is for `std::process::Command` children.
+pub use super::pty::harden_child_env;
+pub mod invariants;
+pub mod record;
+pub use record::RunRecord;
+
+/// The canonical set of reveal keys for scroll/navigation tests.
+///
+/// Sent in order (and cycled) by [`reach_text`] to expose off-screen content:
+/// - `\x1b[B`  — VT100 Down arrow
+/// - `\x1b[6~` — VT100 Page Down
+/// - `j`       — vi-style down
+/// - `G`       — vi-style jump-to-end
+#[cfg(unix)]
+pub const CANONICAL_REVEAL_KEYS: &[&[u8]] = &[
+    b"\x1b[B",  // Down arrow
+    b"\x1b[6~", // Page Down
+    b"j",       // vi down
+    b"G",       // vi end
+];
+
+/// Send scroll/reveal keys to `pty` until `screen_text()` contains `target`.
+///
+/// If the target is already visible on the initial screen, returns `true`
+/// immediately without sending any keys. Otherwise, cycles through `keys` for
+/// up to 6 full rounds (sending each key, sleeping briefly, re-reading the
+/// screen). Returns `true` the instant the target appears, `false` if it never
+/// does within the budget.
+///
+/// `per_key` is the sleep duration **per key** (not total): after each key
+/// send the harness sleeps `per_key` before re-reading the screen.
+/// A value of ~300 ms gives the TUI time to redraw between each key event.
+#[cfg(unix)]
+pub fn reach_text(
+    pty: &mut Pty,
+    target: &str,
+    keys: &[&[u8]],
+    per_key: std::time::Duration,
+) -> bool {
+    if pty.screen_text().contains(target) {
+        return true;
+    }
+    for _ in 0..6 {
+        for &key in keys {
+            pty.send(key);
+            std::thread::sleep(per_key);
+            if pty.screen_text().contains(target) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+use std::path::Path;
+use tempfile::TempDir;
+
+// ---------------------------------------------------------------------------
+// Session
+// ---------------------------------------------------------------------------
+
+/// Owns one throw-away home directory. Every `launch()` call spawns the real
+/// binary against the same home — so the same `Session` can be used for
+/// *relaunch* scenarios (e.g. "boot, quit, reboot to the same home").
+pub struct Session {
+    home: TempDir,
+}
+
+impl Session {
+    /// Create a new session with a fresh temporary home directory.
+    pub fn new() -> Self {
+        Self {
+            home: TempDir::new().expect("tempdir"),
+        }
+    }
+
+    /// The path to this session's home directory.
+    pub fn home(&self) -> &Path {
+        self.home.path()
+    }
+
+    /// Spawn the real binary against this session's home.
+    ///
+    /// Calling `launch()` more than once on the same session re-uses the same
+    /// home directory (the binary reads whatever config/state is there), which
+    /// is how *relaunch* journeys are tested.
+    ///
+    /// If `ConfigState::EnvKeysOnly.materialize(home)` was called before this
+    /// launch, the `.proving-ground-env` sidecar written by `materialize` is
+    /// read and its `KEY=VALUE` pairs are injected into the child's environment
+    /// so the binary sees the fake provider key without a real credential.
+    #[cfg(unix)]
+    pub fn launch(&self) -> Pty {
+        let env_overrides = self.read_env_sidecar();
+        if env_overrides.is_empty() {
+            Pty::spawn(self.home.path())
+        } else {
+            Pty::spawn_with_env(self.home.path(), 40, 120, &env_overrides)
+        }
+    }
+
+    /// Read key=value pairs from the `.proving-ground-env` sidecar file, if
+    /// present.  Returns an empty vec when the file does not exist.
+    #[cfg(unix)]
+    fn read_env_sidecar(&self) -> Vec<(String, String)> {
+        let path = self.home.path().join(ENV_SIDECAR);
+        let Ok(contents) = std::fs::read_to_string(&path) else {
+            return Vec::new();
+        };
+        contents
+            .lines()
+            .filter_map(|line| {
+                let (k, v) = line.split_once('=')?;
+                Some((k.trim().to_string(), v.trim().to_string()))
+            })
+            .collect()
+    }
+
+    /// Spawn the real binary against this session's home with a specific
+    /// terminal size. Task 4 uses this for layout/wrapping tests.
+    #[cfg(unix)]
+    pub fn launch_sized(&self, term: TermShape) -> Pty {
+        let env_overrides = self.read_env_sidecar();
+        if env_overrides.is_empty() {
+            Pty::spawn_sized(self.home.path(), term.rows, term.cols)
+        } else {
+            Pty::spawn_with_env(self.home.path(), term.rows, term.cols, &env_overrides)
+        }
+    }
+}
+
+impl Default for Session {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ConfigState
+// ---------------------------------------------------------------------------
+
+/// Declares what (if any) configuration exists in the session home before
+/// the binary is launched.
+#[derive(Clone, Copy, Debug)]
+pub enum ConfigState {
+    /// No config file and no credential env vars — the binary sees a clean
+    /// slate and will enter the onboarding flow.
+    Fresh,
+
+    /// No config file, but `OPENAI_API_KEY` is present in the child's
+    /// environment. Tests the "key-from-env, no config file" path.
+    EnvKeysOnly,
+
+    /// A minimal OpenAI config is written (`gpt-4o`, dummy base_url) so the
+    /// binary boots directly to the Workspace surface without onboarding.
+    ConfiguredOpenAi,
+
+    /// `config.toml` is written with deliberately invalid TOML bytes.
+    /// Tests the "corrupt config" error path.
+    CorruptConfig,
+
+    /// No config file, but BOTH `OPENAI_API_KEY` and `ANTHROPIC_API_KEY` are
+    /// present in the child's environment.  Tests the "connect-all env-keys"
+    /// path (the `a` shortcut that collects ≥2 detected env keys at once).
+    MultiEnvKeys,
+}
+
+/// Name of the side-channel env file that `ConfigState::EnvKeysOnly`
+/// writes so `Session::launch()` can inject env vars without the caller
+/// needing to change the `launch()` call site.
+pub const ENV_SIDECAR: &str = ".proving-ground-env";
+
+impl ConfigState {
+    /// Write (or not write) the config file for this state into `home`.
+    ///
+    /// For `EnvKeysOnly`, writes a side-channel env file (`ENV_SIDECAR`)
+    /// so that `Session::launch()` can inject the fake provider key into
+    /// the child process without the test needing to call a different
+    /// spawn method.  This is how `session.launch()` can see the key even
+    /// though the caller only calls `materialize(session.home())`.
+    pub fn materialize(&self, home: &Path) {
+        match self {
+            ConfigState::Fresh => {
+                // No config file — leave the home directory empty.
+            }
+            ConfigState::EnvKeysOnly => {
+                // Write the env sidecar so Session::launch() picks it up.
+                // The fake key is safe to write to disk: it is a
+                // well-known test sentinel with no real credentials.
+                std::fs::write(
+                    home.join(ENV_SIDECAR),
+                    "OPENAI_API_KEY=sk-test-harness-envonly-00000000\n",
+                )
+                .expect("write .proving-ground-env");
+            }
+            ConfigState::ConfiguredOpenAi => {
+                // Dummy base_url points at a port that is not listening; the
+                // binary does NOT need the provider to be reachable to render
+                // the Workspace surface — it only hits the provider when the
+                // user sends a prompt.
+                super::pty::write_config(
+                    home,
+                    "openai",
+                    Some("gpt-4o"),
+                    Some("http://127.0.0.1:1"),
+                );
+            }
+            ConfigState::CorruptConfig => {
+                std::fs::write(home.join("config.toml"), b"this is not valid toml {{{")
+                    .expect("write corrupt config.toml");
+            }
+            ConfigState::MultiEnvKeys => {
+                // Write both keys to the env sidecar — no config.toml written.
+                std::fs::write(
+                    home.join(ENV_SIDECAR),
+                    "OPENAI_API_KEY=sk-test-harness-envonly-00000000\nANTHROPIC_API_KEY=sk-ant-harness-envonly-00000000\n",
+                )
+                .expect("write .proving-ground-env for MultiEnvKeys");
+            }
+        }
+    }
+
+    /// Additional environment variable overrides that must be set on the child
+    /// process for this config state.  Used by `run_cell` when spawning via
+    /// `Pty::spawn_with_env`.
+    pub fn env_overrides(&self) -> &[(&'static str, &'static str)] {
+        match self {
+            ConfigState::EnvKeysOnly => &[("OPENAI_API_KEY", "sk-test-harness-envonly-00000000")],
+            ConfigState::MultiEnvKeys => &[
+                ("OPENAI_API_KEY", "sk-test-harness-envonly-00000000"),
+                ("ANTHROPIC_API_KEY", "sk-ant-harness-envonly-00000000"),
+            ],
+            _ => &[],
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// TermShape
+// ---------------------------------------------------------------------------
+
+/// Terminal dimensions for the PTY.
+#[derive(Clone, Copy, Debug)]
+pub struct TermShape {
+    pub rows: u16,
+    pub cols: u16,
+}
+
+impl Default for TermShape {
+    fn default() -> Self {
+        Self {
+            rows: 40,
+            cols: 120,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Cell
+// ---------------------------------------------------------------------------
+
+/// A single test cell: the static metadata + script that `run_cell` executes.
+#[cfg(unix)]
+pub struct Cell {
+    /// Human-readable name used in diagnostics. Must be unique within the
+    /// test file.
+    pub name: &'static str,
+
+    /// Config state to materialize before launching the binary.
+    pub config: ConfigState,
+
+    /// Terminal dimensions for the PTY.
+    pub term: TermShape,
+
+    /// The test script: drives the PTY, then returns.  `run_cell` calls
+    /// `pty.quit()` and captures the `RunRecord` after the script returns.
+    pub script: fn(&mut Pty, &Session),
+}
+
+// ---------------------------------------------------------------------------
+// run_cell
+// ---------------------------------------------------------------------------
+
+/// Execute a `Cell` end-to-end and return the captured `RunRecord`.
+///
+/// 1. Creates a fresh `Session` (throw-away tempdir).
+/// 2. Calls `cell.config.materialize(session.home())`.
+/// 3. Spawns the binary (with any env overrides from `ConfigState`).
+/// 4. Runs `cell.script(&mut pty, &session)`.
+/// 5. Calls `pty.quit()`.
+/// 6. Captures and returns a `RunRecord`.
+#[cfg(unix)]
+pub fn run_cell(cell: &Cell) -> RunRecord {
+    let session = Session::new();
+    cell.config.materialize(session.home());
+
+    let env_overrides: Vec<(String, String)> = cell
+        .config
+        .env_overrides()
+        .iter()
+        .map(|(k, v)| (k.to_string(), v.to_string()))
+        .collect();
+
+    let mut pty = if env_overrides.is_empty() {
+        Pty::spawn_sized(session.home(), cell.term.rows, cell.term.cols)
+    } else {
+        Pty::spawn_with_env(
+            session.home(),
+            cell.term.rows,
+            cell.term.cols,
+            &env_overrides,
+        )
+    };
+
+    (cell.script)(&mut pty, &session);
+
+    // Phase 1: snapshot the screen while the script's final UI state is
+    // visible, BEFORE quit() sends the /exit command and scrolls/clears.
+    let final_screen = record::redact(&pty.screen_text());
+
+    // Phase 2: clean shutdown — sends /exit, waits for process exit.
+    // After this the CrashSentinel Drop has fired, so .dirty-death is gone
+    // for a normal run.
+    pty.quit();
+
+    // Phase 3: read filesystem state (config.toml, .dirty-death) now that
+    // the process has fully exited and its cleanup has run.
+    RunRecord::capture_post_quit(session.home(), &mut pty, final_screen)
+}

--- a/crates/wcore-cli/tests/support/proving_ground/record.rs
+++ b/crates/wcore-cli/tests/support/proving_ground/record.rs
@@ -1,0 +1,184 @@
+//! `RunRecord` — the captured output of one `run_cell` invocation.
+//!
+//! Fields are always redacted before storage so credential shapes never leak
+//! into test output or assertion messages.
+//!
+//! Many fields (`exit`, `config_toml`, `requests`) are scaffolded for later
+//! Tasks and are not yet read by Task 2's single test.
+#![allow(dead_code)]
+
+use std::path::Path;
+
+use super::super::mock_llm::RecordedRequest;
+
+// ---------------------------------------------------------------------------
+// Redaction
+// ---------------------------------------------------------------------------
+
+/// Mask credential shapes before storing any string in a `RunRecord`.
+///
+/// Patterns covered (conservative prefix-match so the redaction is
+/// self-describing in output):
+/// - `sk-ant-…`     Anthropic API keys
+/// - `sk-…`         OpenAI and OpenAI-compatible keys
+/// - `xai-…`        xAI / Grok keys
+/// - `sk-or-…`      OpenRouter keys
+/// - `r8_…`         Replicate tokens
+/// - `gsk_…`        Groq keys
+/// - `eyJ…`         JWT Bearer tokens (base64 header starts with `eyJ`)
+pub fn redact(s: &str) -> String {
+    // Simple state-machine redactor: scan for prefix, then replace until the
+    // next whitespace or end-of-string.  Using a simple loop instead of a
+    // regex dep keeps the implementation self-contained and matches the
+    // project's "no new deps for one function" rule.
+    const PREFIXES: &[&str] = &["sk-ant-", "sk-or-", "sk-", "xai-", "r8_", "gsk_", "eyJ"];
+
+    let mut out = String::with_capacity(s.len());
+    let bytes = s.as_bytes();
+    let mut i = 0;
+
+    'outer: while i < bytes.len() {
+        // Try each prefix at the current position.
+        for &prefix in PREFIXES {
+            if bytes[i..].starts_with(prefix.as_bytes()) {
+                // Emit the redaction label.
+                out.push_str("<REDACTED>");
+                // Skip until whitespace, end-of-string, or a `"` quote
+                // (common in TOML/JSON contexts).
+                i += prefix.len();
+                while i < bytes.len()
+                    && bytes[i] != b' '
+                    && bytes[i] != b'\t'
+                    && bytes[i] != b'\n'
+                    && bytes[i] != b'\r'
+                    && bytes[i] != b'"'
+                    && bytes[i] != b'\''
+                {
+                    i += 1;
+                }
+                continue 'outer;
+            }
+        }
+        // No prefix matched — copy the byte verbatim.
+        out.push(bytes[i] as char);
+        i += 1;
+    }
+
+    out
+}
+
+// ---------------------------------------------------------------------------
+// RunRecord
+// ---------------------------------------------------------------------------
+
+/// The captured outcome of one `run_cell` invocation.
+///
+/// All string fields are redacted via [`redact`] before storage.
+#[derive(Debug)]
+pub struct RunRecord {
+    /// Terminal screen contents at the point `RunRecord::capture` was called
+    /// (after `pty.quit()`). Credential shapes are masked.
+    pub final_screen: String,
+
+    /// 0 on clean exit, 1 on any non-zero exit (portable_pty does not expose
+    /// the raw code), None if still running.
+    pub exit: Option<i32>,
+
+    /// The contents of `<home>/config.toml` at capture time, if it exists.
+    /// Credential shapes are masked.
+    pub config_toml: Option<String>,
+
+    /// Requests recorded by a `MockLlm` server during the cell run.
+    /// Empty when the cell does not wire up a mock (the majority of harness
+    /// cells do not drive LLM turns).
+    pub requests: Vec<RecordedRequest>,
+
+    /// True iff the `<home>/.dirty-death` sentinel file exists at capture
+    /// time.  The binary writes this file when it exits abnormally (panic,
+    /// signal, unclean shutdown).  A well-behaved clean-boot cell must never
+    /// leave this sentinel behind.
+    pub dirty_death: bool,
+}
+
+impl RunRecord {
+    /// Capture the final outcome of a cell run.
+    ///
+    /// Call order in `run_cell`:
+    /// 1. `final_screen = redact(&pty.screen_text())` — snapshot BEFORE quit
+    /// 2. `pty.quit()` — clean shutdown (waits for exit)
+    /// 3. `RunRecord::capture_post_quit(home, &mut pty, final_screen)` — reads
+    ///    filesystem state now that the process has exited cleanly
+    ///
+    /// This two-phase approach ensures:
+    /// - `final_screen` reflects the script's last UI state (e.g. "Workspace")
+    /// - `dirty_death` is checked after the `CrashSentinel` Drop has run, so a
+    ///   clean exit correctly shows `false` (the sentinel file is gone)
+    #[cfg(unix)]
+    pub fn capture_post_quit(
+        home: &Path,
+        pty: &mut super::super::pty::Pty,
+        final_screen: String,
+    ) -> Self {
+        let config_toml = std::fs::read_to_string(home.join("config.toml"))
+            .ok()
+            .map(|s| redact(&s));
+        // Check after clean exit: the CrashSentinel Drop removes the file on
+        // clean shutdown, so this should be false for a well-behaved run.
+        let dirty_death = home.join(".dirty-death").exists();
+
+        // Best-effort: process has exited (quit() waited), so try_wait
+        // should return immediately with a status.
+        let exit = pty
+            .wait_for_exit(std::time::Duration::from_millis(100))
+            .map(|status| if status.success() { 0i32 } else { 1i32 });
+
+        Self {
+            final_screen,
+            exit,
+            config_toml,
+            requests: Vec::new(),
+            dirty_death,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn redact_openai_key() {
+        let s = "api_key = \"sk-ant-harness-not-real-key-0000000000\"";
+        let r = redact(s);
+        assert!(!r.contains("sk-ant-"), "key prefix must be masked");
+        assert!(r.contains("<REDACTED>"), "must contain placeholder");
+    }
+
+    #[test]
+    fn redact_xai_key() {
+        let s = "Authorization: Bearer xai-supersecrettoken123";
+        let r = redact(s);
+        assert!(!r.contains("xai-"), "xai key must be masked");
+        assert!(r.contains("<REDACTED>"));
+    }
+
+    #[test]
+    fn redact_leaves_normal_text_alone() {
+        let s = "hello world no credentials here";
+        assert_eq!(redact(s), s);
+    }
+
+    #[test]
+    fn redact_multiple_keys_in_one_string() {
+        let s = "key1=sk-abc key2=sk-or-xyz";
+        let r = redact(s);
+        assert!(!r.contains("sk-abc"), "first key must be masked");
+        assert!(!r.contains("sk-or-xyz"), "second key must be masked");
+        let count = r.matches("<REDACTED>").count();
+        assert_eq!(count, 2, "two placeholders expected; got: {r}");
+    }
+}

--- a/crates/wcore-cli/tests/support/pty.rs
+++ b/crates/wcore-cli/tests/support/pty.rs
@@ -1,0 +1,280 @@
+//! Shared PTY harness for the wcore-cli integration test suite.
+//!
+//! Exposes [`Pty`], [`boot`], [`write_config`], [`harden_child_env`], and
+//! [`STRIPPED_PROVIDER_ENV`] so multiple integration test binaries can share the
+//! same hermetic harness without copy-paste.
+//!
+//! `Pty` and `boot` are Unix-only (`portable_pty` ConPTY cannot surface stdout
+//! in headless GHA runners — see the module doc in `smoke_p0.rs`).
+//! `write_config`, `harden_child_env`, and `STRIPPED_PROVIDER_ENV` are
+//! cross-platform.
+//!
+//! This is a shared support module included into multiple integration test
+//! binaries.  Each binary uses only a subset of the items, so dead-code
+//! warnings per-binary are expected and suppressed here.
+#![allow(dead_code)]
+
+use std::path::Path;
+
+// ===========================================================================
+// Cross-platform helpers (no #[cfg(unix)] guard).
+// ===========================================================================
+
+/// Seed `<home>/config.toml` for a provider/model, optionally routing the
+/// provider `base_url` at a local mock. `model: None` writes NO model line —
+/// the exact catalog-provider shape the D002 GAP check needs.
+pub fn write_config(home: &Path, provider: &str, model: Option<&str>, base_url: Option<&str>) {
+    let mut toml = format!("[default]\nprovider = \"{provider}\"\n");
+    if let Some(m) = model {
+        toml.push_str(&format!("model = \"{m}\"\n"));
+    }
+    toml.push_str(&format!(
+        "\n[providers.{provider}]\napi_key = \"sk-ant-harness-not-real-key-0000000000\"\n"
+    ));
+    if let Some(url) = base_url {
+        toml.push_str(&format!("base_url = \"{url}\"\n"));
+    }
+    std::fs::write(home.join("config.toml"), toml).expect("write config.toml");
+}
+
+/// The full provider-credential env-var set every spawned child must NOT
+/// inherit, so a run can neither read the developer's real keys nor have
+/// onboarding auto-detect a stray dev credential. ONE source of truth used by
+/// `run_headless`, the PTY spawn, and the `--json-stream` child — keeps the
+/// strip set honest and uniform (M6). `AWS_*` / `VERTEX*` are stripped by name
+/// (the concrete vars Bedrock/Vertex auth reads), not by glob.
+pub const STRIPPED_PROVIDER_ENV: &[&str] = &[
+    "API_KEY",
+    // Core providers.
+    "ANTHROPIC_API_KEY",
+    "OPENAI_API_KEY",
+    "AZURE_OPENAI_API_KEY",
+    "GEMINI_API_KEY",
+    "GOOGLE_API_KEY",
+    "OPENROUTER_API_KEY",
+    "DEEPSEEK_API_KEY",
+    "GROQ_API_KEY",
+    "XAI_API_KEY",
+    "MISTRAL_API_KEY",
+    "COHERE_API_KEY",
+    "PERPLEXITY_API_KEY",
+    "CEREBRAS_API_KEY",
+    "TOGETHER_API_KEY",
+    "FIREWORKS_API_KEY",
+    "NVIDIA_API_KEY",
+    "FLUX_API_KEY",
+    "MOONSHOT_API_KEY",
+    "DASHSCOPE_API_KEY",
+    "ALIBABA_API_KEY",
+    "MINIMAX_API_KEY",
+    // Token-style credentials (not _API_KEY suffix).
+    "REPLICATE_API_TOKEN",
+    "HF_TOKEN",
+    "HUGGINGFACE_API_KEY",
+    "HUGGING_FACE_HUB_TOKEN",
+    // AWS (Bedrock) — concrete vars the provider auth chain reads.
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_SESSION_TOKEN",
+    "AWS_PROFILE",
+    "AWS_REGION",
+    "AWS_DEFAULT_REGION",
+    // Google Vertex.
+    "VERTEX_PROJECT",
+    "VERTEX_LOCATION",
+    "GOOGLE_APPLICATION_CREDENTIALS",
+];
+
+/// Apply the hermetic child env uniformly: point `WAYLAND_HOME` + `HOME` at the
+/// throwaway tempdir, set a deterministic `TERM`, and strip every credential in
+/// [`STRIPPED_PROVIDER_ENV`]. The single place that defines "hermetic child
+/// env" so the headless / PTY / json-stream spawns can never drift apart (M6).
+pub fn harden_child_env(cmd: &mut std::process::Command, home: &Path) {
+    cmd.env("WAYLAND_HOME", home)
+        .env("HOME", home)
+        // Headless / json-stream children get a deterministic non-TTY term. The
+        // PTY spawn (which needs a real terminal type) sets its own TERM and
+        // does NOT route through this helper.
+        .env("TERM", "dumb");
+    for key in STRIPPED_PROVIDER_ENV {
+        cmd.env_remove(key);
+    }
+}
+
+// ===========================================================================
+// PTY harness — Unix only.
+// ===========================================================================
+
+#[cfg(unix)]
+use std::io::{Read, Write};
+#[cfg(unix)]
+use std::time::{Duration, Instant};
+
+#[cfg(unix)]
+use portable_pty::{CommandBuilder, MasterPty, PtySize, native_pty_system};
+
+/// Path to the debug binary under test (Cargo wires this env var).
+#[cfg(unix)]
+fn binary() -> &'static str {
+    env!("CARGO_BIN_EXE_wayland-core")
+}
+
+/// A minimal PTY harness — the proven shape from `harness_tui_flow.rs`,
+/// re-derived here because integration test files compile as separate
+/// binaries and cannot share a non-`support` module.
+#[cfg(unix)]
+pub struct Pty {
+    writer: Box<dyn Write + Send>,
+    parser: std::sync::Arc<std::sync::Mutex<vt100::Parser>>,
+    _master: Box<dyn MasterPty + Send>,
+    child: Box<dyn portable_pty::Child + Send + Sync>,
+    _reader: std::thread::JoinHandle<()>,
+}
+
+#[cfg(unix)]
+impl Pty {
+    pub fn spawn(home: &Path) -> Self {
+        Self::spawn_sized(home, 40, 120)
+    }
+
+    /// Spawn the binary against `home` with an explicit terminal size.
+    /// Used by the Proving Ground cell runner so each cell can declare its
+    /// own `TermShape` (e.g. narrow columns for wrapping tests).
+    pub fn spawn_sized(home: &Path, rows: u16, cols: u16) -> Self {
+        let no_extra: &[(&str, &str)] = &[];
+        Self::spawn_with_env(home, rows, cols, no_extra)
+    }
+
+    /// Spawn the binary against `home` with explicit terminal size and
+    /// additional environment variable overrides injected into the child.
+    /// Used by `run_cell` when `ConfigState::EnvKeysOnly` needs to inject
+    /// `OPENAI_API_KEY` without writing a config file.
+    pub fn spawn_with_env(
+        home: &Path,
+        rows: u16,
+        cols: u16,
+        extra_env: &[(impl AsRef<str>, impl AsRef<str>)],
+    ) -> Self {
+        let pty = native_pty_system()
+            .openpty(PtySize {
+                rows,
+                cols,
+                pixel_width: 0,
+                pixel_height: 0,
+            })
+            .expect("open PTY");
+
+        let mut cmd = CommandBuilder::new(binary());
+        cmd.env("HOME", home);
+        cmd.env("WAYLAND_HOME", home);
+        // The TUI needs a real terminal type (not "dumb") to render; the
+        // hermetic key-strip set is shared with the headless/json-stream
+        // spawns via STRIPPED_PROVIDER_ENV (M6).
+        cmd.env("TERM", "xterm-256color");
+        for key in STRIPPED_PROVIDER_ENV {
+            cmd.env_remove(key);
+        }
+        // Apply caller-supplied env overrides (e.g. OPENAI_API_KEY for EnvKeysOnly).
+        // These are applied AFTER the strip pass so they intentionally survive
+        // the hermetic strip (they are test-supplied, not developer credentials).
+        for (k, v) in extra_env {
+            cmd.env(k.as_ref(), v.as_ref());
+        }
+        cmd.cwd(home);
+        let child = pty.slave.spawn_command(cmd).expect("spawn wayland-core");
+
+        let mut reader = pty.master.try_clone_reader().expect("clone PTY reader");
+        let parser = std::sync::Arc::new(std::sync::Mutex::new(vt100::Parser::new(rows, cols, 0)));
+        let parser_for_thread = std::sync::Arc::clone(&parser);
+        let reader_handle = std::thread::spawn(move || {
+            let mut buf = [0u8; 8192];
+            loop {
+                match reader.read(&mut buf) {
+                    Ok(0) => break,
+                    Ok(n) => {
+                        if let Ok(mut p) = parser_for_thread.lock() {
+                            p.process(&buf[..n]);
+                        }
+                    }
+                    Err(_) => break,
+                }
+            }
+        });
+
+        let writer = pty.master.take_writer().expect("take PTY writer");
+        Self {
+            writer,
+            parser,
+            _master: pty.master,
+            child,
+            _reader: reader_handle,
+        }
+    }
+
+    pub fn screen_text(&self) -> String {
+        let parser = self.parser.lock().expect("parser lock");
+        parser.screen().contents()
+    }
+
+    pub fn wait_for<F: Fn(&str) -> bool>(&self, predicate: F, timeout: Duration, what: &str) {
+        let deadline = Instant::now() + timeout;
+        let mut last = String::new();
+        while Instant::now() < deadline {
+            last = self.screen_text();
+            if predicate(&last) {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(30));
+        }
+        panic!(
+            "timed out after {:?} waiting for {what}.\n--- last screen ---\n{}\n--- end ---",
+            timeout, last
+        );
+    }
+
+    pub fn send(&mut self, bytes: &[u8]) {
+        self.writer.write_all(bytes).expect("write to PTY");
+        self.writer.flush().ok();
+    }
+
+    pub fn wait_for_exit(&mut self, timeout: Duration) -> Option<portable_pty::ExitStatus> {
+        let deadline = Instant::now() + timeout;
+        while Instant::now() < deadline {
+            match self.child.try_wait() {
+                Ok(Some(status)) => return Some(status),
+                Ok(None) => std::thread::sleep(Duration::from_millis(50)),
+                Err(_) => return None,
+            }
+        }
+        None
+    }
+
+    /// Clean shutdown via the proven palette quit path.
+    pub fn quit(&mut self) {
+        self.send(b"/");
+        std::thread::sleep(Duration::from_millis(300));
+        self.send(b"exit\r");
+        let _ = self.wait_for_exit(Duration::from_secs(8));
+    }
+}
+
+#[cfg(unix)]
+impl Drop for Pty {
+    fn drop(&mut self) {
+        if let Ok(None) = self.child.try_wait() {
+            let _ = self.child.kill();
+        }
+    }
+}
+
+/// Boot the TUI to the Workspace surface (chrome wordmark + tab painted).
+#[cfg(unix)]
+pub fn boot(home: &Path) -> Pty {
+    let h = Pty::spawn(home);
+    h.wait_for(
+        |s| s.contains("WAYLAND") && s.contains("Workspace"),
+        Duration::from_secs(60),
+        "TUI to render the chrome wordmark and Workspace tab",
+    );
+    h
+}

--- a/crates/wcore-providers/src/fingerprint.rs
+++ b/crates/wcore-providers/src/fingerprint.rs
@@ -142,6 +142,17 @@ fn slug_for_env_var(name: &str) -> Option<&'static str> {
     Some(slug)
 }
 
+/// The declared `(prefix, slug)` detection table.
+///
+/// Exposed so a network-free registry invariant test can assert that every
+/// prefix we CLAIM to detect maps to a slug the onboarding flow can actually
+/// connect — the `sk-flux-` class of bug, where a key detects but then fails to
+/// connect. See `wcore-providers/tests/detection_registry.rs`.
+#[must_use]
+pub fn declared_prefixes() -> &'static [(&'static str, &'static str)] {
+    UNIQUE_PREFIXES
+}
+
 /// Fingerprint a pasted credential into ranked provider candidates.
 ///
 /// Never makes a network call. The returned [`Fingerprint::candidates`] are a

--- a/crates/wcore-providers/tests/detection_registry.rs
+++ b/crates/wcore-providers/tests/detection_registry.rs
@@ -1,0 +1,51 @@
+use wcore_providers::fingerprint::{declared_prefixes, fingerprint_key};
+
+#[test]
+fn every_declared_prefix_resolves_to_exactly_one_provider() {
+    for (prefix, slug) in declared_prefixes() {
+        let key = format!("{prefix}TESTTESTTEST1234");
+        let fp = fingerprint_key(&key);
+        assert!(fp.is_unambiguous(), "{prefix} must resolve unambiguously");
+        assert_eq!(fp.best().unwrap().slug, *slug, "{prefix} -> wrong provider");
+    }
+}
+
+#[test]
+fn sk_flux_is_a_declared_prefix() {
+    assert!(
+        declared_prefixes()
+            .iter()
+            .any(|(p, s)| *p == "sk-flux-" && *s == "flux-router"),
+        "the Flux Router prefix must be registered (regression: it was missing)"
+    );
+}
+
+/// Detection-only slugs: prefixes declared in the fingerprint table that do NOT
+/// map to a connectable `ProviderType` — a key that fingerprints but then can't
+/// connect (a broken promise to the user). The Proving Ground surfaced
+/// `r8_`/`hf_` (replicate/huggingface) as exactly this class.
+///
+/// They are GRANDFATHERED here so the invariant still blocks any NEWLY-added
+/// broken-promise prefix while preserving today's detection behavior. Removing
+/// these two from the fingerprint table (or wiring real `ProviderType`s for
+/// them) is a tracked follow-up (proving-ground finding #1, wayland-core #53).
+///
+/// Adding a new prefix whose slug isn't connectable — and isn't listed here —
+/// fails the invariant below: wire the `ProviderType`, or don't declare the
+/// prefix until it connects.
+const DETECTION_ONLY_SLUGS: &[&str] = &["replicate", "huggingface"];
+
+#[test]
+fn every_declared_prefix_slug_parses_or_is_known_detection_only() {
+    use wcore_config::config::provider_type_from_slug;
+    for (prefix, slug) in declared_prefixes() {
+        if DETECTION_ONLY_SLUGS.contains(slug) {
+            continue;
+        }
+        assert!(
+            provider_type_from_slug(slug).is_some(),
+            "slug {slug:?} from prefix {prefix:?} has no ProviderType and is not in \
+             DETECTION_ONLY_SLUGS — add it to parse_builtin_provider, or document it as detection-only"
+        );
+    }
+}

--- a/docs/design/2026-06-19-wayland-proving-ground-PLAN.md
+++ b/docs/design/2026-06-19-wayland-proving-ground-PLAN.md
@@ -1,0 +1,359 @@
+# Wayland Proving Ground — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A `just proving-ground` harness that drives the real `wayland-core` binary through a PTY across hermetic Sessions, asserts a deterministic invariant spine, and turns the four known bugs into failing→passing cells — the trustworthy core the overnight generative sweep (M2/M3) builds on.
+
+**Architecture:** Promote the existing PTY harness in `crates/wcore-cli/tests/smoke_p0.rs` into a shared `tests/support/` module, add a `Session` (one temp `WAYLAND_HOME` reused across relaunches so persistence is testable) and a `RunRecord`, write the invariant checks over that record, and express each known bug as a `Cell` (a scripted persona+config+terminal run). M2 (generative explorer) and M3 (overnight runner/report) are **separate follow-on plans** — see spec §"Breadth after the first overnight run".
+
+**Tech Stack:** Rust 2021, `portable_pty` (already a dev-dep), `tempfile`, `wiremock` (`support::mock_llm`), `vt100` 0.15 (pinned). Unix-only for M1 (`#[cfg(unix)]`), matching the existing harness.
+
+## Global Constraints
+
+- **Build on the existing harness — do not reinvent.** Source of truth assets in `crates/wcore-cli/tests/smoke_p0.rs`: `Pty::spawn(home: &Path)`, `pty.screen_text() -> String`, `pty.wait_for(predicate, Duration, what)`, `pty.send(&[u8])`, `pty.wait_for_exit(Duration)`, `pty.quit()`, `boot(home) -> Pty`, `write_config(home, provider, model, base_url)`, `harden_child_env(cmd, home)`, `STRIPPED_PROVIDER_ENV`. Shared test code lives in `crates/wcore-cli/tests/support/` and is included via `#[path = "support/mod.rs"] mod support;`.
+- **Hermeticity:** every Session gets a fresh `TempDir` as `WAYLAND_HOME` + `HOME`; `harden_child_env` strips real provider keys. A run that touches real state is a failure.
+- **M1 is `#[cfg(unix)]` and $0** — no live API, no LLM, no judge. MockLlm only.
+- **`vt100` stays pinned at 0.15** (a `unicode-width` conflict forces it — see smoke_p0.rs).
+- **Plan/spec live in `docs/design/`** (`docs/superpowers/` is gitignored here).
+- Errors: `thiserror` for public types, `anyhow` internally; never `unwrap()` in non-test code without a proven invariant.
+
+---
+
+### Task 1: Promote the PTY harness into shared `support`
+
+**Files:**
+- Create: `crates/wcore-cli/tests/support/pty.rs`
+- Modify: `crates/wcore-cli/tests/support/mod.rs` (add `pub mod pty;`)
+- Modify: `crates/wcore-cli/tests/smoke_p0.rs` (delete the inline `mod pty_smoke { … Pty … }` block + the top-level `write_config`/`harden_child_env`/`STRIPPED_PROVIDER_ENV`; re-import from `support::pty`)
+
+**Interfaces:**
+- Produces: `support::pty::{Pty, boot, write_config, harden_child_env, STRIPPED_PROVIDER_ENV}` with the exact signatures listed in Global Constraints.
+
+- [ ] **Step 1: Move the code, don't change it.** Cut `Pty` (struct + impl), `boot`, `write_config`, `harden_child_env`, `STRIPPED_PROVIDER_ENV` from `smoke_p0.rs` into `crates/wcore-cli/tests/support/pty.rs`. Make each `pub`. Add the `#[cfg(unix)]` guard on `Pty`/`boot` (keep `write_config`/`harden_child_env` cross-platform as they are today). Keep `use portable_pty::{...}` etc. local to the file.
+
+- [ ] **Step 2: Wire the module.** In `crates/wcore-cli/tests/support/mod.rs` add:
+```rust
+#[cfg(unix)]
+pub mod pty;
+```
+(Keep `write_config`/`harden_child_env`/`STRIPPED_PROVIDER_ENV` accessible — if they must stay cross-platform, put them in a non-cfg `pub mod hermetic;` and re-export.)
+
+- [ ] **Step 3: Re-point smoke_p0.rs.** Replace the deleted definitions with `use support::pty::{Pty, boot, write_config, harden_child_env, STRIPPED_PROVIDER_ENV};`.
+
+- [ ] **Step 4: Verify the existing tests still pass (non-lossy extraction).**
+Run: `cargo nextest run -p wcore-cli --test smoke_p0`
+Expected: same pass count as before the move (PTY tests run on unix; `#[ignore]` ones stay ignored).
+
+- [ ] **Step 5: Commit.**
+```bash
+git add crates/wcore-cli/tests/support/ crates/wcore-cli/tests/smoke_p0.rs
+git commit -m "test(proving-ground): promote PTY harness into shared support module"
+```
+
+---
+
+### Task 2: `Session` + `RunRecord` + the cell runner
+
+**Files:**
+- Create: `crates/wcore-cli/tests/support/proving_ground/mod.rs`
+- Create: `crates/wcore-cli/tests/support/proving_ground/record.rs`
+- Modify: `crates/wcore-cli/tests/support/mod.rs` (add `#[cfg(unix)] pub mod proving_ground;`)
+- Test: `crates/wcore-cli/tests/proving_ground.rs` (new integration test file with `#[path = "support/mod.rs"] mod support;`)
+
+**Interfaces:**
+- Produces:
+  - `Session::new() -> Session` — owns one `TempDir`; `session.home() -> &Path`.
+  - `Session::launch(&self) -> support::pty::Pty` — spawns the real binary against the session home (reuses the same home on every call → relaunch).
+  - `RunRecord { final_screen: String, exit: Option<i32>, config_toml: Option<String>, requests: Vec<RecordedRequest>, dirty_death: bool }` (deterministic core; sidecar fields added when an oracle needs them).
+  - `run_cell(cell: &Cell) -> RunRecord` and `Cell { name: &'static str, config: ConfigState, term: TermShape, script: fn(&mut Pty, &Session) }`.
+
+- [ ] **Step 1: Write the failing test** in `crates/wcore-cli/tests/proving_ground.rs`:
+```rust
+#[path = "support/mod.rs"]
+mod support;
+use support::proving_ground::{Session, ConfigState, TermShape, Cell, run_cell};
+
+#[cfg(unix)]
+#[test]
+fn run_cell_captures_a_runrecord_for_a_clean_boot() {
+    let cell = Cell {
+        name: "clean-boot",
+        config: ConfigState::ConfiguredOpenAi,   // writes a minimal config so it boots to Workspace
+        term: TermShape::default(),
+        script: |pty, _s| { pty.wait_for(|t| t.contains("Workspace"), std::time::Duration::from_secs(10), "workspace"); },
+    };
+    let rec = run_cell(&cell);
+    assert!(!rec.dirty_death, "clean boot must not leave a dirty-death sentinel");
+    assert!(rec.final_screen.contains("Workspace"));
+}
+```
+
+- [ ] **Step 2: Run it, watch it fail.**
+Run: `cargo nextest run -p wcore-cli --test proving_ground run_cell_captures_a_runrecord_for_a_clean_boot`
+Expected: FAIL — `support::proving_ground` unresolved.
+
+- [ ] **Step 3: Implement `record.rs`** — the `RunRecord` struct (fields above), plus a `redact(&str) -> String` that masks anything matching the credential shapes (`sk-…`, `xai-…`, etc.) before any field is stored.
+
+- [ ] **Step 4: Implement `proving_ground/mod.rs`:**
+```rust
+pub use super::pty::{Pty, harden_child_env};
+pub mod record;  pub use record::RunRecord;
+use super::mock_llm::{MockLlm, RecordedRequest};
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+
+pub struct Session { home: TempDir }
+impl Session {
+    pub fn new() -> Self { Self { home: TempDir::new().expect("tempdir") } }
+    pub fn home(&self) -> &Path { self.home.path() }
+    pub fn launch(&self) -> Pty { Pty::spawn(self.home.path()) }   // same home each call => relaunch
+}
+
+#[derive(Clone, Copy)]
+pub enum ConfigState { Fresh, EnvKeysOnly, ConfiguredOpenAi, CorruptConfig }
+#[derive(Clone, Copy)]
+pub struct TermShape { pub rows: u16, pub cols: u16 }
+impl Default for TermShape { fn default() -> Self { Self { rows: 40, cols: 120 } } }
+
+pub struct Cell {
+    pub name: &'static str,
+    pub config: ConfigState,
+    pub term: TermShape,
+    pub script: fn(&mut Pty, &Session),
+}
+
+pub fn run_cell(cell: &Cell) -> RunRecord {
+    let session = Session::new();
+    cell.config.materialize(session.home());   // writes config.toml / no-op / corrupt bytes
+    let mut pty = session.launch();
+    (cell.script)(&mut pty, &session);
+    pty.quit();
+    RunRecord::capture(session.home(), &mut pty)  // reads final screen, config.toml, dirty-death sentinel
+}
+```
+(`TermShape` must be threaded into `Pty::spawn` — extend `Pty::spawn(home, TermShape)` and default existing callers to `TermShape::default()` in Task 1's re-point, or add `Pty::spawn_sized`.)
+
+- [ ] **Step 5: Run the test, confirm PASS.**
+Run: `cargo nextest run -p wcore-cli --test proving_ground run_cell_captures_a_runrecord_for_a_clean_boot`
+Expected: PASS.
+
+- [ ] **Step 6: Commit.**
+```bash
+git add crates/wcore-cli/tests/support/proving_ground/ crates/wcore-cli/tests/proving_ground.rs crates/wcore-cli/tests/support/mod.rs
+git commit -m "test(proving-ground): Session + RunRecord + cell runner"
+```
+
+---
+
+### Task 3: KNOWN BUG #1 — onboarding persists across relaunch
+
+**Files:** Modify `crates/wcore-cli/tests/proving_ground.rs`; create `crates/wcore-cli/tests/support/proving_ground/invariants.rs`.
+
+**Interfaces:** Produces `invariants::config_persists(records: &[RunRecord]) -> Result<(), String>`.
+
+- [ ] **Step 1: Write the failing cell** (drives the real onboarding env-keys flow, then relaunches the same Session and asserts it does NOT re-onboard):
+```rust
+#[cfg(unix)]
+#[test]
+fn onboarding_persists_across_relaunch() {
+    let session = Session::new();
+    ConfigState::EnvKeysOnly.materialize(session.home());   // OPENAI_API_KEY in child env, no config.toml
+    // First launch: connect the detected env key (press '1'), complete the flow.
+    let mut p1 = session.launch();
+    p1.wait_for(|t| t.contains("Detected in your environment"), SECS_10, "onboarding");
+    p1.send(b"1");                                          // connect OpenAI
+    p1.wait_for(|t| t.contains("Ready") || t.contains("Workspace"), SECS_10, "connected");
+    p1.send(b"\r");                                          // finish
+    p1.quit();
+    // config.toml MUST now exist with the provider.
+    let cfg = std::fs::read_to_string(session.home().join("config.toml")).unwrap_or_default();
+    assert!(cfg.contains("openai"), "connect must persist a provider to config.toml");
+    // Second launch (same home): MUST land on Workspace, not Onboarding.
+    let mut p2 = session.launch();
+    p2.wait_for(|t| t.contains("Workspace") && !t.contains("connect a provider to begin"),
+                SECS_10, "workspace-not-onboarding");
+    p2.quit();
+}
+```
+
+- [ ] **Step 2: Run it.** Expected: **FAIL** today (the known bug — no config.toml is written / it re-onboards). This failure IS the bug, captured.
+Run: `cargo nextest run -p wcore-cli --test proving_ground onboarding_persists_across_relaunch`
+
+- [ ] **Step 3: Fix the engine** (the actual bug, separate small change): in the onboarding connect path (`crates/wcore-cli/src/tui/surfaces/onboarding.rs`), persist on successful connect, and make the first-run gate (`crates/wcore-cli/src/tui/mod.rs:455`) treat a connected provider as configured. (Detailed engine fix is its own commit; this cell is its acceptance test.)
+
+- [ ] **Step 4: Run it, confirm PASS** after the engine fix.
+
+- [ ] **Step 5: Add the reusable invariant** `config_persists` in `invariants.rs` (asserts: after a connect run, the relaunch record's `final_screen` is Workspace and `config_toml` is `Some` with a provider). Commit.
+```bash
+git commit -m "test(proving-ground): onboarding-persistence cell + config_persists invariant (known bug #1)"
+```
+
+---
+
+### Task 4: KNOWN BUG #2 — `/doctor` content reachable at short height
+
+**Files:** Modify `crates/wcore-cli/tests/proving_ground.rs`, `invariants.rs`.
+
+- [ ] **Step 1: Write the failing cell** — boot configured, open `/doctor` at a deliberately short terminal, assert the DISCOVERED section (last section) is reachable via the canonical reveal keys:
+```rust
+#[cfg(unix)]
+#[test]
+fn doctor_content_reachable_at_short_height() {
+    let session = Session::new();
+    ConfigState::ConfiguredOpenAi.materialize(session.home());
+    let mut p = session.launch_sized(TermShape { rows: 24, cols: 100 });  // short height forces overflow
+    p.send(b"/doctor\r");
+    p.wait_for(|t| t.contains("SYSTEM"), SECS_10, "doctor");
+    // The DISCOVERED/last section must be reachable with canonical scroll keys.
+    let reached = support::proving_ground::reach_text(&mut p, "TOKENS", &CANONICAL_REVEAL_KEYS, SECS_5);
+    assert!(reached, "/doctor must scroll to its last section at 24-row height");
+    p.quit();
+}
+```
+where `CANONICAL_REVEAL_KEYS = [b"\x1b[B" /*Down*/, b"\x1b[6~" /*PgDn*/, b"j", b"G"]` and `reach_text` sends each key, re-reads `screen_text`, returns true if the target appears.
+
+- [ ] **Step 2: Run it.** Expected: **FAIL** today (the scroll bug).
+- [ ] **Step 3: Fix the engine** — make the `/doctor` diagnostics surface scrollable (`crates/wcore-cli/src/tui/surfaces/diagnostics.rs`); its own commit.
+- [ ] **Step 4: Run it, confirm PASS.**
+- [ ] **Step 5: Add `content_reachable` invariant; commit.**
+```bash
+git commit -m "test(proving-ground): /doctor short-height scroll cell + content_reachable invariant (known bug #2)"
+```
+
+---
+
+### Task 5: KNOWN BUG #3 — `sk-flux-` detection (network-free registry invariant)
+
+**Files:** Modify `crates/wcore-providers/src/fingerprint.rs` (expose the registry), create `crates/wcore-providers/tests/detection_registry.rs`.
+
+**Interfaces:** Produces `wcore_providers::fingerprint::declared_prefixes() -> &'static [(&'static str, &'static str)]`.
+
+- [ ] **Step 1: Expose the registry.** In `fingerprint.rs`, add `pub fn declared_prefixes() -> &'static [(&'static str, &'static str)] { UNIQUE_PREFIXES }`.
+
+- [ ] **Step 2: Write the registry-completeness invariant test** (this is the network-free oracle that catches the *class*, not just `sk-flux-`):
+```rust
+use wcore_providers::fingerprint::{declared_prefixes, fingerprint_key};
+#[test]
+fn every_declared_prefix_resolves_to_exactly_one_provider() {
+    for (prefix, slug) in declared_prefixes() {
+        let key = format!("{prefix}TESTTESTTEST1234");
+        let fp = fingerprint_key(&key);
+        assert!(fp.is_unambiguous(), "{prefix} must resolve unambiguously");
+        assert_eq!(fp.best().unwrap().slug, *slug, "{prefix} -> wrong provider");
+    }
+}
+#[test]
+fn sk_flux_is_a_declared_prefix() {
+    assert!(declared_prefixes().iter().any(|(p, s)| *p == "sk-flux-" && *s == "flux-router"),
+            "the Flux Router prefix must be registered (regression: it was missing)");
+}
+```
+
+- [ ] **Step 2b: Run it.** With PR #52 merged this PASSES; on a tree without the fix the second test FAILS — proving the cell catches the regression. (If `sk-flux-` isn't yet on this branch, the failing→passing transition is the fix from PR #52.)
+
+- [ ] **Step 3: Commit.**
+```bash
+git commit -m "test(proving-ground): network-free prefix-registry detection invariant (known bug #3)"
+```
+
+---
+
+### Task 6: KNOWN BUG #4 — build provenance (binary matches source)
+
+**Files:** Create `crates/wcore-cli/build.rs`; modify `crates/wcore-cli/src/main.rs` (surface the hash); modify `crates/wcore-cli/tests/proving_ground.rs`.
+
+**Interfaces:** Produces a `wayland-core --build-info` line containing the embedded git short SHA.
+
+- [ ] **Step 1: Embed the source hash.** `crates/wcore-cli/build.rs`:
+```rust
+use std::process::Command;
+fn main() {
+    let sha = Command::new("git").args(["rev-parse", "--short", "HEAD"]).output()
+        .ok().filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .unwrap_or_else(|| "unknown".into());
+    println!("cargo:rustc-env=WAYLAND_SOURCE_SHA={sha}");
+    println!("cargo:rerun-if-changed=.git/HEAD");
+}
+```
+
+- [ ] **Step 2: Surface it.** In `main.rs`, add a `--build-info` arg that prints `wayland-core <CARGO_PKG_VERSION> (source <WAYLAND_SOURCE_SHA>)` using `env!("WAYLAND_SOURCE_SHA")`.
+
+- [ ] **Step 3: Write the provenance invariant** (catches the stale-build class — the binary under test must match the repo HEAD the harness is gating):
+```rust
+#[test]
+fn binary_matches_repo_head() {
+    let head = std::process::Command::new("git").args(["rev-parse","--short","HEAD"])
+        .output().unwrap();
+    let head = String::from_utf8_lossy(&head.stdout).trim().to_string();
+    let out = std::process::Command::new(env!("CARGO_BIN_EXE_wayland-core")).arg("--build-info")
+        .output().unwrap();
+    let info = String::from_utf8_lossy(&out.stdout);
+    assert!(info.contains(&head), "binary built from {info:?} != repo HEAD {head} (stale build)");
+}
+```
+
+- [ ] **Step 4: Run it, confirm PASS** (a fresh build matches HEAD; a stale prebuilt binary FAILS — exactly the Forge-rebuild class). **Commit.**
+```bash
+git commit -m "feat(cli): embed source SHA + --build-info; test(proving-ground): build-provenance invariant (known bug #4)"
+```
+
+---
+
+### Task 7: `just proving-ground` recipe + flat report
+
+**Files:** Modify `justfile`.
+
+- [ ] **Step 1: Add the recipe** (after the `smoke:` recipe, matching its style):
+```make
+# Wayland Proving Ground — deterministic spine (unix, hermetic, $0)
+proving-ground:
+    cargo nextest run -p wcore-cli --test proving_ground
+    cargo nextest run -p wcore-providers --test detection_registry
+```
+
+- [ ] **Step 2: Run it.**
+Run: `just proving-ground`
+Expected: all cells pass (after the four engine fixes land); a flat per-test pass/fail list — the morning "shit works ok" signal.
+
+- [ ] **Step 3: Commit.**
+```bash
+git add justfile && git commit -m "build(just): proving-ground recipe runs the deterministic spine"
+```
+
+---
+
+### Task 8: Replay-determinism test (findings are trustworthy)
+
+**Files:** Modify `crates/wcore-cli/tests/proving_ground.rs`.
+
+- [ ] **Step 1: Write the test** — run the same cell twice, assert identical *invariant verdicts* (not byte-identical records; timing/intermediate frames differ by design):
+```rust
+#[cfg(unix)]
+#[test]
+fn same_cell_yields_same_verdicts_twice() {
+    let cell = clean_boot_cell();
+    let a = run_cell(&cell); let b = run_cell(&cell);
+    assert_eq!(a.dirty_death, b.dirty_death);
+    assert_eq!(a.final_screen.contains("Workspace"), b.final_screen.contains("Workspace"));
+    assert_eq!(a.config_toml.is_some(), b.config_toml.is_some());
+}
+```
+
+- [ ] **Step 2: Run it, confirm PASS.**
+- [ ] **Step 3: Commit.**
+```bash
+git commit -m "test(proving-ground): replay-determinism over invariant verdicts"
+```
+
+---
+
+## M1 done = the deterministic spine. Next plans (separate, per spec)
+
+- **M2 — Generative explorer:** AI-as-user drives `PtyDriver` across personas×intents×configs×terminal-sizes; invariants check each step; replay-confirm before reporting. New plan: `2026-06-19-wayland-proving-ground-PLAN-M2-explorer.md`.
+- **M3 — Overnight runner + triaged report:** `just proving-ground --overnight` runs the explorer fleet unattended on the box, $-capped, emitting one deduped severity-ranked report with repros. New plan: `…-PLAN-M3-overnight.md`.
+
+## Self-review notes
+- **Spec coverage:** M1 covers spec §1 (PtyDriver + Frame-as-text via screen_text — full enum lands at P3), §2 (RunRecord core), §3 (Session hermeticity), §6.1 invariants (the 6 spine invariants + the 4 known bugs), success criteria 1–3. The generative sweep (spec §6.3/§7), fixtures (§5.2-3), judge, fleet (§8), flywheel (§9), coverage map (§10), and recall criterion (§ success 5) are M2/M3 — explicitly deferred, not omitted.
+- **No placeholders:** every code step shows real code against the real existing APIs.
+- **Type consistency:** `Pty`, `Session`, `RunRecord`, `Cell`, `run_cell`, `ConfigState`, `TermShape`, `declared_prefixes` are used consistently across tasks.

--- a/docs/design/2026-06-19-wayland-proving-ground.md
+++ b/docs/design/2026-06-19-wayland-proving-ground.md
@@ -1,0 +1,323 @@
+# Wayland Proving Ground — Design Spec (v2, post cross-audit)
+
+> **Status:** Design, revised after a 3-auditor cross-audit (architecture · oracle-integrity · solo-founder pragmatics). · **Date:** 2026-06-19
+> **Failure mode this kills:** discovering your own product's bugs from GitHub issues after users hit them.
+
+## Goal
+
+A standing, automated user-simulation QA system that drives the **real** Wayland Core
+binary (and later the desktop app) like dozens of different users, across configs,
+terminals, and platforms — catching lived-flow, usability, and config bugs that unit
+tests miss, **gating releases on deterministic invariants**, and getting smarter over
+time without becoming a second full-time job.
+
+## What the cross-audit changed (read this first)
+
+The first draft had four serious flaws. This version fixes them:
+
+1. **The gate would have missed the bugs it exists to catch.** A fixtures-only gate
+   never exercises real provider logic, and `sk-flux-` was *pre-network detection
+   logic* — no provider response involved. **Fix:** pre-network decision logic
+   (detection, egress, alias/auth branching) becomes **network-free invariants** on the
+   PR gate, driven by the product's own declared registries. This catches the
+   `sk-flux-` class *before it is known*, deterministically, at $0.
+2. **"Slice-first" was applied to the domain, not the machine.** P1 is now genuinely
+   minimal: one driver behavior, a flat record, ~6 invariants, ~15 cells, $0, days.
+3. **Standing AI automation is an abandonment trap.** Standing/CI automation emits
+   **only deterministic invariant pass/fail**. The LLM judge and AI explorers are
+   **on-demand tools**, never a nightly queue. Auto-fix-PR is **cut entirely**.
+4. **The unified `Driver`/`Frame` was false across TUI and DOM.** `Frame` is now an
+   enum; only the persona/intent library and the judge are genuinely cross-driver.
+
+## Scope decision (author override of the audit)
+
+The pragmatics auditor recommended deferring the app and Windows. The author chose to
+**keep app + Windows in the architecture** — so the `Driver` trait is defined now and
+P3/P4 are committed phases. This spec honors that **while** keeping the abstraction
+honest (enum `Frame`, per-variant oracles) and recording the audit's stall-risk: P3
+(Playwright↔embedded-terminal) and P4 (Windows ConPTY) are flagged research seams to
+prototype before their breadth is committed, with **headless + json-stream** as the
+locked Windows fallback if ConPTY TUI capture proves unreliable in CI.
+
+## Non-Goals
+
+- Replacing the existing unit/integration suite — the Proving Ground sits above it.
+- Load/throughput benchmarking; security pen-testing (separate tracks).
+- An autonomous bug-fixer. The system generates failing tests + locator hints, never
+  speculative fix PRs.
+
+---
+
+## Architecture
+
+### 1. Driver trait + honest `Frame` enum
+
+```
+trait Driver {
+    fn start(session: &Session, term: TermShape) -> Self;
+    fn send(&mut self, input: Input);
+    fn snapshot(&self) -> Frame;
+    fn stop(self) -> ExitRecord;
+}
+
+enum Frame {
+    TextGrid(Vt100Snapshot),         // PTY / ConPTY: cells + style attrs
+    Dom { ax_tree: AxTree, shot: PngBytes, embedded: Option<Vt100Snapshot> },
+}
+```
+
+- **PtyDriver** (unix) — promote the existing `smoke_p0.rs` PTY harness. Concrete
+  behavior lands first; it implements the trait.
+- **ConPtyDriver** (Windows, P4) — same trait; **interactive-TUI capture is best-effort
+  and NOT a release gate** (ConPTY headless capture is documented-unreliable in this
+  repo). Windows gating runs on headless + json-stream + Windows invariants.
+- **PlaywrightDriver** (app, P3) — produces `Frame::Dom`. The app embeds an xterm.js
+  terminal, hence the `embedded` field.
+
+**Honest reuse boundary:** invariants over `Frame::TextGrid` are TUI-only; most do not
+auto-apply to `Frame::Dom`. The genuinely cross-driver layer is the **persona/intent
+library** and the **LLM judge** (which reads a screenshot/AX-tree, not a typed grid).
+The spec does not claim oracle reuse across drivers.
+
+### 2. RunRecord — split into asserted core + observability sidecar
+
+- **Deterministic core (asserted, replay-stable):** final normalized frame, the *set*
+  of outgoing HTTP requests, filesystem delta, exit code, stderr, `.dirty-death`
+  sentinel, the resulting `config.toml`/credential-store state (redacted).
+- **Observability sidecar (captured, never asserted byte-equal):** ordered intermediate
+  frames, per-frame + input→first-paint timing. Replay-confirm compares **invariant
+  verdicts**, never the raw record (timing is non-deterministic by construction —
+  the existing harness already polls-with-deadline for exactly this reason).
+- Secrets are **redacted at capture**, before persistence.
+
+### 3. Hermeticity model — Session, not per-run
+
+The headline onboarding bug is a *relaunch* bug, so isolation is per **Session**, not
+per run:
+
+- A **Session** owns one temp `WAYLAND_HOME`. A run *within* a session may relaunch the
+  binary against the *same* home — that is how connect→quit→relaunch persistence is
+  tested. Sessions are isolated from each other.
+- `harden_child_env` (existing) strips the developer's real provider keys/config.
+- **Non-`WAYLAND_HOME` globals are enumerated and individually neutralized** (the
+  "absolute hermeticity" claim is downgraded to this concrete list):
+  - **Forge discovery file** — resolves via `dirs::config_dir()` *by design*
+    (`forge_discovery.rs:81`), NOT `WAYLAND_HOME`. **Prerequisite task:** add a
+    `WAYLAND_FORGE_DISCOVERY_PATH` env override so the session can redirect it; until
+    then the Forge config cell is **excluded from P1** (it is P2 work anyway).
+  - **Forge loopback port 3456** — a fixed singleton; parallel Forge sims would
+    collide. Make the port configurable per session before any Forge cell runs.
+  - **OS keychain** (macOS login keychain) — the keyring credential cell must force a
+    session-local plaintext store unless explicitly testing the keychain path serially.
+
+### 4. The input space
+
+- **Config matrix:** no keys · env-keys-only · pasted-key · OAuth · Ollama ·
+  multi-provider · each `ProviderType` · bad/expired key · `sk-flux-` key · fresh ·
+  existing · partial · corrupt config · keyring-vs-plaintext · egress on/off ·
+  `windows_shell`. (Forge cell deferred per §3.)
+- **Terminal matrix:** `rows×cols` incl. a deliberately **short height** (forces the
+  `/doctor` overflow), `TERM`, color support. **Interaction cells are forced, not
+  sampled** — `/doctor × short-height` is a mandatory cell, not a lucky draw.
+- **Persona × Intent library** (§4a).
+
+#### 4a. Personas & Intents — partitioned by execution layer
+
+Personas: first-timer · power user · **env-keys dev (the stuck case)** · pasted-key ·
+Windows · returning user (expects persistence) · confused user (garbage input) ·
+**impatient user who interrupts** (Ctrl-C, resize mid-op).
+
+Intents are tagged by which layer they can run in:
+- **Deterministic-gate intents** (fixed trajectory): connect a provider · paste a key
+  for detection · scroll/read `/doctor` · edit config via `/config` · switch model ·
+  resume a session · run a *specific* tool · recover from a bad key.
+- **Generative/on-demand intents** (need a live model, non-deterministic, judged):
+  **build a small project** (multi-turn write+edit+bash) · open-ended exploration.
+  These are **never** deterministic-gate cells (a fixture can't produce a correct build
+  without hand-authoring the whole trajectory, which tests nothing).
+
+### 5. Provider fidelity — three distinct mechanisms
+
+The first draft's fatal conflation (fixtures "cover" detection) is split apart:
+
+1. **Network-free decision oracles (PR gate, $0).** Drive the engine's *pre-socket*
+   logic directly from its **own declared registries**: every prefix in the detection
+   table, every provider alias, every egress rule. Assert positively (each declared
+   prefix → exactly one provider) **and negatively** (garbage / look-alike → zero
+   candidates with a non-silent error). A supported-but-undetected prefix is
+   automatically a finding — this is what catches `sk-flux-` *before* it's known.
+2. **Response fixtures (PR gate, stable surface only).** Recorded real responses for
+   *wire* behavior — model lists + happy-path connect handshake in P1. Volatile shapes
+   (errors, auth challenges, streams) stay in live-smoke, not the gate.
+3. **Nightly live-smoke (off the gate, $-capped).** Hits real APIs to catch drift.
+   **Drift is a RED, human-classified finding — never auto-regenerates a fixture**
+   (auto-regen would bake the regression in as the expected answer). A
+   **fixture-freshness invariant** fails any fixture whose last live confirmation is
+   stale or diverged.
+
+### 6. Oracle suite
+
+1. **Invariants (deterministic, CI gate).** Each is falsifiable with a concrete check
+   over the RunRecord core. The set (expanded from audit gaps):
+   - no panic / no `.dirty-death` / exit code intended-only
+   - **config persists**: connect → real process relaunch (same session home) → lands
+     on Workspace, `config.toml` reflects the provider *(catches onboarding bug)*
+   - **onboarding atomicity/reversibility**: Ctrl-C mid-onboarding leaves config
+     *unchanged*, never half-written *(deepest form of the onboarding bug)*
+   - **content reachable** within the *canonical* reveal set (arrows, PgUp/PgDn, wheel,
+     `/`-search); reachable only via an obscure binding is itself a finding *(catches
+     `/doctor` scroll)*
+   - **paste-prefix → exactly one candidate** (network-free, positive + negative)
+     *(catches `sk-flux-`)*
+   - loopback/localhost egress never blocked
+   - **build provenance**: the binary embeds its source hash; assert it equals the repo
+     HEAD under test *(catches the Forge stale-build class)*
+   - **MCP lifecycle**: advertised → discovered → granted → connected → tool-callable;
+     a stale discovery file is detected as stale
+   - **no secret in ANY RunRecord channel** (frame, config, fs delta, request log,
+     stderr) except the redacted credential slot
+   - **error legibility**: a bad/expired key yields a specific, actionable error — never
+     a silent hang or generic failure
+   - **responsiveness** (thresholded, **box-only — not a CI gate**, to avoid runner
+     flake): input→first-paint p95 < 150ms even with a background op in flight; any op
+     > 500ms emits ≥1 progress frame
+   - idempotency: connecting/onboarding twice never duplicates or corrupts state
+   - **`/command` → correct surface** (not merely *a* valid surface), and the surface
+     isn't empty/errored
+   - a model claimed available actually completes a turn *(the MiniMax/Moonshot 401
+     class)*
+2. **Functional outcome oracles** (for fixed-trajectory tool intents only): file
+   written with correct bytes, edit applied, bash exit/stdout matched, **abort
+   atomicity** (an interrupted write leaves the file fully-old or fully-new, never
+   partial).
+3. **LLM judge — ON-DEMAND ONLY.** Reads a **screenshot/AX-tree** (vision-capable, not
+   text frames) + the persona's intent, flags broken/confusing/dead-end/undiscoverable.
+   Never in the gate, never a nightly queue. Calibrated against the author's own
+   "this baffled me" episodes; judge↔human agreement is reported, not assumed.
+
+### 7. Execution modes
+
+- **Deterministic regression matrix** — fixed-input cells vs decision-oracles +
+  response-fixtures, invariants + functional oracles assert, **gates every PR**, $0.
+- **Generative explorers — on-demand, box-only, $-capped.** LLM-as-user drives a live
+  driver; findings replay-confirmed before reporting. **Intermittent findings are
+  reported with a `confirmed_rate`, not discarded** (a race that reproduces 2/10 is a
+  real bug, not noise). Judge classifications require **independent** confirmation
+  (different model or a deterministic oracle), never the same judge re-run.
+
+### 8. Fleet runner
+
+Parallel hermetic *sessions* (a natural Workflow fan-out), each port-isolated and
+global-neutralized per §3. Aggregates deduped, severity-ranked findings, each carrying
+its replayable record. **Not in P1** (P1 runs serially).
+
+### 9. Triage flywheel (no auto-fix)
+
+Confirmed finding → **auto-generate a failing deterministic regression cell + a
+one-line locator hint** (surface + most-likely module). The cell joins the gate
+permanently; coverage compounds. **No auto-PR** — generating a correct engine fix is
+neither safe nor faster-to-review than a one-line locator.
+
+### 10. Coverage map — honest, not "comprehensive"
+
+Enumerates commands/surfaces/config-keys/providers/tools. A cell is reported as
+**"covered under {conditions}, untested under {conditions}"** — never a bare "covered,"
+because every known bug is an *interaction* bug (works at 120×40, breaks at 80×24). The
+sampling strategy and its blind spots (e.g. "pairwise: 2-way covered, 3-way not") are
+named inline. The word "comprehensive" is **forbidden** over a sampled matrix.
+**Not in P1.** Auto-discovery of new surfaces, if built later, is a passive column —
+never a gate-red — so it never couples feature velocity to harness coverage.
+
+---
+
+## Build target — the overnight sweep (≈24–48h to first run, then sharpen nightly)
+
+One push, not a phased crawl. The spine (deterministic, trustworthy) and the sweep
+(generative, finds unknowns) land **together** so it can run overnight and surface bugs
+nobody scripted from night one.
+
+1. **Promote** the `Pty`, `MockLlm`, `harden_child_env`, `STRIPPED_PROVIDER_ENV` assets
+   out of `smoke_p0.rs`/`harness_tui_flow.rs` into shared test-support, re-pointing the
+   existing tests at it and keeping them green (non-lossy; inherits the `vt100` pin +
+   input-delivery-race constraints). Define the `Driver` trait + `Frame` enum;
+   `PtyDriver` is the first impl. `RunRecord` per §2; Session hermeticity per §3.
+2. **Invariant spine** — the deterministic oracles (§6.1). These are the trustworthy
+   pass/fail and the morning's "works ok" signal. They catch all four known bugs by
+   construction.
+3. **Generative explorer (the sweep)** — AI-as-user drives the real `PtyDriver` across
+   personas × intents × configs × terminal sizes, the invariants check every step, and
+   every candidate finding is **replay-confirmed** before it's reported. This is what
+   finds the bugs you didn't think to script.
+4. **Overnight usability judge** — a vision/AX pass over the explorer's records, flagging
+   confusing/dead-end/undiscoverable flows; classifications **independently confirmed**
+   (different model or a deterministic oracle), reported with a confidence, never raw.
+5. **`just proving-ground --overnight`** — runs the explorer fleet unattended on the box
+   and emits **one triaged, deduped, severity-ranked report** with repros: either "spine
+   green, no new findings" or the N findings each with a replayable record + locator
+   hint.
+6. **Replay-determinism test** so the spine's verdicts (and therefore the report) are
+   trustworthy.
+
+**Quality guards (non-negotiable — they are what make the overnight report trustworthy
+instead of a wall of noise):** deterministic invariants as the spine; replay-confirm +
+confidence gating on every generative finding; a hard **$-cap + kill-switch** on the
+explorer/judge spend; secret redaction at capture; Session hermeticity. The deterministic
+spine + the MockLlm-driven cells are $0; the generative explorer's overnight spend is
+budget-capped and runs on the box.
+
+## Breadth after the first overnight run
+The sweep machine exists after the build above; everything else is *more cells, more
+invariants, more drivers* feeding the same machine — not new infrastructure:
+- **Engine breadth** — more invariants/cells; the response-fixture wire tier; the
+  flywheel cell-generator; the blind-fault-injection recall harness (criterion 4);
+  the Forge env-override + port-config prerequisites; tools → MCP → skills.
+- **Desktop app** — `PlaywrightDriver` (`Frame::Dom`); prototype the embedded-terminal
+  seam; reuse personas + judge.
+- **Windows** — headless + json-stream gate + Windows invariants; ConPTY TUI capture
+  best-effort, not gated.
+- **Nightly live-smoke** — real-provider drift, $-capped with a kill-switch.
+
+## Error handling & resilience
+
+- Driver `send`/`snapshot` are deadline-bounded; a hung binary becomes an
+  "unresponsive" finding, never a hung run.
+- Generative runs are token-budget-bounded with a **hard dollar cap + kill-switch**;
+  P1 is provably $0. Nightly live-smoke is per-provider-call-capped.
+- Hermeticity failure (a run touching real state) is itself a test failure.
+
+## Testing the tester
+
+Keep the **replay-determinism test** in P1 (it makes findings trustworthy). Golden
+known-good/known-broken records and a deliberately-broken fixture binary land with the
+gate (P1.5), not before there's a gate.
+
+## Success criteria
+
+The north star: **`just proving-ground --overnight` runs unattended on the box and, by
+morning, produces a trustworthy verdict — "spine green, nothing new" or a triaged bug
+list with repros.**
+
+1. **It runs overnight unattended** and emits one deduped, severity-ranked report with a
+   replayable record per finding.
+2. **It catches the four known bugs** (each a failing→passing cell across the fix).
+3. **It surfaces ≥1 real bug nobody scripted**, replay-confirmed — proving the sweep
+   finds *unknowns*, not just re-confirms knowns.
+4. **The verdict is trustworthy:** the deterministic spine is binary green/red (and goes
+   red on a seeded regression); generative findings carry a `confirmed_rate` + repro;
+   the overnight run stays under its $-cap.
+5. **Detection-power, measured:** blind fault-injection — seed K defects in the
+   connect/config/scroll/detection paths *not* targeted by any cell, and **report recall
+   as a number.** The honest measure of how much it actually catches.
+
+## Risks & open questions
+
+- **ConPTY fidelity (P4)** — likely unreliable in CI; the plan *is* the headless
+  fallback, not the contingency. Interactive-TUI capture is never a gate.
+- **Playwright ↔ embedded-terminal (P3)** — prototype the dual DOM+xterm read before
+  committing P3 breadth.
+- **Judge calibration** — an uncalibrated judge verdict is an unverified claim; measure
+  judge↔human agreement before trusting "usable."
+- **Fixture rot** — the volatile provider surface stays in live-smoke; only stable
+  shapes are fixtured, and drift is human-classified.
+- **Matrix explosion** — sampled for breadth, but interaction cells (`/doctor ×
+  short-height`, etc.) are forced; coverage is reported honestly, never "comprehensive."

--- a/justfile
+++ b/justfile
@@ -183,3 +183,13 @@ check-no-assertion-todos:
 # Run: `just smoke`
 smoke:
     scripts/smoke.sh
+
+# Wayland Proving Ground — deterministic bug-sweep spine (unix, hermetic, $0).
+# Drives the REAL binary over a PTY across throw-away homes and asserts
+# deterministic invariants (config persistence, content reachability, replay
+# determinism), plus the network-free provider-detection registry invariant and
+# the build-provenance (stale-binary) check.
+# Run: `just proving-ground`
+proving-ground:
+    vx cargo nextest run -p wcore-cli --test proving_ground --test build_provenance
+    vx cargo nextest run -p wcore-providers --test detection_registry


### PR DESCRIPTION
Re-cut of #53 onto current main (the stale #53 branch was far behind; this rebuilds it clean and drops work that has since landed).

## What lands

A deterministic, hermetic, $0 **proving-ground** bug-sweep spine: it drives the REAL `wcore-cli` binary over a PTY across throw-away homes and asserts invariants (config persistence, content reachability, replay determinism), plus two provider-hygiene invariants.

## Scope — re-verified against current main

| KNOWN BUG | Status on main | This PR |
|---|---|---|
| #1 onboarding persists across relaunch | ✅ already fixed (#66) | dropped engine fix; keep the cell as a **regression test** |
| #2 `/doctor` reachable at short height | ✅ already fixed (#66) | dropped engine fix; keep the cell as a **regression test** |
| #3 network-free detection registry | partial | **add** `declared_prefixes()` + `detection_registry.rs` |
| #4 build provenance | absent | **add** `build.rs` (`WAYLAND_SOURCE_SHA`) + `--build-info` + `build_provenance.rs` |

**Detection registry (#3):** `sk-flux-`/`FLUX_API_KEY` detection is already on main, so only the helper + test are added — main's `r8_`/`hf_` prefixes are **preserved**. The invariant found `r8_`/`hf_` (replicate/huggingface) are detect-but-can't-connect (no `ProviderType`); they are **grandfathered** into `DETECTION_ONLY_SLUGS` so the invariant still blocks any *new* broken-promise prefix. Removing or wiring those two is a tracked follow-up.

**Build provenance (#4):** dual-mode test — ancestor-of-HEAD locally, exact-match under `CI`; skips gracefully where git is absent.

## Deferred (noted, not dropped)

`smoke_p0.rs` keeps its own inline PTY; consolidating both onto `support::pty` is a follow-up.

## Tests (Hetzner)

- `proving_ground` + `build_provenance`: **14/14**
- `detection_registry`: **3/3**
- clippy clean (wcore-cli + wcore-providers)

`just proving-ground` runs the full gate.

Note: the new detection/redaction tests contain **fake** credential fixtures (`sk-*-harness-*`, `not-real-key`) required to exercise prefix detection and secret redaction.

Supersedes #53.