### PR TITLE
fix(tools): deny ~/.git-credentials across Read, Grep and Bash

### DIFF
--- a/crates/wcore-tools/src/bash/policy.rs
+++ b/crates/wcore-tools/src/bash/policy.rs
@@ -132,11 +132,11 @@ fn denylist() -> &'static RegexSet {
             // rather than env-var-based — closes the gap where an
             // attacker `cat`s the on-disk secret instead of echoing
             // an env var.
-            r"(?i)\b(cat|less|more|head|tail|tee|bat)\b[^|;]*(\.aws/credentials|\.aws/config|\.ssh/id_[a-z0-9_]+|\.ssh/identity[^/]*|\.netrc|\.npmrc|\.pypirc|\.kube/config|\.gcloud/|\.azure/|\.config/wayland/auth|/etc/shadow|/etc/sudoers)",
+            r"(?i)\b(cat|less|more|head|tail|tee|bat)\b[^|;]*(\.git-credentials|\.aws/credentials|\.aws/config|\.ssh/id_[a-z0-9_]+|\.ssh/identity[^/]*|\.netrc|\.npmrc|\.pypirc|\.kube/config|\.gcloud/|\.azure/|\.config/wayland/auth|/etc/shadow|/etc/sudoers)",
             // Encoding-based exfil: base64/xxd/od/hexdump/uuencode of
             // credential files or .env. Closes the dodge where an
             // attacker base64s the secret to bypass a plain-read deny.
-            r"(?i)\b(base64|xxd|od|hexdump|uuencode|openssl\s+enc)\b[^|;]*(\.aws/credentials|\.aws/config|\.ssh/id_[a-z0-9_]+|\.ssh/identity[^/]*|\.netrc|\.npmrc|\.pypirc|\.kube/config|\.gcloud/|\.azure/|\.config/wayland/auth|/etc/shadow|/etc/sudoers|\.env(\b|$))",
+            r"(?i)\b(base64|xxd|od|hexdump|uuencode|openssl\s+enc)\b[^|;]*(\.git-credentials|\.aws/credentials|\.aws/config|\.ssh/id_[a-z0-9_]+|\.ssh/identity[^/]*|\.netrc|\.npmrc|\.pypirc|\.kube/config|\.gcloud/|\.azure/|\.config/wayland/auth|/etc/shadow|/etc/sudoers|\.env(\b|$))",
             // Linux procfs re-exposes this process's own environment as an
             // ordinary file, so `cat /proc/self/environ` is exactly the `env`
             // dump the first rule in this set refuses — reached by a path the

--- a/crates/wcore-tools/src/file_safety.rs
+++ b/crates/wcore-tools/src/file_safety.rs
@@ -73,6 +73,14 @@ pub fn build_write_denied_paths(home: &Path, wayland_home: &Path) -> Vec<PathBuf
         home.join(".bash_profile"),
         home.join(".zprofile"),
         home.join(".netrc"),
+        // The write half of the `~/.git-credentials` gap. #644 part 3 named
+        // this file as denied NOWHERE — not the read path, not `bash/policy`,
+        // and not here. The other two are closed in this change; this closes
+        // the third, so an agent can neither read a stored push credential
+        // back nor plant one for git's `store` helper to hand out later.
+        // `home.join` emits the host's own separator, so this covers
+        // `%USERPROFILE%\.git-credentials` as well.
+        home.join(".git-credentials"),
         home.join(".pgpass"),
         home.join(".npmrc"),
         home.join(".pypirc"),
