### PR TITLE
fix(shell): pass /S so cmd strips the payload's outer quotes

### DIFF
--- a/crates/wcore-config/src/shell.rs
+++ b/crates/wcore-config/src/shell.rs
@@ -73,11 +73,12 @@ pub fn shell_info() -> ShellInfo {
 /// Windows PowerShell override.
 ///
 /// Returns the program + flag(s) that precede the command string in the
-/// BashTool argv: `["sh", "-c"]` on Unix and `["cmd", "/C"]` on Windows by
-/// default. On Windows ONLY, the interpreter can be switched to `powershell` →
+/// BashTool argv: `["sh", "-c"]` on Unix and `["cmd", "/S", "/C"]` on Windows
+/// by default (see [`windows_cmd_payload_prefix`] for why `/S`). On Windows
+/// ONLY, the interpreter can be switched to `powershell` →
 /// `["powershell", "-NoProfile", "-Command"]` (Windows PowerShell 5.1, always
 /// present) or `pwsh` → the same with `pwsh` (PowerShell 7+, if installed). Any
-/// other value falls back to `cmd /C`.
+/// other value falls back to `cmd /S /C`.
 ///
 /// The choice resolves with precedence **`WAYLAND_BASH_SHELL` env (runtime
 /// override) > `[tools] windows_shell` config > default `cmd`**. The config key
@@ -114,8 +115,36 @@ fn bash_shell_prefix_for(is_windows: bool, win_shell: Option<&str>) -> Vec<Strin
             "-NoProfile".to_string(),
             "-Command".to_string(),
         ],
-        _ => vec!["cmd".to_string(), "/C".to_string()],
+        _ => windows_cmd_payload_prefix(),
     }
+}
+
+/// The Windows `cmd.exe` prefix for an argv whose payload will be delivered
+/// with the ONE-OUTER-PAIR quoting — [`push_cmd_payload`] here, and
+/// `wcore_sandbox::backends::windows_cmdline::quote_cmd_payload` on the sandbox
+/// spawn path. Anything that builds such an argv must build it from here.
+///
+/// `/S` IS LOAD-BEARING. Documented in `cmd /?`: cmd reads the tail after `/C`
+/// with two branches, and takes the quote-PRESERVING one when there is no `/S`,
+/// the tail holds exactly two quotes, none of `&<>()@^|` sit between them,
+/// whitespace does, and the text between them names an executable file. The
+/// wrapper's own pair satisfies the first four for any ordinary command, so the
+/// last one — a question about the operator's machine, invisible to the quoting
+/// layer — decided whether the pair was stripped. When it was not, cmd resolved
+/// the leading token as the program and passed the rest of the line, still
+/// carrying the unmatched closing `"`, to the child.
+///
+/// Measured on Windows 11 build 26200 against the shipped v0.13.0 binary
+/// (FerroxLabs/wayland#943, and the surviving half of #929): `cmd /c echo
+/// NESTED` printed `NESTED"` — one stray `0x22`. `echo NOQUOTE` was clean
+/// (`echo` is an internal command, so nothing on disk answers the executable
+/// test) and so was `cmd /c echo A && cmd /c echo B` (the `&` disqualifies the
+/// preserving branch); both already reached the stripping branch, and `/S`
+/// leaves them byte-identical. With `/S` that branch is the ONLY branch: the
+/// outer pair is always stripped and the remainder always runs verbatim, so
+/// delivery no longer depends on what the operator happened to type.
+pub fn windows_cmd_payload_prefix() -> Vec<String> {
+    vec!["cmd".to_string(), "/S".to_string(), "/C".to_string()]
 }
 
 /// Normalize a `WAYLAND_BASH_SHELL` / `[tools] windows_shell` value to its
