### PR TITLE
feat(anvil): gate closure/probe + cost ledger (A1.3+A1.4)

### DIFF
--- a/crates/wcore-agent/src/orchestration/anvil/gates.rs
+++ b/crates/wcore-agent/src/orchestration/anvil/gates.rs
@@ -1,0 +1,628 @@
+//! Anvil gate machinery — closure pinning, the pre-climb executability probe,
+//! injection fencing, and the flake-quarantine policy (A1.3 slice, spec §5).
+//!
+//! A Tier-1 gate is a REAL executable (repo tests / build / lint / typecheck /
+//! schema / land-gate) — the only tier that can earn the reserved `verified`
+//! stamp (spec §2). This module pins that gate so the climb runs against a
+//! stable, hashed invocation closure and refuses up front if the gate cannot
+//! even execute. It deliberately owns only the gate PRIMITIVES; the climb loop
+//! that consumes them (probe → ensemble → surgical → escalate, fail-set
+//! acceptance, receipt emission) lands in the climb slice (A1.5).
+//!
+//! ## What is pinned (spec §5 gate closure pinning)
+//! The FULL invocation closure — command + argv + env allowlist + cwd + the
+//! transitive inputs (config files, fixtures, helpers, goldens, conftest,
+//! package scripts) — is hashed into a single `gate_closure_digest`. ANY closure
+//! drift during the climb aborts the candidate ([`GateClosure::drifted`]). A
+//! task whose deliverable IS a gate change carves the files-under-edit OUT of
+//! the closure so authoring them is not mistaken for drift (`carve_out`).
+//!
+//! ## Untrusted by construction (spec §5)
+//! Gates are untrusted code: the probe runs them in the exec sandbox with
+//! network DENIED and a minimized env (no ambient secrets), and their raw
+//! stdout/stderr never surfaces verbatim — only the typed, bounded,
+//! control-stripped [`BoundedGateOutput`] may reach a caller that feeds a model
+//! prompt (injection fencing).
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use sha2::{Digest, Sha256};
+use wcore_sandbox::backends::SandboxBackend;
+use wcore_sandbox::{NetworkPolicy, SandboxCommand, SandboxError, SandboxManifest, SyscallPolicy};
+
+/// Errors that prevent a gate closure from being pinned. A closure that cannot
+/// be pinned cannot gate a climb — these fail the climb closed, never silently.
+#[derive(Debug, thiserror::Error)]
+pub enum GateError {
+    /// A gate must have a command; an empty argv is a caller bug.
+    #[error("gate closure has no argv (a Tier-1 gate must have a command)")]
+    EmptyArgv,
+    /// A declared transitive input could not be read at pin time. A closure that
+    /// hashes a file it cannot read is not a closure — surface it.
+    #[error("gate closure input unreadable: {path} ({source})")]
+    InputUnreadable {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+}
+
+/// The unpinned description of a Tier-1 gate invocation (spec §5 closure).
+#[derive(Debug, Clone)]
+pub struct GateSpec {
+    /// `argv[0]` is the program; the rest are its arguments.
+    pub argv: Vec<String>,
+    /// Working directory the gate runs in.
+    pub cwd: PathBuf,
+    /// Names of environment variables whose values are allowed to survive into
+    /// the sandbox. The NAMES are pinned (part of the closure); the values are
+    /// resolved at probe time from a scrubbed env, so an ambient secret outside
+    /// this list can never reach the gate.
+    pub env_allowlist: Vec<String>,
+    /// Transitive inputs whose CONTENT is pinned: config, fixtures, helpers,
+    /// goldens, conftest, package scripts. Their bytes are hashed into the
+    /// closure digest and re-checked for drift.
+    pub inputs: Vec<PathBuf>,
+}
+
+/// A pinned gate closure: a [`GateSpec`] plus the content digest of its whole
+/// invocation closure. `digest` is the `gate_closure_digest` the climb journal
+/// (§6.5) and the `AnvilReceipt` event (§8) carry.
+#[derive(Debug, Clone)]
+pub struct GateClosure {
+    spec: GateSpec,
+    /// Content digest of each pinned input, parallel to `spec.inputs`.
+    input_digests: Vec<[u8; 32]>,
+    digest: [u8; 32],
+}
+
+impl GateClosure {
+    /// Pin `spec`, excluding any `carve_out` path from the closure (the
+    /// test-authoring carve-out, spec §5: a task that edits a gate file must not
+    /// trip drift on its own deliverable). Reads + hashes every remaining
+    /// transitive input; a missing/unreadable input fails closed.
+    pub fn pin(mut spec: GateSpec, carve_out: &[PathBuf]) -> Result<Self, GateError> {
+        if spec.argv.is_empty() {
+            return Err(GateError::EmptyArgv);
+        }
+        spec.inputs.retain(|p| !carve_out.iter().any(|c| c == p));
+        let mut input_digests = Vec::with_capacity(spec.inputs.len());
+        for p in &spec.inputs {
+            let bytes = std::fs::read(p).map_err(|e| GateError::InputUnreadable {
+                path: p.clone(),
+                source: e,
+            })?;
+            input_digests.push(sha256(&bytes));
+        }
+        let digest = closure_digest(&spec, &input_digests);
+        Ok(Self {
+            spec,
+            input_digests,
+            digest,
+        })
+    }
+
+    /// The raw `gate_closure_digest`.
+    #[must_use]
+    pub fn digest(&self) -> [u8; 32] {
+        self.digest
+    }
+
+    /// The `gate_closure_digest` as 64 lowercase hex chars (receipt/journal form).
+    #[must_use]
+    pub fn digest_hex(&self) -> String {
+        hex32(&self.digest)
+    }
+
+    /// The pinned spec (read-only).
+    #[must_use]
+    pub fn spec(&self) -> &GateSpec {
+        &self.spec
+    }
+
+    /// Whether any pinned input's content changed since pinning, or an input
+    /// became unreadable. Spec §5: ANY closure drift aborts the candidate.
+    #[must_use]
+    pub fn drifted(&self) -> bool {
+        for (path, pinned) in self.spec.inputs.iter().zip(&self.input_digests) {
+            match std::fs::read(path) {
+                Ok(bytes) => {
+                    if sha256(&bytes) != *pinned {
+                        return true;
+                    }
+                }
+                // A vanished or unreadable pinned input is drift.
+                Err(_) => return true,
+            }
+        }
+        false
+    }
+
+    /// Run the pinned gate ONCE on the baseline before any builder spawns
+    /// (spec §5 pre-climb probe), through `backend` with network denied and a
+    /// minimized env. Returns whether the gate ran (and its baseline result) or
+    /// could not execute here — in which case the climb must refuse, never
+    /// burning ensemble budget to rediscover it.
+    pub async fn probe_baseline(
+        &self,
+        backend: &dyn SandboxBackend,
+        opts: &ProbeOpts,
+    ) -> BaselineProbe {
+        let manifest = SandboxManifest {
+            network: NetworkPolicy::Deny,
+            env: minimized_env(&self.spec.env_allowlist),
+            syscall_policy: SyscallPolicy::Inherit,
+            timeout: Some(opts.timeout),
+            fs_read_allow: opts.fs_read_allow.clone(),
+            fs_write_allow: opts.fs_write_allow.clone(),
+            ..Default::default()
+        };
+        let cmd = SandboxCommand {
+            argv: self.spec.argv.clone(),
+            cwd: Some(self.spec.cwd.clone()),
+        };
+        match backend.execute(&manifest, cmd).await {
+            Ok(out) => BaselineProbe::Ran {
+                exit_code: out.exit_code,
+                clean: out.exit_code == 0,
+                diagnostics: BoundedGateOutput::from_bytes(&out.stderr),
+            },
+            Err(e) => classify_exec_error(&e),
+        }
+    }
+}
+
+/// Sandbox knobs for the pre-climb probe. The fs allowlists point at the
+/// ISOLATED gate snapshot (spec §5) — never the mutable worktree copy — so the
+/// baseline gate cannot read or write outside the snapshot.
+#[derive(Debug, Clone)]
+pub struct ProbeOpts {
+    /// Wall-clock budget for the baseline gate run.
+    pub timeout: Duration,
+    /// Read roots the gate is permitted (the snapshot + toolchain).
+    pub fs_read_allow: Vec<PathBuf>,
+    /// Write roots the gate is permitted (its own scratch inside the snapshot).
+    pub fs_write_allow: Vec<PathBuf>,
+}
+
+/// Outcome of the pre-climb gate probe.
+#[derive(Debug, Clone)]
+pub enum BaselineProbe {
+    /// The gate EXECUTED. `clean` is `exit_code == 0`: a clean baseline. A
+    /// non-zero exit is a pre-existing failure set, surfaced (never silently
+    /// pinned as if green) so a dirty/weakened suite is visible to the climb.
+    Ran {
+        exit_code: i32,
+        clean: bool,
+        diagnostics: BoundedGateOutput,
+    },
+    /// The gate could NOT execute here (no sandbox backend, spawn refused,
+    /// missing toolchain, or the required isolation cannot be enforced). Spec §5:
+    /// refuse the climb immediately.
+    CannotExecute(String),
+}
+
+impl BaselineProbe {
+    /// Whether the baseline is clean (the gate ran and passed). A climb may only
+    /// pin a gate whose baseline is clean; otherwise the pre-existing failures
+    /// are surfaced first.
+    #[must_use]
+    pub fn is_clean_baseline(&self) -> bool {
+        matches!(self, BaselineProbe::Ran { clean: true, .. })
+    }
+}
+
+/// Map a sandbox error from the probe to the "cannot execute → refuse" outcome.
+/// EVERY sandbox error means the gate could not run as required (network-denied,
+/// minimized env); per spec §5 that refuses the climb rather than proceeding
+/// without the gate's isolation. Kept separate + pure so the decision is unit
+/// tested without a live backend.
+fn classify_exec_error(err: &SandboxError) -> BaselineProbe {
+    let reason = match err {
+        SandboxError::ExecFailed(m) => format!("gate could not be spawned: {m}"),
+        SandboxError::Timeout => "gate probe exceeded its time budget".to_string(),
+        SandboxError::PolicyNotSupported(m) => {
+            format!("required sandbox isolation cannot be enforced here: {m}")
+        }
+        other => format!("gate could not execute under the required isolation: {other}"),
+    };
+    BaselineProbe::CannotExecute(reason)
+}
+
+/// Maximum bytes of gate output retained for diagnostics. Gate output is
+/// untrusted; only a bounded tail is ever kept.
+const MAX_DIAG_BYTES: usize = 2048;
+
+/// A typed, bounded, control-stripped view of a gate's raw output — the ONLY
+/// form of gate stdout/stderr allowed to reach a caller that may feed a model
+/// prompt (injection fencing, spec §5). Raw bytes never leave the gate layer:
+/// this keeps at most [`MAX_DIAG_BYTES`] of the TAIL, lossily decoded, with
+/// control characters (other than newline/tab) replaced.
+#[derive(Debug, Clone)]
+pub struct BoundedGateOutput {
+    tail: String,
+    truncated: bool,
+}
+
+impl BoundedGateOutput {
+    /// Build a bounded, sanitized view from raw gate output bytes.
+    #[must_use]
+    pub fn from_bytes(raw: &[u8]) -> Self {
+        let truncated = raw.len() > MAX_DIAG_BYTES;
+        let start = raw.len().saturating_sub(MAX_DIAG_BYTES);
+        let mut tail = String::new();
+        for ch in String::from_utf8_lossy(&raw[start..]).chars() {
+            if ch == '\n' || ch == '\t' || !ch.is_control() {
+                tail.push(ch);
+            } else {
+                // Strip other control chars (ANSI/escape/carriage-return noise)
+                // so nothing steers a terminal or a prompt.
+                tail.push('\u{FFFD}');
+            }
+        }
+        Self { tail, truncated }
+    }
+
+    /// The sanitized, bounded diagnostic tail (safe to surface).
+    #[must_use]
+    pub fn tail(&self) -> &str {
+        &self.tail
+    }
+
+    /// Whether the original output exceeded the cap and was truncated.
+    #[must_use]
+    pub fn truncated(&self) -> bool {
+        self.truncated
+    }
+}
+
+/// N-of-M stability required for the reserved `verified` stamp (spec §5 flake
+/// quarantine): a check that flips on identical code is flaky and quarantined,
+/// and `verified` requires `required`-of-`of` passing runs on the final
+/// candidate. A1.3 defines the policy + predicates; the climb slice (A1.5)
+/// drives the repeated gate runs that feed them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StabilityPolicy {
+    pub required: u32,
+    pub of: u32,
+}
+
+impl StabilityPolicy {
+    /// Build a policy, clamped so `1 <= required <= of`.
+    #[must_use]
+    pub fn new(required: u32, of: u32) -> Self {
+        let of = of.max(1);
+        Self {
+            required: required.clamp(1, of),
+            of,
+        }
+    }
+
+    /// Whether `passes` passing runs (out of `self.of` identical-code runs) meets
+    /// the stability bar.
+    #[must_use]
+    pub fn met(&self, passes: u32) -> bool {
+        passes >= self.required
+    }
+
+    /// A check whose per-run pass/fail observations include BOTH a pass and a
+    /// fail on identical code is flaky → quarantined out of the gate.
+    #[must_use]
+    pub fn is_flaky(observations: &[bool]) -> bool {
+        observations.iter().any(|&b| b) && observations.iter().any(|&b| !b)
+    }
+}
+
+impl Default for StabilityPolicy {
+    /// 3-of-3: three identical-code runs must all pass to stamp `verified`.
+    fn default() -> Self {
+        Self { required: 3, of: 3 }
+    }
+}
+
+/// SHA-256 of `bytes` (the codebase-wide content-hash primitive).
+fn sha256(bytes: &[u8]) -> [u8; 32] {
+    let mut h = Sha256::new();
+    h.update(bytes);
+    h.finalize().into()
+}
+
+/// Lowercase-hex encode a 32-byte digest.
+fn hex32(d: &[u8; 32]) -> String {
+    let mut s = String::with_capacity(64);
+    for b in d {
+        s.push_str(&format!("{b:02x}"));
+    }
+    s
+}
+
+/// Minimized env for the sandboxed gate: the allowlisted NAMES resolved from the
+/// current process env. The sandbox scrubs the host env `env -i` style, so only
+/// these survive — no ambient `*_API_KEY`/token reaches the untrusted gate.
+fn minimized_env(allowlist: &[String]) -> Vec<(String, String)> {
+    allowlist
+        .iter()
+        .filter_map(|k| std::env::var(k).ok().map(|v| (k.clone(), v)))
+        .collect()
+}
+
+/// Canonical, unambiguous SHA-256 over the whole invocation closure. Every field
+/// is length-prefixed so no two distinct closures can collide by concatenation.
+/// argv is ordered (order is semantic); the env allowlist and inputs are sorted
+/// (they are sets), so an identical closure always yields an identical digest.
+fn closure_digest(spec: &GateSpec, input_digests: &[[u8; 32]]) -> [u8; 32] {
+    let mut h = Sha256::new();
+    h.update(b"anvil-gate-closure-v1");
+
+    // argv — ordered.
+    h.update((spec.argv.len() as u64).to_le_bytes());
+    for a in &spec.argv {
+        h.update((a.len() as u64).to_le_bytes());
+        h.update(a.as_bytes());
+    }
+
+    // env allowlist — a set: sort + dedup for order-independence.
+    let mut env = spec.env_allowlist.clone();
+    env.sort();
+    env.dedup();
+    h.update((env.len() as u64).to_le_bytes());
+    for e in &env {
+        h.update((e.len() as u64).to_le_bytes());
+        h.update(e.as_bytes());
+    }
+
+    // cwd.
+    let cwd = spec.cwd.to_string_lossy();
+    h.update((cwd.len() as u64).to_le_bytes());
+    h.update(cwd.as_bytes());
+
+    // inputs — a set of (path, content-digest): sort by path.
+    let mut inputs: Vec<(&PathBuf, &[u8; 32])> =
+        spec.inputs.iter().zip(input_digests.iter()).collect();
+    inputs.sort_by(|a, b| a.0.cmp(b.0));
+    h.update((inputs.len() as u64).to_le_bytes());
+    for (path, d) in inputs {
+        let p = path.to_string_lossy();
+        h.update((p.len() as u64).to_le_bytes());
+        h.update(p.as_bytes());
+        h.update(&d[..]);
+    }
+
+    h.finalize().into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn spec_in(dir: &std::path::Path, argv: &[&str], inputs: &[&str]) -> GateSpec {
+        GateSpec {
+            argv: argv.iter().map(|s| s.to_string()).collect(),
+            cwd: dir.to_path_buf(),
+            env_allowlist: vec!["PATH".to_string()],
+            inputs: inputs.iter().map(|n| dir.join(n)).collect(),
+        }
+    }
+
+    #[test]
+    fn empty_argv_fails_closed() {
+        let dir = TempDir::new().unwrap();
+        let spec = spec_in(dir.path(), &[], &[]);
+        assert!(matches!(
+            GateClosure::pin(spec, &[]),
+            Err(GateError::EmptyArgv)
+        ));
+    }
+
+    #[test]
+    fn missing_input_fails_closed() {
+        let dir = TempDir::new().unwrap();
+        let spec = spec_in(dir.path(), &["cargo", "test"], &["does-not-exist.toml"]);
+        assert!(matches!(
+            GateClosure::pin(spec, &[]),
+            Err(GateError::InputUnreadable { .. })
+        ));
+    }
+
+    #[test]
+    fn digest_is_stable_and_hex_is_64_chars() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("fix.toml"), b"fixture-bytes").unwrap();
+        let a =
+            GateClosure::pin(spec_in(dir.path(), &["cargo", "test"], &["fix.toml"]), &[]).unwrap();
+        let b =
+            GateClosure::pin(spec_in(dir.path(), &["cargo", "test"], &["fix.toml"]), &[]).unwrap();
+        assert_eq!(
+            a.digest(),
+            b.digest(),
+            "identical closures hash identically"
+        );
+        assert_eq!(a.digest_hex().len(), 64);
+        assert!(
+            a.digest_hex()
+                .chars()
+                .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase())
+        );
+    }
+
+    #[test]
+    fn argv_env_and_input_content_all_change_the_digest() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("fix.toml"), b"v1").unwrap();
+        let base =
+            GateClosure::pin(spec_in(dir.path(), &["cargo", "test"], &["fix.toml"]), &[]).unwrap();
+
+        // Different argv.
+        let argv2 = GateClosure::pin(
+            spec_in(dir.path(), &["cargo", "nextest"], &["fix.toml"]),
+            &[],
+        )
+        .unwrap();
+        assert_ne!(base.digest(), argv2.digest(), "argv must affect the digest");
+
+        // Different env allowlist.
+        let mut s = spec_in(dir.path(), &["cargo", "test"], &["fix.toml"]);
+        s.env_allowlist.push("HOME".to_string());
+        let env2 = GateClosure::pin(s, &[]).unwrap();
+        assert_ne!(
+            base.digest(),
+            env2.digest(),
+            "env allowlist must affect the digest"
+        );
+
+        // Different input content.
+        std::fs::write(dir.path().join("fix.toml"), b"v2").unwrap();
+        let content2 =
+            GateClosure::pin(spec_in(dir.path(), &["cargo", "test"], &["fix.toml"]), &[]).unwrap();
+        assert_ne!(
+            base.digest(),
+            content2.digest(),
+            "input content must affect the digest"
+        );
+    }
+
+    #[test]
+    fn drift_detects_content_change_and_deletion_but_not_stability() {
+        let dir = TempDir::new().unwrap();
+        let fix = dir.path().join("fix.toml");
+        std::fs::write(&fix, b"pinned").unwrap();
+        let closure =
+            GateClosure::pin(spec_in(dir.path(), &["cargo", "test"], &["fix.toml"]), &[]).unwrap();
+        assert!(!closure.drifted(), "an unchanged closure has not drifted");
+
+        std::fs::write(&fix, b"tampered").unwrap();
+        assert!(closure.drifted(), "changed input content is drift");
+
+        std::fs::write(&fix, b"pinned").unwrap();
+        assert!(
+            !closure.drifted(),
+            "restoring the exact bytes clears the drift"
+        );
+
+        std::fs::remove_file(&fix).unwrap();
+        assert!(closure.drifted(), "a vanished pinned input is drift");
+    }
+
+    #[test]
+    fn carveout_excludes_edited_gate_files_from_the_closure() {
+        let dir = TempDir::new().unwrap();
+        let edited = dir.path().join("test_under_edit.rs");
+        std::fs::write(&edited, b"original").unwrap();
+        let closure = GateClosure::pin(
+            spec_in(dir.path(), &["cargo", "test"], &["test_under_edit.rs"]),
+            std::slice::from_ref(&edited),
+        )
+        .unwrap();
+        // The carved-out file is not part of the closure, so editing it — the
+        // task's own deliverable — is not drift.
+        std::fs::write(&edited, b"the authored change").unwrap();
+        assert!(
+            !closure.drifted(),
+            "editing a carved-out gate file must not trip closure drift"
+        );
+    }
+
+    #[test]
+    fn cannot_execute_maps_every_sandbox_error_to_refusal() {
+        for e in [
+            SandboxError::ExecFailed("no backend".into()),
+            SandboxError::Timeout,
+            SandboxError::PolicyNotSupported("network-deny".into()),
+            SandboxError::NetworkDenied("blocked".into()),
+        ] {
+            assert!(
+                matches!(classify_exec_error(&e), BaselineProbe::CannotExecute(_)),
+                "{e:?} must refuse the climb"
+            );
+        }
+    }
+
+    #[test]
+    fn baseline_clean_predicate() {
+        let clean = BaselineProbe::Ran {
+            exit_code: 0,
+            clean: true,
+            diagnostics: BoundedGateOutput::from_bytes(b""),
+        };
+        let dirty = BaselineProbe::Ran {
+            exit_code: 1,
+            clean: false,
+            diagnostics: BoundedGateOutput::from_bytes(b"1 failed"),
+        };
+        assert!(clean.is_clean_baseline());
+        assert!(
+            !dirty.is_clean_baseline(),
+            "a non-zero baseline is not clean"
+        );
+        assert!(!BaselineProbe::CannotExecute("x".into()).is_clean_baseline());
+    }
+
+    #[test]
+    fn bounded_output_strips_control_chars_and_caps_length() {
+        // Control chars (except \n and \t) are replaced.
+        let out = BoundedGateOutput::from_bytes(b"ok\x1b[31mred\x07\nline\ttab");
+        assert!(!out.truncated());
+        assert!(out.tail().contains('\n') && out.tail().contains('\t'));
+        assert!(
+            !out.tail().contains('\x1b') && !out.tail().contains('\x07'),
+            "escape/bell control chars must not survive: {:?}",
+            out.tail()
+        );
+
+        // Oversized output is truncated to the TAIL and flagged.
+        let big = vec![b'a'; MAX_DIAG_BYTES + 500];
+        let out = BoundedGateOutput::from_bytes(&big);
+        assert!(out.truncated());
+        assert!(out.tail().len() <= MAX_DIAG_BYTES);
+    }
+
+    #[test]
+    fn stability_policy_clamps_and_scores() {
+        let p = StabilityPolicy::new(5, 3); // required clamped to of
+        assert_eq!(p, StabilityPolicy { required: 3, of: 3 });
+        assert!(p.met(3));
+        assert!(!p.met(2));
+
+        let z = StabilityPolicy::new(0, 0); // clamped up to 1-of-1
+        assert_eq!(z, StabilityPolicy { required: 1, of: 1 });
+
+        assert_eq!(
+            StabilityPolicy::default(),
+            StabilityPolicy { required: 3, of: 3 }
+        );
+    }
+
+    #[test]
+    fn flake_is_a_mixed_observation_set() {
+        assert!(StabilityPolicy::is_flaky(&[true, false, true]));
+        assert!(!StabilityPolicy::is_flaky(&[true, true, true]));
+        assert!(!StabilityPolicy::is_flaky(&[false, false]));
+        assert!(!StabilityPolicy::is_flaky(&[]));
+    }
+
+    #[test]
+    fn minimized_env_only_surfaces_allowlisted_present_vars() {
+        // SAFETY: single-threaded test; set a known var then read it back.
+        unsafe {
+            std::env::set_var("ANVIL_GATES_TEST_VAR", "present");
+        }
+        let env = minimized_env(&[
+            "ANVIL_GATES_TEST_VAR".to_string(),
+            "ANVIL_GATES_DEFINITELY_UNSET_VAR".to_string(),
+        ]);
+        assert!(
+            env.iter()
+                .any(|(k, v)| k == "ANVIL_GATES_TEST_VAR" && v == "present")
+        );
+        assert!(
+            !env.iter()
+                .any(|(k, _)| k == "ANVIL_GATES_DEFINITELY_UNSET_VAR"),
+            "an unset allowlisted var must not appear"
+        );
+        unsafe {
+            std::env::remove_var("ANVIL_GATES_TEST_VAR");
+        }
+    }
+}

