### PR TITLE
feat(anvil): A1.1 engine skeleton + kill-switch + forge verb

### DIFF
--- a/crates/wcore-agent/src/orchestration/anvil/mod.rs
+++ b/crates/wcore-agent/src/orchestration/anvil/mod.rs
@@ -1,0 +1,136 @@
+//! Anvil — native gated-forge engine (sibling of [`crate::orchestration::council`]).
+//! A1 skeleton slice.
+//!
+//! Anvil forges a candidate that passes a REAL executable gate, then stamps a
+//! `verified` receipt. It rides the DRIVER rail: [`drive_climb`] is the entry
+//! point, mirroring `council::drive_council` — NOT the test-only `GraphConfig`
+//! scaffolding (spec §3, v2 correction).
+//!
+//! This slice establishes the module seam and the shared terminal-state
+//! vocabulary. The climb loop (probe → ensemble → surgical → escalate), gate
+//! closure pinning, ledger, and the `AnvilReceipt` protocol event land in the
+//! subsequent A1 PRs. The whole engine is kill-switched via
+//! [`wcore_config::anvil::AnvilConfig::enabled`] (default `false`).
+//!
+//! Spec: `docs/design/2026-07-12-anvil-native-gated-forge-design.md` (v2).
+
+use wcore_config::anvil::AnvilConfig;
+
+/// Terminal state of a climb — the COMPLETE enum (spec §6.5). Every climb ends
+/// in exactly one of these, and each maps to a published receipt. It lives here
+/// because it is the shared vocabulary the whole A1 stack is built around; the
+/// climb logic that actually produces each variant lands in the climb slice
+/// (A1.5). There is no silent fourth exit.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TerminalState {
+    /// All checks green with the required stability on a real Tier-1 gate — the
+    /// ONLY state that earns the reserved `verified` stamp (spec §2 vocabulary).
+    Verified,
+    /// User-confirmed derived criteria passed (Tier-2). Stamped
+    /// `criteria-checked`, never `verified`.
+    CriteriaChecked,
+    /// Self-generated checks only (Tier-3) — correlated evidence, not truth.
+    /// Stamped `self-checked`, visually quarantined.
+    SelfChecked,
+    /// Some checks remain uncracked; the user is offered escalate / show
+    /// attempts / accept-partial.
+    NeedsEscalation,
+    /// Could not proceed, for a stated reason (e.g. the gate cannot execute).
+    Blocked(String),
+    /// The user or host cancelled; partial work is reported honestly.
+    Cancelled,
+    /// A time budget was exhausted mid-climb.
+    TimedOut,
+    /// Exec was refused (posture / permissions) before or during the climb.
+    PermissionDenied,
+    /// A crash was caught and the climb recovered from its journal.
+    CrashedRecovered,
+    /// A newer climb for the same task superseded this one.
+    Superseded,
+}
+
+impl TerminalState {
+    /// Whether this state earns the reserved `verified` stamp. ONLY a real
+    /// Tier-1 gate passing with stability does — the honesty vocabulary of
+    /// spec §2 hangs off this being a single, tight predicate.
+    #[must_use]
+    pub fn is_verified(&self) -> bool {
+        matches!(self, TerminalState::Verified)
+    }
+}
+
+/// Outcome of a climb. A1 skeleton carries only the terminal state; the receipt
+/// payload, settled spend, and gate/artifact digests are added as their slices
+/// land.
+#[derive(Debug, Clone)]
+pub struct ClimbResult {
+    /// How the climb ended.
+    pub terminal: TerminalState,
+}
+
+/// Errors that abort a climb before it can produce a terminal state.
+#[derive(Debug, thiserror::Error)]
+pub enum AnvilError {
+    /// Anvil is disabled by its kill switch (`[anvil] enabled = false`).
+    #[error("Anvil is disabled (set `enabled = true` under `[anvil]`)")]
+    Disabled,
+}
+
+/// Drive a gated-forge climb for `task` (spec §6). Mirrors the
+/// `council::drive_council` driver-rail entry.
+///
+/// A1 skeleton: enforces the kill-switch, then returns an honest `Blocked`
+/// terminal — the probe → ensemble → surgical → escalate loop, gate machinery,
+/// and receipt emission land in the later A1 slices. The kill-switch is checked
+/// here as an invariant even though the CLI entry also checks it, because
+/// `drive_climb` will gain a second (in-turn `/forge`) caller.
+pub async fn drive_climb(task: &str, cfg: &AnvilConfig) -> Result<ClimbResult, AnvilError> {
+    if !cfg.enabled {
+        return Err(AnvilError::Disabled);
+    }
+    let _ = task;
+    Ok(ClimbResult {
+        terminal: TerminalState::Blocked(
+            "Anvil A1 climb engine is not yet implemented (skeleton slice)".into(),
+        ),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn drive_climb_refuses_when_disabled() {
+        let cfg = AnvilConfig { enabled: false };
+        let err = drive_climb("task", &cfg).await.unwrap_err();
+        assert!(matches!(err, AnvilError::Disabled));
+    }
+
+    #[tokio::test]
+    async fn drive_climb_enabled_returns_blocked_skeleton() {
+        let cfg = AnvilConfig { enabled: true };
+        let res = drive_climb("task", &cfg).await.unwrap();
+        assert!(matches!(res.terminal, TerminalState::Blocked(_)));
+        // The skeleton must never claim verification.
+        assert!(!res.terminal.is_verified());
+    }
+
+    #[test]
+    fn only_verified_state_reports_verified() {
+        assert!(TerminalState::Verified.is_verified());
+        for s in [
+            TerminalState::CriteriaChecked,
+            TerminalState::SelfChecked,
+            TerminalState::NeedsEscalation,
+            TerminalState::Blocked("x".into()),
+            TerminalState::Cancelled,
+            TerminalState::TimedOut,
+            TerminalState::PermissionDenied,
+            TerminalState::CrashedRecovered,
+            TerminalState::Superseded,
+        ] {
+            assert!(!s.is_verified(), "{s:?} must not report verified");
+        }
+    }
+}

--- a/crates/wcore-agent/src/orchestration/mod.rs
+++ b/crates/wcore-agent/src/orchestration/mod.rs
@@ -28,6 +28,8 @@ fn tool_dispatch_timeout(category: ToolCategory) -> Duration {
     }
 }
 
+// Anvil — native gated-forge engine (`drive_climb`), sibling of council.
+pub mod anvil;
 // Crucible (Mixture-of-Providers) council: cross-provider proposers + a
 // provenance-aware aggregator. Hosts `CouncilProviderResolver`, which keys a
 // provider id to an `Arc<dyn LlmProvider>` (resolution lives here, not in the

--- a/crates/wcore-cli/src/anvil.rs
+++ b/crates/wcore-cli/src/anvil.rs
@@ -1,0 +1,38 @@
+//! CLI surface: `wayland-core forge "<task>"` — the explicit Anvil verb.
+//!
+//! Mirrors [`crate::crucible::run_crucible`]: it enforces the `[anvil] enabled`
+//! kill-switch before doing anything, then routes to the `drive_climb` engine
+//! seam. A1 skeleton — the climb currently returns an honest
+//! not-yet-implemented terminal; the real loop lands in later A1 slices.
+
+use clap::Args;
+use wcore_agent::orchestration::anvil::drive_climb;
+use wcore_config::config::load_merged_config_file;
+
+/// Arguments for `wayland-core forge`.
+#[derive(Args, Debug)]
+pub struct ForgeArgs {
+    /// The task to forge. Anvil is for work with a REAL, checkable gate
+    /// (tests / build / lint) — it forges a candidate that passes it.
+    pub task: String,
+}
+
+/// Entry point for `wayland-core forge`.
+pub async fn run_forge(args: ForgeArgs) -> anyhow::Result<()> {
+    let cf = load_merged_config_file(None)?;
+
+    if !cf.anvil.enabled {
+        anyhow::bail!(
+            "Anvil is disabled. Set `enabled = true` under `[anvil]` in your config \
+             to forge gated tasks. (A1 is kill-switched until the slice completes.)"
+        );
+    }
+
+    match drive_climb(&args.task, &cf.anvil).await {
+        Ok(result) => {
+            println!("forge: {:?}", result.terminal);
+            Ok(())
+        }
+        Err(e) => anyhow::bail!("forge: {e}"),
+    }
+}

--- a/crates/wcore-cli/src/lib.rs
+++ b/crates/wcore-cli/src/lib.rs
@@ -82,6 +82,8 @@ pub mod workflow;
 // touching the user's home dir.
 pub mod cron;
 
+// Anvil (gated forge): `wayland-core forge "<task>"` — kill-switched engine.
+pub mod anvil;
 // Crucible (Mixture-of-Providers): `wayland-core crucible "<task>"` runs the
 // cross-provider council — N pinned-provider proposers fused by a fenced,
 // read-only aggregator. Self-contained one-shot handler.

--- a/crates/wcore-cli/src/main.rs
+++ b/crates/wcore-cli/src/main.rs
@@ -498,6 +498,10 @@ enum TopCmd {
         #[arg(long)]
         terminal: bool,
     },
+    /// Anvil (gated forge) — forge a candidate that passes a REAL executable
+    /// gate (tests / build / lint), then stamp a verified receipt. Requires
+    /// `[anvil] enabled = true`; kill-switched until the A1 slice completes.
+    Forge(wcore_cli::anvil::ForgeArgs),
     /// v0.7.0 Task 1.C.1: print resolved project context from WAYLAND.md /
     /// AGENTS.md / .wayland/context.md / CLAUDE.md walking up from cwd.
     ProjectContext,
@@ -1032,6 +1036,13 @@ async fn run() -> anyhow::Result<ExitCode> {
                     }
                 }
             }
