### PR TITLE
docs(release): correct the soak figure to the tagged tree

### DIFF
--- a/docs/releases/v0.12.26.md
+++ b/docs/releases/v0.12.26.md
@@ -459,7 +459,15 @@ it states:
 | Windows live reproducer, committed tree | 100/100 (baseline ~33% failure) |
 | Windows `nextest`, swarm + sandbox | 277/277 |
 | Linux `nextest`, swarm + sandbox | 263/263 |
-| Full soak on the release tree | 2,017 / 2,018 |
+| Full soak, measured on the `v0.12.26` tag | 2,019 / 2,020 run (3,265 collected, 75 skipped) |
+
+The soak figure above was re-measured against the tagged tree rather than carried
+over. An earlier draft of this table quoted `2,017 / 2,018`, which was a real
+result — but of `6b50bb28`, a tree that never shipped. The suite grew between
+that commit and the tag. The single failure is unchanged and is the swarm
+workspace over-reservation defect named under
+[Next up in 0.12.27](#next-up-in-01227): known, deliberately reverted before the
+cut, not introduced by this release.
 
 Issue #942 (Windows Bash producing no output) was re-measured against the
 shipped artifact on real Windows 11 build 26200: the reporter's exact command


### PR DESCRIPTION
The v0.12.26 notes quoted a soak of `2,017 / 2,018`. That was a real measurement of `6b50bb28` — a tree that never shipped.

Re-measured against the `v0.12.26` tag (run `31238757610`, ref `v0.12.26`):

```
2020/3265 tests run: 2019 passed (2 slow), 1 failed, 75 skipped
```

Single failure is `wcore-swarm::dispatch_smoke dispatches_4_noop_workers_in_parallel` — the swarm workspace over-reservation defect deliberately reverted before the cut and already named under "Next up in 0.12.27". Not new, not introduced.

Docs only.