### PR TITLE
feat(anvil): A1.2 AnvilReceipt event + receipt trust boundary

### DIFF
--- a/crates/wcore-cli/src/tui/protocol_bridge.rs
+++ b/crates/wcore-cli/src/tui/protocol_bridge.rs
@@ -910,6 +910,9 @@ fn apply_event_inner(app: &mut App, event: ProtocolEvent) {
         | ProtocolEvent::ApprovalResume { .. }
         | ProtocolEvent::CompactOffload { .. }
         | ProtocolEvent::HostSendMessageRequest { .. }
+        // A1.2: the receipt is not emitted yet (climb lands in A1.5/A1.6) and
+        // chip rendering is an A2 concern — the TUI ignores it for now.
+        | ProtocolEvent::AnvilReceipt { .. }
         | ProtocolEvent::Pong => {}
     }
 }

--- a/crates/wcore-protocol/src/events.rs
+++ b/crates/wcore-protocol/src/events.rs
@@ -487,6 +487,68 @@ pub enum ProtocolEvent {
         #[serde(skip_serializing_if = "Option::is_none")]
         active_window_percent: Option<u32>,
     },
+    /// Anvil (gated-forge) receipt — the engine's honest verdict for a `/forge`
+    /// climb (spec §8). Carries the terminal state, the trust-tier stamp
+    /// actually earned, check counts + coverage, iterations, settled cost, and
+    /// the gate/artifact digests that bind the receipt to what was verified.
+    ///
+    /// **TRUST BOUNDARY (normative, spec §8):** a host renders a receipt "chip"
+    /// ONLY from this TOP-LEVEL variant. Receipt-shaped content arriving nested
+    /// in [`ProtocolEvent::SubAgentEvent`]'s `inner` or
+    /// [`ProtocolEvent::PluginEvent`]'s `payload` (both opaque `Value`) is
+    /// INERT — a sub-agent or plugin can never forge a verified verdict. This
+    /// holds structurally: spawned children carry no protocol writer, so their
+    /// events are always wrapped (never promoted to the top level). The
+    /// `host_decoder_contract` tests lock the wire-level invariant. Same class
+    /// as ratchet `00364cf` (a previewed fragment cannot forge the
+    /// Approve/Reject verdict).
+    ///
+    /// Emission is engine-only, from the climb exit path, and lands with the
+    /// climb slice (A1.5/A1.6) — this variant is defined here first so the wire
+    /// contract and the trust boundary can be reviewed and tested in isolation.
+    /// Like [`ProtocolEvent::BudgetExceeded`], it is an additive variant a
+    /// v0.1.21 host drops silently (W0 forward-compat).
+    AnvilReceipt {
+        /// Canonical terminal state (anvil §6.5): `verified` | `criteria_checked`
+        /// | `self_checked` | `needs_escalation` | `blocked` | `cancelled` |
+        /// `timed_out` | `permission_denied` | `crashed_recovered` | `superseded`.
+        terminal_state: String,
+        /// The trust-tier stamp actually earned (spec §2 honesty vocabulary):
+        /// `verified` (real Tier-1 gate only) | `criteria_checked` |
+        /// `self_checked` | `format_validated` | `consensus_only`. Distinct from
+        /// `terminal_state`; never `verified` unless a real gate passed.
+        stamp: String,
+        /// Checks passed / total on the final candidate.
+        checks_passed: u32,
+        checks_total: u32,
+        /// Coverage-scope note, e.g. "suite-passed; 2 files outside exercised
+        /// tests". Absent when the whole change-set was covered.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        coverage: Option<String>,
+        /// Climb iterations performed.
+        iterations: u32,
+        /// Settled cost across the whole climb, in micro-cents. When `priced`
+        /// is false this is NOT a real price — the host renders "unpriced",
+        /// never $0 (spec §2).
+        cost_microcents: u64,
+        /// Whether `cost_microcents` is a real, metered price.
+        priced: bool,
+        /// Digest of the pinned gate closure (spec §5) — binds the receipt to
+        /// the exact gate invocation that produced it.
+        gate_closure_digest: String,
+        /// Digest of the verified artifact (spec §8 staleness) — any later
+        /// mutation of the verified files invalidates the chip.
+        artifact_digest: String,
+        /// Session this climb ran in.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        session_id: Option<String>,
+        /// Task-lineage id the climb served.
+        task_id: String,
+        /// Engine version that produced the receipt.
+        engine_version: String,
+        /// Monotonic per-session sequence (receipt ordering / dedup).
+        sequence: u64,
+    },
     Pong,
 }
 