@@ -388,16 +417,32 @@ fn push_cmd_payload(cmd: &mut Command, payload: &str) {
     #[cfg(windows)]
     {
         use std::os::windows::process::CommandExt;
-        let mut quoted = String::with_capacity(payload.len() + 2);
-        quoted.push('"');
-        quoted.push_str(payload);
-        quoted.push('"');
-        cmd.as_std_mut().raw_arg(quoted);
+        cmd.as_std_mut().raw_arg(wrap_cmd_payload(payload));
     }
     #[cfg(not(windows))]
     {
         cmd.arg(payload);
     }
+}
+
+/// The one-outer-pair spelling itself, split out of [`push_cmd_payload`] so the
+/// exact text handed to `cmd.exe` is assertable on any host. The payload's own
+/// bytes are passed through untouched — nothing inside the pair may be added,
+/// removed or escaped, because that text is the command the operator wrote.
+///
+/// Mirrors `wcore_sandbox::backends::windows_cmdline::quote_cmd_payload`, which
+/// applies the same rule on the sandbox spawn path.
+///
+/// Only Windows spawns through it; off Windows it exists for the tests, which
+/// are the only thing that can catch a regression in this rule from a Linux or
+/// macOS job.
+#[cfg(any(windows, test))]
+fn wrap_cmd_payload(payload: &str) -> String {
+    let mut out = String::with_capacity(payload.len() + 2);
+    out.push('"');
+    out.push_str(payload);
+    out.push('"');
+    out
 }
 
 #[cfg(test)]
@@ -466,6 +511,148 @@ mod tests {
         assert_ne!(idx, 0);
     }
 
