### PR TITLE
fix(linux): the release binary must start without ALSA installed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -251,10 +251,70 @@ jobs:
             --binary "target/${TARGET}/release/wayland-core" \
             --max-glibc "${GLIBC_FLOOR}"
 
+      # THE SECOND GATE, and the one v0.12.26-rc.1 needed.
+      #
+      # The glibc floor check above reads SYMBOL versions. It says nothing about
+      # whole SHARED OBJECTS the loader must find, so it passed while the
+      # artifact carried `NEEDED libasound.so.2` and could not start on any host
+      # without ALSA installed. The executable smoke on rockylinux:9 did catch
+      # it — but that step is `if: matrix.target == 'x86_64-unknown-linux-gnu'`,
+      # and the aarch64 artifact is never executed at all (its smoke checks file
+      # size and the ELF e_machine byte). So exactly one of two Linux targets
+      # was covered, by a check that runs after packaging.
+      #
+      # This reads DT_NEEDED directly, on BOTH Linux targets, at build time.
+      # readelf is architecture-neutral, so aarch64 gets the same guarantee
+      # without needing to run.
+      #
+      # The allowlist is what a stock enterprise Linux provides. Adding a name
+      # here is a deliberate decision to raise the runtime requirements of every
+      # Linux user, and should be argued for in the PR that does it.
+      - name: Verify no unexpected shared-library dependency (both Linux targets)
+        if: runner.os == 'Linux'
+        shell: bash
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          set -euo pipefail
+          bin="target/${TARGET}/release/wayland-core"
+          needed="$(readelf -d "$bin" | sed -nE 's/.*\(NEEDED\).*\[(.+)\].*/\1/p' | sort -u)"
+          echo "DT_NEEDED for ${TARGET}:"
+          echo "${needed}" | sed 's/^/  /'
+
+          # Prove the gate can fail before trusting it: a name that is NOT in
+          # the allowlist must be rejected by the same matcher used below.
+          if printf 'libasound.so.2\n' | grep -qxvF -f <(printf '%s\n' \
+                libc.so.6 libm.so.6 libdl.so.2 libpthread.so.0 librt.so.1 \
+                libgcc_s.so.1 ld-linux-x86-64.so.2 ld-linux-aarch64.so.1 \
+                libssl.so.3 libcrypto.so.3 libseccomp.so.2 libdbus-1.so.3); then
+            echo "self-test: gate correctly rejects libasound.so.2"
+          else
+            echo "ERROR: self-test failed — this gate cannot reject anything"; exit 1
+          fi
+
+          unexpected="$(printf '%s\n' "${needed}" | grep -vxF -f <(printf '%s\n' \
+                libc.so.6 libm.so.6 libdl.so.2 libpthread.so.0 librt.so.1 \
+                libgcc_s.so.1 ld-linux-x86-64.so.2 ld-linux-aarch64.so.1 \
+                libssl.so.3 libcrypto.so.3 libseccomp.so.2 libdbus-1.so.3) || true)"
+          if [ -n "${unexpected}" ]; then
+            echo "ERROR: artifact requires shared libraries outside the allowlist:"
+            echo "${unexpected}" | sed 's/^/  /'
+            echo "A Linux user without these installed cannot start the binary at all."
+            exit 1
+          fi
+          echo "OK: every DT_NEEDED entry is on the allowlist"
+
+      # `voice` is NOT a default feature — see crates/wcore-cli/Cargo.toml for
+      # why. It is enabled HERE, for macOS and Windows only, because cpal uses
+      # CoreAudio and WASAPI on those platforms and neither adds a runtime
+      # dependency that can be absent. Linux is built without it: `alsa-sys`
+      # links `libasound.so.2` as a hard `DT_NEEDED`, and v0.12.26-rc.1 shipped
+      # a Linux binary that could not start on a host without ALSA. The
+      # "no libasound in DT_NEEDED" gate below is what keeps that true.
       - name: Build release binary (macOS / Windows)
         if: runner.os != 'Linux'
         shell: bash
-        run: vx cargo build --release --target ${{ matrix.target }} -p wcore-cli
+        run: vx cargo build --release --target ${{ matrix.target }} -p wcore-cli --features voice
 
       - name: Package binary (Unix)
         if: runner.os != 'Windows'

--- a/crates/wcore-cli/Cargo.toml
+++ b/crates/wcore-cli/Cargo.toml
@@ -28,7 +28,7 @@ harness = false
 # M5.4: remote-registry gates the network-backed `GitHubReleasesResolver`
 # behind a feature flag (default ON for v0.6) so unit tests stay offline
 # and a stripped build can disable the reqwest dep entirely.
-default = ["remote-registry", "workflow", "monitor", "review_artifact", "voice"]
+default = ["remote-registry", "workflow", "monitor", "review_artifact"]
 remote-registry = ["dep:reqwest", "dep:wcore-egress"]
 # User-flow harness Layer 3: the `harness_failure_injection` integration
 # test reproduces the audit's hang-class bugs (wedged MCP server, Ctrl+C
@@ -53,12 +53,31 @@ workflow = []
 monitor = []
 review_artifact = []
 # Issue #14 — re-exports wcore-agent's `voice` feature (cpal mic capture).