+            TopCmd::Forge(args) => match wcore_cli::anvil::run_forge(args).await {
+                Ok(()) => Ok(ExitCode::SUCCESS),
+                Err(e) => {
+                    eprintln!("wayland-core forge: {e:#}");
+                    Ok(ExitCode::FAILURE)
+                }
+            },
             // methodology #27: production caller for project_context::scan
             // (v0.7.0 Task 1.C.1).
             TopCmd::ProjectContext => {

--- a/crates/wcore-config/src/anvil.rs
+++ b/crates/wcore-config/src/anvil.rs
@@ -1,0 +1,48 @@
+//! Anvil (native gated-forge engine) configuration — the on-disk `[anvil]`
+//! block. OFF by default (`enabled = false`), mirroring `[crucible]`.
+//!
+//! Anvil is the checkable-reward sibling of Crucible: when a task has a REAL
+//! executable gate, Anvil forges a candidate that passes it and stamps a
+//! `verified` receipt. A1 is the engine slice — kill-switched here until the
+//! climb loop, gate machinery, ledger, receipt event, and adversarial tests
+//! all land. See `docs/design/2026-07-12-anvil-native-gated-forge-design.md`.
+
+use serde::{Deserialize, Serialize};
+
+/// Top-level `[anvil]` configuration.
+///
+/// `Default` is derived: every field's default is its type default, and the
+/// kill-switch `enabled` therefore defaults to `false` — Anvil is off unless a
+/// `[anvil]` block explicitly turns it on.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(default)]
+pub struct AnvilConfig {
+    /// Kill-switch. `false` (the default) keeps Anvil inert: the `forge`
+    /// subcommand (and, later, the `/forge` verb and auto-detector) refuse.
+    /// Every A1 PR lands behind this flag until the slice is complete.
+    pub enabled: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_off() {
+        assert!(!AnvilConfig::default().enabled);
+    }
+
+    #[test]
+    fn absent_table_deserializes_to_disabled() {
+        // An absent/empty `[anvil]` table must yield the disabled default —
+        // the kill-switch fails safe when the block is omitted.
+        let cfg: AnvilConfig = toml::from_str("").unwrap();
+        assert!(!cfg.enabled);
+    }
+
+    #[test]
+    fn enabled_round_trips() {
+        let cfg: AnvilConfig = toml::from_str("enabled = true\n").unwrap();
+        assert!(cfg.enabled);
+    }
+}

--- a/crates/wcore-config/src/config.rs
+++ b/crates/wcore-config/src/config.rs
@@ -336,6 +336,13 @@ pub struct ConfigFile {
     /// `ConfigFile`-only) to build the council.
     #[serde(default)]
     pub crucible: crate::crucible::CrucibleConfig,
+
+    /// Anvil (native gated-forge engine) — opt-in `[anvil]` block. OFF by
+    /// default (`enabled = false`), kill-switched until the A1 slice completes.
+    /// Lives on `ConfigFile` (the on-disk shape) alongside `[crucible]`; the
+    /// `forge` entry point reads it via `load_merged_config_file`.
+    #[serde(default)]
+    pub anvil: crate::anvil::AnvilConfig,
 }
 
 /// Wave SD — top-level `[storage]` block in `config.toml`.
@@ -3647,6 +3654,12 @@ fn merge_config_files(global: ConfigFile, project: ConfigFile) -> ConfigFile {
         global.crucible
     };
 
+    let anvil = if project.anvil.enabled {
+        project.anvil
+    } else {
+        global.anvil
+    };
+
     ConfigFile {
         default,
         providers,
@@ -3671,6 +3684,7 @@ fn merge_config_files(global: ConfigFile, project: ConfigFile) -> ConfigFile {
         security,
         session_cap,
         crucible,
+        anvil,
     }
 }
 

--- a/crates/wcore-config/src/lib.rs
+++ b/crates/wcore-config/src/lib.rs
@@ -25,6 +25,8 @@ pub mod chatgpt_catalog;
 pub mod compact;
 pub mod compat;
 pub mod config;
+// Anvil (native gated-forge engine): `[anvil]` kill-switch config.
+pub mod anvil;
 // THE KERNEL (#255): single per-turn context-window computation. See the
 // module header. Co-located with `limits` (the per-model window table).
 pub mod context_window;


### PR DESCRIPTION
First slice of **Anvil** (native gated-forge engine) — the engine skeleton, kill-switched OFF. Part of the A1 stack per the v2 spec (`docs/design/2026-07-12-anvil-native-gated-forge-design.md`).

## What lands

- **`[anvil]` config** with an `enabled` kill-switch (default `false`), mirroring `[crucible]`; merged project-over-global like crucible in `merge_config_files`.
- **`orchestration/anvil` module** — built on the **DRIVER rail** (`drive_climb` beside `drive_council`), NOT GraphConfig/ForgeFlow (v2 correction §3). Ships the entry seam + the **complete §6.5 `TerminalState` enum** (verified / criteria-checked / self-checked / needs-escalation / blocked / cancelled / timed-out / permission-denied / crashed-recovered / superseded) with an `is_verified()` predicate that only `Verified` satisfies (spec §2 honesty vocabulary).
- **`wayland-core forge "<task>"`** verb, mirroring `run_crucible`: refuses when disabled.

## Deliberately inert

`enabled` defaults false; `drive_climb` is a stub returning an honest `Blocked` terminal. The climb loop, gate closure pinning, ledger, and the `AnvilReceipt` protocol event land in A1.2–A1.6. **Nothing activates from this PR.**

## Verification (Hetzner)

- clippy clean (wcore-config / wcore-agent / wcore-cli); `fmt --check` stable
- 6/6 anvil tests (config default-off + round-trip; `drive_climb` refuses-when-disabled + blocked-skeleton; terminal-state predicate)
- 41/41 wcore-config merge tests — no regression from the `anvil` merge addition

## A1 stack (for Core B review context)

A1.1 skeleton (this) → A1.2 `AnvilReceipt` event + host trust boundary + forgery test → A1.3 `gates.rs` closure pinning + pre-climb probe + flake quarantine → A1.4 `ledger.rs` atomic reservation → A1.5 `climb.rs` `drive_climb` (worktree isolation, fail-set acceptance, journal) → A1.6 wire + golden transcripts + adversarial tests. Highest-risk review targets are A1.2 (trust boundary) and A1.5 (climb).

Anvil #227 (design). Kill-switched; no cut impact.