### PR TITLE
feat(anvil): A1 native gated-forge engine — live-proven /forge (A1.3–A1.6)

### DIFF
--- a/crates/wcore-agent/src/orchestration/anvil/climb.rs
+++ b/crates/wcore-agent/src/orchestration/anvil/climb.rs
@@ -1,0 +1,739 @@
+//! Anvil climb — the DECISION CORE of the gated-forge loop (spec §6.2/§6.3).
+//!
+//! This slice (A1.5a) is the pure, deterministic heart of the climb: given the
+//! per-check results of a gate run, it answers the two questions the loop turns
+//! on — *is this candidate an acceptable step?* (fail-set acceptance discipline,
+//! spec §6.3, audit consensus HIGH) and *which of several candidates is best?*
+//! (the deterministic total order, spec §6.2). It also clusters checks that
+//! co-flip so the surgical stage can repair them jointly (§6.3).
+//!
+//! It is deliberately free of async, spawning, sandbox, and filesystem I/O: the
+//! acceptance rule and the candidate order are exactly the places a subtle bug
+//! silently ships a false `verified`, so they are isolated here where every edge
+//! is unit-tested. The async engine loop (`run_climb` over the builder/gate
+//! seams), the append-only journal, the per-workspace lease, and per-candidate
+//! worktree isolation build on top of this core in the next slice (A1.5b), and
+//! the real spawner/gate wiring + receipt emission land in A1.6. The public
+//! `super::drive_climb` facade stays kill-switched until then.
+//!
+//! Spec: `docs/design/2026-07-12-anvil-native-gated-forge-design.md` (v2) §6.
+
+use std::cmp::Reverse;
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+
+use sha2::{Digest, Sha256};
+
+use super::gates::BoundedGateOutput;
+
+/// Severity class of a single gate check. The ordering is load-bearing: a climb
+/// step is judged on the *worst* failure it leaves standing (see
+/// [`evaluate_acceptance`]), and `Ord` here (declaration order, ascending) is
+/// that judgement. `Safety` is the untradeable class — a regression that breaks
+/// a safety-class check is never accepted, however many cosmetic checks it makes
+/// pass (spec §6.3).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Severity {
+    /// Formatting, lint style, docs — never blocks correctness.
+    Cosmetic,
+    /// A real but low-stakes failure (a narrow unit test, a warning-as-error).
+    Minor,
+    /// A broad correctness failure (build break, a core test suite).
+    Major,
+    /// Safety/security-class: data loss, auth, memory safety, a migration guard.
+    /// A regression here is never tradeable (spec §6.3).
+    Safety,
+}
+
+impl Severity {
+    /// Whether this is the untradeable safety class.
+    #[must_use]
+    pub fn is_safety_class(self) -> bool {
+        matches!(self, Severity::Safety)
+    }
+}
+
+/// Stable identifier of a single gate check (a test name, lint id, build target).
+/// Ordered so the fail-set, its digest, and the candidate order are all
+/// deterministic regardless of the order the gate emitted its checks.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct CheckId(String);
+
+impl CheckId {
+    /// Wrap a raw check identifier.
+    pub fn new(id: impl Into<String>) -> Self {
+        Self(id.into())
+    }
+
+    /// The identifier as a string slice.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<&str> for CheckId {
+    fn from(s: &str) -> Self {
+        Self(s.to_owned())
+    }
+}
+
+impl From<String> for CheckId {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
+impl fmt::Display for CheckId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// The result of one check within a gate run.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CheckOutcome {
+    /// Which check this is.
+    pub id: CheckId,
+    /// Whether it passed on this run.
+    pub passed: bool,
+    /// How much a failure of this check matters (drives acceptance, spec §6.3).
+    pub severity: Severity,
+}
+
+impl CheckOutcome {
+    /// Convenience constructor.
+    pub fn new(id: impl Into<CheckId>, passed: bool, severity: Severity) -> Self {
+        Self {
+            id: id.into(),
+            passed,
+            severity,
+        }
+    }
+}
+
+/// The per-check outcome of running the pinned gate against one candidate — the
+/// granular view the climb reasons over. (The whole-suite `exit_code` from
+/// [`super::gates::GateClosure::probe_baseline`] is retained for the receipt, but
+/// acceptance needs the *set* of failing checks, not one aggregate bit.)
+#[derive(Debug, Clone)]
+pub struct GateReport {
+    /// Every check the gate reported, in the order the gate emitted them.
+    pub checks: Vec<CheckOutcome>,
+    /// The gate process's overall exit code (0 == whole suite green).
+    pub exit_code: i32,
+    /// Bounded, control-stripped diagnostic tail — the only gate output allowed
+    /// to reach a model prompt (injection fencing, spec §5).
+    pub diagnostics: BoundedGateOutput,
+}
+
+impl GateReport {
+    /// The set of failing checks (a check failing in ANY listed outcome is a
+    /// fail — a duplicate passing outcome never clears it). This is the value the
+    /// acceptance discipline compares.
+    #[must_use]
+    pub fn fail_set(&self) -> FailSet {
+        let mut fails = BTreeMap::new();
+        for c in &self.checks {
+            if !c.passed {
+                // A check id that fails on any outcome is failing; keep the
+                // highest severity seen for it so a fail is never under-weighted.
+                fails
+                    .entry(c.id.clone())
+                    .and_modify(|s: &mut Severity| *s = (*s).max(c.severity))
+                    .or_insert(c.severity);
+            }
+        }
+        FailSet(fails)
+    }
+
+    /// Number of checks that passed on this run.
+    #[must_use]
+    pub fn passed(&self) -> usize {
+        self.checks.iter().filter(|c| c.passed).count()
+    }
+
+    /// Total number of checks the gate reported.
+    #[must_use]
+    pub fn total(&self) -> usize {
+        self.checks.len()
+    }
+
+    /// Whether every reported check passed. An EMPTY report is never green — a
+    /// gate that ran no checks has verified nothing (spec §2 honesty).
+    #[must_use]
+    pub fn all_green(&self) -> bool {
+        !self.checks.is_empty() && self.checks.iter().all(|c| c.passed)
+    }
+
+    /// The climb score = the count of passing checks. Higher is better; it is the
+    /// primary key of the candidate order (spec §6.2).
+    #[must_use]
+    pub fn score(&self) -> u32 {
+        // A gate cannot plausibly emit more than u32::MAX checks; saturate rather
+        // than risk a wrap on a pathological input.
+        u32::try_from(self.passed()).unwrap_or(u32::MAX)
+    }
+}
+
+/// The set of checks failing on a run, keyed by id with their severity. Cheap to
+/// compare; the unit the acceptance rule (spec §6.3) operates on.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct FailSet(BTreeMap<CheckId, Severity>);
+
+impl FailSet {
+    /// Build a fail-set directly from `(id, severity)` pairs.
+    pub fn from_pairs(pairs: impl IntoIterator<Item = (CheckId, Severity)>) -> Self {
+        Self(pairs.into_iter().collect())
+    }
+
+    /// Whether nothing is failing.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// How many checks are failing.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Whether `id` is in the failing set.
+    #[must_use]
+    pub fn contains(&self, id: &CheckId) -> bool {
+        self.0.contains_key(id)
+    }
+
+    /// The failing check ids (sorted).
+    pub fn ids(&self) -> impl Iterator<Item = &CheckId> {
+        self.0.keys()
+    }
+
+    /// Whether every check failing in `self` is also failing in `other` — i.e.
+    /// `self` introduces no failure `other` did not already have. This is the
+    /// "new fail-set ⊆ old fail-set" test at the core of acceptance (spec §6.3).
+    #[must_use]
+    pub fn is_subset_of(&self, other: &FailSet) -> bool {
+        self.0.keys().all(|id| other.0.contains_key(id))
+    }
+
+    /// The severities of the failing checks, sorted WORST-FIRST (descending).
+    /// Comparing two of these vectors lexicographically answers "whose worst
+    /// standing failure is less bad" — the basis of the severity-Pareto trade in
+    /// [`evaluate_acceptance`].
+    #[must_use]
+    pub fn severity_vector(&self) -> Vec<Severity> {
+        let mut v: Vec<Severity> = self.0.values().copied().collect();
+        v.sort_unstable_by(|a, b| b.cmp(a));
+        v
+    }
+
+    /// Checks failing in `self` but not in `other` — the regressions a step
+    /// introduces relative to `other`. Ordered by id (deterministic).
+    #[must_use]
+    pub fn introduced_vs(&self, other: &FailSet) -> Vec<(CheckId, Severity)> {
+        self.0
+            .iter()
+            .filter(|(id, _)| !other.0.contains_key(id))
+            .map(|(id, sev)| (id.clone(), *sev))
+            .collect()
+    }
+
+    /// A stable 64-bit digest of the failing-id SET (independent of insertion
+    /// order — the keys are already sorted). Used purely as a deterministic
+    /// tie-break in the candidate order so the winner never depends on the order
+    /// candidates were produced.
+    #[must_use]
+    pub fn fail_hash(&self) -> u64 {
+        let mut hasher = Sha256::new();
+        for id in self.0.keys() {
+            hasher.update(id.as_str().as_bytes());
+            // NUL separator so ["ab","c"] and ["a","bc"] never collide.
+            hasher.update([0u8]);
+        }
+        let digest = hasher.finalize();
+        let mut first8 = [0u8; 8];
+        first8.copy_from_slice(&digest[..8]);
+        u64::from_be_bytes(first8)
+    }
+}
+
+/// The verdict on whether a climb step may be kept (spec §6.3 acceptance).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Acceptance {
+    /// Keep the candidate. `strict` is true when it strictly improved — it
+    /// eliminated at least one failure with no regression, or it reduced the
+    /// worst standing severity. A non-strict accept is a lateral move (the same
+    /// fail-set), kept because it regressed nothing but counted toward plateau
+    /// detection by the loop (A1.5b).
+    Accept {
+        /// Whether the step made strict progress (vs. a lateral, no-regression move).
+        strict: bool,
+    },
+    /// Reject the candidate; the reason is logged (spec §6.3 "rejected trade-ups
+    /// are logged").
+    Reject(RejectReason),
+}
+
+/// Why a candidate step was rejected.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RejectReason {
+    /// A safety-class check that was NOT failing in the base now fails. Never
+    /// tradeable, regardless of what else the step fixed (spec §6.3).
+    SafetyRegression(CheckId),
+    /// The step introduced non-safety regressions and its worst-first severity
+    /// profile is not strictly better than the base's — so it is not a valid
+    /// severity trade.
+    NotAnImprovement,
+}
+
+/// Decide whether `candidate`'s fail-set is an acceptable step from `base`'s
+/// (spec §6.3, audit consensus HIGH). The rule, in order:
+///
+/// 1. **Subset (the common case).** If the candidate introduces NO new failure
+///    (its fail-set ⊆ the base's), keep it. It is `strict` when it also cleared
+///    at least one failure; equal fail-sets are a lateral, non-strict accept.
+/// 2. **Safety is untradeable.** If the candidate introduces a *safety-class*
+///    failure the base did not have, reject — no amount of other progress buys
+///    a safety regression.
+/// 3. **Severity trade (worst-first).** Otherwise the candidate introduced only
+///    non-safety regressions; accept it only if its severity profile, compared
+///    WORST-FAILURE-FIRST, is strictly better than the base's — i.e. it may take
+///    on lower-severity failures only in exchange for eliminating a strictly
+///    higher-severity one. (This is the deterministic reading of the spec's
+///    "Pareto improvement on the severity vector": the max standing severity must
+///    strictly drop. A transient regression that is NOT such an improvement — a
+///    mid-migration compile break — is handled by the loop's bounded multi-step
+///    transaction path, §6.3, not by single-step acceptance.)
+#[must_use]
+pub fn evaluate_acceptance(base: &FailSet, candidate: &FailSet) -> Acceptance {
+    let introduced = candidate.introduced_vs(base);
+
+    if introduced.is_empty() {
+        // candidate ⊆ base: no new failures. Strict iff it cleared something.
+        let cleared_something = candidate.len() < base.len();
+        return Acceptance::Accept {
+            strict: cleared_something,
+        };
+    }
+
+    // Regressions exist. A safety-class regression ends it immediately.
+    if let Some((id, _)) = introduced.iter().find(|(_, sev)| sev.is_safety_class()) {
+        return Acceptance::Reject(RejectReason::SafetyRegression(id.clone()));
+    }
+
+    // Non-safety regressions only: allow the trade iff the worst-first severity
+    // profile strictly improves (lexicographic compare of the descending vectors;
+    // shorter — fewer fails — wins on an otherwise-equal prefix).
+    if candidate.severity_vector() < base.severity_vector() {
+        Acceptance::Accept { strict: true }
+    } else {
+        Acceptance::Reject(RejectReason::NotAnImprovement)
+    }
+}
+
+/// Identifier of a candidate build within a climb (a builder/attempt id).
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct CandidateId(String);
+
+impl CandidateId {
+    /// Wrap a raw candidate identifier.
+    pub fn new(id: impl Into<String>) -> Self {
+        Self(id.into())
+    }
+
+    /// The identifier as a string slice.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<&str> for CandidateId {
+    fn from(s: &str) -> Self {
+        Self(s.to_owned())
+    }
+}
+
+/// One candidate build and how it did against the gate.
+#[derive(Debug, Clone)]
+pub struct Candidate {
+    /// Which builder/attempt produced it.
+    pub id: CandidateId,
+    /// Its per-check gate result.
+    pub report: GateReport,
+    /// What it cost to produce (microcents) — the last tie-break in the order.
+    pub cost_microcents: u64,
+}
+
+impl Candidate {
+    /// The deterministic rank key (spec §6.2). See [`RankKey`].
+    #[must_use]
+    pub fn rank_key(&self) -> RankKey {
+        let fails = self.report.fail_set();
+        RankKey {
+            neg_score: Reverse(self.report.score()),
+            fail_count: fails.len(),
+            severity_desc: fails.severity_vector(),
+            fail_hash: fails.fail_hash(),
+            cost_microcents: self.cost_microcents,
+            id: self.id.clone(),
+        }
+    }
+}
+
+/// The total order on candidates (spec §6.2): `(score, |fails|, severity-weighted
+/// fail vector, fail-id hash, cost)`. `Ord` is defined so the LEAST key is the
+/// BEST candidate — [`best`] selects the minimum. It is a genuine *total* order:
+/// score/fail-count/severity are the substance, and the fail-id hash, cost, and
+/// finally the candidate id break every remaining tie, so the winner never
+/// depends on the order candidates were generated.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct RankKey {
+    /// Higher score is better, so it is reversed: a smaller key wins.
+    neg_score: Reverse<u32>,
+    /// Fewer failing checks is better.
+    fail_count: usize,
+    /// Worst-first severities; a worse top severity sorts later (loses).
+    severity_desc: Vec<Severity>,
+    /// Deterministic tie-break across distinct fail SETS of equal shape.
+    fail_hash: u64,
+    /// Cheaper is better (only reached when the fail profile is identical).
+    cost_microcents: u64,
+    /// Ultimate tie-break so identical reports still order deterministically.
+    id: CandidateId,
+}
+
+/// Select the single best candidate under the deterministic total order (spec
+/// §6.2). `None` for an empty slate. Because [`RankKey`] is a total order, the
+/// choice is independent of the input order.
+#[must_use]
+pub fn best(candidates: &[Candidate]) -> Option<&Candidate> {
+    candidates.iter().min_by_key(|c| c.rank_key())
+}
+
+/// Group checks that co-flip across `observations` so the surgical stage repairs
+/// them jointly (spec §6.3 coupled-failure clustering). Two checks are coupled
+/// when they fail in exactly the same subset of observations — a shared root
+/// cause moves them together. Each returned cluster is a set of check ids with an
+/// identical failing-observation signature; a check that never fails in any
+/// observation is not part of any cluster. Deterministic (ordered by signature).
+#[must_use]
+pub fn coupled_clusters(observations: &[FailSet]) -> Vec<BTreeSet<CheckId>> {
+    // signature (sorted observation indices where the check fails) -> cluster.
+    let mut by_signature: BTreeMap<Vec<usize>, BTreeSet<CheckId>> = BTreeMap::new();
+    // The universe of checks that failed at least once.
+    let mut universe: BTreeSet<&CheckId> = BTreeSet::new();
+    for obs in observations {
+        universe.extend(obs.ids());
+    }
+    for id in universe {
+        let signature: Vec<usize> = observations
+            .iter()
+            .enumerate()
+            .filter(|(_, obs)| obs.contains(id))
+            .map(|(i, _)| i)
+            .collect();
+        // A check in `universe` failed somewhere, so its signature is non-empty.
+        by_signature
+            .entry(signature)
+            .or_default()
+            .insert(id.clone());
+    }
+    by_signature.into_values().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn out(id: &str, passed: bool, sev: Severity) -> CheckOutcome {
+        CheckOutcome::new(id, passed, sev)
+    }
+
+    fn report(checks: Vec<CheckOutcome>, exit: i32) -> GateReport {
+        GateReport {
+            checks,
+            exit_code: exit,
+            diagnostics: BoundedGateOutput::from_bytes(b""),
+        }
+    }
+
+    fn failset(pairs: &[(&str, Severity)]) -> FailSet {
+        FailSet::from_pairs(pairs.iter().map(|(id, s)| (CheckId::from(*id), *s)))
+    }
+
+    // ── Severity / gate model ────────────────────────────────────────────────
+
+    #[test]
+    fn severity_orders_cosmetic_below_safety() {
+        assert!(Severity::Cosmetic < Severity::Minor);
+        assert!(Severity::Minor < Severity::Major);
+        assert!(Severity::Major < Severity::Safety);
+        assert!(Severity::Safety.is_safety_class());
+        assert!(!Severity::Major.is_safety_class());
+    }
+
+    #[test]
+    fn empty_report_is_never_green() {
+        let r = report(vec![], 0);
+        assert!(!r.all_green(), "a gate that ran no checks verified nothing");
+        assert_eq!(r.score(), 0);
+    }
+
+    #[test]
+    fn all_green_requires_every_check_pass() {
+        let green = report(
+            vec![
+                out("a", true, Severity::Major),
+                out("b", true, Severity::Minor),
+            ],
+            0,
+        );
+        assert!(green.all_green());
+        assert_eq!(green.score(), 2);
+
+        let red = report(
+            vec![
+                out("a", true, Severity::Major),
+                out("b", false, Severity::Minor),
+            ],
+            1,
+        );
+        assert!(!red.all_green());
+        assert_eq!(red.score(), 1);
+    }
+
+    #[test]
+    fn fail_set_keeps_highest_severity_on_duplicate_id() {
+        // Same id reported twice failing at different severities → the worst wins.
+        let r = report(
+            vec![
+                out("dup", false, Severity::Minor),
+                out("dup", false, Severity::Safety),
+                out("ok", true, Severity::Major),
+            ],
+            1,
+        );
+        let fs = r.fail_set();
+        assert_eq!(fs.len(), 1);
+        assert_eq!(fs.severity_vector(), vec![Severity::Safety]);
+    }
+
+    #[test]
+    fn fail_set_passing_duplicate_never_clears_a_fail() {
+        let r = report(
+            vec![
+                out("x", false, Severity::Major),
+                out("x", true, Severity::Major),
+            ],
+            1,
+        );
+        assert!(r.fail_set().contains(&CheckId::from("x")));
+    }
+
+    // ── Acceptance discipline (spec §6.3) ────────────────────────────────────
+
+    #[test]
+    fn subset_with_a_fix_is_a_strict_accept() {
+        let base = failset(&[("a", Severity::Major), ("b", Severity::Minor)]);
+        let cand = failset(&[("a", Severity::Major)]); // fixed b, no new fails
+        assert_eq!(
+            evaluate_acceptance(&base, &cand),
+            Acceptance::Accept { strict: true }
+        );
+    }
+
+    #[test]
+    fn equal_fail_set_is_a_lateral_non_strict_accept() {
+        let base = failset(&[("a", Severity::Major)]);
+        let cand = failset(&[("a", Severity::Major)]);
+        assert_eq!(
+            evaluate_acceptance(&base, &cand),
+            Acceptance::Accept { strict: false }
+        );
+    }
+
+    #[test]
+    fn green_candidate_from_failing_base_is_strict_accept() {
+        let base = failset(&[("a", Severity::Major)]);
+        let cand = FailSet::default(); // all green
+        assert_eq!(
+            evaluate_acceptance(&base, &cand),
+            Acceptance::Accept { strict: true }
+        );
+    }
+
+    #[test]
+    fn introducing_a_safety_regression_is_always_rejected() {
+        // Base has two cosmetic fails; candidate clears BOTH but breaks safety.
+        let base = failset(&[("fmt1", Severity::Cosmetic), ("fmt2", Severity::Cosmetic)]);
+        let cand = failset(&[("auth", Severity::Safety)]);
+        assert_eq!(
+            evaluate_acceptance(&base, &cand),
+            Acceptance::Reject(RejectReason::SafetyRegression(CheckId::from("auth"))),
+        );
+    }
+
+    #[test]
+    fn trading_a_major_for_a_minor_is_a_valid_severity_improvement() {
+        // Eliminates the Major, introduces a Minor → worst severity drops.
+        let base = failset(&[("build", Severity::Major)]);
+        let cand = failset(&[("lint", Severity::Minor)]);
+        assert_eq!(
+            evaluate_acceptance(&base, &cand),
+            Acceptance::Accept { strict: true }
+        );
+    }
+
+    #[test]
+    fn trading_a_minor_for_a_major_is_rejected() {
+        // Introduces a strictly WORSE failure — not an improvement.
+        let base = failset(&[("lint", Severity::Minor)]);
+        let cand = failset(&[("build", Severity::Major)]);
+        assert_eq!(
+            evaluate_acceptance(&base, &cand),
+            Acceptance::Reject(RejectReason::NotAnImprovement),
+        );
+    }
+
+    #[test]
+    fn same_worst_severity_but_more_fails_is_rejected() {
+        // Worst stays Major, but the candidate adds a second Major → not better.
+        let base = failset(&[("b1", Severity::Major)]);
+        let cand = failset(&[("b1", Severity::Major), ("b2", Severity::Major)]);
+        assert_eq!(
+            evaluate_acceptance(&base, &cand),
+            Acceptance::Reject(RejectReason::NotAnImprovement),
+        );
+    }
+
+    // ── Deterministic total order (spec §6.2) ────────────────────────────────
+
+    fn cand(id: &str, checks: Vec<CheckOutcome>, cost: u64) -> Candidate {
+        Candidate {
+            id: CandidateId::from(id),
+            report: report(checks, 0),
+            cost_microcents: cost,
+        }
+    }
+
+    #[test]
+    fn best_prefers_higher_score_then_fewer_fails() {
+        let low = cand(
+            "low",
+            vec![
+                out("a", true, Severity::Minor),
+                out("b", false, Severity::Minor),
+            ],
+            10,
+        );
+        let high = cand(
+            "high",
+            vec![
+                out("a", true, Severity::Minor),
+                out("b", true, Severity::Minor),
+            ],
+            999, // costlier, but score wins first
+        );
+        let slate = vec![low, high];
+        assert_eq!(best(&slate).unwrap().id.as_str(), "high");
+    }
+
+    #[test]
+    fn best_prefers_lower_worst_severity_at_equal_score() {
+        // Both score 1/2 (one fail each) but differ in the failing severity.
+        let worse = cand(
+            "worse",
+            vec![
+                out("a", true, Severity::Minor),
+                out("b", false, Severity::Safety),
+            ],
+            5,
+        );
+        let better = cand(
+            "better",
+            vec![
+                out("a", true, Severity::Minor),
+                out("b", false, Severity::Cosmetic),
+            ],
+            5,
+        );
+        let slate = vec![worse, better];
+        assert_eq!(best(&slate).unwrap().id.as_str(), "better");
+    }
+
+    #[test]
+    fn best_breaks_a_true_tie_by_cost() {
+        // Identical fail profile (same id + severity), differ only in cost.
+        let dear = cand("dear", vec![out("a", false, Severity::Minor)], 100);
+        let cheap = cand("cheap", vec![out("a", false, Severity::Minor)], 10);
+        let slate = vec![dear, cheap];
+        assert_eq!(best(&slate).unwrap().id.as_str(), "cheap");
+    }
+
+    #[test]
+    fn best_is_independent_of_input_order() {
+        let mk = || {
+            vec![
+                cand("c", vec![out("a", true, Severity::Minor)], 3),
+                cand("a", vec![out("a", false, Severity::Minor)], 1),
+                cand("b", vec![out("a", true, Severity::Minor)], 9),
+            ]
+        };
+        let mut forward = mk();
+        let mut reversed = mk();
+        reversed.reverse();
+        assert_eq!(
+            best(&forward).unwrap().id.as_str(),
+            best(&reversed).unwrap().id.as_str(),
+        );
+        // Sorting by the key is likewise stable regardless of starting order.
+        forward.sort_by_key(Candidate::rank_key);
+        reversed.sort_by_key(Candidate::rank_key);
+        let f: Vec<_> = forward.iter().map(|c| c.id.as_str()).collect();
+        let r: Vec<_> = reversed.iter().map(|c| c.id.as_str()).collect();
+        assert_eq!(f, r);
+    }
+
+    #[test]
+    fn best_of_empty_slate_is_none() {
+        assert!(best(&[]).is_none());
+    }
+
+    // ── Coupled-failure clustering (spec §6.3) ───────────────────────────────
+
+    #[test]
+    fn checks_that_co_flip_cluster_together() {
+        // a & b always fail together; c fails alone in obs 1.
+        let observations = vec![
+            failset(&[("a", Severity::Major), ("b", Severity::Major)]),
+            failset(&[
+                ("a", Severity::Major),
+                ("b", Severity::Major),
+                ("c", Severity::Minor),
+            ]),
+        ];
+        let clusters = coupled_clusters(&observations);
+        assert!(
+            clusters.contains(&BTreeSet::from([CheckId::from("a"), CheckId::from("b")])),
+            "a and b share a signature and must cluster: {clusters:?}",
+        );
+        assert!(clusters.contains(&BTreeSet::from([CheckId::from("c")])));
+        assert_eq!(clusters.len(), 2);
+    }
+
+    #[test]
+    fn never_failing_checks_are_not_clustered() {
+        let observations = vec![failset(&[("a", Severity::Major)]), FailSet::default()];
+        let clusters = coupled_clusters(&observations);
+        // Only `a` ever failed.
+        assert_eq!(clusters, vec![BTreeSet::from([CheckId::from("a")])]);
+    }
+
+    #[test]
+    fn no_observations_yields_no_clusters() {
+        assert!(coupled_clusters(&[]).is_empty());
+    }
+}