-# 27-C4: now ON by default. The feature only *links* the OS audio library —
-# on a host with no input device `build_voice_mode_backend` returns `None`
-# and the `voice_mode` tool hides via `Tool::is_available() == false`, so a
-# headless server still starts cleanly. Cost of the default: the Linux binary
-# gains a dynamic dependency on libasound.so.2 (ALSA), and building it needs
-# the ALSA dev headers (`libasound2-dev` / `alsa-lib-devel`).
+#
+# NOT in `default`, and that is load-bearing on Linux.
+#
+# 27-C4 put this in `default` on the reasoning that "the feature only *links*
+# the OS audio library" and that "a host with no input device" still starts,
+# because `build_voice_mode_backend` returns `None` and `voice_mode` hides via
+# `Tool::is_available() == false`. That conflates two different things. A
+# missing input DEVICE is handled. A missing ALSA LIBRARY is not: `alsa-sys`
+# links `libasound.so.2` as a hard `DT_NEEDED`, so the dynamic loader refuses
+# the process before `main` runs. Measured on rockylinux:9 at the declared
+# glibc floor, the v0.12.26-rc.1 artifact could not even print `--version`:
+#
+#   /s/wayland-core: error while loading shared libraries: libasound.so.2:
+#   cannot open shared object file: No such file or directory
+#
+# `alsa-sys` 0.3.1 offers no dlopen path — its build.rs is a bare
+# `pkg_config::probe_library("alsa")` — so the only way a Linux binary starts
+# without ALSA present is to not link it.
+#
+# macOS and Windows have no such exposure: cpal uses CoreAudio and WASAPI,
+# which are always present. `release.yml` therefore builds the four
+# macOS/Windows targets with `--features voice` and leaves Linux without it,
+# so voice stays on by default everywhere it is free. A Linux user who wants
+# it builds with `--features voice` and the ALSA dev headers
+# (`libasound2-dev` / `alsa-lib-devel`).
 voice = ["wcore-agent/voice"]
 
 [dependencies]

--- a/docs/releases/ANNOUNCEMENT-v0.12.26-rc.2.md
+++ b/docs/releases/ANNOUNCEMENT-v0.12.26-rc.2.md
@@ -1,0 +1,143 @@
+# Wayland Core 0.12.26-rc.2 — the honesty release
+
+**2026-08-05.** Release candidate for 0.12.26. 2,918 commits since 0.12.25:
+250 features, 629 fixes, 519 new tests, 740 documentation changes. The largest
+release we have shipped, and not mostly because of new surface.
+
+```bash
+npm install @ferroxlabs/wayland-core@next
+```
+
+This is a **pre-release**. The stable 0.12.25 line is untouched — a plain
+`npm install @ferroxlabs/wayland-core` still gets you stable.
+
+> **rc.1 was withdrawn before it reached npm.** It shipped a Linux x86_64
+> binary that could not start on a host without ALSA installed, because we put
+> voice in the default feature set and that adds a hard `libasound.so.2`
+> dependency on Linux. Our own release smoke — which runs the published
+> artifact on a clean Rocky Linux 9 — caught it and refused to publish. The tag
+> and pre-release were deleted; nothing reached the registry. rc.2 fixes it and
+> adds the build-time gate that would have caught it on both Linux targets
+> instead of one. We are telling you this rather than quietly renumbering,
+> because that is the entire point of this release.
+
+---
+
+## The short version
+
+We spent this cycle holding the product to one rule: **nothing lies to the
+user, and nothing loses their data.**
+
+That turned out to be a much bigger job than adding features. Most of what
+follows is the product being made to tell the truth about what it can actually
+do.
+
+**Some of this release is us withdrawing claims.** Discord and Slack are now
+documented and enforced as *at-most-once* delivery, because that is what those
+platforms actually do — our exactly-once claim was wrong. Matrix's exactly-once
+guarantee now ships with the precondition it always had. An advertised egress
+safety interlock that did not exist has been removed rather than implemented in
+name only. We think a release note that only lists wins is a release note that
+lies by omission.
+
+## The headlines
+
+**Your credentials.** The plaintext credential fallback is gone, replaced by a
+fail-closed ladder. A host with no secure store now refuses to save a secret
+instead of quietly writing it in the clear — and tells you so. We also found
+and fixed a defect where two concurrent writers could splice two different
+secrets together, with no crash to warn you. Three surfaces that reported a
+*locked* token store as "signed out" now tell the truth.
+
+**Your privacy.** `memory.enabled = false` did not stop memory from recording.
+It does now. A bare `[memory]` block in a repo you cloned could silently undo
+your global opt-out. It cannot now. You can see and switch off exactly what
+memory puts in your prompt.
+
+**Your data survives a crash.** Sessions are crash-complete and durable. A
+clean exit used to write a journal the product could not read back — fixed, and
+older journals recover without loosening the checksum. Backups capture live
+SQLite consistently instead of archiving three files that disagree with each
+other. Skill rollback is atomic instead of rewriting your directory file by
+file.
+
+**Windows is a first-class platform now, not a caveat.** It got the largest
+share of this release. The last release blocker was a Windows defect where a
+read-only accounting scan demanded delete rights, so a live `git` process in
+your checkout would kill a perfectly healthy worker and report the wrong
+reason. Path handling, log rotation, worktree reclaim, the sandbox probe, shell
+quoting, daemon survival — all repaired, and the AppContainer probe went from
+140 ms/op to 68 ms/op under 24-way contention.
+
+**Durable Goals across five engines.** One canonical Goal taxonomy and one
+terminal transition, driven from the shipped binary over Anvil, Council,
+Crucible, ForgeFlows and Direct — controllable from the host protocol, the CLI
+and the TUI, and observable over the JSON stream.
+
+**A gateway you can actually operate.** Exactly-once delivery ledger,
+observable drain, a single-owner inbound lease, and abandoned deliveries you
+can name, acknowledge and re-send instead of losing. Plus `gateway
+support-bundle`, redacted and proved by canary.
+
+**Every MCP server was unusable.** The model was never told a hydrated tool was
+callable. That is fixed.
+
+**Releases you can verify.** A signed release manifest with a role-scoped trust
+root, a deterministic CycloneDX SBOM, keyless Sigstore build provenance on every
+archive, and an updater that binds the download to the signed digest and fails
+closed.
+
+## What we changed about how we work
+
+Several gates in this repo could not fail. One could not pass. Both are equally
+worthless, and we found both.
+
+A deleted failing test used to satisfy the merge gate. A bare `cargo test`
+could report vacuous green. A leg with zero tests read as a pass. The
+anti-vacuity linter we wrote to catch this had never actually run — and found
+four real problems the first time it did. Meanwhile the Windows packaged gate
+had *no reachable pass state at all*, because it demanded kernel resource
+samples that Windows Job Objects never produce.
+
+Where a harness was wrong rather than the product, this release says so. A
+significant number of commits are recorded as instrument repairs, not as
+product fixes, because pretending otherwise would inflate the changelog with
+bugs that never existed.
+
+## Breaking changes
+
+- `--dangerously-skip-permissions` is split into two named tiers, so the flag
+  name shows you when sandbox bypass is included.
+- The plaintext credential fallback is removed.
+- `[default] read_only` now actually enforces.
+- An untrusted project config can no longer raise `max_tokens` / `max_turns`.
+- The egress master switch is operator-owned, not project-negotiable.
+- Discord delivery is at-most-once.
+- OAuth tokens move into the credential ladder.
+- Voice is default-on for macOS and Windows and opt-in on Linux, because
+  linking ALSA means the binary cannot start without it.
+
+## Known open items
+
+We ship the list rather than the impression. Two sibling code paths still
+request delete rights on a read-only walk on Windows — same class as the
+blocker we just closed, deliberately left out of this RC because they are
+unmeasured and measure-then-fix is what worked. A delete-disposition errno is
+still stringified where the new retry cannot read it. Startup log residuals,
+log rotation on the new headless log, two named retry-masked flakes, and a
+dated dependency-suppression expiry are all tracked.
+
+**Full detail:** [`docs/releases/v0.12.26-rc.2.md`](./v0.12.26-rc.2.md)
+
+## Verification
+
+All three platform CI legs green — Windows, Linux, macOS — plus all six release
+target builds, the eval acceptance gate, browser e2e, lint, supply chain, OSV,
+bench regression and the release rehearsal.
+
+The Windows blocker was proven closed with 100/100 live runs on the committed
+tree against a ~33% baseline failure rate, 277/277 on the Windows swarm and
+sandbox suites, and 263/263 on Linux.
+
+Please file anything you hit. An RC is the point at which we most want to be
+told we are wrong.

