### PR TITLE
fix(agent): deny approval prompt on EOF, not approve

### DIFF
--- a/crates/wcore-agent/src/confirm.rs
+++ b/crates/wcore-agent/src/confirm.rs
@@ -144,9 +144,22 @@ impl ToolConfirmer {
         // semantics for interactive callers.
         let _ = io::stderr().flush();
 
+        self.decide_from_answer(tool_name, &mut io::stdin().lock())
+    }
+
+    /// Read one answer from `reader` and map it to a decision.
+    ///
+    /// Split out of `check_for` so the mapping is testable without a real
+    /// TTY. EOF is the security-critical case: `read_line` reports it as
+    /// `Ok(0)`, not `Err`, and leaves `input` empty. Falling through to the
+    /// empty-line "yes" default would turn a closed stdin — Ctrl-D at the
+    /// prompt, or a pipe that ended — into consent that was never given, so
+    /// EOF fails closed exactly like an I/O error.
+    fn decide_from_answer<R: BufRead>(&mut self, tool_name: &str, reader: &mut R) -> ConfirmResult {
         let mut input = String::new();
-        if io::stdin().lock().read_line(&mut input).is_err() {
-            return ConfirmResult::Denied;
+        match reader.read_line(&mut input) {
+            Ok(0) | Err(_) => return ConfirmResult::Denied,
+            Ok(_) => {}
         }
 
         match input.trim().to_lowercase().as_str() {
@@ -306,6 +319,43 @@ mod tests {
             assert!(confirmer.requires_confirmation_for("AskUserQuestion", ToolCategory::Info));
             assert!(confirmer.approval_is_input_bound("AskUserQuestion"));
         }
+    }
+
+    // Ctrl-D at the approval prompt must NOT approve the tool. `read_line`
+    // reports EOF as `Ok(0)`, never `Err`, so the old `is_err()` guard fell
+    // straight through to the `"" => Approved` arm: closing stdin granted
+    // consent the user never gave.
+    #[test]
+    fn eof_at_prompt_is_denied_not_approved() {
+        let mut confirmer = ToolConfirmer::new(false, vec![]);
+        let mut eof = io::Cursor::new(Vec::new());
+        assert_eq!(
+            confirmer.decide_from_answer("Bash", &mut eof),
+            ConfirmResult::Denied,
+            "EOF (Ctrl-D / closed stdin) must fail closed, not be read as the \
+             empty-line default"
+        );
+    }
+
+    // The boundary the fix turns on: an empty LINE is a real answer and keeps
+    // its historical "yes" meaning, while EOF is the absence of any answer.
+    // Both leave `input` empty after trimming, so only the `Ok(0)` vs `Ok(n)`
+    // distinction separates them.
+    #[test]
+    fn empty_line_still_approves_but_eof_does_not() {
+        let mut confirmer = ToolConfirmer::new(false, vec![]);
+        let mut newline = io::Cursor::new(b"\n".to_vec());
+        assert_eq!(
+            confirmer.decide_from_answer("Bash", &mut newline),
+            ConfirmResult::Approved,
+            "pressing Enter is an affirmative answer and must stay Approved"
+        );
+        let mut eof = io::Cursor::new(Vec::new());
+        assert_eq!(
+            confirmer.decide_from_answer("Bash", &mut eof),
+            ConfirmResult::Denied,
+            "EOF is the absence of an answer and must not share Enter's default"
+        );
     }
 
     #[test]

--- a/crates/wcore-agent/src/orchestration/d1_refusal_terminal_tests.rs
+++ b/crates/wcore-agent/src/orchestration/d1_refusal_terminal_tests.rs
@@ -203,7 +203,7 @@ async fn approval_denial_control_leaves_turn_committable() {
 
     let denied_block = ContentBlock::ToolResult {
         tool_use_id: "d1-denial".into(),
-        content: "Tool execution denied by user".into(),
+        content: "Tool execution denied: approval was not granted".into(),
         is_error: true,
     };
     let denied = record_terminal_denial(

--- a/crates/wcore-agent/src/orchestration/mod.rs
+++ b/crates/wcore-agent/src/orchestration/mod.rs
@@ -877,7 +877,11 @@ fn confirm_call(
         ConfirmResult::Approved => Ok(ConfirmedCall::Execute { approval_bound }),
         ConfirmResult::Denied => Ok(ConfirmedCall::Denied(ContentBlock::ToolResult {
             tool_use_id: id.clone(),
-            content: "Tool execution denied by user".to_string(),
+            // Not "denied by user": `ToolConfirmer` also denies when there
+            // is no interactive terminal to ask, and on EOF at the prompt.
+            // The message must not assert a human decision that never
+            // happened — it reports the outcome, approval was not granted.
+            content: "Tool execution denied: approval was not granted".to_string(),
             is_error: true,
         })),
         ConfirmResult::Quit => Err(ExecutionControl::Quit),

--- a/crates/wcore-agent/tests/orchestration_test.rs
+++ b/crates/wcore-agent/tests/orchestration_test.rs
@@ -172,7 +172,7 @@ async fn concurrent_confirmation_preserves_original_result_order() {
             is_error,
         } => {
             assert_eq!(tool_use_id, "id-denied");
-            assert_eq!(content, "Tool execution denied by user");
+            assert_eq!(content, "Tool execution denied: approval was not granted");
             assert!(*is_error);
         }
         other => panic!("expected ToolResult, got {other:?}"),


### PR DESCRIPTION
Closes the approval prompt's EOF handling.

## The defect
`confirm.rs` guarded the read with `read_line(...).is_err()`. **`read_line` reports EOF as `Ok(0)`, never `Err`**, and leaves the buffer empty — so EOF fell through to the `match input.trim() { "y" | "yes" | "" => Approved }` arm.

**Pressing Ctrl-D at an approval prompt approved the tool.** So did a closed stdin or an ended pipe. Consent that was never given.

```rust
-  if io::stdin().lock().read_line(&mut input).is_err() {
+  match reader.read_line(&mut input) {
+      Ok(0) | Err(_) => return ConfirmResult::Denied,
```

The read/decide mapping moved into `decide_from_answer<R: BufRead>` so the EOF path is reachable from a test at all — the non-TTY branch returns before the prompt renders, so there was otherwise no seam.

## Also fixed
`orchestration/mod.rs` emitted **"Tool execution denied by user"** on the non-TTY branch, where no user was asked. Now "Tool execution denied: approval was not granted". The word *denied* is kept deliberately — `typed_execution_policy_e2e_test.rs:70` matches on `contains("denied")`.

## Two sub-claims REFUTED, deliberately not "fixed"
- Piping `n` does **not** run the tool: `confirm.rs:126` already denies on `!is_terminal()` before the prompt renders.
- The TTY block is a documented interactive choice, not this defect.

## Verification
- `cargo test -p wcore-agent`: **3441 passed, 0 failed**, 10 ignored, 178 binaries.
- Red arm: reverted to `is_err()`, `touch`ed, **grep-confirmed the mutation landed on code at line 160** — not the comment at 325 that quotes `is_err()`. Result:
  ```
  assertion `left == right` failed: EOF (Ctrl-D / closed stdin) must fail closed,
  not be read as the empty-line default
    left: Approved
   right: Denied
  ```
  That is the symptom itself, not a compile break.
- `clippy -p wcore-agent --all-targets -- -D warnings` exit 0; `fmt --check` clean; `check --workspace --all-targets` exit 0.

## Known limitation
`ConfirmResult::Denied` carries no reason, so the single arm at `mod.rs:880` serves all three denials (typed `n`, no TTY, EOF) and cannot name which fired. Plumbing a reason means adding a field to the public `ConfirmResult` enum — deliberately out of scope. Per-case detail is still logged via the existing `tracing::debug!`.