--- a/crates/wcore-agent/src/orchestration/anvil/engine.rs
+++ b/crates/wcore-agent/src/orchestration/anvil/engine.rs
@@ -1,0 +1,520 @@
+//! Anvil climb engine — the loop that turns the A1.5 decision core + substrate
+//! into a real forge (spec §6). `run_climb` seeds a candidate, runs the pinned
+//! gate, climbs by surgical fail-set-accepted steps, and produces an honest
+//! terminal state + receipt payload.
+//!
+//! The loop is written over two injected seams so it is unit-testable without a
+//! live spawner or sandbox (the same discipline as the rest of anvil):
+//! - [`Builder`] produces a candidate in an isolated worktree (real impl: a
+//!   forked sub-agent with edit tools; test impl: a fake).
+//! - [`GateExecutor`] runs the pinned gate against a candidate's worktree and
+//!   returns the per-check [`GateReport`] (real impl: the sandbox + a gate-output
+//!   parser; test impl: a fake).
+//!
+//! The real seams and the `/forge` wiring live in [`super::forge`]; this file is
+//! the engine. It consumes every substrate piece: the gate closure + probe
+//! ([`super::gates`]), the cost ledger ([`super::ledger`]), the acceptance +
+//! order decision core ([`super::climb`]), the crash-recovery journal
+//! ([`super::journal`]).
+//!
+//! Spec: `docs/design/2026-07-12-anvil-native-gated-forge-design.md` (v2) §6.
+
+use std::path::{Path, PathBuf};
+
+use async_trait::async_trait;
+
+use super::TerminalState;
+use super::climb::{Acceptance, CandidateId, CheckId, GateReport, evaluate_acceptance};
+use super::gates::StabilityPolicy;
+use super::journal::{ClimbJournal, JournalEntry, JournalKind};
+use super::ledger::{ClimbLedger, LedgerEntry};
+
+/// A candidate build the climb produced, in its own isolated worktree.
+#[derive(Debug, Clone)]
+pub struct BuiltCandidate {
+    /// Which attempt produced it.
+    pub id: CandidateId,
+    /// The isolated worktree holding this candidate's changes.
+    pub worktree: PathBuf,
+    /// What producing it cost (settled into the ledger).
+    pub spend: LedgerEntry,
+}
+
+/// Feedback handed to the [`Builder`] for a surgical attempt: the checks still
+/// failing on the current best, plus the bounded, injection-fenced diagnostic
+/// tail (never raw gate output).
+#[derive(Debug, Clone)]
+pub struct BuildFeedback {
+    /// The checks the builder should fix.
+    pub failing: Vec<CheckId>,
+    /// Bounded, sanitized diagnostics (from [`GateReport::diagnostics`]).
+    pub diagnostics: String,
+}
+
+/// Produces candidate builds. The real implementation forks a sub-agent with
+/// edit tools into an isolated worktree; tests use a fake.
+#[async_trait]
+pub trait Builder: Send + Sync {
+    /// Build a candidate for `task`. `feedback` is `None` for the initial probe
+    /// and `Some` for a surgical attempt targeting the still-failing checks.
+    async fn build(
+        &self,
+        task: &str,
+        feedback: Option<&BuildFeedback>,
+    ) -> Result<BuiltCandidate, EngineError>;
+}
+
+/// Runs the pinned gate against a candidate worktree. The real implementation
+/// executes the closure in the sandbox and parses per-check results; tests use a
+/// fake.
+#[async_trait]
+pub trait GateExecutor: Send + Sync {
+    /// Run the gate against `worktree` and return its per-check report.
+    async fn run(&self, worktree: &Path) -> Result<GateReport, EngineError>;
+}
+
+/// A climb aborted before it could produce a terminal state through the normal
+/// path — surfaced honestly, never swallowed.
+#[derive(Debug, thiserror::Error)]
+pub enum EngineError {
+    /// A builder could not produce a candidate (spawn refused, crashed).
+    #[error("builder failed: {0}")]
+    Builder(String),
+    /// The gate could not execute against a candidate (sandbox refused).
+    #[error("gate execution failed: {0}")]
+    Gate(String),
+}
+
+/// Static parameters of a climb.
+#[derive(Debug, Clone)]
+pub struct ClimbParams {
+    /// The task being forged.
+    pub task: String,
+    /// N-of-M stability required before the reserved `verified` stamp.
+    pub stability: StabilityPolicy,
+    /// Hard cap on climb iterations (probe counts as 1).
+    pub max_iterations: u32,
+    /// The pinned gate closure digest (hex), for the journal + receipt.
+    pub gate_closure_digest: String,
+}
+
+/// The result of a climb — everything the receipt needs (spec §8).
+#[derive(Debug, Clone)]
+pub struct ClimbOutcome {
+    /// How the climb ended (spec §6.5).
+    pub terminal: TerminalState,
+    /// The honesty-vocabulary stamp earned (spec §2) — `verified` ONLY for a
+    /// real Tier-1 gate passing with stability.
+    pub stamp: String,
+    /// Passing / total checks on the final candidate.
+    pub checks_passed: u32,
+    /// Total checks on the final candidate.
+    pub checks_total: u32,
+    /// Iterations performed.
+    pub iterations: u32,
+    /// The winning candidate's worktree, if any reached a keepable state.
+    pub best_worktree: Option<PathBuf>,
+}
+
+/// The reserved `verified` stamp string.
+const STAMP_VERIFIED: &str = "verified";
+/// Stamp for a gate that went green but could not prove stability (flaky) — not
+/// verification (spec §2/§5).
+const STAMP_SELF_CHECKED: &str = "self_checked";
+/// Stamp when nothing keepable was produced.
+const STAMP_NONE: &str = "none";
+
+/// Drive a gated-forge climb over the injected seams (spec §6.1–6.3, minimal A1
+/// shape): probe → gate → surgical fail-set-accepted climb → terminal. Every
+/// paid step is journalled before it is trusted, and the ledger caps spend.
+///
+/// This is the engine the real `/forge` path constructs the seams for; it does
+/// NOT emit the receipt (the caller does, at the single top-level exit, spec §8)
+/// nor acquire the lease / pin the gate (its caller owns those).
+pub async fn run_climb(
+    params: &ClimbParams,
+    builder: &dyn Builder,
+    gate: &dyn GateExecutor,
+    ledger: &ClimbLedger,
+    journal: &mut ClimbJournal,
+) -> ClimbOutcome {
+    let mut iterations: u32 = 0;
+
+    // ── Probe: the initial candidate. ────────────────────────────────────────
+    let probe = match builder.build(&params.task, None).await {
+        Ok(c) => c,
+        Err(e) => return blocked(format!("probe builder failed: {e}")),
+    };
+    let mut report = match gate_and_record(gate, &probe, ledger, journal, params).await {
+        Ok(r) => r,
+        Err(e) => return blocked(format!("probe gate failed: {e}")),
+    };
+    iterations += 1;
+    let mut best = (probe, report.clone());
+
+    if let Some(done) = check_verified(gate, &best, iterations, params).await {
+        return done;
+    }
+
+    // ── Surgical climb: fix the failing checks, accept only non-regressions. ──
+    while iterations < params.max_iterations {
+        if ledger.is_exhausted() {
+            break;
+        }
+        let feedback = feedback_from(&report);
+        let candidate = match builder.build(&params.task, Some(&feedback)).await {
+            Ok(c) => c,
+            // A failed surgical attempt is not fatal — keep the best so far.
+            Err(_) => break,
+        };
+        let candidate_report =
+            match gate_and_record(gate, &candidate, ledger, journal, params).await {
+                Ok(r) => r,
+                Err(_) => continue,
+            };
+        iterations += 1;
+
+        // Accept iff the new fail-set is a non-regression on the current best
+        // (spec §6.3 — safety-class never traded).
+        match evaluate_acceptance(&best.1.fail_set(), &candidate_report.fail_set()) {
+            Acceptance::Accept { .. } => {
+                journal_step(
+                    journal,
+                    JournalKind::Promote,
+                    &candidate,
+                    &candidate_report,
+                    ledger,
+                );
+                best = (candidate, candidate_report.clone());
+                report = candidate_report;
+                if let Some(done) = check_verified(gate, &best, iterations, params).await {
+                    return done;
+                }
+            }
+            Acceptance::Reject(_) => { /* logged via journal Candidate; keep best */ }
+        }
+    }
+
+    // ── No stable-green candidate: report honestly. ──────────────────────────
+    terminal_from_best(&best.1, iterations)
+}
+
+/// Run the gate on `candidate`, settle its build cost + a gate-exec entry into
+/// the ledger, and journal the candidate step. Returns the report.
+async fn gate_and_record(
+    gate: &dyn GateExecutor,
+    candidate: &BuiltCandidate,
+    ledger: &ClimbLedger,
+    journal: &mut ClimbJournal,
+    params: &ClimbParams,
+) -> Result<GateReport, EngineError> {
+    // Charge the builder's spend (reserve+settle keeps the cap honest even though
+    // the actual is already known — the reservation is the race-free gate §7).
+    if let Ok(res) = ledger.reserve(candidate.spend.cost_microcents, candidate.spend.wallclock) {
+        ledger.settle(res, candidate.spend.clone());
+    }
+    let report = gate.run(&candidate.worktree).await?;
+    // Journal the gated candidate (with the pinned gate digest) before it is
+    // acted on — crash recovery replays from here (spec §6.5).
+    let fail_ids = report
+        .fail_set()
+        .ids()
+        .map(|c| c.as_str().to_string())
+        .collect();
+    let entry = JournalEntry::new(
+        JournalKind::Candidate,
+        candidate.id.as_str(),
+        ledger.settled_microcents(),
+    )
+    .with_gate_digest(params.gate_closure_digest.as_str())
+    .with_candidate(candidate.id.as_str())
+    .with_result(report.score(), fail_ids);
+    let _ = journal.append(entry);
+    Ok(report)
+}
+
+/// If `best` is green AND clears the stability bar, produce the `verified`
+/// outcome; otherwise `None` (keep climbing). A green-but-flaky gate is NOT
+/// verification (spec §5 flake quarantine).
+async fn check_verified(
+    gate: &dyn GateExecutor,
+    best: &(BuiltCandidate, GateReport),
+    iterations: u32,
+    params: &ClimbParams,
+) -> Option<ClimbOutcome> {
+    if !best.1.all_green() {
+        return None;
+    }
+    if stability_holds(gate, &best.0.worktree, params.stability).await {
+        Some(ClimbOutcome {
+            terminal: TerminalState::Verified,
+            stamp: STAMP_VERIFIED.to_string(),
+            checks_passed: best.1.score(),
+            checks_total: u32::try_from(best.1.total()).unwrap_or(u32::MAX),
+            iterations,
+            best_worktree: Some(best.0.worktree.clone()),
+        })
+    } else {
+        // Green once but not stably — honest self-checked, quarantined (spec §2).
+        Some(ClimbOutcome {
+            terminal: TerminalState::NeedsEscalation,
+            stamp: STAMP_SELF_CHECKED.to_string(),
+            checks_passed: best.1.score(),
+            checks_total: u32::try_from(best.1.total()).unwrap_or(u32::MAX),
+            iterations,
+            best_worktree: Some(best.0.worktree.clone()),
+        })
+    }
+}
+
+/// Re-run the gate `stability.of - 1` more times on the SAME worktree; the stamp
+/// requires `stability.required` of `stability.of` identical-code passes (spec §5).
+async fn stability_holds(
+    gate: &dyn GateExecutor,
+    worktree: &Path,
+    stability: StabilityPolicy,
+) -> bool {
+    let mut passes = 1; // the run that already went green
+    for _ in 1..stability.of {
+        match gate.run(worktree).await {
+            Ok(r) if r.all_green() => passes += 1,
+            // A single non-green (or errored) rerun means the check flipped on
+            // identical code — flaky, so verification is not earned.
+            _ => return false,
+        }
+    }
+    stability.met(passes)
+}
+
+/// Build surgical feedback from the current report.
+fn feedback_from(report: &GateReport) -> BuildFeedback {
+    BuildFeedback {
+        failing: report.fail_set().ids().cloned().collect(),
+        diagnostics: report.diagnostics.tail().to_string(),
+    }
+}
+
+/// Journal a candidate/promote step (best-effort; a journal I/O error must not
+/// crash the climb, but it IS surfaced by degrading crash-recovery — logged).
+fn journal_step(
+    journal: &mut ClimbJournal,
+    kind: JournalKind,
+    candidate: &BuiltCandidate,
+    report: &GateReport,
+    ledger: &ClimbLedger,
+) {
+    let fail_ids = report
+        .fail_set()
+        .ids()
+        .map(|c| c.as_str().to_string())
+        .collect();
+    let entry = JournalEntry::new(kind, candidate.id.as_str(), ledger.settled_microcents())
+        .with_candidate(candidate.id.as_str())
+        .with_result(report.score(), fail_ids);
+    let _ = journal.append(entry);
+}
+
+/// Terminal state when no stable-green candidate was reached.
+fn terminal_from_best(report: &GateReport, iterations: u32) -> ClimbOutcome {
+    let (terminal, stamp) = if report.all_green() {
+        (TerminalState::NeedsEscalation, STAMP_SELF_CHECKED)
+    } else {
+        (TerminalState::NeedsEscalation, STAMP_NONE)
+    };
+    ClimbOutcome {
+        terminal,
+        stamp: stamp.to_string(),
+        checks_passed: report.score(),
+        checks_total: u32::try_from(report.total()).unwrap_or(u32::MAX),
+        iterations,
+        best_worktree: None,
+    }
+}
+
+/// A `Blocked` outcome for a stated reason (spec §6.5).
+fn blocked(reason: String) -> ClimbOutcome {
+    ClimbOutcome {
+        terminal: TerminalState::Blocked(reason),
+        stamp: STAMP_NONE.to_string(),
+        checks_passed: 0,
+        checks_total: 0,
+        iterations: 0,
+        best_worktree: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::climb::{CheckOutcome, Severity};
+    use super::super::gates::BoundedGateOutput;
+    use super::super::ledger::LedgerCap;
+    use super::*;
+    use std::sync::Mutex;
+
+    fn report(checks: Vec<CheckOutcome>) -> GateReport {
+        let exit = if checks.iter().all(|c| c.passed) && !checks.is_empty() {
+            0
+        } else {
+            1
+        };
+        GateReport {
+            checks,
+            exit_code: exit,
+            diagnostics: BoundedGateOutput::from_bytes(b"diag"),
+        }
+    }
+
+    fn ok(id: &str) -> CheckOutcome {
+        CheckOutcome::new(id, true, Severity::Major)
+    }
+    fn bad(id: &str) -> CheckOutcome {
+        CheckOutcome::new(id, false, Severity::Major)
+    }
+
+    /// A builder that yields a fixed sequence of worktree ids.
+    struct SeqBuilder {
+        next: Mutex<u32>,
+    }
+    #[async_trait]
+    impl Builder for SeqBuilder {
+        async fn build(
+            &self,
+            _task: &str,
+            _fb: Option<&BuildFeedback>,
+        ) -> Result<BuiltCandidate, EngineError> {
+            let mut n = self.next.lock().unwrap();
+            let id = format!("c{n}");
+            *n += 1;
+            Ok(BuiltCandidate {
+                id: CandidateId::new(id.clone()),
+                worktree: PathBuf::from(format!("/wt/{id}")),
+                spend: LedgerEntry::gate_exec(std::time::Duration::from_millis(1)),
+            })
+        }
+    }
+
+    /// A gate that returns a scripted report per worktree path, keyed by call order.
+    struct ScriptGate {
+        reports: Mutex<std::collections::VecDeque<GateReport>>,
+        // A stable report to repeat for stability reruns of a green candidate.
+        stable_green: bool,
+    }
+    #[async_trait]
+    impl GateExecutor for ScriptGate {
+        async fn run(&self, _wt: &Path) -> Result<GateReport, EngineError> {
+            let mut q = self.reports.lock().unwrap();
+            if q.len() == 1 && self.stable_green {
+                // repeat the last (green) report for stability reruns
+                return Ok(q.front().unwrap().clone());
+            }
+            q.pop_front()
+                .ok_or_else(|| EngineError::Gate("no more scripted reports".into()))
+        }
+    }
+
+    fn params(stability_of: u32) -> ClimbParams {
+        ClimbParams {
+            task: "t".into(),
+            stability: StabilityPolicy::new(stability_of, stability_of),
+            max_iterations: 5,
+            gate_closure_digest: "deadbeef".into(),
+        }
+    }
+
+    async fn run(reports: Vec<GateReport>, stable_green: bool, stab_of: u32) -> ClimbOutcome {
+        let builder = SeqBuilder {
+            next: Mutex::new(0),
+        };
+        let gate = ScriptGate {
+            reports: Mutex::new(reports.into()),
+            stable_green,
+        };
+        let ledger = ClimbLedger::new("t", LedgerCap::unlimited());
+        let dir = tempfile::tempdir().unwrap();
+        let mut journal = ClimbJournal::open(dir.path().join("j")).unwrap();
+        run_climb(&params(stab_of), &builder, &gate, &ledger, &mut journal).await
+    }
+
+    #[tokio::test]
+    async fn probe_green_and_stable_is_verified() {
+        // Probe green; stability 1-of-1 (no reruns needed).
+        let out = run(vec![report(vec![ok("a"), ok("b")])], true, 1).await;
+        assert_eq!(out.terminal, TerminalState::Verified);
+        assert_eq!(out.stamp, "verified");
+        assert_eq!((out.checks_passed, out.checks_total), (2, 2));
+        assert_eq!(out.iterations, 1);
+        assert!(out.best_worktree.is_some());
+    }
+
+    #[tokio::test]
+    async fn green_but_flaky_is_not_verified() {
+        // Probe green, but a stability rerun (3-of-3) flips to red → self_checked.
+        let mut q = vec![report(vec![ok("a")])]; // probe green
+        q.push(report(vec![bad("a")])); // rerun flips → flaky
+        let out = run(q, false, 3).await;
+        assert_ne!(out.terminal, TerminalState::Verified);
+        assert_eq!(out.stamp, "self_checked");
+    }
+
+    #[tokio::test]
+    async fn surgical_step_that_fixes_a_check_is_promoted_to_verified() {
+        // Probe fails b; surgical attempt fixes it → green → verified (1-of-1).
+        let out = run(
+            vec![
+                report(vec![ok("a"), bad("b")]), // probe
+                report(vec![ok("a"), ok("b")]),  // surgical fix
+            ],
+            true,
+            1,
+        )
+        .await;
+        assert_eq!(out.terminal, TerminalState::Verified);
+        assert_eq!(out.iterations, 2);
+    }
+
+    #[tokio::test]
+    async fn regressing_candidate_is_rejected_best_retained() {
+        // Probe fails b (Major); surgical introduces a NEW Major fail → rejected;
+        // no green reached → needs_escalation, not verified.
+        let out = run(
+            vec![
+                report(vec![ok("a"), bad("b")]),  // probe: {b}
+                report(vec![bad("a"), bad("b")]), // surgical: {a,b} ⊃ {b} → reject
+                report(vec![ok("a"), bad("b")]),  // next attempt: back to {b} (no progress)
+                report(vec![ok("a"), bad("b")]),
+                report(vec![ok("a"), bad("b")]),
+            ],
+            false,
+            1,
+        )
+        .await;
+        assert_ne!(out.terminal, TerminalState::Verified);
+    }
+
+    #[tokio::test]
+    async fn probe_builder_failure_is_blocked() {
+        struct DeadBuilder;
+        #[async_trait]
+        impl Builder for DeadBuilder {
+            async fn build(
+                &self,
+                _t: &str,
+                _f: Option<&BuildFeedback>,
+            ) -> Result<BuiltCandidate, EngineError> {
+                Err(EngineError::Builder("spawn refused".into()))
+            }
+        }
+        struct NoGate;
+        #[async_trait]
+        impl GateExecutor for NoGate {
+            async fn run(&self, _w: &Path) -> Result<GateReport, EngineError> {
+                Err(EngineError::Gate("unreachable".into()))
+            }
+        }
+        let ledger = ClimbLedger::new("t", LedgerCap::unlimited());
+        let dir = tempfile::tempdir().unwrap();
+        let mut journal = ClimbJournal::open(dir.path().join("j")).unwrap();
+        let out = run_climb(&params(1), &DeadBuilder, &NoGate, &ledger, &mut journal).await;
+        assert!(matches!(out.terminal, TerminalState::Blocked(_)));
+    }
+}

--- a/crates/wcore-agent/src/orchestration/anvil/forge.rs
+++ b/crates/wcore-agent/src/orchestration/anvil/forge.rs
@@ -1,0 +1,470 @@
+//! Anvil forge wiring — the REAL seams that make [`super::engine::run_climb`] a
+//! live gated-forge (spec §6), plus [`drive_climb_full`] which assembles the
+//! substrate (gate closure + probe, ledger, journal, lease) around them and
+//! emits the [`ProtocolEvent::AnvilReceipt`] at the single climb exit (spec §8).
+//!
+//! - [`SandboxGate`] runs the pinned gate against a candidate's worktree through
+//!   the sandbox (network-denied, minimized env), reusing the tested
+//!   [`GateClosure::run_at`] exec path.
+//! - [`SpawnBuilder`] forks a sub-agent with edit tools into a per-candidate git
+//!   worktree. A1-minimal isolation: the builder runs SERIALLY and the process
+//!   cwd is pointed at the candidate worktree for the fork (the spawner carries
+//!   no per-fork cwd today); the per-workspace [`ClimbLease`] makes the serial
+//!   assumption safe. Parallel-ensemble isolation is the documented follow-up.
+//!
+//! Spec: `docs/design/2026-07-12-anvil-native-gated-forge-design.md` (v2) §5/§6/§8.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use parking_lot::Mutex;
+use sha2::{Digest, Sha256};
+
+use wcore_config::anvil::AnvilConfig;
+use wcore_protocol::events::ProtocolEvent;
+use wcore_protocol::writer::ProtocolEmitter;
+use wcore_sandbox::backends::SandboxBackend;
+use wcore_swarm::worktree::WorktreeManager;
+use wcore_types::spawner::{ForkOverrides, Spawner, SubAgentConfig};
+
+use super::TerminalState;
+use super::climb::{CandidateId, CheckOutcome, GateReport, Severity};
+use super::engine::{
+    BuildFeedback, Builder, BuiltCandidate, ClimbOutcome, ClimbParams, EngineError, GateExecutor,
+    run_climb,
+};
+use super::gates::{BaselineProbe, GateClosure, GateSpec, ProbeOpts, StabilityPolicy};
+use super::journal::ClimbJournal;
+use super::lease::ClimbLease;
+use super::ledger::{ClimbLedger, LedgerCap, LedgerEntry};
+
+/// The system read roots a gate needs beyond the worktree (toolchain, libs).
+/// Broad but read-only + network-denied; tightening per-gate is a follow-up.
+const SYSTEM_READ_ROOTS: &[&str] = &["/usr", "/bin", "/lib", "/lib64", "/etc", "/opt"];
+/// Wall-clock budget for one gate run.
+const GATE_TIMEOUT: Duration = Duration::from_secs(120);
+/// Edit tools a forge builder needs (empty would be read-only, spawner.rs:854).
+const BUILDER_TOOLS: &[&str] = &["Read", "Write", "Edit", "Bash", "Grep", "Glob"];
+
+/// Errors assembling or running a live forge.
+#[derive(Debug, thiserror::Error)]
+pub enum ForgeError {
+    /// Anvil is kill-switched off.
+    #[error("Anvil is disabled (`[anvil] enabled = false`)")]
+    Disabled,
+    /// No gate command configured — a gated-forge with no gate verifies nothing.
+    #[error("no gate configured: set `[anvil] gate = [\"cargo\", \"test\"]`")]
+    NoGate,
+    /// The workspace is already leased by another climb.
+    #[error("workspace is busy: {0}")]
+    Lease(String),
+    /// The gate closure could not be pinned.
+    #[error("gate closure: {0}")]
+    Gate(String),
+    /// The climb journal could not be opened.
+    #[error("journal: {0}")]
+    Journal(String),
+    /// The worktree manager could not be created (not a git repo?).
+    #[error("worktree: {0}")]
+    Worktree(String),
+    /// The pre-climb probe found the gate cannot execute here (spec §5).
+    #[error("gate cannot execute on the baseline: {0}")]
+    GateUnrunnable(String),
+}
+
+/// A [`GateExecutor`] backed by the sandbox + a pinned [`GateClosure`].
+pub struct SandboxGate {
+    closure: GateClosure,
+    backend: Box<dyn SandboxBackend>,
+    opts: ProbeOpts,
+}
+
+impl SandboxGate {
+    /// Build a sandbox-backed gate executor.
+    #[must_use]
+    pub fn new(closure: GateClosure, backend: Box<dyn SandboxBackend>, opts: ProbeOpts) -> Self {
+        Self {
+            closure,
+            backend,
+            opts,
+        }
+    }
+}
+
+#[async_trait]
+impl GateExecutor for SandboxGate {
+    async fn run(&self, worktree: &Path) -> Result<GateReport, EngineError> {
+        match self
+            .closure
+            .run_at(&*self.backend, &self.opts, worktree)
+            .await
+        {
+            BaselineProbe::Ran {
+                exit_code,
+                clean,
+                diagnostics,
+            } => {
+                // A1-minimal: the whole gate is one Tier-1 check (0 exit == pass).
+                // Per-check parsing (cargo-test/pytest → many CheckOutcomes) is a
+                // documented follow-up; the acceptance/order core already handles
+                // multi-check sets when a parser lands.
+                let check = CheckOutcome::new("gate", clean, Severity::Major);
+                Ok(GateReport {
+                    checks: vec![check],
+                    exit_code,
+                    diagnostics,
+                })
+            }
+            BaselineProbe::CannotExecute(why) => Err(EngineError::Gate(why)),
+        }
+    }
+}
+
+/// A [`Builder`] that forks a sub-agent with edit tools into a per-candidate git
+/// worktree (A1-minimal serial isolation — see the module docs).
+pub struct SpawnBuilder<'a> {
+    spawner: &'a dyn Spawner,
+    worktrees: WorktreeManager,
+    base_ref: String,
+    counter: Mutex<u32>,
+}
+
+impl<'a> SpawnBuilder<'a> {
+    /// Build a spawn-backed builder rooted at `worktrees`, branching candidates
+    /// off `base_ref` (e.g. `"HEAD"`).
+    pub fn new(
+        spawner: &'a dyn Spawner,
+        worktrees: WorktreeManager,
+        base_ref: impl Into<String>,
+    ) -> Self {
+        Self {
+            spawner,
+            worktrees,
+            base_ref: base_ref.into(),
+            counter: Mutex::new(0),
+        }
+    }
+}
+
+#[async_trait]
+impl Builder for SpawnBuilder<'_> {
+    async fn build(
+        &self,
+        task: &str,
+        feedback: Option<&BuildFeedback>,
+    ) -> Result<BuiltCandidate, EngineError> {
+        let n = {
+            let mut c = self.counter.lock();
+            let v = *c;
+            *c += 1;
+            v
+        };
+        let id = format!("cand-{n}");
+        let branch = format!("anvil/{id}");
+        let worktree = self
+            .worktrees
+            .create_worker_tree(&id, &branch, &self.base_ref)
+            .await
+            .map_err(|e| EngineError::Builder(format!("worktree create: {e}")))?;
+
+        let prompt = build_prompt(task, feedback, &worktree);
+        let sub = SubAgentConfig {
+            name: id.clone(),
+            prompt,
+            max_turns: 12,
+            max_tokens: 16_384,
+            system_prompt: Some(FORGE_SYSTEM_PROMPT.to_string()),
+            provider: None,
+            model: None,
+            temperature: None,
+        };
+        let overrides = ForkOverrides {
+            model: None,
+            effort: None,
+            allowed_tools: BUILDER_TOOLS.iter().map(|s| (*s).to_string()).collect(),
+        };
+
+        // A1-minimal serial isolation: the spawner has no per-fork cwd, and a
+        // forked agent's edits land in the PARENT process cwd. Point it at the
+        // candidate worktree for the fork, then restore. Safe because the climb
+        // is serial (one builder at a time) under the per-workspace lease.
+        let prev =
+            std::env::current_dir().map_err(|e| EngineError::Builder(format!("cwd read: {e}")))?;
+        std::env::set_current_dir(&worktree)
+            .map_err(|e| EngineError::Builder(format!("cwd set: {e}")))?;
+        let result = self.spawner.spawn_fork(sub, overrides).await;
+        // Always restore, even on a builder error.
+        let _ = std::env::set_current_dir(&prev);
+
+        // Concise progress line (stderr): the builder ran and how it went.
+        eprintln!(
+            "[anvil-forge] builder {id}: error={} turns={} tokens={}+{} worktree={}",
+            result.is_error,
+            result.turns,
+            result.usage.input_tokens,
+            result.usage.output_tokens,
+            worktree.display(),
+        );
+
+        if result.is_error {
+            return Err(EngineError::Builder(format!(
+                "builder agent errored: {}",
+                result.text
+            )));
+        }
+
+        // Cost accounting: tokens are known; catalog price is not wired in A1, so
+        // the entry is UNPRICED (the receipt renders "unpriced", never $0, §2).
+        let spend = LedgerEntry::provider_call(
+            "forge-builder",
+            None,
+            result.usage.input_tokens,
+            result.usage.output_tokens,
+            0,
+            false,
+            Duration::ZERO,
+        );
+        Ok(BuiltCandidate {
+            id: CandidateId::new(id),
+            worktree,
+            spend,
+        })
+    }
+}
+
+/// System prompt for a forge builder sub-agent.
+const FORGE_SYSTEM_PROMPT: &str = "You are a forge builder. Implement the requested change using the \
+Write/Edit/Bash tools so the project's gate passes. ALL files you create or edit MUST live under the \
+working directory given in the task — use that ABSOLUTE path as the root for every path (do NOT rely on \
+the shell's current directory, which is NOT the working directory). Make the smallest change that \
+satisfies the task. Do not explain — just make the edits.";
+
+/// Compose the builder prompt from the task, the candidate's ABSOLUTE worktree
+/// root (a forked builder does not inherit it as its shell cwd — A1-minimal
+/// isolation limitation), and (for a surgical attempt) the failing checks.
+fn build_prompt(task: &str, feedback: Option<&BuildFeedback>, worktree: &Path) -> String {
+    let root = worktree.display();
+    match feedback {
+        None => format!(
+            "Working directory (root for ALL file paths): {root}\n\nTask: {task}\n\n\
+             Create/edit files under {root} so the gate passes."
+        ),
+        Some(fb) => {
+            let failing: Vec<&str> = fb
+                .failing
+                .iter()
+                .map(super::climb::CheckId::as_str)
+                .collect();
+            format!(
+                "Working directory (root for ALL file paths): {root}\n\nTask: {task}\n\n\
+                 The gate still fails these checks: {}.\nDiagnostics (bounded):\n{}\n\n\
+                 Fix ONLY what is needed to make the gate pass; keep every file under {root}.",
+                failing.join(", "),
+                fb.diagnostics,
+            )
+        }
+    }
+}
+
+/// Assemble and run a live gated-forge climb, emitting the receipt at exit.
+///
+/// The caller supplies the `spawner` (already built with a provider) and the
+/// `emitter` (the top-level protocol writer — the receipt is trusted ONLY from
+/// this top-level emission, spec §8). `workspace` is the git repo root the forge
+/// runs against.
+pub async fn drive_climb_full(
+    task: &str,
+    cfg: &AnvilConfig,
+    workspace: &Path,
+    spawner: &dyn Spawner,
+    emitter: &Arc<dyn ProtocolEmitter>,
+    session_id: Option<String>,
+) -> Result<ClimbOutcome, ForgeError> {
+    if !cfg.enabled {
+        return Err(ForgeError::Disabled);
+    }
+    if cfg.gate.is_empty() {
+        return Err(ForgeError::NoGate);
+    }
+
+    // Per-workspace lease — no two climbs (or climb + user edits) interleave.
+    let _lease = ClimbLease::acquire(workspace).map_err(|e| ForgeError::Lease(e.to_string()))?;
+
+    // Pin the gate closure (spec §5). The gate runs at each candidate's worktree.
+    let spec = GateSpec {
+        argv: cfg.gate.clone(),
+        cwd: workspace.to_path_buf(),
+        env_allowlist: Vec::new(),
+        inputs: Vec::new(),
+    };
+    let closure = GateClosure::pin(spec, &[]).map_err(|e| ForgeError::Gate(e.to_string()))?;
+    let digest = closure.digest_hex();
+
+    // Sandbox backend + read/write allowlists (worktree + system toolchain).
+    let backend = wcore_sandbox::default_for_platform();
+    let mut fs_read_allow: Vec<PathBuf> = SYSTEM_READ_ROOTS.iter().map(PathBuf::from).collect();
+    fs_read_allow.push(workspace.to_path_buf());
+    let opts = ProbeOpts {
+        timeout: GATE_TIMEOUT,
+        fs_read_allow,
+        fs_write_allow: vec![workspace.to_path_buf()],
+    };
+
+    // Pre-climb probe (spec §5): if the gate cannot execute on the baseline,
+    // refuse before spending any builder budget.
+    if let BaselineProbe::CannotExecute(why) = closure.probe_baseline(&*backend, &opts).await {
+        return Err(ForgeError::GateUnrunnable(why));
+    }
+
+    // Journal + ledger.
+    let journal_path = workspace
+        .join(".wayland")
+        .join("anvil")
+        .join("climb.journal");
+    let mut journal =
+        ClimbJournal::open(&journal_path).map_err(|e| ForgeError::Journal(e.to_string()))?;
+    let ledger = ClimbLedger::new(task, LedgerCap::unlimited());
+
+    // Seams.
+    let worktrees =
+        WorktreeManager::new(workspace).map_err(|e| ForgeError::Worktree(e.to_string()))?;
+    let builder = SpawnBuilder::new(spawner, worktrees, "HEAD");
+    let gate = SandboxGate::new(closure, backend, opts);
+
+    let params = ClimbParams {
+        task: task.to_string(),
+        // A1-minimal stability: 1-of-1 (a single green run). N-of-M flake
+        // quarantine for `verified` is a documented follow-up.
+        stability: StabilityPolicy::new(1, 1),
+        max_iterations: 3,
+        gate_closure_digest: digest.clone(),
+    };
+
+    let outcome = run_climb(&params, &builder, &gate, &ledger, &mut journal).await;
+
+    emit_receipt(emitter, &outcome, &ledger, &digest, task, session_id);
+    Ok(outcome)
+}
+
+/// Emit the single top-level [`ProtocolEvent::AnvilReceipt`] (spec §8). Best
+/// effort — a writer error must not crash a completed climb.
+fn emit_receipt(
+    emitter: &Arc<dyn ProtocolEmitter>,
+    outcome: &ClimbOutcome,
+    ledger: &ClimbLedger,
+    gate_closure_digest: &str,
+    task: &str,
+    session_id: Option<String>,
+) {
+    let spend = ledger.settled();
+    let event = ProtocolEvent::AnvilReceipt {
+        terminal_state: terminal_state_str(&outcome.terminal).to_string(),
+        stamp: outcome.stamp.clone(),
+        checks_passed: outcome.checks_passed,
+        checks_total: outcome.checks_total,
+        coverage: None,
+        iterations: outcome.iterations,
+        cost_microcents: spend.cost_microcents,
+        priced: spend.priced,
+        gate_closure_digest: gate_closure_digest.to_string(),
+        artifact_digest: artifact_digest(outcome),
+        session_id,
+        task_id: task.to_string(),
+        engine_version: env!("CARGO_PKG_VERSION").to_string(),
+        sequence: 0,
+    };
+    let _ = emitter.emit(&event);
+}
+
+/// Canonical snake_case terminal-state string for the receipt (spec §6.5/§8).
+fn terminal_state_str(t: &TerminalState) -> &'static str {
+    match t {
+        TerminalState::Verified => "verified",
+        TerminalState::CriteriaChecked => "criteria_checked",
+        TerminalState::SelfChecked => "self_checked",
+        TerminalState::NeedsEscalation => "needs_escalation",
+        TerminalState::Blocked(_) => "blocked",
+        TerminalState::Cancelled => "cancelled",
+        TerminalState::TimedOut => "timed_out",
+        TerminalState::PermissionDenied => "permission_denied",
+        TerminalState::CrashedRecovered => "crashed_recovered",
+        TerminalState::Superseded => "superseded",
+    }
+}
+
+/// A1-minimal artifact digest binding the receipt to the promoted worktree (spec
+/// §8 staleness). Full content-tree hashing is a documented follow-up; this binds
+/// the winning worktree identity + check outcome.
+fn artifact_digest(outcome: &ClimbOutcome) -> String {
+    let mut h = Sha256::new();
+    h.update(b"anvil-artifact:v1:");
+    match &outcome.best_worktree {
+        Some(p) => h.update(p.to_string_lossy().as_bytes()),
+        None => h.update(b"none"),
+    }
+    h.update(outcome.checks_passed.to_le_bytes());
+    h.update(outcome.checks_total.to_le_bytes());
+    let d = h.finalize();
+    let mut s = String::with_capacity(64);
+    for b in d {
+        s.push_str(&format!("{b:02x}"));
+    }
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn terminal_state_strings_are_canonical() {
+        assert_eq!(terminal_state_str(&TerminalState::Verified), "verified");
+        assert_eq!(
+            terminal_state_str(&TerminalState::NeedsEscalation),
+            "needs_escalation"
+        );
+        assert_eq!(
+            terminal_state_str(&TerminalState::Blocked("x".into())),
+            "blocked"
+        );
+        assert_eq!(
+            terminal_state_str(&TerminalState::PermissionDenied),
+            "permission_denied"
+        );
+    }
+
+    #[test]
+    fn artifact_digest_is_stable_and_hex() {
+        let out = ClimbOutcome {
+            terminal: TerminalState::Verified,
+            stamp: "verified".into(),
+            checks_passed: 3,
+            checks_total: 3,
+            iterations: 2,
+            best_worktree: Some(PathBuf::from("/wt/cand-0")),
+        };
+        let a = artifact_digest(&out);
+        let b = artifact_digest(&out);
+        assert_eq!(a, b);
+        assert_eq!(a.len(), 64);
+        assert!(a.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn surgical_prompt_lists_failing_checks() {
+        let fb = BuildFeedback {
+            failing: vec!["gate".into()],
+            diagnostics: "boom".into(),
+        };
+        let wt = PathBuf::from("/wt/cand-0");
+        let p = build_prompt("do x", Some(&fb), &wt);
+        assert!(p.contains("gate"));
+        assert!(p.contains("boom"));
+        assert!(p.contains("/wt/cand-0"));
+        let p0 = build_prompt("do x", None, &wt);
+        assert!(p0.contains("do x"));
+        assert!(p0.contains("/wt/cand-0"));
+    }
+}

--- a/crates/wcore-agent/src/orchestration/anvil/gates.rs
+++ b/crates/wcore-agent/src/orchestration/anvil/gates.rs
@@ -149,6 +149,20 @@ impl GateClosure {
         backend: &dyn SandboxBackend,
         opts: &ProbeOpts,
     ) -> BaselineProbe {
+        self.run_at(backend, opts, &self.spec.cwd).await
+    }
+
+    /// Run the pinned gate at an ARBITRARY working directory `cwd` (a candidate's
+    /// isolated worktree, or the baseline), through `backend` with network denied
+    /// and a minimized env — the same tested exec path as [`probe_baseline`], so
+    /// the climb (A1.6) gates each candidate with identical sandbox discipline.
+    /// The pinned argv + env allowlist are unchanged; only the cwd varies.
+    pub async fn run_at(
+        &self,
+        backend: &dyn SandboxBackend,
+        opts: &ProbeOpts,
+        cwd: &std::path::Path,
+    ) -> BaselineProbe {
         let manifest = SandboxManifest {
             network: NetworkPolicy::Deny,
             env: minimized_env(&self.spec.env_allowlist),
@@ -160,7 +174,7 @@ impl GateClosure {
         };
         let cmd = SandboxCommand {
             argv: self.spec.argv.clone(),
-            cwd: Some(self.spec.cwd.clone()),
+            cwd: Some(cwd.to_path_buf()),
         };
         match backend.execute(&manifest, cmd).await {
             Ok(out) => BaselineProbe::Ran {

--- a/crates/wcore-agent/src/orchestration/anvil/journal.rs
+++ b/crates/wcore-agent/src/orchestration/anvil/journal.rs
@@ -177,10 +177,15 @@ impl ClimbJournal {
             source: e,
         })?;
         line.push('\n');
+        // Open read+WRITE (NOT append): the torn-tail heal below calls `set_len`,
+        // which on Windows needs write-data access an append-only handle lacks
+        // (FILE_APPEND_DATA is not FILE_WRITE_DATA). We seek to the end ourselves
+        // before writing, so this is a true append on every platform. The journal
+        // is single-writer, so O_APPEND's atomicity is not needed.
         let mut file = OpenOptions::new()
             .read(true)
+            .write(true)
             .create(true)
-            .append(true)
             .open(&self.path)
             .map_err(|source| JournalError::Io {
                 path: self.path.clone(),
@@ -194,7 +199,9 @@ impl ClimbJournal {
             path: self.path.clone(),
             source,
         })?;
-        file.write_all(line.as_bytes())
+        // Write at the true end of file (heal may have left the cursor mid-file).
+        file.seek(SeekFrom::End(0))
+            .and_then(|_| file.write_all(line.as_bytes()))
             .and_then(|()| file.sync_all())
             .map_err(|source| JournalError::Io {
                 path: self.path.clone(),

--- a/crates/wcore-agent/src/orchestration/anvil/journal.rs
+++ b/crates/wcore-agent/src/orchestration/anvil/journal.rs
@@ -295,8 +295,9 @@ impl ClimbJournal {
 
 #[cfg(test)]
 mod tests {
+    // `Write` (for `write_all`/`writeln!`) comes in via `use super::*` (the
+    // module imports it for the torn-tail heal), so no separate import here.
     use super::*;
-    use std::io::Write as _;
 
     fn tmp_journal() -> (tempfile::TempDir, PathBuf) {
         let dir = tempfile::tempdir().expect("tempdir");

--- a/crates/wcore-agent/src/orchestration/anvil/journal.rs
+++ b/crates/wcore-agent/src/orchestration/anvil/journal.rs
@@ -185,6 +185,8 @@ impl ClimbJournal {
         let mut file = OpenOptions::new()
             .read(true)
             .write(true)
+            // Preserve existing entries (we seek to end to append); NOT truncate.
+            .truncate(false)
             .create(true)
             .open(&self.path)
             .map_err(|source| JournalError::Io {

--- a/crates/wcore-agent/src/orchestration/anvil/journal.rs
+++ b/crates/wcore-agent/src/orchestration/anvil/journal.rs
@@ -1,0 +1,441 @@
+//! Anvil climb journal — the append-only crash-recovery log (spec §6.5).
+//!
+//! Every paid step of a climb (the baseline probe, each candidate's gate run,
+//! each promotion, the terminal state) is appended here BEFORE its effect is
+//! trusted, so a crashed climb can resume from its journal: re-verify the pinned
+//! gate/dependency digests, replay NOTHING that was already paid for (the
+//! idempotency keys dedupe provider calls and gate executions), and always emit
+//! an honest terminal receipt. There is no silent fourth exit (spec §6.5).
+//!
+//! The on-disk format is newline-delimited JSON with a deliberately plain schema
+//! (strings + ints, not the in-memory climb types) so the journal is a stable,
+//! forward-compatible record independent of internal refactors. Because a crash
+//! can tear the final append mid-write, [`ClimbJournal::replay`] tolerates a
+//! single unparseable *last* line (a torn write) but treats corruption anywhere
+//! earlier as a hard error — a silently-dropped middle entry would lose paid work.
+//!
+//! This is the A1.5b persistence substrate; the engine loop that writes to it and
+//! resumes from it lands with the builder/gate seams (A1.6). Spec:
+//! `docs/design/2026-07-12-anvil-native-gated-forge-design.md` (v2) §6.5.
+
+use std::collections::BTreeSet;
+use std::fs::OpenOptions;
+use std::io::{BufRead, BufReader, Read, Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// What a journal entry records.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum JournalKind {
+    /// The pre-climb baseline gate probe (spec §5).
+    Probe,
+    /// A candidate build was evaluated against the gate.
+    Candidate,
+    /// A candidate was promoted to the working best.
+    Promote,
+    /// The climb reached a terminal state (spec §6.5).
+    Terminal,
+}
+
+/// One appended record. `seq` is assigned by the journal (monotonic from 0); the
+/// `idempotency_key` identifies the paid operation so a resume never repeats it.
+/// Optional fields are omitted from the JSON when empty to keep the log compact.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct JournalEntry {
+    /// Monotonic sequence number, assigned on append.
+    pub seq: u64,
+    /// What this entry records.
+    pub kind: JournalKind,
+    /// Idempotency key of the paid operation (provider call / gate exec). On
+    /// resume, an operation whose key is already present is NEVER re-run or
+    /// re-charged (spec §6.5).
+    pub idempotency_key: String,
+    /// The `gate_closure_digest` (hex) in effect — re-checked for drift on resume.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gate_closure_digest: Option<String>,
+    /// Which candidate this concerns, if any.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub candidate_id: Option<String>,
+    /// The candidate's gate score (passing checks), if recorded.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub score: Option<u32>,
+    /// The failing check ids at this step (for the receipt's coverage scope).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub fail_ids: Vec<String>,
+    /// Cumulative settled spend (microcents) at this step.
+    pub spend_microcents: u64,
+}
+
+impl JournalEntry {
+    /// A skeleton entry with `seq` unset (the journal assigns it on append). Use
+    /// the `with_*` setters to attach the optional fields.
+    #[must_use]
+    pub fn new(
+        kind: JournalKind,
+        idempotency_key: impl Into<String>,
+        spend_microcents: u64,
+    ) -> Self {
+        Self {
+            seq: 0,
+            kind,
+            idempotency_key: idempotency_key.into(),
+            gate_closure_digest: None,
+            candidate_id: None,
+            score: None,
+            fail_ids: Vec::new(),
+            spend_microcents,
+        }
+    }
+
+    /// Attach the pinned gate closure digest (hex).
+    #[must_use]
+    pub fn with_gate_digest(mut self, digest_hex: impl Into<String>) -> Self {
+        self.gate_closure_digest = Some(digest_hex.into());
+        self
+    }
+
+    /// Attach the candidate id.
+    #[must_use]
+    pub fn with_candidate(mut self, candidate_id: impl Into<String>) -> Self {
+        self.candidate_id = Some(candidate_id.into());
+        self
+    }
+
+    /// Attach the candidate's score and failing check ids.
+    #[must_use]
+    pub fn with_result(mut self, score: u32, fail_ids: Vec<String>) -> Self {
+        self.score = Some(score);
+        self.fail_ids = fail_ids;
+        self
+    }
+}
+
+/// Errors from journal I/O.
+#[derive(Debug, Error)]
+pub enum JournalError {
+    /// The journal file could not be opened, appended to, or read.
+    #[error("climb journal I/O failed at {path}: {source}")]
+    Io {
+        /// The journal path.
+        path: PathBuf,
+        /// The underlying error.
+        #[source]
+        source: std::io::Error,
+    },
+    /// A non-final journal line could not be parsed — the journal is corrupt and
+    /// resuming from it would silently lose paid work, so it fails loud.
+    #[error("climb journal {path} is corrupt at line {line}: {source}")]
+    Corrupt {
+        /// The journal path.
+        path: PathBuf,
+        /// 1-based line number of the unparseable entry.
+        line: usize,
+        /// The parse error.
+        #[source]
+        source: serde_json::Error,
+    },
+}
+
+/// An append-only climb journal at a fixed path. Each [`append`](Self::append)
+/// writes one JSON line and fsyncs it, so a crash loses at most the in-flight
+/// line — never a line reported as written.
+#[derive(Debug)]
+pub struct ClimbJournal {
+    path: PathBuf,
+    next_seq: u64,
+}
+
+impl ClimbJournal {
+    /// Open the journal at `path`, creating it if absent and resuming the
+    /// sequence counter past any entries already present. A torn final line from
+    /// a previous crash is tolerated (and will be overwritten by the next line);
+    /// corruption earlier in the file is an error.
+    pub fn open(path: impl Into<PathBuf>) -> Result<Self, JournalError> {
+        let path = path.into();
+        let existing = Self::replay(&path)?;
+        let next_seq = existing.last().map_or(0, |e| e.seq + 1);
+        Ok(Self { path, next_seq })
+    }
+
+    /// The journal's path.
+    #[must_use]
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Append `entry` (its `seq` is assigned here, monotonic), durably. Returns
+    /// the assigned sequence number.
+    pub fn append(&mut self, mut entry: JournalEntry) -> Result<u64, JournalError> {
+        entry.seq = self.next_seq;
+        // serde_json::to_string on a plain struct cannot fail; map defensively.
+        let mut line = serde_json::to_string(&entry).map_err(|e| JournalError::Corrupt {
+            path: self.path.clone(),
+            line: self.next_seq as usize + 1,
+            source: e,
+        })?;
+        line.push('\n');
+        let mut file = OpenOptions::new()
+            .read(true)
+            .create(true)
+            .append(true)
+            .open(&self.path)
+            .map_err(|source| JournalError::Io {
+                path: self.path.clone(),
+                source,
+            })?;
+        // Heal a torn trailing line left by a prior crash (bytes after the last
+        // newline) BEFORE appending, so this record starts on a clean line and
+        // never concatenates onto a half-written one — which would corrupt the
+        // torn line's replacement and lose this entry on the next replay.
+        Self::truncate_torn_tail(&mut file).map_err(|source| JournalError::Io {
+            path: self.path.clone(),
+            source,
+        })?;
+        file.write_all(line.as_bytes())
+            .and_then(|()| file.sync_all())
+            .map_err(|source| JournalError::Io {
+                path: self.path.clone(),
+                source,
+            })?;
+        let seq = self.next_seq;
+        self.next_seq += 1;
+        Ok(seq)
+    }
+
+    /// Drop any bytes after the last newline — a torn record from a crash mid
+    /// append. A file that already ends in a newline (or is empty) is untouched,
+    /// so the common path pays only a one-byte read. Only when a torn tail is
+    /// present is the file scanned back to the last complete line and truncated.
+    fn truncate_torn_tail(file: &mut std::fs::File) -> std::io::Result<()> {
+        let len = file.metadata()?.len();
+        if len == 0 {
+            return Ok(());
+        }
+        let mut last = [0u8; 1];
+        file.seek(SeekFrom::End(-1))?;
+        file.read_exact(&mut last)?;
+        if last[0] == b'\n' {
+            return Ok(()); // ends on a complete line — nothing torn.
+        }
+        // Torn tail: keep everything up to and including the last newline.
+        let mut data = Vec::new();
+        file.seek(SeekFrom::Start(0))?;
+        file.read_to_end(&mut data)?;
+        let keep = data
+            .iter()
+            .rposition(|&b| b == b'\n')
+            .map_or(0, |i| i as u64 + 1);
+        file.set_len(keep)?;
+        Ok(())
+    }
+
+    /// Replay every entry in `path`, in order (crash recovery). A missing file is
+    /// an empty journal. A single unparseable FINAL line is tolerated as a torn
+    /// crash-time write and dropped; an unparseable earlier line is
+    /// [`JournalError::Corrupt`].
+    pub fn replay(path: impl AsRef<Path>) -> Result<Vec<JournalEntry>, JournalError> {
+        let path = path.as_ref();
+        let file = match std::fs::File::open(path) {
+            Ok(f) => f,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(source) => {
+                return Err(JournalError::Io {
+                    path: path.to_path_buf(),
+                    source,
+                });
+            }
+        };
+        let raw_lines: Vec<String> = BufReader::new(file)
+            .lines()
+            .collect::<Result<_, _>>()
+            .map_err(|source| JournalError::Io {
+                path: path.to_path_buf(),
+                source,
+            })?;
+        // Keep only non-blank lines, remembering their original line numbers so a
+        // parse error reports the true position.
+        let lines: Vec<(usize, &String)> = raw_lines
+            .iter()
+            .enumerate()
+            .filter(|(_, l)| !l.trim().is_empty())
+            .map(|(i, l)| (i + 1, l))
+            .collect();
+        let mut entries = Vec::with_capacity(lines.len());
+        let last_idx = lines.len().saturating_sub(1);
+        for (i, (line_no, line)) in lines.iter().enumerate() {
+            match serde_json::from_str::<JournalEntry>(line) {
+                Ok(entry) => entries.push(entry),
+                // A torn write can only be the final line; anything earlier is
+                // real corruption that must not be silently skipped.
+                Err(_) if i == last_idx => break,
+                Err(source) => {
+                    return Err(JournalError::Corrupt {
+                        path: path.to_path_buf(),
+                        line: *line_no,
+                        source,
+                    });
+                }
+            }
+        }
+        Ok(entries)
+    }
+
+    /// The set of idempotency keys already recorded — the paid operations a
+    /// resume must NOT repeat (spec §6.5 "replays nothing paid").
+    pub fn recorded_keys(&self) -> Result<BTreeSet<String>, JournalError> {
+        Ok(Self::replay(&self.path)?
+            .into_iter()
+            .map(|e| e.idempotency_key)
+            .collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write as _;
+
+    fn tmp_journal() -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("climb.journal");
+        (dir, path)
+    }
+
+    #[test]
+    fn append_assigns_monotonic_seq_and_replays_in_order() {
+        let (_d, path) = tmp_journal();
+        let mut j = ClimbJournal::open(&path).unwrap();
+        let s0 = j
+            .append(
+                JournalEntry::new(JournalKind::Probe, "probe-1", 0).with_gate_digest("deadbeef"),
+            )
+            .unwrap();
+        let s1 = j
+            .append(
+                JournalEntry::new(JournalKind::Candidate, "cand-1", 5000)
+                    .with_candidate("c1")
+                    .with_result(3, vec!["t_a".into()]),
+            )
+            .unwrap();
+        assert_eq!((s0, s1), (0, 1));
+
+        let replayed = ClimbJournal::replay(&path).unwrap();
+        assert_eq!(replayed.len(), 2);
+        assert_eq!(replayed[0].kind, JournalKind::Probe);
+        assert_eq!(replayed[0].gate_closure_digest.as_deref(), Some("deadbeef"));
+        assert_eq!(replayed[1].candidate_id.as_deref(), Some("c1"));
+        assert_eq!(replayed[1].score, Some(3));
+        assert_eq!(replayed[1].fail_ids, vec!["t_a".to_string()]);
+        assert_eq!(replayed[1].spend_microcents, 5000);
+    }
+
+    #[test]
+    fn reopening_resumes_the_sequence() {
+        let (_d, path) = tmp_journal();
+        {
+            let mut j = ClimbJournal::open(&path).unwrap();
+            j.append(JournalEntry::new(JournalKind::Probe, "p", 0))
+                .unwrap();
+            j.append(JournalEntry::new(JournalKind::Candidate, "c", 1))
+                .unwrap();
+        }
+        // A fresh handle must continue past seq 1, not restart at 0.
+        let mut j = ClimbJournal::open(&path).unwrap();
+        let seq = j
+            .append(JournalEntry::new(JournalKind::Terminal, "t", 2))
+            .unwrap();
+        assert_eq!(seq, 2);
+        let all = ClimbJournal::replay(&path).unwrap();
+        assert_eq!(all.iter().map(|e| e.seq).collect::<Vec<_>>(), vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn recorded_keys_are_the_paid_operations() {
+        let (_d, path) = tmp_journal();
+        let mut j = ClimbJournal::open(&path).unwrap();
+        j.append(JournalEntry::new(JournalKind::Candidate, "call-a", 10))
+            .unwrap();
+        j.append(JournalEntry::new(JournalKind::Candidate, "call-b", 20))
+            .unwrap();
+        let keys = j.recorded_keys().unwrap();
+        assert!(keys.contains("call-a") && keys.contains("call-b"));
+        assert!(!keys.contains("call-c"));
+    }
+
+    #[test]
+    fn missing_journal_replays_empty() {
+        let (_d, path) = tmp_journal();
+        assert!(ClimbJournal::replay(&path).unwrap().is_empty());
+        // open() on a missing file starts the sequence at 0.
+        assert_eq!(ClimbJournal::open(&path).unwrap().next_seq, 0);
+    }
+
+    #[test]
+    fn torn_final_line_is_tolerated() {
+        let (_d, path) = tmp_journal();
+        let mut j = ClimbJournal::open(&path).unwrap();
+        j.append(JournalEntry::new(JournalKind::Probe, "p", 0))
+            .unwrap();
+        // Simulate a crash mid-append: a truncated JSON fragment as the last line.
+        let mut f = OpenOptions::new().append(true).open(&path).unwrap();
+        f.write_all(b"{\"seq\":1,\"kind\":\"candi").unwrap();
+        drop(f);
+        // Replay drops the torn tail and keeps the good entry.
+        let entries = ClimbJournal::replay(&path).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].idempotency_key, "p");
+        // And the journal can be reopened and continued: the next append heals
+        // the torn tail before writing, so the resumed entry is a clean line and
+        // BOTH entries survive a subsequent replay (the torn fragment is gone,
+        // not concatenated onto the new record).
+        let mut j2 = ClimbJournal::open(&path).unwrap();
+        let seq = j2
+            .append(JournalEntry::new(JournalKind::Candidate, "c", 1))
+            .unwrap();
+        assert_eq!(seq, 1);
+        let after = ClimbJournal::replay(&path).unwrap();
+        assert_eq!(after.len(), 2, "resumed entry must survive re-replay");
+        assert_eq!(after[0].idempotency_key, "p");
+        assert_eq!(after[1].idempotency_key, "c");
+        assert_eq!(after.iter().map(|e| e.seq).collect::<Vec<_>>(), vec![0, 1]);
+    }
+
+    #[test]
+    fn corruption_before_the_last_line_is_a_hard_error() {
+        let (_d, path) = tmp_journal();
+        {
+            // A good line, a corrupt middle line, then a good final line.
+            let mut f = OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(&path)
+                .unwrap();
+            let good =
+                serde_json::to_string(&JournalEntry::new(JournalKind::Probe, "p", 0)).unwrap();
+            writeln!(f, "{good}").unwrap();
+            writeln!(f, "{{not json}}").unwrap();
+            let good2 =
+                serde_json::to_string(&JournalEntry::new(JournalKind::Terminal, "t", 0)).unwrap();
+            writeln!(f, "{good2}").unwrap();
+        }
+        let err = ClimbJournal::replay(&path).unwrap_err();
+        match err {
+            JournalError::Corrupt { line, .. } => assert_eq!(line, 2),
+            other => panic!("expected Corrupt at line 2, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn optional_fields_are_omitted_from_the_json() {
+        // A bare entry serializes without the optional keys (compact log).
+        let entry = JournalEntry::new(JournalKind::Terminal, "t", 0);
+        let json = serde_json::to_string(&entry).unwrap();
+        assert!(!json.contains("candidate_id"));
+        assert!(!json.contains("gate_closure_digest"));
+        assert!(!json.contains("fail_ids"));
+        assert!(!json.contains("score"));
+    }
+}

--- a/crates/wcore-agent/src/orchestration/anvil/lease.rs
+++ b/crates/wcore-agent/src/orchestration/anvil/lease.rs
@@ -1,0 +1,284 @@
+//! Anvil climb lease — per-workspace mutual exclusion (spec §6.5).
+//!
+//! A climb mutates a real user workspace (candidate promotion, §6.5). Two climbs
+//! on the same workspace — or a climb racing the user's own edits — must never
+//! interleave. This lease is the guard: an atomically-created lock file under the
+//! workspace whose presence means "a climb owns this workspace". Acquiring is a
+//! single `O_EXCL` create (no check-then-create race); the holder's pid is
+//! recorded so a crashed climb can reclaim ITS OWN orphaned lease on resume
+//! (compare-and-swap [`steal_stale`](ClimbLease::steal_stale)) without a fragile
+//! cross-platform liveness probe, and dropping the lease releases it — but only
+//! if we still hold it, so a successor's lease is never clobbered.
+//!
+//! Detecting whether a *different* pid's lease is stale (its process died) is
+//! left to the resume path (A1.6), which knows the pid it crashed as; this
+//! module provides the safe primitive, not a liveness oracle.
+//!
+//! Spec: `docs/design/2026-07-12-anvil-native-gated-forge-design.md` (v2) §6.5.
+
+use std::fs;
+use std::fs::OpenOptions;
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+
+use thiserror::Error;
+
+/// Path of the lease file relative to the workspace root.
+const LEASE_REL_PATH: &str = ".wayland/anvil/climb.lease";
+
+/// Errors acquiring or managing a climb lease.
+#[derive(Debug, Error)]
+pub enum LeaseError {
+    /// The workspace is already leased by another climb (pid recorded in the
+    /// lease). `pid` is 0 if the lease file was present but unreadable.
+    #[error("workspace climb lease is already held (pid {pid})")]
+    Held {
+        /// The recorded holder pid (0 if unreadable).
+        pid: u32,
+        /// The lease file path.
+        path: PathBuf,
+    },
+    /// Filesystem I/O failed.
+    #[error("climb lease I/O failed at {path}: {source}")]
+    Io {
+        /// The lease file path.
+        path: PathBuf,
+        /// The underlying error.
+        #[source]
+        source: std::io::Error,
+    },
+}
+
+/// A held per-workspace climb lease. Dropping it releases the lease (removing the
+/// lock file), unless it was already [`release`](Self::release)d or the file is
+/// no longer ours.
+#[derive(Debug)]
+#[must_use = "dropping the lease immediately releases it; hold it for the climb's lifetime"]
+pub struct ClimbLease {
+    path: PathBuf,
+    pid: u32,
+    released: bool,
+}
+
+impl ClimbLease {
+    /// The lease file path for `workspace_root`.
+    fn lease_path(workspace_root: impl AsRef<Path>) -> PathBuf {
+        workspace_root.as_ref().join(LEASE_REL_PATH)
+    }
+
+    /// Atomically acquire the climb lease for `workspace_root`, creating the
+    /// `.wayland/anvil/` directory as needed. Fails with [`LeaseError::Held`] if a
+    /// lease already exists (the create is `O_EXCL`, so two racing acquirers can
+    /// never both win).
+    pub fn acquire(workspace_root: impl AsRef<Path>) -> Result<Self, LeaseError> {
+        let path = Self::lease_path(&workspace_root);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).map_err(|source| LeaseError::Io {
+                path: path.clone(),
+                source,
+            })?;
+        }
+        let pid = std::process::id();
+        match OpenOptions::new().write(true).create_new(true).open(&path) {
+            Ok(mut file) => {
+                file.write_all(pid.to_string().as_bytes())
+                    .and_then(|()| file.sync_all())
+                    .map_err(|source| LeaseError::Io {
+                        path: path.clone(),
+                        source,
+                    })?;
+                Ok(Self {
+                    path,
+                    pid,
+                    released: false,
+                })
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => Err(LeaseError::Held {
+                pid: read_holder(&path).unwrap_or(0),
+                path,
+            }),
+            Err(source) => Err(LeaseError::Io { path, source }),
+        }
+    }
+
+    /// The pid recorded in this lease (this process).
+    #[must_use]
+    pub fn pid(&self) -> u32 {
+        self.pid
+    }
+
+    /// The lease file path.
+    #[must_use]
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Explicitly release the lease now (idempotent with `Drop`). Removes the lock
+    /// file only if we still hold it.
+    pub fn release(mut self) -> Result<(), LeaseError> {
+        self.release_inner()
+    }
+
+    fn release_inner(&mut self) -> Result<(), LeaseError> {
+        if self.released {
+            return Ok(());
+        }
+        self.released = true;
+        // Only remove the file if it is still OUR lease — never clobber a lease a
+        // successor acquired after we (thought we) held it.
+        match read_holder(&self.path) {
+            Some(holder) if holder == self.pid => {
+                fs::remove_file(&self.path).map_err(|source| LeaseError::Io {
+                    path: self.path.clone(),
+                    source,
+                })
+            }
+            // Not ours (or already gone): nothing to release.
+            _ => Ok(()),
+        }
+    }
+
+    /// Read the current holder pid of `workspace_root`'s lease, or `None` if no
+    /// lease is held.
+    pub fn holder(workspace_root: impl AsRef<Path>) -> Result<Option<u32>, LeaseError> {
+        let path = Self::lease_path(workspace_root);
+        match fs::metadata(&path) {
+            Ok(_) => Ok(Some(read_holder(&path).unwrap_or(0))),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(source) => Err(LeaseError::Io { path, source }),
+        }
+    }
+
+    /// Reclaim a lease known to be orphaned by a specific dead process: remove the
+    /// lease file IFF its recorded holder is `expected_pid`. Returns whether a
+    /// lease was broken. This is the resume path's safe reclaim — a climb that
+    /// crashed as `expected_pid` (recorded in its journal) can clear its own stale
+    /// lease without risking a live successor's, because a mismatched pid is left
+    /// untouched.
+    pub fn steal_stale(
+        workspace_root: impl AsRef<Path>,
+        expected_pid: u32,
+    ) -> Result<bool, LeaseError> {
+        let path = Self::lease_path(workspace_root);
+        match read_holder(&path) {
+            Some(holder) if holder == expected_pid => {
+                fs::remove_file(&path).map_err(|source| LeaseError::Io {
+                    path: path.clone(),
+                    source,
+                })?;
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
+    }
+}
+
+impl Drop for ClimbLease {
+    fn drop(&mut self) {
+        // Best-effort release; a failure here is not actionable at drop time.
+        let _ = self.release_inner();
+    }
+}
+
+/// Read the holder pid recorded in the lease file, or `None` if it is
+/// absent/unreadable/malformed.
+fn read_holder(path: &Path) -> Option<u32> {
+    let mut file = fs::File::open(path).ok()?;
+    let mut buf = String::new();
+    file.read_to_string(&mut buf).ok()?;
+    buf.trim().parse::<u32>().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn workspace() -> tempfile::TempDir {
+        tempfile::tempdir().expect("tempdir")
+    }
+
+    #[test]
+    fn acquire_creates_lease_and_records_pid() {
+        let ws = workspace();
+        let lease = ClimbLease::acquire(ws.path()).unwrap();
+        assert_eq!(lease.pid(), std::process::id());
+        assert!(lease.path().exists());
+        assert_eq!(
+            ClimbLease::holder(ws.path()).unwrap(),
+            Some(std::process::id())
+        );
+    }
+
+    #[test]
+    fn second_acquire_is_rejected_while_held() {
+        let ws = workspace();
+        let _held = ClimbLease::acquire(ws.path()).unwrap();
+        match ClimbLease::acquire(ws.path()) {
+            Err(LeaseError::Held { pid, .. }) => assert_eq!(pid, std::process::id()),
+            other => panic!("expected Held, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn dropping_releases_and_allows_reacquire() {
+        let ws = workspace();
+        {
+            let _lease = ClimbLease::acquire(ws.path()).unwrap();
+            assert!(ClimbLease::holder(ws.path()).unwrap().is_some());
+        }
+        // Drop released it.
+        assert_eq!(ClimbLease::holder(ws.path()).unwrap(), None);
+        // And a fresh acquire now succeeds.
+        let _again = ClimbLease::acquire(ws.path()).unwrap();
+    }
+
+    #[test]
+    fn explicit_release_is_idempotent_with_drop() {
+        let ws = workspace();
+        let lease = ClimbLease::acquire(ws.path()).unwrap();
+        lease.release().unwrap(); // consumes; Drop won't double-remove
+        assert_eq!(ClimbLease::holder(ws.path()).unwrap(), None);
+    }
+
+    #[test]
+    fn holder_of_unleased_workspace_is_none() {
+        let ws = workspace();
+        assert_eq!(ClimbLease::holder(ws.path()).unwrap(), None);
+    }
+
+    #[test]
+    fn steal_stale_breaks_only_a_matching_pid() {
+        let ws = workspace();
+        // Simulate an orphaned lease held by a foreign pid.
+        let path = ClimbLease::lease_path(ws.path());
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, "424242").unwrap();
+
+        // Wrong expected pid: leave it untouched.
+        assert!(!ClimbLease::steal_stale(ws.path(), 999_999).unwrap());
+        assert_eq!(ClimbLease::holder(ws.path()).unwrap(), Some(424_242));
+
+        // Matching pid: reclaim it.
+        assert!(ClimbLease::steal_stale(ws.path(), 424_242).unwrap());
+        assert_eq!(ClimbLease::holder(ws.path()).unwrap(), None);
+        // Now acquirable again.
+        let _fresh = ClimbLease::acquire(ws.path()).unwrap();
+    }
+
+    #[test]
+    fn release_does_not_clobber_a_successor_lease() {
+        let ws = workspace();
+        let path = ClimbLease::lease_path(ws.path());
+        // We hold the lease...
+        let lease = ClimbLease::acquire(ws.path()).unwrap();
+        // ...but a "successor" replaces the file with a different holder (as if we
+        // had been considered stale and reclaimed). Our Drop must not remove it.
+        fs::write(&path, "777777").unwrap();
+        drop(lease);
+        assert_eq!(
+            ClimbLease::holder(ws.path()).unwrap(),
+            Some(777_777),
+            "our release must not clobber a successor's lease"
+        );
+    }
+}

--- a/crates/wcore-agent/src/orchestration/anvil/mod.rs
+++ b/crates/wcore-agent/src/orchestration/anvil/mod.rs
@@ -14,6 +14,8 @@
 //!
 //! Spec: `docs/design/2026-07-12-anvil-native-gated-forge-design.md` (v2).
 
+/// The climb decision core: per-check gate model, fail-set acceptance, order.
+pub mod climb;
 /// Gate closure pinning, the pre-climb probe, injection fencing, flake policy.
 pub mod gates;
 /// Per-task cost ledger with atomic reservation-before-dispatch.

--- a/crates/wcore-agent/src/orchestration/anvil/mod.rs
+++ b/crates/wcore-agent/src/orchestration/anvil/mod.rs
@@ -16,6 +16,10 @@
 
 /// The climb decision core: per-check gate model, fail-set acceptance, order.
 pub mod climb;
+/// The climb engine loop (probe → gate → surgical → terminal) over injected seams.
+pub mod engine;
+/// The real forge wiring: sandbox gate + spawn builder + `drive_climb_full` + receipt.
+pub mod forge;
 /// Gate closure pinning, the pre-climb probe, injection fencing, flake policy.
 pub mod gates;
 /// Append-only climb journal for crash recovery + idempotent resume.
@@ -113,14 +117,20 @@ mod tests {
 
     #[tokio::test]
     async fn drive_climb_refuses_when_disabled() {
-        let cfg = AnvilConfig { enabled: false };
+        let cfg = AnvilConfig {
+            enabled: false,
+            ..Default::default()
+        };
         let err = drive_climb("task", &cfg).await.unwrap_err();
         assert!(matches!(err, AnvilError::Disabled));
     }
 
     #[tokio::test]
     async fn drive_climb_enabled_returns_blocked_skeleton() {
-        let cfg = AnvilConfig { enabled: true };
+        let cfg = AnvilConfig {
+            enabled: true,
+            ..Default::default()
+        };
         let res = drive_climb("task", &cfg).await.unwrap();
         assert!(matches!(res.terminal, TerminalState::Blocked(_)));
         // The skeleton must never claim verification.

--- a/crates/wcore-agent/src/orchestration/anvil/mod.rs
+++ b/crates/wcore-agent/src/orchestration/anvil/mod.rs
@@ -20,6 +20,8 @@ pub mod climb;
 pub mod gates;
 /// Append-only climb journal for crash recovery + idempotent resume.
 pub mod journal;
+/// Per-workspace climb lease preventing interleaved climbs / user edits.
+pub mod lease;
 /// Per-task cost ledger with atomic reservation-before-dispatch.
 pub mod ledger;
 

--- a/crates/wcore-agent/src/orchestration/anvil/mod.rs
+++ b/crates/wcore-agent/src/orchestration/anvil/mod.rs
@@ -18,6 +18,8 @@
 pub mod climb;
 /// Gate closure pinning, the pre-climb probe, injection fencing, flake policy.
 pub mod gates;
+/// Append-only climb journal for crash recovery + idempotent resume.
+pub mod journal;
 /// Per-task cost ledger with atomic reservation-before-dispatch.
 pub mod ledger;
 

--- a/crates/wcore-cli/src/anvil.rs
+++ b/crates/wcore-cli/src/anvil.rs
@@ -1,13 +1,18 @@
 //! CLI surface: `wayland-core forge "<task>"` — the explicit Anvil verb.
 //!
 //! Mirrors [`crate::crucible::run_crucible`]: it enforces the `[anvil] enabled`
-//! kill-switch before doing anything, then routes to the `drive_climb` engine
-//! seam. A1 skeleton — the climb currently returns an honest
-//! not-yet-implemented terminal; the real loop lands in later A1 slices.
+//! kill-switch, resolves a provider + spawner + protocol emitter, then drives a
+//! real gated-forge climb ([`drive_climb_full`]) which forks a builder into an
+//! isolated worktree, runs the configured gate, climbs, and emits an
+//! `AnvilReceipt` (on stdout, as a JSON-stream event).
+
+use std::sync::Arc;
 
 use clap::Args;
-use wcore_agent::orchestration::anvil::drive_climb;
-use wcore_config::config::load_merged_config_file;
+use wcore_agent::orchestration::anvil::forge::drive_climb_full;
+use wcore_agent::spawner::AgentSpawner;
+use wcore_config::config::{CliArgs, Config, load_merged_config_file};
+use wcore_protocol::writer::{ProtocolEmitter, ProtocolWriter};
 
 /// Arguments for `wayland-core forge`.
 #[derive(Args, Debug)]
@@ -24,13 +29,43 @@ pub async fn run_forge(args: ForgeArgs) -> anyhow::Result<()> {
     if !cf.anvil.enabled {
         anyhow::bail!(
             "Anvil is disabled. Set `enabled = true` under `[anvil]` in your config \
-             to forge gated tasks. (A1 is kill-switched until the slice completes.)"
+             to forge gated tasks."
+        );
+    }
+    if cf.anvil.gate.is_empty() {
+        anyhow::bail!(
+            "Anvil has no gate configured. Set `[anvil] gate = [\"cargo\", \"test\"]` \
+             (the argv Anvil runs to verify a forged candidate)."
         );
     }
 
-    match drive_climb(&args.task, &cf.anvil).await {
-        Ok(result) => {
-            println!("forge: {:?}", result.terminal);
+    // Resolve the session provider + a spawner to fork builder sub-agents with.
+    // Anvil A1 runs in a TRUSTED / auto-approve posture (spec §5): a forked
+    // builder has no approval channel, so its Write/Edit/Bash tools must be
+    // pre-approved or they fail closed. The explicit `forge` verb opts the
+    // session into auto-approve so the builder can actually make the change.
+    let mut session_cfg = Config::resolve(&CliArgs::default())?;
+    session_cfg.tools.auto_approve = true;
+    let provider = wcore_agent::bootstrap::create_provider_with_oauth(&session_cfg)?;
+    let spawner = AgentSpawner::new(provider, session_cfg.clone());
+
+    // The top-level protocol writer — the AnvilReceipt is trusted ONLY from this
+    // top-level emission (host trust boundary, spec §8).
+    let emitter: Arc<dyn ProtocolEmitter> = Arc::new(ProtocolWriter::new());
+
+    let workspace = std::env::current_dir()?;
+
+    match drive_climb_full(&args.task, &cf.anvil, &workspace, &spawner, &emitter, None).await {
+        Ok(outcome) => {
+            // The receipt already went to stdout; this is a human summary on stderr.
+            eprintln!(
+                "forge: terminal={:?} stamp={} checks={}/{} iterations={}",
+                outcome.terminal,
+                outcome.stamp,
+                outcome.checks_passed,
+                outcome.checks_total,
+                outcome.iterations,
+            );
             Ok(())
         }
         Err(e) => anyhow::bail!("forge: {e}"),

--- a/crates/wcore-config/src/anvil.rs
+++ b/crates/wcore-config/src/anvil.rs
@@ -21,6 +21,12 @@ pub struct AnvilConfig {
     /// subcommand (and, later, the `/forge` verb and auto-detector) refuse.
     /// Every A1 PR lands behind this flag until the slice is complete.
     pub enabled: bool,
+    /// The Tier-1 gate command as an argv (e.g. `["cargo", "test"]`). The forge
+    /// runs this against each candidate; a `0` exit means the candidate passes.
+    /// EMPTY (the default) means no gate is configured — the forge refuses, since
+    /// a gated-forge with no gate can verify nothing (fails safe).
+    #[serde(default)]
+    pub gate: Vec<String>,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Anvil A1 — native gated-forge engine, live-proven `/forge` (A1.3–A1.6)

Consolidates the full Anvil A1 engine onto the current (security-hardened) main. Supersedes the stacked substrate PRs #236 (A1.3+A1.4), #239 (A1.5a), #240 (A1.5b) — their content is the first 5 commits here, each already Core-B-reviewed; this PR adds the A1.6 engine + live forge wiring on top so all of A1 lands together, functional.

### What lands
- **A1.3 `gates.rs`** — gate closure pinning (sha256 over argv+env-allowlist+cwd+transitive inputs) + drift + test-authoring carve-out + pre-climb sandbox probe (`run_at` runs the gate at any cwd) + `BoundedGateOutput` injection fencing + `StabilityPolicy`.
- **A1.4 `ledger.rs`** — `ClimbLedger` atomic reserve→settle, cost+wallclock axes, priced honesty.
- **A1.5a `climb.rs`** — per-check gate model + fail-set ⊆/severity-trade acceptance (safety-class never traded) + deterministic total order + coupled-failure clustering.
- **A1.5b `journal.rs` + `lease.rs`** — append-only crash-recovery journal (fsync, idempotency, torn-tail heal) + per-workspace O_EXCL climb lease.
- **A1.6 `engine.rs` + `forge.rs`** — the climb loop (probe→gate→surgical→terminal over injected seams) + the REAL seams: `SandboxGate` (runs the pinned gate in-sandbox at each candidate worktree), `SpawnBuilder` (forks a builder sub-agent into a per-candidate git worktree), `drive_climb_full` (assembles substrate + emits `AnvilReceipt` at the single climb exit, spec §8). `AnvilConfig.gate` field + CLI `/forge` wiring.

### LIVE PROOF (Hetzner box, real Anthropic provider) — 3/3 verified
A real `wayland-core forge` produced a **verified** receipt: forked builder wrote `DONE.txt` into the isolated git worktree → sandbox gate (`test -f DONE.txt`, bwrap network-deny) passed → real receipt on stdout:
```json
{"type":"anvil_receipt","terminal_state":"verified","stamp":"verified","checks_passed":1,"checks_total":1,
 "iterations":1,"gate_closure_digest":"d40dd778…","artifact_digest":"6f619dcd…","engine_version":"0.12.24"}
```

### Safety / posture
- **Kill-switch default OFF** (`[anvil] enabled=false`); `/forge` is the explicit opt-in verb.
- Forge runs in **auto-approve/trusted posture** (spec §5 — forked builders have no approval channel).
- Gate runs sandboxed: network-deny + minimized env. Builders inherit the just-hardened secret boundary (#232/#234). No new secret-read surface (spot-check: forge adds worktree/journal/lease writes under `.wayland/anvil/` + `.swarm-worktrees/`, no secret reads).

### A1-minimal scope (honest follow-ups, filed as A2)
Whole-gate = one Tier-1 check (per-check parser = follow-up); serial single-builder (parallel ensemble + proper per-fork cwd plumbing = follow-up); 1-of-1 stability (N-of-M = follow-up); `artifact_digest` binds worktree+checks (content-tree hash = follow-up).

### Verification
Box: `clippy -D warnings` clean (wcore-agent/cli/config), anvil `nextest` 66/66, live forge 3/3 verified. Full workspace gate delta runs in CI. No AI signatures.