+    /// `cmd.exe`'s DOCUMENTED handling of the tail after `/C` (`cmd /?`),
+    /// expressed as a predicate: `true` when cmd takes branch **1** and
+    /// PRESERVES the quote pair instead of stripping it.
+    ///
+    /// Branch 1 fires only when ALL of these hold: no `/S` switch; exactly two
+    /// quote characters; none of `&<>()@^|` between them; at least one
+    /// whitespace character between them; and the text between them names an
+    /// executable file. That last condition is a question about the host
+    /// filesystem rather than about the string, so each case states it —
+    /// `cmd` answers it with the same space-delimited prefix search that makes
+    /// an unquoted `C:\Program Files\x` try `C:\Program.exe` first, so a
+    /// payload whose FIRST token is a real program on disk satisfies it and a
+    /// payload that starts with an *internal* command (`echo`) does not.
+    ///
+    /// When branch 1 fires, the pair [`wrap_cmd_payload`] added survives into
+    /// the executed text: cmd resolves the leading token as the program and
+    /// hands the rest of the line — still carrying the now-unmatched closing
+    /// `"` — to the child. Branch 2 is the behaviour the wrapper is written
+    /// against: strip exactly the outer pair, run the remainder verbatim.
+    fn cmd_preserves_the_outer_pair(
+        prefix: &[String],
+        payload: &str,
+        names_an_executable_file: bool,
+    ) -> bool {
+        if prefix.iter().any(|a| a.eq_ignore_ascii_case("/s")) {
+            return false;
+        }
+        let tail = wrap_cmd_payload(payload);
+        if tail.matches('"').count() != 2 {
+            return false;
+        }
+        let between = &tail[1..tail.len() - 1];
+        if between.contains(['&', '<', '>', '(', ')', '@', '^', '|']) {
+            return false;
+        }
+        if !between.contains(char::is_whitespace) {
+            return false;
+        }
+        names_an_executable_file
+    }
+
+    /// #943 — MEASURED on real Windows 11 build 26200 against the shipped
+    /// v0.13.0 binary: `wayland-core sandbox exec "cmd /c echo NESTED"` printed
+    /// `NESTED"` (`4e 45 53 54 45 44 22`), one stray `0x22` the operator never
+    /// wrote. Identical bytes on 0.12.26-rc.2, so the release did not close it.
+    ///
+    /// The wrapper is correct and the payload is correct; what was missing is
+    /// the switch that makes cmd's handling of the wrapper DETERMINISTIC.
+    /// Without `/S`, whether the outer pair is stripped depends on the quote
+    /// count, on which metacharacters the payload happens to contain, and on
+    /// whether its first token happens to name a program on that machine —
+    /// three properties of the operator's command, none of which the quoting
+    /// layer can see.
+    #[test]
+    fn a_wrapped_payload_beginning_with_a_program_name_is_not_left_quoted() {
+        let prefix = bash_shell_prefix_for(true, None);
+        assert!(
+            !cmd_preserves_the_outer_pair(&prefix, "cmd /c echo NESTED", true),
+            "cmd.exe keeps the wrapper's quotes for this payload, so the child \
+             receives the trailing `\"` as part of its last argument and echoes \
+             it (#943). The prefix {prefix:?} must carry /S so the outer pair is \
+             always stripped."
+        );
+        // The same shape reported under #929, whose empty-output half IS fixed.
+        assert!(!cmd_preserves_the_outer_pair(
+            &prefix,
+            "cmd /c echo SHELL_CMD",
+            true
+        ));
+    }
+
+    /// The two shapes that measured CLEAN on the same box bound the fix: both
+    /// already reach branch 2 today, so neither may move. Asserted against the
+    /// pre-fix prefix as well as the current one — a change that altered these
+    /// would be a regression no matter which branch it came from.
+    #[test]
+    fn the_two_measured_clean_shapes_are_unchanged() {
+        let before: Vec<String> = vec!["cmd".into(), "/C".into()];
+        let after = bash_shell_prefix_for(true, None);
+        for (payload, names_an_executable_file, why) in [
+            (
+                "echo NOQUOTE",
+                false,
+                "`echo` is an internal cmd command, not a file on disk, so \
+                 branch 1's executable test already fails",
+            ),
+            (
+                "cmd /c echo A && cmd /c echo B",
+                true,
+                "`&` between the quotes already disqualifies branch 1",
+            ),
+        ] {
+            assert!(
+                !cmd_preserves_the_outer_pair(&before, payload, names_an_executable_file),
+                "{payload:?} was measured clean BEFORE the fix: {why}"
+            );
+            assert!(
+                !cmd_preserves_the_outer_pair(&after, payload, names_an_executable_file),
+                "{payload:?} must stay byte-identical AFTER the fix: {why}"
+            );
+        }
+    }
+
+    /// The fix must NOT be in the payload text. A wrapper that "helpfully"
+    /// trimmed a trailing quote would satisfy the symptom and corrupt every
+    /// command that legitimately ends in one — so the bytes between the pair
+    /// stay exactly the caller's, for the defect shape and both controls.
+    #[test]
+    fn the_wrapper_adds_one_pair_and_touches_nothing_inside_it() {
+        assert_eq!(
+            wrap_cmd_payload("cmd /c echo NESTED"),
+            r#""cmd /c echo NESTED""#
+        );
+        assert_eq!(wrap_cmd_payload("echo NOQUOTE"), r#""echo NOQUOTE""#);
+        assert_eq!(
+            wrap_cmd_payload("cmd /c echo A && cmd /c echo B"),
+            r#""cmd /c echo A && cmd /c echo B""#
+        );
+        // A payload that already ends in a quote keeps it.
+        assert_eq!(wrap_cmd_payload(r#"echo "a""#), r#""echo "a"""#);
+        // No CRT escaping may appear: cmd does not undo `\"`.
+        assert!(!wrap_cmd_payload(r#"echo "a""#).contains(r#"\""#));
+    }
+
+    /// The extra switch must not hide the payload from the rule that quotes
+    /// it: `/S` sits before `/C`, and the payload is still the entry after the
+    /// flag.
+    #[test]
+    fn the_payload_is_still_located_with_the_extra_switch_in_front() {
+        assert_eq!(cmd_payload_index("cmd", &["/S", "/C", "echo hi"]), Some(2));
+        assert_eq!(cmd_payload_index("cmd", &["/s", "/c", "echo hi"]), Some(2));
+        let prefix = bash_shell_prefix_for(true, None);
+        let flag = prefix
+            .iter()
+            .position(|a| a.eq_ignore_ascii_case("/c"))
+            .expect("the cmd prefix must carry /C");
+        assert!(
+            prefix[..flag].iter().any(|a| a.eq_ignore_ascii_case("/s")),
+            "/S is only a switch when it PRECEDES the /C tail: {prefix:?}"
+        );
+    }
+
     #[test]
     fn shell_info_returns_platform_appropriate_values() {
         let info = shell_info();
@@ -490,9 +677,12 @@ mod tests {
 
     #[test]
     fn bash_prefix_windows_defaults_to_cmd() {
-        assert_eq!(bash_shell_prefix_for(true, None), vec!["cmd", "/C"]);
+        assert_eq!(bash_shell_prefix_for(true, None), vec!["cmd", "/S", "/C"]);
         // An unrecognized value falls back to cmd, never an empty/invalid argv.
-        assert_eq!(bash_shell_prefix_for(true, Some("bash")), vec!["cmd", "/C"]);
+        assert_eq!(
+            bash_shell_prefix_for(true, Some("bash")),
+            vec!["cmd", "/S", "/C"]
+        );
     }
 
     #[test]
@@ -546,16 +736,32 @@ mod tests {
         // are sandbox-supported selectors).
         assert_eq!(
             bash_shell_prefix_for(true, Some(r"C:\Program Files\Git\bin\bash.exe")),
-            vec!["cmd", "/C"]
+            vec!["cmd", "/S", "/C"]
         );
     }
 
+    /// Guard against drift between the prefix defaults and `shell_info()`:
+    /// same interpreter, same trailing flag.
+    ///
+    /// The prefix carries ONE extra switch on Windows and `shell_info()` must
+    /// NOT grow it. `shell_info()` feeds [`shell_command_builder`] and
+    /// [`mcp_stdio_command_builder`], which append their line RAW with no outer
+    /// pair of their own; an MCP transport line such as `"C:\Program
+    /// Files\nodejs\node.exe" server.js` is exactly the shape cmd's
+    /// quote-PRESERVING branch exists to serve, and `/S` would strip the quotes
+    /// off that program path and break the launch. The switch belongs only
+    /// where the payload is wrapped — see [`windows_cmd_payload_prefix`].
     #[test]
     fn bash_prefix_default_branches_match_shell_info() {
-        // Guard against drift between the prefix defaults and shell_info().
         let info = shell_info();
-        let expected = vec![info.program.to_string(), info.flag.to_string()];
-        assert_eq!(bash_shell_prefix_for(cfg!(windows), None), expected);
+        let prefix = bash_shell_prefix_for(cfg!(windows), None);
+        assert_eq!(prefix.first().map(String::as_str), Some(info.program));
+        assert_eq!(prefix.last().map(String::as_str), Some(info.flag));
+        let extra: Vec<&str> = prefix[1..prefix.len() - 1]
+            .iter()
+            .map(String::as_str)
+            .collect();
+        assert_eq!(extra, if cfg!(windows) { vec!["/S"] } else { vec![] });
     }
 
     #[tokio::test]

--- a/crates/wcore-sandbox/src/backends/no_sandbox.rs
+++ b/crates/wcore-sandbox/src/backends/no_sandbox.rs
@@ -229,7 +229,7 @@ impl SandboxBackend for NoSandboxBackend {
 
 #[cfg(all(test, windows))]
 mod windows_cmd_delivery_tests {
-    //! The Windows Bash surface runs `["cmd", "/C", <command>]` (see
+    //! The Windows Bash surface runs `["cmd", "/S", "/C", <command>]` (see
     //! `wcore_config::shell::bash_shell_argv_prefix`), and this backend is what
     //! the relaxed Windows default and `WAYLAND_SANDBOX=none` both spawn
     //! through. These are LIVE tests: they run a real `cmd.exe` and grade the
@@ -237,8 +237,13 @@ mod windows_cmd_delivery_tests {
 
     use super::*;
 
-    /// `["cmd", "/C", payload]` with the minimum env `cmd.exe` needs to start.
-    /// The env is still scrubbed — only these two names are injected.
+    /// The production Windows Bash argv with the minimum env `cmd.exe` needs to
+    /// start, so these live tests measure the shape the agent actually spawns.
+    /// The prefix is owned by `wcore_config::shell::windows_cmd_payload_prefix`
+    /// (this crate does not depend on `wcore-config`, so it is mirrored here);
+    /// `/S` is what makes cmd strip the outer pair `quote_cmd_payload` adds
+    /// instead of leaving it in the executed text (#943). The env is still
+    /// scrubbed — only these two names are injected.
     fn cmd_job(payload: &str) -> (SandboxManifest, SandboxCommand) {
         let mut manifest = SandboxManifest::default();
         for key in ["PATH", "SYSTEMROOT"] {
@@ -251,7 +256,7 @@ mod windows_cmd_delivery_tests {
         (
             manifest,
             SandboxCommand {
-                argv: vec!["cmd".into(), "/C".into(), payload.into()],
+                argv: vec!["cmd".into(), "/S".into(), "/C".into(), payload.into()],
                 cwd: None,
             },
         )
@@ -358,6 +363,51 @@ mod windows_cmd_delivery_tests {
             std::fs::read_dir(dir.path())
                 .map(|entries| entries.flatten().map(|e| e.file_name()).collect::<Vec<_>>())
                 .unwrap_or_default()
+        );
+    }
+
+    /// **#943.** A payload that is itself a `cmd /c ...` must arrive whole.
+    ///
+    /// MEASURED on Windows 11 build 26200 against the shipped v0.13.0 binary
+    /// (and identically on 0.12.26-rc.2): `cmd /c echo NESTED` printed
+    /// `4e 45 53 54 45 44 22` — `NESTED` plus one `"` the operator never wrote.
+    /// `cmd.exe` had taken the quote-PRESERVING branch for its tail, so the
+    /// pair `quote_cmd_payload` adds survived into the executed text and its
+    /// closing quote reached the child as data. The argv now carries `/S`,
+    /// which leaves cmd only the stripping branch.
+    ///
+    /// The two shapes that measured CLEAN are asserted beside it, because they
+    /// are what bounds the fix: `echo NOQUOTE` never took the preserving branch
+    /// (`echo` is internal, so nothing on disk answers its executable test) and
+    /// neither did the chained form (`&` disqualifies it). A fix that trimmed
+    /// trailing quotes instead of correcting the switch would move these.
+    #[tokio::test]
+    async fn a_nested_cmd_payload_arrives_without_a_stray_quote() {
+        for (payload, expected) in [
+            ("cmd /c echo NESTED", "NESTED"),
+            ("cmd /c echo SHELL_CMD", "SHELL_CMD"),
+            ("echo NOQUOTE", "NOQUOTE"),
+        ] {
+            let output = run(payload).await;
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            assert_eq!(
+                stdout.trim_end(),
+                expected,
+                "{payload:?} produced {:x?}; a trailing 0x22 is #943 — the \
+                 wrapper's own quote executed as part of the command",
+                output.stdout
+            );
+        }
+        // cmd's `echo` emits the space that precedes `&&`, so grade each line
+        // trimmed: what is under test is the absence of a stray quote, not
+        // cmd's trailing whitespace.
+        let chained = run("cmd /c echo A && cmd /c echo B").await;
+        let text = String::from_utf8_lossy(&chained.stdout);
+        let lines: Vec<&str> = text.lines().map(str::trim_end).collect();
+        assert_eq!(
+            lines,
+            vec!["A", "B"],
+            "the chained nested form was clean before the fix and must stay so"
         );
     }
 

--- a/crates/wcore-sandbox/src/backends/windows_cmdline.rs
+++ b/crates/wcore-sandbox/src/backends/windows_cmdline.rs
@@ -100,6 +100,16 @@ pub(crate) fn cmd_payload_index(argv: &[String]) -> Option<usize> {
 /// `cmd` strips exactly the outer pair and executes the remainder as written.
 /// Deliberately NOT the CRT `\"` escaping `std::process::Command` applies —
 /// see the module docs for the measured corruption that produces.
+///
+/// PRECONDITION: the invocation must carry `/S`. Without it `cmd` has a second,
+/// quote-PRESERVING branch for its tail and takes it whenever the tail holds
+/// exactly two quotes, no `&<>()@^|` between them, whitespace between them, and
+/// text between them that names an executable file — which an ordinary
+/// `<program> <args>` payload inside this pair satisfies. The pair then survives
+/// into the executed text and its closing `"` reaches the child as data
+/// (measured: `cmd /c echo NESTED` printed `NESTED"`, FerroxLabs/wayland#943).
+/// Build the argv from `wcore_config::shell::windows_cmd_payload_prefix`, which
+/// supplies the switch.
 pub(crate) fn quote_cmd_payload(payload: &str) -> String {
     let mut out = String::with_capacity(payload.len() + 2);
     out.push('"');
@@ -169,10 +179,13 @@ mod tests {
     fn payload_index_is_found_only_for_a_cmd_invocation_that_has_one() {
         let argv = |v: &[&str]| v.iter().map(|s| s.to_string()).collect::<Vec<_>>();
         assert_eq!(
-            cmd_payload_index(&argv(&["cmd", "/C", "echo hi"])),
-            Some(2),
-            "the default BashTool argv on Windows"
+            cmd_payload_index(&argv(&["cmd", "/S", "/C", "echo hi"])),
+            Some(3),
+            "the default BashTool argv on Windows — the `/S` that makes cmd \
+             strip this payload's outer pair must not hide the payload from \
+             the rule that adds it (#943)"
         );
+        assert_eq!(cmd_payload_index(&argv(&["cmd", "/C", "echo hi"])), Some(2));
         assert_eq!(cmd_payload_index(&argv(&["cmd", "/d", "/c", "x"])), Some(3));
         assert_eq!(cmd_payload_index(&argv(&["cmd", "/K", "x"])), Some(2));
         // Not a cmd invocation: `/c` here is the child program's own flag and

--- a/crates/wcore-tools/src/bash.rs
+++ b/crates/wcore-tools/src/bash.rs
@@ -183,7 +183,10 @@ fn downgrade_powershell_for_sandbox(argv: &mut Vec<String>, blocks_powershell: b
         return;
     }
     // The powershell/pwsh prefix is `[shell, "-NoProfile", "-Command", <command>]`;
-    // the user's command is the last element. Replace the whole prefix with `cmd /C`.
+    // the user's command is the last element. Replace the whole prefix with the
+    // canonical cmd one — taken from `wcore_config::shell` rather than spelled
+    // out here, because that prefix carries the `/S` the payload quoting on the
+    // spawn path depends on (#943) and a second copy would silently drift.
     let command = argv.last().cloned().unwrap_or_default();
     static WARNED: std::sync::Once = std::sync::Once::new();
     WARNED.call_once(|| {
@@ -194,7 +197,8 @@ fn downgrade_powershell_for_sandbox(argv: &mut Vec<String>, blocks_powershell: b
              Set `[tools] windows_shell = cmd` (or WAYLAND_BASH_SHELL=cmd) to silence this."
         );
     });
-    *argv = vec!["cmd".to_string(), "/C".to_string(), command];
+    *argv = wcore_config::shell::windows_cmd_payload_prefix();
+    argv.push(command);
 }
 
 /// Whether a freshly selected legacy platform backend enforces

--- a/crates/wcore-tools/src/bash/tests.rs
+++ b/crates/wcore-tools/src/bash/tests.rs
@@ -830,7 +830,9 @@ fn downgrade_powershell_swaps_to_cmd_when_blocked() {
         "echo hello".to_string(),
     ];
     downgrade_powershell_for_sandbox(&mut argv, true);
-    assert_eq!(argv, vec!["cmd", "/C", "echo hello"]);
+    // `/S` comes with the prefix: the payload is quoted as one outer pair on the
+    // spawn path, and only `/S` makes cmd strip exactly that pair (#943).
+    assert_eq!(argv, vec!["cmd", "/S", "/C", "echo hello"]);
 }
 
 #[test]
@@ -842,7 +844,7 @@ fn downgrade_powershell_handles_pwsh_and_exe_suffix() {
         "ls -la".to_string(),
     ];
     downgrade_powershell_for_sandbox(&mut argv, true);
-    assert_eq!(argv, vec!["cmd", "/C", "ls -la"]);
+    assert_eq!(argv, vec!["cmd", "/S", "/C", "ls -la"]);
 }
 
 #[test]
@@ -863,7 +865,8 @@ fn downgrade_powershell_noop_when_sandbox_allows_powershell() {
 
 #[test]
 fn downgrade_powershell_noop_for_cmd_prefix() {
-    let mut argv = vec!["cmd".to_string(), "/C".to_string(), "echo hi".to_string()];
+    let mut argv = wcore_config::shell::windows_cmd_payload_prefix();
+    argv.push("echo hi".to_string());
     let before = argv.clone();
     downgrade_powershell_for_sandbox(&mut argv, true);
     assert_eq!(argv, before, "cmd prefix is already sandbox-compatible");


### PR DESCRIPTION
Fixes a Windows output-corruption defect **measured live on the shipped v0.13.0 binary**, not inferred.

## The measurement
Real Windows 11 (build 26200), `wayland-core sandbox exec`:

```
cmd /c echo NESTED   ->  stdout "NESTED\""   hex: 4e 45 53 54 45 44 22   <-- stray 0x22
```

Byte-identical on 0.12.26-rc.2 **and** 0.13.0 — the release did not fix it. `cmd /c echo SHELL_CMD` shows the same, so **#929 carries this too** (its empty-output half *is* fixed).

**Both controls held**, which is what bounds the fix:
- `echo NOQUOTE` (no nesting) → clean. So it is not the harness.
- `cmd /c echo A && cmd /c echo B` (chained) → clean.

## Derived mechanism
Not the payload text, and not the quoting helpers — a **missing switch on the invocation they were written against**.

The Windows Bash argv is `["cmd", "/C", <command>]`. The payload is deliberately not CRT-escaped: `push_cmd_payload` and `quote_cmd_payload` wrap it in **one outer quote pair** and `raw_arg` it, on the documented premise that *"cmd strips exactly that outer pair and executes the remainder verbatim"*.

**That premise is only unconditionally true under `/S`.** Per `cmd /?`, cmd takes the quote-**preserving** branch when all of: no `/S`; exactly two quotes; none of `&<>()@^|` between them; whitespace between them; **and the text between them names an executable file**. The wrapper's own pair satisfies the first four for any ordinary command — so the last condition, a fact about the operator's machine invisible to the quoting layer, decided whether the pair was stripped. When it wasn't, cmd resolved the leading token as the program and passed the rest still carrying the unmatched `"`, so the inner cmd ran `echo NESTED"`.

This explains all three measurements exactly: `echo` is an **internal** command so nothing on disk answers the executable test; the chained form is disqualified by `&`. Both already reached the stripping branch, and `/S` leaves them byte-identical.

## The fix
`windows_cmd_payload_prefix() -> ["cmd", "/S", "/C"]` becomes the single owner of that prefix. `wcore-tools/src/bash.rs` had a second hardcoded `["cmd","/C",…]`; it now builds from the shared helper.

**`shell_info()` deliberately keeps the bare `/C`** — it feeds `shell_command_builder`/`mcp_stdio_command_builder`, which append their line raw with no pair of their own, and an MCP line like `"C:\Program Files\nodejs\node.exe" server.js` *needs* the preserving branch. `/S` there would break the launch. The anti-drift guard test now states that relationship rather than equality.

## Tests
Assert the exact argument string handed to cmd, so this is testable off Windows. Includes `the_two_measured_clean_shapes_are_unchanged` (both controls, asserted against the **pre-fix** prefix *and* the current one) and `the_wrapper_adds_one_pair_and_touches_nothing_inside_it` — which forbids the tempting "strip trailing quotes" fix.

`wcore-config` 717/0 · `wcore-tools` 1567/0 · `wcore-sandbox` 169/0.
`clippy --workspace -- -D warnings` exit 0, **and** `--target x86_64-pc-windows-gnu` exit 0 (sees `cfg(windows)` code host clippy is blind to; caveat gnu ≠ msvc). `fmt` clean.

Red arm: reverted `/S`, grep-confirmed on the fn body not a doc line, `touch`ed → wcore-config **4 failed**, wcore-tools **2 failed**. The two control tests stayed **green** through the red arm — they pin the controls independently of the fix.

Positive control on the Windows-only module: injected `let _: () = 1;` into the new live test and confirmed windows-gnu clippy fails E0308 — proving that `#[cfg(all(test, windows))]` block really is compiled by that leg rather than silently skipped.

## The claim I am NOT making
**This has not been verified against the live symptom.** No `cmd.exe` was executed in this work. A Windows run must confirm: (1) `NESTED` with no trailing `22`, and the same for `SHELL_CMD`; (2) both controls byte-identical; (3) `cargo nextest run -p wcore-sandbox` on Windows; (4) no regression on the AppContainer leg.

## Found, deliberately untouched
`wcore-cli/src/tui/statusline/exec.rs` and `crash_sentinel.rs` build their own `cmd /C` invocations with plain `Command::arg` and no `/S` — they carry this class and the older `\"` one. Separate changes, not this row.