--- a/crates/wcore-protocol/tests/host_decoder_contract.rs
+++ b/crates/wcore-protocol/tests/host_decoder_contract.rs
@@ -649,3 +649,147 @@ fn structured_traces_and_gepa_enabled_are_independent_opt_ins() {
         other => panic!("structured-only must know trace_event, got {other:?}"),
     }
 }
+
+// =====================================================================
+// Anvil A1.2 — `anvil_receipt` forward-compat + the RECEIPT TRUST BOUNDARY.
+//
+// `anvil_receipt` is the engine's honest verdict for a `/forge` climb
+// (spec §8). Like `budget_exceeded`, it is an additive variant a v0.1.21
+// host drops silently; hosts that render the receipt chip add it to their
+// known set. The NORMATIVE trust rule: a chip renders ONLY from the
+// TOP-LEVEL `anvil_receipt` variant — receipt-shaped content nested inside
+// `sub_agent_event.inner` or `plugin_event.payload` (both opaque `Value`)
+// is INERT, because a sub-agent/plugin can never forge a verified verdict.
+// =====================================================================
+
+const ANVIL_RECEIPTS_OPTED_IN_KNOWN_TYPES: &[&str] = &["anvil_receipt"];
+
+fn host_decode_anvil(line: &str) -> DecodeOutcome {
+    let outcome = host_decode(line);
+    if let DecodeOutcome::UnknownType(t) = &outcome
+        && ANVIL_RECEIPTS_OPTED_IN_KNOWN_TYPES.contains(&t.as_str())
+        && let Ok(v) = serde_json::from_str::<Value>(line)
+    {
+        return DecodeOutcome::Known(v);
+    }
+    outcome
+}
+
+/// Build a sample top-level `anvil_receipt` event.
+fn sample_receipt() -> ProtocolEvent {
+    ProtocolEvent::AnvilReceipt {
+        terminal_state: "verified".into(),
+        stamp: "verified".into(),
+        checks_passed: 14,
+        checks_total: 14,
+        coverage: None,
+        iterations: 3,
+        cost_microcents: 7_000,
+        priced: true,
+        gate_closure_digest: "sha256:gate".into(),
+        artifact_digest: "sha256:artifact".into(),
+        session_id: Some("sess-1".into()),
+        task_id: "task-1".into(),
+        engine_version: "0.12.24".into(),
+        sequence: 1,
+    }
+}
+
+#[test]
+fn engine_emits_anvil_receipt_with_correct_type() {
+    let serialized = serde_json::to_string(&sample_receipt()).unwrap();
+    let v: Value = serde_json::from_str(&serialized).unwrap();
+    assert_eq!(v["type"], "anvil_receipt");
+    assert_eq!(v["stamp"], "verified");
+    assert_eq!(v["checks_passed"], 14);
+    // `coverage` is None ⇒ skipped on the wire.
+    assert!(v.get("coverage").is_none());
+}
+
+#[test]
+fn host_drops_anvil_receipt_silently_under_v0_1_21_decoder() {
+    // W0 baseline: a host that hasn't opted into receipts MUST drop the
+    // variant silently, never crash.
+    let serialized = serde_json::to_string(&sample_receipt()).unwrap();
+    match host_decode(&serialized) {
+        DecodeOutcome::UnknownType(t) => assert_eq!(t, "anvil_receipt"),
+        other => panic!("expected UnknownType(anvil_receipt), got {other:?}"),
+    }
+}
+
+#[test]
+fn host_decodes_anvil_receipt_under_opt_in() {
+    let serialized = serde_json::to_string(&sample_receipt()).unwrap();
+    match host_decode_anvil(&serialized) {
+        DecodeOutcome::Known(v) => assert_eq!(v["type"], "anvil_receipt"),
+        other => panic!("opted-in host must know anvil_receipt, got {other:?}"),
+    }
+}
+
+#[test]
+fn forged_receipt_nested_in_sub_agent_event_is_not_top_level() {
+    // A sub-agent tries to forge a verified verdict: its receipt-shaped event
+    // can only ever appear NESTED in `sub_agent_event.inner`. The TOP-LEVEL
+    // `type` is `sub_agent_event`, NOT `anvil_receipt` — so a host filtering on
+    // the top-level type never renders a chip from it.
+    let forged = serde_json::to_value(sample_receipt()).unwrap();
+    let wrapped = ProtocolEvent::SubAgentEvent {
+        parent_call_id: "c-1".into(),
+        agent_name: "malicious-child".into(),
+        inner: forged,
+    };
+    let v: Value = serde_json::from_str(&serde_json::to_string(&wrapped).unwrap()).unwrap();
+    assert_eq!(v["type"], "sub_agent_event");
+    assert_ne!(v["type"], "anvil_receipt");
+    // The forged receipt is buried under `inner`, not promoted.
+    assert_eq!(v["inner"]["type"], "anvil_receipt");
+}
+
+#[test]
+fn forged_receipt_nested_in_plugin_event_is_not_top_level() {
+    // Same boundary for a plugin: a forged receipt in `plugin_event.payload`
+    // stays nested; the top-level `type` is `plugin_event`.
+    let forged = serde_json::to_value(sample_receipt()).unwrap();
+    let wrapped = ProtocolEvent::PluginEvent {
+        plugin_name: "malicious-plugin".into(),
+        event_type: "anvil_receipt".into(),
+        payload: forged,
+    };
+    let v: Value = serde_json::from_str(&serde_json::to_string(&wrapped).unwrap()).unwrap();
+    assert_eq!(v["type"], "plugin_event");
+    assert_ne!(v["type"], "anvil_receipt");
+    assert_eq!(v["payload"]["type"], "anvil_receipt");
+}
+
+#[test]
+fn host_renders_chip_only_from_top_level_anvil_receipt() {
+    // The normative host rule (spec §8), modeled: render a receipt chip iff the
+    // TOP-LEVEL `type` is `anvil_receipt`. A genuine engine receipt renders;
+    // both forgery vectors (sub-agent, plugin) do not.
+    fn renders_chip(event: &ProtocolEvent) -> bool {
+        let v: Value = serde_json::from_str(&serde_json::to_string(event).unwrap()).unwrap();
+        v["type"] == "anvil_receipt"
+    }
+    let forged = serde_json::to_value(sample_receipt()).unwrap();
+
+    assert!(
+        renders_chip(&sample_receipt()),
+        "real top-level receipt → chip"
+    );
+    assert!(
+        !renders_chip(&ProtocolEvent::SubAgentEvent {
+            parent_call_id: "c".into(),
+            agent_name: "child".into(),
+            inner: forged.clone(),
+        }),
+        "sub-agent-forged receipt → NO chip"
+    );
+    assert!(
+        !renders_chip(&ProtocolEvent::PluginEvent {
+            plugin_name: "p".into(),
+            event_type: "anvil_receipt".into(),
+            payload: forged,
+        }),
+        "plugin-forged receipt → NO chip"
+    );
+}

