### PR TITLE
docs(release): record the read-tool deny-list fix and three known issues

### DIFF
--- a/docs/releases/v0.12.26-rc.2.md
+++ b/docs/releases/v0.12.26-rc.2.md
@@ -132,6 +132,18 @@ lies by omission.
 
 ## Security
 
+- **The credential deny-list is now enforced on every read tool, not just
+  `Read`.** `Read` refused `/etc/shadow` and `~/.ssh/id_rsa`; `Grep`, `Glob` and
+  `Bash` never consulted the same list, so the boundary was enforced on one tool
+  and walked around with its siblings — and `Grep` returns matched line CONTENT,
+  not just names. Four paths closed: `Read` of the per-process procfs subtree
+  (`/proc/self/environ` returned the agent's own provider keys), `Grep` and
+  `Glob` at a deny-listed target, and `Bash` running `cat /proc/self/environ` —
+  the same environment dump `env` and `printenv` were already refused for. The
+  check is extracted to one shared `validate_search_root` so a fifth tool cannot
+  repeat the pattern. Every guard is mutation-confirmed, and each refusal test
+  is paired with a negative control so a guard that refuses everything cannot
+  pass. See "Known open items" for the recursive-parent residual.
 - **Fail-closed credential ladder** replaces the plaintext fallback entirely;
   upper tiers are trait objects so a host can supply its own store.
 - **Two concurrent writers could splice two secrets together** in `chunked_put`
@@ -618,6 +630,24 @@ Recorded rather than omitted. None is release-gating for an RC.
 - **`mark_open_object_for_delete` embeds its errno as text**, so a sharing
   violation landing on the delete disposition rather than the open is invisible
   to the new retry. Never observed in any instrumented run.
+- **Swarm dispatch over-reserves workspace.** Dispatching N workers demands a
+  flat 8 GiB each plus a 512 MiB margin regardless of how large the repository
+  actually is, so four workers require 32.5 GiB free even on a one-commit repo.
+  A measured-reservation fix was written for this release and **withdrawn before
+  the cut**: it charged its floor to every retained workspace rather than only
+  the new one, which made admission unsatisfiable near the 256-worktree quota on
+  any host with less than ~128 GiB free. The real fix separates "how many exist"
+  from "how many are being created" and is scheduled for 0.12.27.
+- **The Grep/Glob credential deny-list covers direct targets, not recursive
+  parents.** `Grep {path:"/etc/shadow"}` is refused; `Grep {path:"/etc"}` is not
+  filtered per entry. Per-entry filtering is not uniformly available across the
+  `rg`/`grep`/`findstr` backends, and implementing it for `rg` alone would make
+  the boundary depend on which binary happens to be installed. Deliberate, and
+  recorded at `path_validation::validate_search_root`.
+- **`Windows live-acceptance` is a permanently-red gate.** It has failed every
+  soak run in recorded history on `concurrent_allow_and_deny_identities_do_not_
+  interfere`. A gate that has never passed cannot distinguish a regression from
+  the status quo, so it currently neither blocks nor certifies anything.
 - Startup log spew residuals; log rotation on the new headless log file.
 - `deny.toml` suppressions carry a dated expiry of 2026-09-02.
 - Windows journey: the default adapter set still cannot pass honestly.


### PR DESCRIPTION
Docs-only, for the 0.12.26 cut.

**Security section** — the four credential-disclosure paths closed in #260 (Read procfs, Grep, Glob, Bash `/proc/*/environ`), the shared `validate_search_root` extraction, and the note that every guard is mutation-confirmed with negative controls.

**Known open items** — three things found overnight that we chose to ship with, each stated with its reason rather than omitted:

1. **Swarm workspace over-reservation.** 4 workers demand 32.5 GiB on a one-commit repo. Includes why the measured-reservation fix was *withdrawn* before the cut: it charged its floor to every retained workspace instead of only the new one, making admission unsatisfiable near the 256-worktree quota below ~128 GiB free. Real fix (separating existing-vs-new worker counts) scheduled for 0.12.27.
2. **Grep/Glob deny-list covers direct targets, not recursive parents.** With the reasoning for why per-entry filtering was not done: it is not uniform across rg/grep/findstr, and doing it for rg alone would make the boundary depend on which binary is installed.
3. **`Windows live-acceptance` is a permanently-red gate** — failed every soak run in recorded history, so it can neither block nor certify.