--- a/crates/wcore-agent/src/orchestration/anvil/ledger.rs
+++ b/crates/wcore-agent/src/orchestration/anvil/ledger.rs
@@ -1,0 +1,579 @@
+//! Anvil cost ledger — one per-task-lineage budget with ATOMIC
+//! reservation-before-dispatch (A1.4 slice, spec §7).
+//!
+//! Every provider call and gate execution reserves capacity from the ledger
+//! ATOMICALLY before it dispatches, so parallel builders can never race a
+//! check-then-launch past the budget. Actuals reconcile after
+//! ([`ClimbLedger::settle`]); an exhausted reservation refuses, and the caller
+//! cancels the undispatched work. The ledger covers BOTH axes the climb
+//! spends — provider **tokens/cost** and gate **exec wallclock** (test suites
+//! are a real cost, spec §7) — and reports reserved-vs-settled totals plus the
+//! `priced` flag the receipt needs (spec §2 honesty vocabulary: unpriced spend
+//! renders "unpriced", never `$0`).
+//!
+//! ## Shared envelope, not a shared type
+//! Spec §1 requires Anvil and Crucible to share ONE spend envelope per task so
+//! the two can never stack spend on a goal. That is a VALUE contract — identical
+//! units (`u64` microcents + a `priced: bool`, exactly what `CouncilSpend` and
+//! `ProtocolEvent::AnvilReceipt` already speak) — not type inheritance. The
+//! ledger therefore composes those units rather than extending council's
+//! `CouncilSpend` (whose accumulation is bound to council's proposal model).
+//!
+//! ## Scope
+//! A1.4 is the ledger PRIMITIVE + its accounting. The climb loop that actually
+//! wraps each dispatch in reserve→settle, carries residual budget into
+//! escalation, journals per-iteration spend, and emits the receipt lands with
+//! the climb slice (A1.5).
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use parking_lot::Mutex;
+use wcore_types::crucible::MICROCENTS_PER_USD;
+
+/// Which budget axis a reservation tripped.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Axis {
+    /// Provider cost, in microcents.
+    Cost,
+    /// Gate/provider exec wallclock.
+    Wallclock,
+}
+
+impl std::fmt::Display for Axis {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Axis::Cost => write!(f, "cost (microcents)"),
+            Axis::Wallclock => write!(f, "wallclock (ms)"),
+        }
+    }
+}
+
+/// Reserving would exceed the per-task budget on `axis`. The caller cancels the
+/// undispatched work rather than overspending. Values are microcents for
+/// [`Axis::Cost`] and milliseconds for [`Axis::Wallclock`].
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error(
+    "climb budget exhausted on {axis}: committed {committed} + requested {requested} exceeds cap {cap}"
+)]
+pub struct Exhausted {
+    pub axis: Axis,
+    pub committed: u64,
+    pub requested: u64,
+    pub cap: u64,
+}
+
+/// What kind of dispatch a settled entry accounts for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LedgerEntryKind {
+    /// A model/provider call (has tokens + a possibly-priced cost).
+    ProviderCall,
+    /// A gate execution (its cost is exec wallclock; tokens are zero).
+    GateExec,
+}
+
+/// One settled dispatch — the anvil analog of council's `ProviderSpend`,
+/// extended with the exec-wallclock axis and a gate-execution kind.
+#[derive(Debug, Clone, PartialEq)]
+pub struct LedgerEntry {
+    pub kind: LedgerEntryKind,
+    pub provider: Option<String>,
+    pub model: Option<String>,
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    /// Cost in microcents (0 when unpriced — see `priced`).
+    pub cost_microcents: u64,
+    /// Whether `cost_microcents` is a real, metered catalog price. A single
+    /// unpriced entry makes the whole climb's settled spend unpriced.
+    pub priced: bool,
+    /// Exec wallclock this dispatch consumed.
+    pub wallclock: Duration,
+}
+
+impl LedgerEntry {
+    /// A settled provider call.
+    #[must_use]
+    pub fn provider_call(
+        provider: impl Into<String>,
+        model: Option<String>,
+        input_tokens: u64,
+        output_tokens: u64,
+        cost_microcents: u64,
+        priced: bool,
+        wallclock: Duration,
+    ) -> Self {
+        Self {
+            kind: LedgerEntryKind::ProviderCall,
+            provider: Some(provider.into()),
+            model,
+            input_tokens,
+            output_tokens,
+            cost_microcents,
+            priced,
+            wallclock,
+        }
+    }
+
+    /// A settled gate execution — cost is its wallclock; no tokens, and it is
+    /// `priced` (wallclock is always a real, metered cost).
+    #[must_use]
+    pub fn gate_exec(wallclock: Duration) -> Self {
+        Self {
+            kind: LedgerEntryKind::GateExec,
+            provider: None,
+            model: None,
+            input_tokens: 0,
+            output_tokens: 0,
+            cost_microcents: 0,
+            priced: true,
+            wallclock,
+        }
+    }
+}
+
+/// The per-task budget ceiling. Either axis may be uncapped (`None`); §7's
+/// "conservative configured upper bound" is expressed by supplying a cap.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct LedgerCap {
+    pub max_microcents: Option<u64>,
+    pub max_wallclock: Option<Duration>,
+}
+
+impl LedgerCap {
+    /// No ceiling on either axis (reservations never exhaust).
+    #[must_use]
+    pub fn unlimited() -> Self {
+        Self::default()
+    }
+
+    /// A cost-only ceiling.
+    #[must_use]
+    pub fn cost(max_microcents: u64) -> Self {
+        Self {
+            max_microcents: Some(max_microcents),
+            max_wallclock: None,
+        }
+    }
+}
+
+/// The settled-spend rollup for the receipt (spec §8) and the future
+/// `ClimbResult.spend`. `cost_microcents` + `priced` match
+/// `ProtocolEvent::AnvilReceipt` byte-for-byte.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SettledSpend {
+    pub cost_microcents: u64,
+    /// False if ANY settled entry was unpriced (spec §2: render "unpriced").
+    pub priced: bool,
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub wallclock: Duration,
+}
+
+impl SettledSpend {
+    /// Settled cost in USD (display only — accounting stays integer microcents).
+    #[must_use]
+    pub fn cost_usd(&self) -> f64 {
+        self.cost_microcents as f64 / MICROCENTS_PER_USD
+    }
+}
+
+/// A granted reservation. Holding it keeps `est` committed against the budget;
+/// [`ClimbLedger::settle`] reconciles it with actuals (releasing the estimate
+/// and charging the real cost), and DROPPING it without settling releases the
+/// estimate (the dispatch was cancelled). Either way the estimate never leaks.
+#[derive(Debug)]
+#[must_use = "a reservation must be settled or dropped; leaking it holds budget"]
+pub struct Reservation {
+    inner: Arc<Mutex<Inner>>,
+    est_microcents: u64,
+    est_wallclock: Duration,
+    /// True while this reservation still holds its estimate outstanding.
+    live: bool,
+}
+
+impl Reservation {
+    /// The reserved cost estimate (microcents).
+    #[must_use]
+    pub fn est_microcents(&self) -> u64 {
+        self.est_microcents
+    }
+}
+
+impl Drop for Reservation {
+    fn drop(&mut self) {
+        // Released without settling ⇒ the dispatch was cancelled; return the
+        // estimate to the budget. `settle` clears `live` first, so it never
+        // double-releases (and never re-locks — parking_lot is not reentrant).
+        if self.live {
+            let mut inner = self.inner.lock();
+            inner.outstanding_microcents = inner
+                .outstanding_microcents
+                .saturating_sub(self.est_microcents);
+            inner.outstanding_wallclock = inner
+                .outstanding_wallclock
+                .saturating_sub(self.est_wallclock);
+        }
+    }
+}
+
+#[derive(Debug)]
+struct Inner {
+    task_id: String,
+    cap: LedgerCap,
+    /// Sum of granted-but-not-yet-settled reservation estimates.
+    outstanding_microcents: u64,
+    outstanding_wallclock: Duration,
+    /// Sum of settled actuals.
+    settled_microcents: u64,
+    settled_wallclock: Duration,
+    total_input_tokens: u64,
+    total_output_tokens: u64,
+    /// True until an unpriced entry settles.
+    all_priced: bool,
+    entries: Vec<LedgerEntry>,
+}
+
+/// A single per-task-lineage cost ledger. Cheap to [`Clone`] (shares one locked
+/// core) so every parallel builder reserves against the SAME budget — the lock
+/// makes reservation atomic, so no two builders can both pass a check-then-launch
+/// past the ceiling.
+#[derive(Clone)]
+pub struct ClimbLedger {
+    inner: Arc<Mutex<Inner>>,
+}
+
+impl ClimbLedger {
+    /// A fresh ledger for `task_id` (the lineage key) with budget `cap`.
+    #[must_use]
+    pub fn new(task_id: impl Into<String>, cap: LedgerCap) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(Inner {
+                task_id: task_id.into(),
+                cap,
+                outstanding_microcents: 0,
+                outstanding_wallclock: Duration::ZERO,
+                settled_microcents: 0,
+                settled_wallclock: Duration::ZERO,
+                total_input_tokens: 0,
+                total_output_tokens: 0,
+                all_priced: true,
+                entries: Vec::new(),
+            })),
+        }
+    }
+
+    /// Atomically reserve capacity BEFORE dispatch. Rejects with [`Exhausted`]
+    /// when the reservation would push committed spend (settled + outstanding)
+    /// past a capped axis; otherwise the estimate is held outstanding until the
+    /// returned [`Reservation`] is settled or dropped. This single locked op is
+    /// the race-free gate spec §7 requires.
+    pub fn reserve(
+        &self,
+        est_microcents: u64,
+        est_wallclock: Duration,
+    ) -> Result<Reservation, Exhausted> {
+        let mut inner = self.inner.lock();
+
+        if let Some(cap) = inner.cap.max_microcents {
+            let committed = inner
+                .settled_microcents
+                .saturating_add(inner.outstanding_microcents);
+            if committed.saturating_add(est_microcents) > cap {
+                return Err(Exhausted {
+                    axis: Axis::Cost,
+                    committed,
+                    requested: est_microcents,
+                    cap,
+                });
+            }
+        }
+        if let Some(cap) = inner.cap.max_wallclock {
+            let committed = inner
+                .settled_wallclock
+                .saturating_add(inner.outstanding_wallclock);
+            if committed.saturating_add(est_wallclock) > cap {
+                return Err(Exhausted {
+                    axis: Axis::Wallclock,
+                    committed: dur_ms(committed),
+                    requested: dur_ms(est_wallclock),
+                    cap: dur_ms(cap),
+                });
+            }
+        }
+
+        inner.outstanding_microcents = inner.outstanding_microcents.saturating_add(est_microcents);
+        inner.outstanding_wallclock = inner.outstanding_wallclock.saturating_add(est_wallclock);
+        Ok(Reservation {
+            inner: Arc::clone(&self.inner),
+            est_microcents,
+            est_wallclock,
+            live: true,
+        })
+    }
+
+    /// Reconcile a reservation with the actual spend: release its estimate and
+    /// charge the real `actual` (which may be more or less than the estimate).
+    pub fn settle(&self, mut reservation: Reservation, actual: LedgerEntry) {
+        let mut inner = self.inner.lock();
+        inner.outstanding_microcents = inner
+            .outstanding_microcents
+            .saturating_sub(reservation.est_microcents);
+        inner.outstanding_wallclock = inner
+            .outstanding_wallclock
+            .saturating_sub(reservation.est_wallclock);
+
+        inner.settled_microcents = inner
+            .settled_microcents
+            .saturating_add(actual.cost_microcents);
+        inner.settled_wallclock = inner.settled_wallclock.saturating_add(actual.wallclock);
+        inner.total_input_tokens = inner.total_input_tokens.saturating_add(actual.input_tokens);
+        inner.total_output_tokens = inner
+            .total_output_tokens
+            .saturating_add(actual.output_tokens);
+        if !actual.priced {
+            inner.all_priced = false;
+        }
+        inner.entries.push(actual);
+
+        // Cleared BEFORE the guard drops so `Reservation::drop` sees it settled
+        // and does not re-lock (parking_lot is not reentrant) or double-release.
+        reservation.live = false;
+    }
+
+    /// The lineage/task id this ledger accounts for.
+    #[must_use]
+    pub fn task_id(&self) -> String {
+        self.inner.lock().task_id.clone()
+    }
+
+    /// Total settled cost (microcents).
+    #[must_use]
+    pub fn settled_microcents(&self) -> u64 {
+        self.inner.lock().settled_microcents
+    }
+
+    /// Currently outstanding (reserved-but-unsettled) cost estimate (microcents).
+    #[must_use]
+    pub fn outstanding_microcents(&self) -> u64 {
+        self.inner.lock().outstanding_microcents
+    }
+
+    /// Remaining cost budget (cap − committed), or `None` when cost is uncapped.
+    #[must_use]
+    pub fn residual_microcents(&self) -> Option<u64> {
+        let inner = self.inner.lock();
+        inner.cap.max_microcents.map(|cap| {
+            let committed = inner
+                .settled_microcents
+                .saturating_add(inner.outstanding_microcents);
+            cap.saturating_sub(committed)
+        })
+    }
+
+    /// Whether any capped axis has no residual budget left.
+    #[must_use]
+    pub fn is_exhausted(&self) -> bool {
+        let inner = self.inner.lock();
+        let cost_out = matches!(inner.cap.max_microcents, Some(cap)
+            if inner.settled_microcents.saturating_add(inner.outstanding_microcents) >= cap);
+        let wall_out = matches!(inner.cap.max_wallclock, Some(cap)
+            if inner.settled_wallclock.saturating_add(inner.outstanding_wallclock) >= cap);
+        cost_out || wall_out
+    }
+
+    /// The settled-spend rollup for the receipt / `ClimbResult.spend`.
+    #[must_use]
+    pub fn settled(&self) -> SettledSpend {
+        let inner = self.inner.lock();
+        SettledSpend {
+            cost_microcents: inner.settled_microcents,
+            priced: inner.all_priced,
+            input_tokens: inner.total_input_tokens,
+            output_tokens: inner.total_output_tokens,
+            wallclock: inner.settled_wallclock,
+        }
+    }
+
+    /// A snapshot of every settled entry (for the climb journal, A1.5).
+    #[must_use]
+    pub fn entries(&self) -> Vec<LedgerEntry> {
+        self.inner.lock().entries.clone()
+    }
+}
+
+/// Duration → whole milliseconds as `u64` (saturating). Used only for the
+/// wallclock figures in [`Exhausted`]; accounting keeps the full `Duration`.
+fn dur_ms(d: Duration) -> u64 {
+    u64::try_from(d.as_millis()).unwrap_or(u64::MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn call(cost: u64, priced: bool) -> LedgerEntry {
+        LedgerEntry::provider_call(
+            "anthropic",
+            None,
+            10,
+            20,
+            cost,
+            priced,
+            Duration::from_millis(5),
+        )
+    }
+
+    #[test]
+    fn reserve_within_cost_cap_succeeds_and_exceeding_is_exhausted() {
+        let l = ClimbLedger::new("task-1", LedgerCap::cost(1000));
+        let r1 = l.reserve(600, Duration::ZERO).expect("600 fits under 1000");
+        assert_eq!(l.outstanding_microcents(), 600);
+        assert_eq!(l.residual_microcents(), Some(400));
+
+        // A second reservation must see the first's outstanding commitment —
+        // this is the race-free property: 600 + 500 > 1000.
+        let err = l
+            .reserve(500, Duration::ZERO)
+            .expect_err("500 more overflows");
+        assert_eq!(err.axis, Axis::Cost);
+        assert_eq!(err.committed, 600);
+
+        // Exactly hitting the cap is allowed.
+        let _r2 = l
+            .reserve(400, Duration::ZERO)
+            .expect("600 + 400 == cap is allowed");
+        assert_eq!(l.residual_microcents(), Some(0));
+        assert!(l.is_exhausted());
+        drop(r1);
+    }
+
+    #[test]
+    fn wallclock_cap_is_enforced_independently() {
+        let l = ClimbLedger::new(
+            "task-w",
+            LedgerCap {
+                max_microcents: None,
+                max_wallclock: Some(Duration::from_secs(10)),
+            },
+        );
+        let _r = l.reserve(0, Duration::from_secs(7)).expect("7s fits");
+        let err = l
+            .reserve(0, Duration::from_secs(4))
+            .expect_err("7s + 4s > 10s");
+        assert_eq!(err.axis, Axis::Wallclock);
+        assert_eq!(err.cap, 10_000, "cap reported in ms");
+    }
+
+    #[test]
+    fn settle_releases_estimate_and_charges_actual() {
+        let l = ClimbLedger::new("task-s", LedgerCap::cost(1000));
+        let r = l.reserve(600, Duration::ZERO).unwrap();
+        // Actual came in UNDER the estimate: only the actual is charged, the
+        // reservation delta is released back.
+        l.settle(r, call(500, true));
+        assert_eq!(l.settled_microcents(), 500);
+        assert_eq!(l.outstanding_microcents(), 0);
+        assert_eq!(l.residual_microcents(), Some(500));
+    }
+
+    #[test]
+    fn dropping_a_reservation_without_settling_releases_it() {
+        let l = ClimbLedger::new("task-d", LedgerCap::cost(1000));
+        {
+            let _r = l.reserve(700, Duration::ZERO).unwrap();
+            assert_eq!(l.residual_microcents(), Some(300));
+        } // dropped here without settling ⇒ cancelled dispatch
+        assert_eq!(l.outstanding_microcents(), 0);
+        assert_eq!(l.residual_microcents(), Some(1000));
+    }
+
+    #[test]
+    fn unpriced_entry_makes_whole_climb_unpriced() {
+        let l = ClimbLedger::new("task-p", LedgerCap::unlimited());
+        let r1 = l.reserve(100, Duration::ZERO).unwrap();
+        l.settle(r1, call(100, true));
+        assert!(l.settled().priced, "all priced so far");
+        let r2 = l.reserve(0, Duration::ZERO).unwrap();
+        l.settle(r2, call(0, false)); // catalog miss
+        let s = l.settled();
+        assert!(!s.priced, "one unpriced entry ⇒ climb unpriced (spec §2)");
+        assert_eq!(s.cost_microcents, 100);
+    }
+
+    #[test]
+    fn unlimited_cap_never_exhausts_and_has_no_residual() {
+        let l = ClimbLedger::new("task-u", LedgerCap::unlimited());
+        let r = l.reserve(u64::MAX / 2, Duration::from_secs(3600)).unwrap();
+        assert_eq!(l.residual_microcents(), None);
+        assert!(!l.is_exhausted());
+        l.settle(r, call(u64::MAX / 2, true));
+        assert!(!l.is_exhausted());
+    }
+
+    #[test]
+    fn settled_rollup_accumulates_tokens_cost_and_wallclock() {
+        let l = ClimbLedger::new("task-r", LedgerCap::unlimited());
+        let r1 = l.reserve(100, Duration::from_millis(10)).unwrap();
+        l.settle(
+            r1,
+            LedgerEntry::provider_call("a", None, 5, 7, 100, true, Duration::from_millis(10)),
+        );
+        let r2 = l.reserve(0, Duration::from_millis(20)).unwrap();
+        l.settle(r2, LedgerEntry::gate_exec(Duration::from_millis(20)));
+        let s = l.settled();
+        assert_eq!(s.cost_microcents, 100);
+        assert_eq!(s.input_tokens, 5);
+        assert_eq!(s.output_tokens, 7);
+        assert_eq!(s.wallclock, Duration::from_millis(30));
+        assert_eq!(l.entries().len(), 2);
+        assert_eq!(l.task_id(), "task-r");
+    }
+
+    #[test]
+    fn cost_usd_converts_microcents() {
+        // 1 USD = 100_000_000 microcents.
+        let s = SettledSpend {
+            cost_microcents: 100_000_000,
+            priced: true,
+            input_tokens: 0,
+            output_tokens: 0,
+            wallclock: Duration::ZERO,
+        };
+        assert!((s.cost_usd() - 1.0).abs() < 1e-9);
+    }
+
+    /// Atomicity under real parallelism: N threads each try to reserve the same
+    /// unit from a shared ledger whose cap admits exactly K. EXACTLY K may
+    /// succeed — the lock makes reservation race-free, so the ceiling is never
+    /// over-committed.
+    #[test]
+    fn parallel_reservations_never_exceed_the_cap() {
+        const UNIT: u64 = 100;
+        const K: u64 = 8;
+        const THREADS: usize = 32;
+        let l = ClimbLedger::new("task-race", LedgerCap::cost(UNIT * K));
+
+        // Collect granted reservations so they stay OUTSTANDING (dropping them
+        // would release their estimate and defeat the assertion).
+        let granted: Arc<Mutex<Vec<Reservation>>> = Arc::new(Mutex::new(Vec::new()));
+        std::thread::scope(|scope| {
+            for _ in 0..THREADS {
+                let l = l.clone();
+                let granted = Arc::clone(&granted);
+                scope.spawn(move || {
+                    if let Ok(r) = l.reserve(UNIT, Duration::ZERO) {
+                        granted.lock().push(r);
+                    }
+                });
+            }
+        });
+
+        assert_eq!(
+            granted.lock().len() as u64,
+            K,
+            "exactly the cap's worth of reservations may be granted"
+        );
+        assert_eq!(l.outstanding_microcents(), UNIT * K);
+        assert!(l.is_exhausted());
+    }
+}

--- a/crates/wcore-agent/src/orchestration/anvil/mod.rs
+++ b/crates/wcore-agent/src/orchestration/anvil/mod.rs
@@ -14,6 +14,9 @@
 //!
 //! Spec: `docs/design/2026-07-12-anvil-native-gated-forge-design.md` (v2).
 
+/// Gate closure pinning, the pre-climb probe, injection fencing, flake policy.
+pub mod gates;
+
 use wcore_config::anvil::AnvilConfig;
 
 /// Terminal state of a climb — the COMPLETE enum (spec §6.5). Every climb ends

--- a/crates/wcore-agent/src/orchestration/anvil/mod.rs
+++ b/crates/wcore-agent/src/orchestration/anvil/mod.rs
@@ -16,6 +16,8 @@
 
 /// Gate closure pinning, the pre-climb probe, injection fencing, flake policy.
 pub mod gates;
+/// Per-task cost ledger with atomic reservation-before-dispatch.
+pub mod ledger;
 
 use wcore_config::anvil::AnvilConfig;
 


### PR DESCRIPTION
Anvil **A1.3** — the Tier-1 gate primitives, per spec v2 §5. **Stacked on #230 (A1.1)** — `gates.rs` lives in the anvil module #230 creates, so this PR is based on `feat/anvil-a1-skeleton`; GitHub will retarget it to `main` when #230 merges. Built ahead per the NO-IDLE rule; **arm auto-merge when #230 lands**.

## What lands
A new `crates/wcore-agent/src/orchestration/anvil/gates.rs` — the gate machinery the climb (A1.5) consumes. No behaviour is wired yet; Anvil stays kill-switched off.

- **Gate closure pinning** (§5): `GateClosure::pin` hashes the FULL invocation closure — argv + env allowlist (names) + cwd + the CONTENT of every transitive input (config/fixtures/helpers/goldens/conftest/package scripts) — into one sha256 `gate_closure_digest`. `drifted()` re-reads + re-hashes; ANY change (or a vanished input) aborts the candidate.
- **Test-authoring carve-out** (§5): `pin` excludes files-under-edit from the closure, so a task whose deliverable IS a gate change does not trip drift on its own work.
- **Pre-climb probe** (§5): `probe_baseline` runs the gate ONCE on the baseline through the exec sandbox with `NetworkPolicy::Deny` + a minimized env (host env scrubbed, only allowlisted names survive — no ambient secrets). A non-zero exit is a *surfaced* pre-existing failure set; any *inability to execute* (no backend, spawn refused, isolation unenforceable) refuses the climb rather than burning ensemble budget to rediscover it.
- **Injection fencing** (§5): raw gate stdout/stderr never surfaces — only `BoundedGateOutput`, a typed, length-capped (2 KiB tail), control-char-stripped view.
- **Flake quarantine** (§5): `StabilityPolicy` (N-of-M) + `is_flaky` — the policy `verified` requires; the repeated-run loop lands with the climb (A1.5).

Deferred to A1.5 (noted in the module doc): the probe→ensemble→surgical→escalate loop, fail-set acceptance, ledger, `AnvilReceipt` emission, journal.

## Verification (Hetzner)
`cargo check -p wcore-agent` clean · `cargo clippy -p wcore-agent --all-targets -- -D warnings` clean · `cargo test -p wcore-agent --lib orchestration::anvil` → **15/15 passed** (12 new gates tests + 3 skeleton). No prod code is wired to it; kill-switch unchanged.