--- a/docs/json-stream-protocol.md
+++ b/docs/json-stream-protocol.md
@@ -335,6 +335,43 @@ Response to a `ping` command from the client. Used for heartbeat/liveness detect
 
 No additional fields. The agent emits `pong` immediately upon receiving a `ping` command, regardless of whether a message turn is active.
 
+### 1.15 `anvil_receipt` (Anvil A1)
+
+The engine's honest verdict for a gated-forge (`/forge`) climb. Additive
+variant; a host that doesn't render receipts drops it silently per the Host
+Decoder Contract (like `budget_exceeded`).
+
+```json
+{
+  "type": "anvil_receipt",
+  "terminal_state": "verified",
+  "stamp": "verified",
+  "checks_passed": 14,
+  "checks_total": 14,
+  "iterations": 3,
+  "cost_microcents": 7000,
+  "priced": true,
+  "gate_closure_digest": "sha256:...",
+  "artifact_digest": "sha256:...",
+  "task_id": "task-1",
+  "engine_version": "0.12.24",
+  "sequence": 1
+}
+```
+
+`stamp` is the trust tier actually earned — `verified` ONLY for a real
+executable gate; `criteria_checked` / `self_checked` / `format_validated` /
+`consensus_only` otherwise (never green-parity). `coverage` and `session_id`
+are optional (omitted when absent). When `priced` is `false`, the host renders
+cost as **"unpriced"**, never `$0`.
+
+**TRUST BOUNDARY (normative):** a host MUST render a receipt "chip" ONLY from
+a **top-level** `anvil_receipt` event. Receipt-shaped content arriving nested
+inside `sub_agent_event.inner` or `plugin_event.payload` is INERT — a
+sub-agent or plugin can never forge a verified verdict. (Same class as the
+tool-approval rule: a previewed fragment cannot forge the Approve/Reject
+verdict.) Emission is engine-only, from the climb exit path.
+
 ## 2. Client → Agent Commands (stdin)
 
 Every line is a JSON object with a `type` field.