--- a/docs/releases/v0.12.26-rc.2.md
+++ b/docs/releases/v0.12.26-rc.2.md
@@ -1,0 +1,647 @@
+# Wayland Core v0.12.26-rc.2
+
+**Release candidate — 2026-08-05.** Published as a GitHub **pre-release**;
+npm dist-tag **`next`**, not `latest`.
+
+> ### rc.1 was withdrawn
+>
+> `v0.12.26-rc.1` was tagged, built, and then **withdrawn before npm publish**.
+> Its release and tag were deleted; npm was never published, so no version of
+> it reached the registry.
+>
+> **Why:** the Linux x86_64 artifact could not start on a host without ALSA
+> installed —
+> `libasound.so.2: cannot open shared object file` — because shipping voice in
+> the default feature set put a hard `DT_NEEDED` on `libasound.so.2`. The
+> release pipeline's own executable smoke on rockylinux:9 caught it and
+> correctly refused to publish to npm.
+>
+> rc.2 fixes that (see [Voice](#media-voice-and-vision)) and adds the build-time
+> gate that would have caught it on **both** Linux targets rather than one.
+
+`npm install @ferroxlabs/wayland-core` continues to serve the stable 0.12.25
+line. To take the RC deliberately:
+
+```bash
+npm install @ferroxlabs/wayland-core@next
+```
+
+---
+
+## What this release is
+
+2,918 commits since v0.12.25 — 250 `feat`, 629 `fix`, 519 `test`, 740 `docs`.
+It is the largest release in the project's history and it is overwhelmingly a
+**correctness and honesty** release.
+
+The governing rule for the whole cycle was: **nothing lies to the user, and
+nothing loses their data.** A large fraction of what follows is not new
+surface — it is the product being made to tell the truth about what it can
+actually do, and to stop dropping things it promised to keep.
+
+Three consequences worth stating up front:
+
+1. **Several claims were downgraded, not upgraded.** Discord and Slack are now
+   documented and enforced as *at-most-once*, not exactly-once, because that is
+   what the real platforms do. Matrix's exactly-once guarantee is now stated
+   with its actual precondition. See [Corrections](#corrections-claims-we-withdrew).
+2. **Some defaults changed.** Read-only mode now actually enforces; an
+   untrusted project config can no longer raise your limits; the plaintext
+   credential fallback is gone. See [Breaking changes](#breaking-changes).
+3. **This is an RC.** Known open items are listed at the end rather than
+   omitted.
+
+---
+
+## Table of contents
+
+- [Breaking changes](#breaking-changes)
+- [Corrections — claims we withdrew](#corrections-claims-we-withdrew)
+- [Security](#security)
+- [Privacy](#privacy)
+- [Credentials and authentication](#credentials-and-authentication)
+- [Durable sessions, journal and crash recovery](#durable-sessions-journal-and-crash-recovery)
+- [Goals and orchestration](#goals-and-orchestration)
+- [Channels and the gateway](#channels-and-the-gateway)
+- [Execution backends](#execution-backends)
+- [Sandbox and process containment](#sandbox-and-process-containment)
+- [Windows](#windows)
+- [macOS](#macos)
+- [Media, voice and vision](#media-voice-and-vision)
+- [Cost, budget and cache economics](#cost-budget-and-cache-economics)
+- [Memory and the user model](#memory-and-the-user-model)
+- [Skills](#skills)
+- [MCP](#mcp)
+- [Providers](#providers)
+- [Migration and portability](#migration-and-portability)
+- [Backup, restore and rollback](#backup-restore-and-rollback)
+- [Repository index and search](#repository-index-and-search)
+- [Host protocol and Desktop contract](#host-protocol-and-desktop-contract)
+- [CLI and TUI](#cli-and-tui)
+- [Plugins](#plugins)
+- [Supply chain and release integrity](#supply-chain-and-release-integrity)
+- [Evaluation, certification and evidence](#evaluation-certification-and-evidence)
+- [Refactors](#refactors)
+- [Engineering quality — how we stopped fooling ourselves](#engineering-quality--how-we-stopped-fooling-ourselves)
+- [Known open items](#known-open-items)
+
+---
+
+## Breaking changes
+
+| Change | Why |
+|---|---|
+| **`--dangerously-skip-permissions` split into two named danger tiers** (`--dangerously-skip-permissions` and `--dangerously-skip-permissions-and-sandbox`) | The old single flag silently included sandbox bypass. The superset is now visible in the flag name itself. |
+| **Discord delivery is `at-most-once`**, not exactly-once | Measured at the real platform. The old claim was false. |
+| **Plaintext credential fallback removed** | Replaced by a fail-closed credential ladder. A host with no secure store now refuses to save rather than writing cleartext. |
+| **`[default] read_only` now actually enforces** | It was previously advisory in paths that mattered. |
+| **An untrusted project config can no longer raise `max_tokens` / `max_turns`** | Project-level config could previously widen operator limits. |
+| **The egress master switch is operator-owned** | A project can no longer negotiate it. |
+| **A project `[memory]` block can no longer defeat a global memory opt-out** | Privacy defect: cloning a repo could silently re-enable memory. |
+| **OAuth tokens move into the credential ladder** | They were reachable in cleartext. |
+| **Skills lifecycle opt-out no longer fails open** for untrusted projects | |
+| **`voice` is no longer a default feature on Linux** (it stays default-on for macOS and Windows) | The Linux build linked `libasound.so.2` as a hard `DT_NEEDED`, so the binary could not start at all on a host without ALSA. See [Voice](#media-voice-and-vision). |
+
+---
+
+## Corrections — claims we withdrew
+
+This section exists because a release that only lists wins is a release that
+lies by omission.
+
+- **Discord: exactly-once → at-most-once.** Measured against the real Discord
+  API. The dedup token both adapters send is now actually used rather than
+  discarded, but the platform guarantee is at-most-once and is now stated so.
+- **Slack: at-most-once.** `slack.com` ignores the `Idempotency-Key` header we
+  were sending. Documented and enforced.
+- **Matrix: exactly-once holds only below the message length cap.** Above the
+  cap the transport splits, and the guarantee does not survive. The product now
+  says so and asks the question per message.
+- **`is_concurrency_safe` was unbacked** across 45 declarations, and
+  `doc_tool`'s was false in production. The declaration is now made true rather
+  than asserted.
+- **Advertised safety interlock on egress did not exist.** Removed the
+  advertisement rather than pretending.
+- **KNOWN-ISSUES falsely claimed OAuth tokens are stored in plaintext** after
+  that had been fixed. Corrected.
+- **Browser and CUA capabilities were advertised from linkage, not liveness.**
+  Now advertised only when actually live.
+- **`piper_download` was advertised and did not resolve.** De-advertised.
+
+---
+
+## Security
+
+- **Fail-closed credential ladder** replaces the plaintext fallback entirely;
+  upper tiers are trait objects so a host can supply its own store.
+- **Two concurrent writers could splice two secrets together** in `chunked_put`
+  with no crash required — spanned keyring writes are now serialized across
+  processes and anchored at `wayland_config_dir`.
+- **Remote sandbox bypass rejected**; sandbox bypass cannot be activated by
+  configuration or environment, only by an explicit local Dangerous launch.
+- **Reserved authority** (nine closed actions, one principal, a root that fails
+  closed).
+- **Session authority isolated**; session cancel authority sealed and enforced;
+  session expiry enforced; sandbox runtimes scoped per session.
+- **Managed execution floor** wired, with a runtime approval snapshot ratchet
+  and child-sourced approval request ratcheting.
+- **Trust bound to executable state** rather than declared state.
+- **REST bypass of role gating closed** (F24-E-H1, HIGH).
+- **ssh injection recorded**, its tautological guard replaced, non-exposure
+  proven; every value crossing the ssh boundary is quoted.
+- **Imported executable content classified and contained** under the GHSA-8r7g
+  contract; the execute bit is stripped from imported peer content and that is
+  reported.
+- **Credential scrubbing** made a type invariant rather than a call-site habit,
+  including credentials embedded in free-form plan details.
+- **OCR secret scanning** for contextual and fragmented evidence (CUA).
+- **RUSTSEC-2026-0222** patched (wasmtime 36.0.12 → 36.0.13).
+- **quick-xml suppressions dropped**, closed at source.
+- **Dependency policy actually executed** — it had never once run.
+- **Secrets redacted at capture** in the eval path, with residual sinks closed
+  and the full redaction walk preserved.
+- **Receipt signing secrets wiped.**
+- **Memory prompt injection gated.**
+- **Forged host trust-tags defanged** in persona SOUL.
+
+## Privacy
+
+- **`memory.enabled = false` now actually stops recording.** It previously did
+  not.
+- **A bare `[memory]` block in a cloned repo can no longer undo a global
+  opt-out**, and a refused project opt-in now warns.
+- **Host bypass closed** — `set_memory_api` refuses when memory is off.
+- **Memory activation surface** added: see and switch off what memory puts in
+  your prompt.
+- **Home-path ratchet scoped** to where a home path is actually a bug.
+- **Redacted evidence bundle**, refused whole if any projection leaks.
+- **Personal identifiers scrubbed** from committed evidence.
+
+## Credentials and authentication
+
+- Credential ladder with `auth add` and the TUI key modal routed through it.
+- `get_many` kept positionally aligned across tiers.
+- **Three surfaces stopped reporting a locked token store as "signed out."**
+- A lock must never claim a heartbeat it does not have — heartbeat thread
+  creation failure now propagates instead of silently degrading.
+- Credential name field narrowed to an identifier shape.
+- Keyring writability proven on Windows; dead pins healed.
+- A TUI operator on a keyless host is now told crash replay protection is off.
+- Durable sessions degrade explicitly at startup when no secure store exists,
+  and the product reports **why** they are off, not just that they are.
+- Operators can **require** durable sessions instead of accepting the degrade.
+
+## Durable sessions, journal and crash recovery
+
+- **Crash-complete session persistence**; interrupted turn state sealed; tool
+  effects made crash-durable.
+- `wayland-core session` operator surface and verbs over the session substrate.
+- Journal: storage authority gaps closed, fail-closed on uncertain storage,
+  replay publication races closed, snapshot authority hardened and revalidated,
+  durable stream events retained, serde tag collision avoided.
+- **Clean exit wrote a journal the product could not read back** — fixed, with
+  pre-fix journals recoverable without loosening the checksum.
+- Checksum material hashed **as written**, not as a re-encoding.
+- Compactions published with a rename that can replace an open file.
+- The writer lock no longer blocks Windows readers.
+- One path representation reported from every entry point.
+- Each engine decides whether it can seal, rather than a process global; a host
+  that cannot seal journals without the seal, and the wire **names** the
+  journaled-without-replay session.
+
+## Goals and orchestration
+
+- **Durable Goal kernel** built over the existing F12 chain.
+- **One canonical Goal terminal taxonomy** lifted into `wcore-types`, with a
+  single canonical transition driven from the shipped binary across **all five
+  loop owners** (Anvil, Council, Crucible, ForgeFlows, Direct).
+- Typed **Goal control command set on the host protocol**; the CLI command loop
+  answers them; the TUI issues them and renders refusals; durable Goal state is
+  shown in the terminal.
+- `goal stream` — the host-protocol view of a durable Goal.
+- Durable Goals observable over the JSON stream.
+- **Durable Fleet task ledger with an epoch fence**, wired into the Fleet
+  dispatcher; dependencies enforced at the durable boundary, not only in the
+  query; an agent releasing its own claim must present its own epoch.
+- Loop-owner claim carries a lease so a dead owner cannot deadlock its Goal.
+- Anvil's host-observed gate evidence recorded rather than discarded.
+
+## Channels and the gateway
+
+- **Exactly-once delivery ledger and observable drain state**; drain publishes
+  `Draining` and is bounded by what the runtime can take.
+- **Gateway lifecycle machine** and a Windows-safe instance lock.
+- **Single-owner inbound polling lease** across all three `start_all` sites;
+  the installed service outranks a session and the loser reacquires.
+- **Abandoned deliveries are nameable, acknowledgeable and re-sendable** by an
+  operator, and are exempt from compaction until reviewed.
+- Outcome-unknown deliveries are no longer re-sent to destinations that cannot
+  dedupe.
+- `gateway support-bundle` — redacted operator support bundle, proved by canary.
+- **Typed-client roles, command idempotency, event cursor and negotiation**;
+  role gating has an operator switch and its REST bypass is closed.
+- Per-platform work: Slack (`chat.update`/`chat.delete`, setup probe, auth
+  classifier, bounded start-time `auth.test`), Discord (gateway URL path,
+  rustls CryptoProvider, MESSAGE_CREATE logging, edit/delete, config-level
+  `api_base_url`/`gateway_url`), Telegram (edit/delete, config seam), Matrix
+  (`m.replace`/redaction, `/sync` cursor persisted across restarts), MS Teams
+  (activity PUT/DELETE, inbound attachment parsing, fixture-pointable
+  endpoints), Email (extra TLS trust anchor, reject an empty
+  `tls_root_cert_path`, stop the IMAP poller discarding all but the largest
+  message), WhatsApp (opt-in Node bridge backend seam, probe no longer greens a
+  bridge with no deps or pairing), Twilio + WhatsApp delivery identity on the
+  wire.
+- **Native-action capability declaration** plus a cross-adapter conformance
+  matrix and five declared negative adapters; `channel actions` prints the
+  matrix and can gate on `--require`.
+- Channel health: `Unauthenticated` has a producer; Slack and Discord publish
+  auth rejection from every outbound surface; a probe fails when a config could
+  not be constructed; opt-in channel health gate stops the probe claiming an
+  unmeasured negative.
+- A reloaded channel carries **both** its access policy and its tool posture; a
+  reload no longer erases what it did not re-evaluate.
+- One `ChannelManager` per gateway (it previously started two).
+- Inbound access policy follows `WAYLAND_HOME`; an inbound SMS conversation is
+  the peer, not the bot's number.
+- Cron: leases the schedule so exactly one process fires; every trigger type
+  reachable from the shipped binary; trigger vocabulary, bounded retry and an
+  enforced history cap; the silent-acceptance hole in event/webhook/poll
+  triggers closed; a scheduled channel delivery must address a conversation.
+
+## Execution backends
+
+- **Provider-neutral execution-backend contract** with four reference backends,
+  mirrored into the plugin API.
+- `wayland-core backend` operator surface; `receipt verify --against-backend`
+  checks identity, not just integrity.
+- **Cloud backend actually creates, runs and hibernates a machine**; a
+  cancelled cloud run writes a `Cancelled` receipt.
+- **Node contract with attested attribution.**
+- **Orphan scanner** and a hostile fail-closed matrix; a scanner that cannot
+  see must say so rather than report zero.
+- ssh runner cleans up its task root when the task fails.
+
+## Sandbox and process containment
+
+- **Own and reap process trees** across platforms.
+- Hard-containment authority as an opaque one-use value derived from a live
+  probe; a live `CandidateSeal` bound to an isolated checkout.
+- **Operator-observable containment surface**; the activeness reading can be
+  taken through `sandbox exec` when the delegated path cannot spawn.
+- Handle-relative primitives: lock-file primitive, `rename_into` through the NT
+  primitive, observational directory open without the `DELETE` bit.
+- Delegated mutation workspaces isolated; transactional workers contained;
+  worker worktree paths confined; delegated shell writes bound.
+- AppContainer: execution identities isolated, ACL lease persistence hardened,
+  stale leases reclaimed instead of wedging, 0-byte leases from an interrupted
+  create reclaimed, `fs_read_deny` made a real control via protected-DACL
+  removal, child cwd bound to the retained authority.
+- Tests no longer write leases into the production directory.
+
+## Windows
+
+Windows received the single largest share of this release.
+
+- **The release blocker:** two `ERROR_SHARING_VIOLATION` defects in the swarm
+  workspace lifecycle.
+  1. The **workspace-accounting walk demanded `DELETE` on a read-only scan**, so
+     a live `git` process inside the checkout killed a *healthy* worker and
+     reported the wrong cause. A live product defect, not a test flake.
+  2. **Destructive cleanup now retries** a bounded, errno-gated sharing
+     violation, and once the budget is spent fails exactly as before.
+- Path handling: `\\?\` verbatim prefixes stripped from `lpCurrentDirectory`;
+  swarm roots de-verbatimized (a silent break of the capacity probe); one
+  representation for the transaction root and its authorities; `atomic_write`
+  past `MAX_PATH`; five divergent UNC checks consolidated onto one module.
+- **Log rotation and worktree reclaim actually work.**
+- The AppContainer probe taken off the ready path and off the tokio worker;
+  profile RPCs taken out of the global lock (**140 → 68 ms/op at 24-way**;
+  probe 3381 → 1188 ms); a successful probe shared across processes; a
+  transient probe retried rather than refused, and its refusal carries a cause.
+- Shell: stopped layering argv quoting on the Windows `cmd` command line;
+  `cmd.exe /c|/k` payload quoting; `cmd.exe` matched as an exact final path
+  component.
+- The Windows daemon survives its session; the Windows task recovers a
+  hard-killed gateway; `CTRL_BREAK`/`CTRL_C_EVENT` handler control fires
+  correctly.
+- Missing media ancestor reads as `NotFound`; unopenable grep targets surfaced;
+  identity-aware file observation implemented off Unix.
+- Windows clippy `-D warnings` cleared across newly reachable code.
+
+## macOS
+
+- One spelling for every path that crosses a boundary.
+- A finished root is not a containment failure.
+- The probe closure stays callable twice; probe budget survives signature
+  validation.
+- Symlinked ancestors resolved so macOS temp paths are ingestible.
+- Root-churn discrimination by event **kind** — a blanket root drop had blinded
+  macOS file watching.
+- `kinfo_proc` read by measured offset with a `p_pid` self-check.
+- The acoustic voice suite is honestly gated and given a real self-hosted
+  runner rather than silently passing on a VM that cannot record.
+
+## Media, voice and vision
+
+- **Voice is default-on for macOS and Windows, opt-in on Linux.** Barge-in made
+  real (killable playback, wired interrupt, live readiness gate).
+
+  27-C4 originally put `voice` in the default feature set on all platforms,
+  reasoning that the feature "only *links* the OS audio library" and that a
+  host with no input device still starts cleanly. That conflates two different
+  failures. A missing input **device** is handled — `build_voice_mode_backend`
+  returns `None` and the tool hides. A missing ALSA **library** is not:
+  `alsa-sys` links `libasound.so.2` as a hard `DT_NEEDED`, so the dynamic
+  loader refuses the process before `main` runs. rc.1's Linux artifact could
+  not print `--version` on a stock rockylinux:9.
+
+  `alsa-sys` 0.3.1 offers no dlopen path — its `build.rs` is a bare
+  `pkg_config::probe_library("alsa")` — so the only way a Linux binary starts
+  without ALSA present is to not link it. macOS and Windows have no equivalent
+  exposure (CoreAudio and WASAPI are always present), so `release.yml` builds
+  those four targets with `--features voice` and leaves Linux without it.
+
+  Linux users who want voice build with `--features voice` plus the ALSA dev
+  headers (`libasound2-dev` / `alsa-lib-devel`). The product reports voice as
+  **absent from the build** rather than as a broken device — a fix that landed
+  in this same release.
+- `voice_mode` reported as absent from the build rather than as an unprobed
+  device.
+- **Declared media bounds are now the enforced ones.**
+- Every media intake consolidated onto **one bounded chokepoint**; open-once
+  intake; images gated on the vision record.
+- STT backend and vision backend resolved before config moves into the engine;
+  the transcription resolver can reach a configured OpenAI-wire provider.
+- Per-provider default image model via `ProviderCompat`.
+- MS Teams inbound attachments parsed.
+
+## Cost, budget and cache economics
+
+- **Daily spend ceiling** with a config path and a durable store; a daily-cap
+  refusal no longer latches the session behind a `Continue`.
+- Proactive budget envelopes enforced; a narrowed execution envelope
+  **sub-allocated to delegated children**.
+- Budget grants validated and made idempotent on the protocol.
+- **Cache/compaction ledger** — session-scoped quality, invalidation,
+  token-pressure and cost-truth record — wired into the engine and exposed via
+  `wayland-core cache` (report/list/show/verify).
+- Cost truth records its **source**: a family-rate estimate is not spend.
+- Ledger totals across sessions, because no single session can show
+  restart-fragmented spend.
+- Cost attributed to the **route**, not the compat profile.
+- Media cost accounted for TTS, the three vision backends (including
+  `video_analyze`), every billable transcription call, and the
+  `wayland-core image` subcommand; billing basis declared with token and
+  character units; `media_pricing` merged across global and project config.
+- A declared-free endpoint outranks the catalog price.
+
+## Memory and the user model
+
+- Memory controls put in the user's hands, delegated through the type the CLI
+  holds.
+- **Recall provenance** and operator controls over it.
+- `/memory why` and `/memory correct` show **what** each item says, not just its
+  id; the no-store refusal stays a `SlashError`.
+- Every recall control extended to the semantic partition, with the nudge bound
+  surfaced.
+- `/usermodel` control surface with `show` displaying inferred beliefs marked by
+  origin; a user-authored correction layer with render precedence; the
+  `/memory` nudge facade removed.
+
+## Skills
+
+- **Governed promotion, revocation and rollback on the shipped binary**,
+  surfaced through `/skill govern` with journal events rendered.
+- **Rollback made atomic** — stage, fsync, `rename(2)`. It was previously
+  writing the user's directory file by file.
+- A rollback staging tree is never discovered as a skill.
+- Revoked skills' auto-draft router seeds dropped at hydration.
+- Session catalogs isolated; bundled catalogs isolated per session; generated
+  drafts contained; namespaced drafts classified; lazy visibility revalidated.
+
+## MCP
+
+- **Every MCP server was unusable** — the model was never told a hydrated tool
+  was callable. Fixed, along with both `ToolSearch` defects reported by the
+  Desktop lane.
+- Runtime removal lifecycle; resource-only servers supported; readiness bound to
+  launch context and modelled as executable readiness; connection lifecycle
+  serialized; tools exposed before provider turns; the CLI awaits MCP before the
+  first turn.
+- A corpse-only process group is a completed teardown, not `EPERM`.
+
+## Providers
+
+- **Semantic failover** enforced.
+- Configurable stream timeout.
+- Orphaned stream workers stopped; blind tool-call loops prevented; abandoned
+  health probes recovered.
+- Provider failure types preserved and retry evidence emitted.
+
+## Migration and portability
+
+- Typed, redacted, deterministic **migrate discovery**, with importers for
+  **openclaw, grok and gemini-cli** peers.
+- Every provenance record bound to where the bytes landed; imported data content
+  actually written, and only what was written counted.
+- Quarantine index written atomically; quarantine module path resolution fixed.
+- The containment contract measured at real import scale.
+- A peer profile mapping to neither provider nor model now warns.
+
+## Backup, restore and rollback
+
+- **Backup archive, verify, restore and write-ahead journal.**
+- Live SQLite captured **consistently** into the journal undo store — the trio
+  was previously archived as three independent files, and `restore --replace`
+  had the same torn-SQLite defect on the rollback side.
+- Newer-schema archives refused; older-schema and truncated restores covered;
+  unrestorable archived paths refused before the first write.
+- **Scoped operation journal** — declared scope, absent-set, exact
+  reverse-apply — plus rollback for `migrate`.
+- A dead owner's restore recovered before occupancy and before a new journal.
+- SQLite journal mode selected per filesystem class at every call site.
+
+## Repository index and search
+
+- **`wayland-core index`** — build, status, search, verify.
+- Persistent incremental repomap index with git-respecting scope; WAL
+  checkpointed after a refresh so reported size is steady-state; unknown store
+  schema versions refused explicitly.
+- `index status` reports `semantic status=unavailable` with a reason rather than
+  faking a capability.
+
+## Host protocol and Desktop contract
+
+- **Desktop producer contract sealed**, negotiated, and generated fixtures
+  compared as bytes.
+- Workflow lifecycle ordering, run correlation and terminal absorption; terminal
+  integrity and workflow authority enforced.
+- Wire criticality typed; policy snapshots versioned; incomplete `ready`
+  rejected; a **degraded `ready` is now stated instead of silently dropping
+  `session_id`**.
+- Capability activation typed; capability truth surfaced on the CLI; capability
+  outcomes proven and startup truth reported.
+- Runtime diagnostics wire pinned; truthful runtime state exposed.
+- JSON stream I/O bounded; an error frame emitted when startup refuses.
+- The published Desktop schema made **satisfiable**, unmodelled producer events
+  declared, and both gated.
+
+## CLI and TUI
+
+- Quiet default startup, terminated headless stdout, de-jargoned `--help`.
+- The non-TTY error advised `-p`, which is `--provider` — corrected.
+- Diagnostics log created with the first record rather than at startup, bounded,
+  with the fallback announced.
+- Danger tiers named so the superset is visible in the flag.
+- TUI: the onboarding card no longer appears over a configured session and no
+  longer eats your first message; `SPACE` is prose, not an accelerator;
+  shortcut-vs-prose rule settled so documented shortcuts keep working;
+  formatters read what tools actually emit and never invent a value; `raw_text`
+  no longer trims; the rebound provider and model are mirrored onto the status
+  bar.
+- Durable-Goal control and state reachable from the terminal.
+- `channel actions` table columns widened so `no (platform)` does not shift them.
+- Composer images ingested.
+
+## Plugins
+
+- **Plugin approval is a load-time gate, not a prompt.**
+- Ten missing plugin lifecycle verbs added.
+- `plugins.toml` loaded from disk at engine boot.
+- Both shipped plugin templates unbroken against `cargo-generate`.
+
+## Supply chain and release integrity
+
+- **Signed release manifest** with a role-scoped trust root and a closed
+  four-state ledger; the real FerroxLabs release trust root substituted.
+- `release.yml` wired to publish the signed manifest, drilled end to end.
+- **Deterministic CycloneDX SBOM** from the locked graph.
+- The downloaded archive bound to the digest the manifest signed; an ordered,
+  **fail-closed update decision** in the shipped updater.
+- Release manifest carries the lifecycle facts an attestation cannot.
+- **Rollback rehearsal and state-separation drill** run in CI — including
+  fixing a control that had been passing for the wrong reason.
+- The builder's source path no longer baked into the release binary; full
+  source identity embedded; `--locked` builds restored.
+
+## Evaluation, certification and evidence
+
+The `wcore-eval` and scenario crates account for 98 user-facing commits alone.
+
+- Verifiable receipts built from runs, projected into formats, redacted for
+  reporting, and bound to live fixtures and exact artifacts.
+- Authoritative receipts required; hollow and ambiguous receipt evidence
+  rejected; receipt authority gaps exposed; supersession supported with a
+  refusal to overwrite a signed receipt.
+- Canonical scenario catalog, provider run plans, offline provider plans,
+  platform-specific scenario planning, scenario runtime contracts.
+- Packaged binary identity verified; exact binary scenarios executed and their
+  artifacts sealed.
+- Linux and native process trees owned; cgroup authority enforced; cleanup
+  reaper integration restored; a clean Windows exit no longer graded as `Hung`.
+- **Certification contract, severity rubric and skip taxonomy**; all 60 Phase 28
+  findings adjudicated; the certification receipt signed and verified two
+  independent ways.
+- **Soak harness with VOID rules and a positive control behind every
+  observable.**
+- E5 black-box probe set, marker verifier, results validator, matrix generator
+  with fail-closed construction, candidate resolver reading the surface
+  inventory off the binary.
+- Drift detection (`f28-check-drift.py`), a signed drift ledger and a disclosed
+  supersession.
+- **Scorecard** types, asymmetric verifier and the `wayland-scorecard` binary;
+  surface inventory from the shipped binary with maturity as a truth.
+- Frontier trial harness with three unconstructible forgeries; per-tool dialect
+  compiler and discovery meter; an executable cohort gate that exits non-zero
+  when ineligible.
+- Claims register, checker and renderer; confound and unresolved-ID rules;
+  redacted evidence bundle.
+- **Setup-to-recovery journey driver** and receipt verifier across all three
+  platforms, with the adapter set an explicit parameter and repeats graded by
+  delivery identity rather than message body.
+
+## Refactors
+
+- Credential ladder upper tiers became trait objects.
+- WhatsApp bridge split into `mod`/`preflight`/`rpc` under the 1000-line rule.
+- Five divergent UNC checks consolidated onto one honestly-named module.
+- Every media intake consolidated onto one bounded chokepoint.
+- Journal reducer split from its tests; protocol contract fixture support split.
+- Config resolution provenance preserved.
+- `CEILING_IN_FLIGHT` deleted — an unreachable clamp operand.
+- The provenance builder made readable and its dead fusion wrapper dropped.
+- Task assignment passed into `exec_task` instead of read from process env.
+- Cron/exec-backend state injected per-thread rather than via process env.
+- Eval session inputs grouped.
+
+## Engineering quality — how we stopped fooling ourselves
+
+A recurring theme this cycle was gates that could not fail, or could not pass.
+
+- **A deleted failing test no longer satisfies the merge gate.**
+- **Bare `cargo test` vacuous-green hole closed**, with an anti-vacuity linter
+  that requires nextest, `--no-run`, or an explicit annotation. The gate itself
+  had never run — and had four real findings when it did.
+- **Zero tests is no longer reported as green** on the Windows soak or any leg;
+  each leg asserts it produced test signal.
+- Gates that could **never pass** were found and fixed — the packaged driver
+  gate on Windows (identified by SHA-256 of the hashed receipt), and the
+  authority-evidence gate that demanded kernel resource samples Windows Job
+  Objects never produce.
+- Positive controls added behind observables; instrument repairs separated from
+  product findings throughout (a large number of "the harness was wrong, not the
+  product" commits are recorded honestly rather than quietly dropped).
+- Retried-away failures no longer have their output discarded.
+- **A shared-library gate now runs on both Linux targets at build time.** The
+  existing glibc-floor check reads SYMBOL versions and says nothing about whole
+  shared objects the loader must find — which is why it passed on an artifact
+  carrying `NEEDED libasound.so.2` that could not start. The executable smoke
+  did catch it, but only on `x86_64-unknown-linux-gnu`: the aarch64 artifact is
+  never executed at all, its smoke checking file size and the ELF `e_machine`
+  byte. One of two Linux targets was covered, by a check that ran after
+  packaging. The new gate reads `DT_NEEDED` directly against an explicit
+  allowlist, on both targets, before packaging — and carries a self-test that
+  proves it rejects `libasound.so.2` before it is trusted.
+- Contract corpus regenerated and its extractors fixed — the DEFERRED gate had
+  been accepting prose as a declaration and self-passing.
+
+---
+
+## Known open items
+
+Recorded rather than omitted. None is release-gating for an RC.
+
+- **Two sibling read-walks still request `DELETE` on Windows** —
+  `worktree/candidate.rs:462` and `worktree/parent.rs:1415`. Same defect class
+  as the accounting fix above; excluded from this RC because they are
+  unmeasured, and measure-then-fix is the discipline that closed the blocker.
+- **`mark_open_object_for_delete` embeds its errno as text**, so a sharing
+  violation landing on the delete disposition rather than the open is invisible
+  to the new retry. Never observed in any instrumented run.
+- Startup log spew residuals; log rotation on the new headless log file.
+- `deny.toml` suppressions carry a dated expiry of 2026-09-02.
+- Windows journey: the default adapter set still cannot pass honestly.
+- Two retry-masked test flakes remain named and tracked.
+
+See the repository issue tracker for the full list.
+
+---
+
+## Verification for this RC
+
+| check | result |
+|---|---|
+| CI — Windows (`CI (Array)`) | pass |
+| CI — Linux containerized | pass |
+| CI — macOS | pass |
+| Six release target builds | pass |
+| Browser live e2e, Eval acceptance gate (F01) | pass |
+| Lint, Supply Chain, OSV Scanner, Bench regression | pass |
+| Release Rehearsal, macOS native suites | pass |
+| Windows live reproducer, committed tree | 100/100 (baseline ~33% failure) |
+| Windows `nextest`, swarm + sandbox | 277/277 |
+| Linux `nextest`, swarm + sandbox | 263/263 |
+
+Release archives carry keyless Sigstore build-provenance attestations; npm
+packages publish with `--provenance`. `wayland-core self-update` verifies the
+attestation with `gh attestation verify` and **fails closed** if `gh` is absent.


### PR DESCRIPTION
rc.1 shipped a Linux x86_64 binary that could not start on a host without ALSA — `libasound.so.2: cannot open shared object file`. The dynamic loader refused the process before `main`; `--version` did not print. Our own release smoke on rockylinux:9 caught it and correctly skipped the npm publish. The rc.1 tag and pre-release are withdrawn; nothing reached the registry.

**Cause.** 27-C4 put `voice` in the default feature set on the reasoning that it "only *links* the OS audio library." A missing input *device* is handled; a missing ALSA *library* is fatal, because alsa-sys links libasound as a hard DT_NEEDED. `wcore-agent`'s own Cargo.toml had it right — OFF by default so the binary does not link the OS audio library.

**Why not dlopen.** alsa-sys 0.3.1 has no such path (`build.rs` is a bare `pkg_config::probe_library("alsa")`). Lazy loading means forking the crate.

**Fix.** `voice` leaves the defaults; release.yml enables it for the four macOS/Windows targets where CoreAudio and WASAPI are always present. Voice stays default-on everywhere it is free.

**New gate.** The glibc-floor check reads symbol versions, not whole shared objects, so it passed this artifact. The executable smoke only runs for x86_64 — aarch64 is never executed. A build-time step now reads DT_NEEDED against an allowlist on **both** Linux targets, with a self-test proving it rejects libasound before it is trusted.

**Verified both directions** on hetzner, in the same almalinux:9 container CI uses and the same rockylinux:9 that rejected rc.1:
- fixed: 8 DT_NEEDED entries, no libasound; `wayland-core 0.12.26`, exit 0
- ablation with `--features voice`: libasound returns, same smoke fails exit 127

clippy `-p wcore-cli --all-targets -D warnings` clean without the feature.