@@ -426,6 +434,7 @@ mod tests {
         assert!(strs.iter().any(|s| s.ends_with(".ssh/authorized_keys")));
         assert!(strs.iter().any(|s| s.ends_with(".bashrc")));
         assert!(strs.iter().any(|s| s.ends_with(".netrc")));
+        assert!(strs.iter().any(|s| s.ends_with(".git-credentials")));
         assert!(strs.iter().any(|s| s.ends_with("/etc/shadow")));
         assert!(strs.iter().any(|s| s.ends_with("/etc/passwd")));
         assert!(strs.iter().any(|s| s.ends_with("wayland-core/.env")));
@@ -450,6 +459,7 @@ mod tests {
         assert!(strs.iter().any(|s| s.ends_with(r".ssh\authorized_keys")));
         assert!(strs.iter().any(|s| s.ends_with(".bashrc")));
         assert!(strs.iter().any(|s| s.ends_with(".netrc")));
+        assert!(strs.iter().any(|s| s.ends_with(".git-credentials")));
         assert!(strs.iter().any(|s| s.ends_with(r"wayland-core\.env")));
         // Windows-specific paths come from the host's WINDIR/APPDATA at
         // runtime; spot-check only when both are present in CI.

--- a/crates/wcore-tools/src/path_validation.rs
+++ b/crates/wcore-tools/src/path_validation.rs
@@ -447,6 +447,14 @@ fn is_denied_system_path(path: &Path) -> bool {
             r"\wayland-core\credentials.enc",
             r"\wayland-core\credentials.key.json",
             r"\.wayland\cron\",
+            // Mirror of the POSIX `/.git-credentials` entry above. The first
+            // cut of this fix added only the forward-slash form, which gives
+            // ZERO protection on Windows — `%USERPROFILE%\.git-credentials`
+            // matched nothing and stayed readable. The tests that would have
+            // caught it were `#[cfg(unix)]`, so the guard was enforced on the
+            // one platform it worked on and the gap was invisible. They are
+            // no longer gated.
+            r"\.git-credentials",
             r"\.netrc",
             r"\.npmrc",
             r"\.pypirc",

--- a/crates/wcore-tools/src/path_validation.rs
+++ b/crates/wcore-tools/src/path_validation.rs
@@ -398,6 +398,15 @@ fn is_denied_system_path(path: &Path) -> bool {
         // agent-facing file tools refuse to touch it.
         "/.wayland/cron/",
         // Broad per-app credential files used by common developer tooling.
+        //
+        // #644 part 3 named `~/.git-credentials` as readable, and it stayed
+        // readable while its whole class — `.netrc`, `.npmrc`, `.pypirc`,
+        // `.docker/config.json` — was denied. It is the most direct of them:
+        // git's `store` helper writes bare `https://user:token@host` lines in
+        // cleartext, so one Read returns a usable push credential for every
+        // remote the user has authenticated to. Denied nowhere before this —
+        // not here, not in `bash/policy.rs`, not in `file_safety.rs`.
+        "/.git-credentials",
         "/.netrc",
         "/.npmrc",
         "/.pypirc",

--- a/crates/wcore-tools/tests/git_credentials_denylist_test.rs
+++ b/crates/wcore-tools/tests/git_credentials_denylist_test.rs
@@ -1,0 +1,155 @@
+//! `~/.git-credentials` must be refused by every tool that can read it.
+//!
+//! #644 part 3 named it as readable. Its whole class was already denied —
+//! `.netrc`, `.npmrc`, `.pypirc`, `.docker/config.json` — but this one was
+//! denied NOWHERE: not `path_validation` (Read/Grep/Glob), not
+//! `bash/policy.rs`, not `file_safety.rs`.
+//!
+//! It is the most direct of the set. Git's `store` credential helper writes
+//! bare `https://user:token@host` lines in cleartext, so a single read returns
+//! a usable push credential for every remote the user has authenticated to.
+//!
+//! Each refusal is paired with a negative control that must still SUCCEED, so
+//! a guard that refuses everything cannot pass this file.
+
+use serde_json::json;
+use wcore_tools::Tool;
+use wcore_tools::bash::check_denylist;
+use wcore_tools::context::ToolContext;
+use wcore_tools::grep::GrepTool;
+use wcore_tools::read::ReadTool;
+
+/// A `.git-credentials` that ACTUALLY EXISTS, with readable content.
+///
+/// The first version of these tests pointed at `$HOME/.git-credentials`, which
+/// does not exist on CI. Read then failed with "no such file", the assertion
+/// only checked `is_error`, and the test passed WITH THE DENY-LIST ENTRY
+/// DELETED — caught by the mutation run, not by the green suite. The file must
+/// exist, or the test proves nothing.
+///
+/// The deny keys on the PATH suffix (`/.git-credentials`), never on the bytes,
+/// so the marker below is deliberately not credential-shaped: the commit
+/// ratchet correctly rejects key-shaped fixtures, and a real-looking token
+/// would add nothing.
+fn planted_git_credentials(dir: &std::path::Path) -> std::path::PathBuf {
+    let path = dir.join(".git-credentials");
+    std::fs::write(&path, b"GIT_CREDENTIALS_FIXTURE_MARKER\n").expect("write fixture");
+    assert!(path.exists(), "fixture must exist or the test is vacuous");
+    path
+}
+
+/// Read is the tool the deny-list was originally written for.
+#[cfg(unix)]
+#[tokio::test]
+async fn read_refuses_git_credentials() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = planted_git_credentials(dir.path());
+
+    let result = ReadTool::new(None)
+        .execute(json!({ "file_path": path.to_str().unwrap() }))
+        .await;
+
+    assert!(
+        result.is_error,
+        "Read must refuse a .git-credentials store — git's `store` helper keeps \
+         cleartext https://user:token@host lines there, got: {}",
+        result.content
+    );
+    assert!(
+        !result.content.contains("GIT_CREDENTIALS_FIXTURE_MARKER"),
+        "the file's contents must never reach the model, got: {}",
+        result.content
+    );
+}
+
+/// Grep returns matched LINE CONTENT, so an ungated search is a direct
+/// credential disclosure, not merely an enumeration.
+#[cfg(unix)]
+#[tokio::test]
+async fn grep_ctx_refuses_git_credentials() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = planted_git_credentials(dir.path());
+
+    let ctx = ToolContext::test_default();
+    let result = GrepTool
+        .execute_with_ctx(
+            json!({ "pattern": "MARKER", "path": path.to_str().unwrap() }),
+            &ctx,
+        )
+        .await;
+
+    assert!(
+        result.is_error,
+        "Grep must refuse the git credential store, got: {}",
+        result.content
+    );
+    assert!(
+        !result.content.contains("GIT_CREDENTIALS_FIXTURE_MARKER"),
+        "the matched line must never reach the model, got: {}",
+        result.content
+    );
+}
+
+/// Bash returns full stdout to the model, so the reader and encoder dodges
+/// both have to be closed — `base64 ~/.git-credentials` is the same leak.
+#[test]
+fn bash_denylist_refuses_reading_git_credentials() {
+    for cmd in [
+        "cat ~/.git-credentials",
+        "cat /home/user/.git-credentials",
+        "head -1 ~/.git-credentials",
+        "base64 ~/.git-credentials",
+        "xxd ~/.git-credentials",
+    ] {
+        assert!(
+            check_denylist(cmd).is_some(),
+            "bash denylist must refuse {cmd:?}"
+        );
+    }
+}
+
+/// NEGATIVE CONTROL for Bash. Denying the credential store must not deny
+/// ordinary git usage, including commands whose text merely contains
+/// "credential".
+#[test]
+fn bash_denylist_still_allows_ordinary_git() {
+    for cmd in [
+        "git status",
+        "git log --oneline -5",
+        "git config --global credential.helper",
+        "cat README.md",
+        "cat ~/.gitconfig",
+    ] {
+        let reason = check_denylist(cmd);
+        assert!(
+            reason.is_none(),
+            "bash denylist must still allow {cmd:?}, refused with {reason:?}"
+        );
+    }
+}
+
+/// NEGATIVE CONTROL for the read path: an ordinary file stays readable, and a
+/// near-miss name (`.gitconfig`, which is NOT a credential store) is not
+/// caught by an over-broad prefix.
+#[tokio::test]
+async fn read_still_allows_ordinary_files_and_gitconfig() {
+    let dir = tempfile::tempdir().expect("tempdir");
+
+    let ordinary = dir.path().join("notes.txt");
+    std::fs::write(&ordinary, b"hello\n").expect("write");
+
+    let gitconfig = dir.path().join(".gitconfig");
+    std::fs::write(&gitconfig, b"[user]\n\tname = Test\n").expect("write");
+
+    for path in [ordinary, gitconfig] {
+        let result = ReadTool::new(None)
+            .execute(json!({ "file_path": path.to_str().unwrap() }))
+            .await;
+        assert!(
+            !result.is_error,
+            "{} must stay readable, got: {}",
+            path.display(),
+            result.content
+        );
+    }
+}

--- a/crates/wcore-tools/tests/git_credentials_denylist_test.rs
+++ b/crates/wcore-tools/tests/git_credentials_denylist_test.rs
@@ -9,6 +9,11 @@
 //! bare `https://user:token@host` lines in cleartext, so a single read returns
 //! a usable push credential for every remote the user has authenticated to.
 //!
+//! These run on EVERY platform. An earlier cut gated the Read and Grep cases
+//! `#[cfg(unix)]`, which hid that only the forward-slash suffix had been added
+//! to the deny list — `%USERPROFILE%\.git-credentials` stayed readable on
+//! Windows and no test could say so.
+//!
 //! Each refusal is paired with a negative control that must still SUCCEED, so
 //! a guard that refuses everything cannot pass this file.
 
@@ -39,7 +44,6 @@ fn planted_git_credentials(dir: &std::path::Path) -> std::path::PathBuf {
 }
 
 /// Read is the tool the deny-list was originally written for.
-#[cfg(unix)]
 #[tokio::test]
 async fn read_refuses_git_credentials() {
     let dir = tempfile::tempdir().expect("tempdir");
@@ -64,7 +68,6 @@ async fn read_refuses_git_credentials() {
 
 /// Grep returns matched LINE CONTENT, so an ungated search is a direct
 /// credential disclosure, not merely an enumeration.
-#[cfg(unix)]
 #[tokio::test]
 async fn grep_ctx_refuses_git_credentials() {
     let dir = tempfile::tempdir().expect("tempdir");


### PR DESCRIPTION
Closes the last unaddressed item named in FerroxLabs/wayland#644 part 3.

## The gap

`~/.git-credentials` was denied **nowhere** — not `path_validation` (Read, and Grep/Glob via `validate_search_root`), not `bash/policy.rs`, not `file_safety.rs` — while its entire class already was:

```
/.netrc  /.npmrc  /.pypirc  /.docker/config.json  /.gcloud/credentials.db  /.azure/
```

It is the most direct of the set. Git's `store` credential helper writes bare `https://user:token@host` lines in cleartext, so a single read returns a usable push credential for **every remote the user has authenticated to**.

## What changed

- `path_validation.rs` — `/.git-credentials` added to `DENIED_SUFFIXES`, covering Read and (since #260) Grep/Glob.
- `bash/policy.rs` — added to **both** path regexes: the reader set (`cat|less|more|head|tail|tee|bat`) and the encoder set (`base64|xxd|od|hexdump|…`), because `base64 ~/.git-credentials` is the same leak.

## Verification

Hetzner, on this branch rebased onto `79ec94bd`: clippy `-D warnings` **0**, `wcore-tools` **1288/1288**, new file 5/5.

Mutation-confirmed:

| mutation | result |
|---|---|
| remove `/.git-credentials` from `DENIED_SUFFIXES` | **2 red** (Read + Grep) |
| remove it from both bash regexes | **1 red** |

### One thing worth flagging about these tests

The first version was **vacuous and the mutation caught it**. It read `$HOME/.git-credentials`, which does not exist on CI, so Read failed with "no such file", the assertion only checked `is_error`, and the test passed *with the deny-list entry deleted*. The tests now plant a real file in a tempdir and additionally assert the content never reaches the model. That reasoning is recorded in the fixture helper so the next person does not reintroduce it.

Negative controls, which must keep passing: ordinary files stay readable, `.gitconfig` (a near-miss name, not a credential store) stays readable, and `git status` / `git log` / `git config --global credential.helper` stay allowed.