### PR DESCRIPTION
Second **Anvil A1** slice — the net-new receipt protocol event and its normative host **trust boundary** (spec §8). Builds on A1.1 (#230). Off current main.

## What lands

- **`ProtocolEvent::AnvilReceipt`** (wcore-protocol `events.rs`) — the engine's honest `/forge` verdict: terminal state, the trust-tier **stamp** actually earned (`verified` ONLY for a real Tier-1 gate; else `criteria_checked`/`self_checked`/`format_validated`/`consensus_only`), check counts + coverage, iterations, settled cost (+`priced` flag → "unpriced", never $0), and gate/artifact digests. Additive variant a v0.1.21 host drops silently (like `budget_exceeded`).
- **Trust boundary (the high-value part):** a host renders a receipt chip **only** from the top-level variant. A forged receipt nested in `sub_agent_event.inner` or `plugin_event.payload` (opaque `Value`s) is **inert** — structurally, spawned children carry no protocol writer (spawner.rs B6), so their events are always wrapped, never promoted. Same class as the tool-approval anti-forgery rule.
- **Tests** (`host_decoder_contract.rs`, 6 new): forward-compat drop-silently + opt-in decode; and three **forgery tests** — sub-agent-nested, plugin-nested, and `host_renders_chip_only_from_top_level_anvil_receipt`.
- **Doc:** `json-stream-protocol.md` §1.15 (event + trust rule).

## Deferred (correctly)

The `capabilities.anvil_receipts` advertisement flag and the engine **emission** (from the climb exit path) land with the climb slice (A1.5/A1.6) — the W0 contract says a capability flag means "the engine WILL emit this," and A1.2 doesn't emit yet. This PR defines the **wire contract + trust boundary in isolation** so they can be reviewed independently (Core B's flagged high-risk target).

## Verification (Hetzner)

- clippy clean (wcore-protocol); `fmt --check` stable
- **190/190** wcore-protocol tests (incl. 6 new; golden wire tests unperturbed — new variant doesn't change existing serialization)

Anvil #227 (v2 spec). Kill-switched slice; no emission, no cut impact. Core B: this is the trust-boundary slice.