### PR TITLE
feat(browser): wire opt-in Camoufox binary provisioning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9374,6 +9374,7 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "chromiumoxide",
+ "flate2",
  "futures",
  "ipnet",
  "libc",
@@ -9382,6 +9383,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
+ "tar",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -9397,6 +9399,7 @@ dependencies = [
  "which 6.0.3",
  "wiremock",
  "workspace-hack",
+ "zip 2.4.2",
 ]
 
 [[package]]

--- a/crates/wcore-browser/Cargo.toml
+++ b/crates/wcore-browser/Cargo.toml
@@ -47,6 +47,12 @@ parking_lot.workspace = true
 # PATHEXT-aware on Windows; same version wcore-sandbox already pins.
 which = "6"
 
+# F7 — archive extraction for the opt-in Camoufox binary provisioning path.
+# Format is chosen by magic bytes, so both are needed on every platform.
+tar.workspace    = true
+flate2.workspace = true
+zip.workspace    = true
+
 # Wave BR — supervisor uses libc::kill(pid, 0) for parent-PID liveness probes.
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }

--- a/crates/wcore-browser/src/binary.rs
+++ b/crates/wcore-browser/src/binary.rs
@@ -13,6 +13,13 @@
 //!   * Offline mode (`offline = true`) fails fast with [`BinaryError::OfflineMissing`]
 //!     when the cache miss would otherwise trigger a network call.
 //!
+//!   * `provision_camoufox(&CamoufoxDownloadConfig)` - the supervisor-facing
+//!     entry point. Opt-in (disabled by default) and fail-closed: with the
+//!     feature off nothing is fetched, and with it on but no operator-pinned
+//!     SHA-256 for the resolved platform artifact it REFUSES rather than
+//!     fetching an unverified executable. Handles per-platform artifact
+//!     selection, archive extraction, and the Unix executable bit.
+//!
 //! Tests use a wiremock server as the download origin so no live network
 //! hit is required — proves the wire-shape end-to-end including SHA
 //! verification and rejection of tampered payloads.
@@ -60,6 +67,20 @@ pub enum BinaryError {
     PlaceholderSha,
     #[error("download server HTTP {status} at {url}")]
     HttpStatus { status: u16, url: String },
+    #[error(
+        "Camoufox auto-download is enabled but no artifact is configured for platform {0} - add [browser.camoufox_download.artifacts.\"{0}\"] with a url and sha256"
+    )]
+    UnconfiguredPlatform(String),
+    #[error(
+        "Camoufox auto-download is enabled but no sha256 is pinned for platform {0}; refusing to fetch an unverified executable - set browser.camoufox_download.artifacts.\"{0}\".sha256"
+    )]
+    UnpinnedDigest(String),
+    #[error("archive extraction failed: {0}")]
+    Extract(String),
+    #[error("archive did not contain the configured executable at {0}")]
+    MissingExecutable(String),
+    #[error("unsafe path in configuration or archive: {0}")]
+    UnsafePath(String),
 }
 
 /// Manager surface — `ensure_camoufox` downloads if missing, verifies SHA,
@@ -207,6 +228,152 @@ impl BrowserBinaryManager {
             })
         }
     }
+
+    /// Provision a runnable Camoufox executable from operator configuration.
+    ///
+    /// This is the entry point the supervisor calls. Before it existed,
+    /// [`Self::ensure_camoufox`] had zero production callers, so a host
+    /// without `camofox-browser` on PATH simply failed at first use.
+    ///
+    /// **Opt-in and fail-closed.** Exactly three outcomes:
+    ///
+    ///   * `Ok(None)` - auto-download is disabled (the default). Nothing is
+    ///     fetched, nothing is written, the caller keeps the program it had.
+    ///   * `Ok(Some(path))` - an artifact whose bytes matched the
+    ///     operator-pinned SHA-256 was installed, unpacked if it was an
+    ///     archive, and made executable.
+    ///   * `Err(_)` - an actionable refusal. An enabled download with no
+    ///     artifact configured for this platform, or an artifact with no
+    ///     pinned digest, is [`BinaryError::UnconfiguredPlatform`] /
+    ///     [`BinaryError::UnpinnedDigest`]. There is deliberately no path
+    ///     that fetches an unverified binary, and none that falls back to
+    ///     running one.
+    pub async fn provision_camoufox(
+        &self,
+        download: &wcore_config::browser::CamoufoxDownloadConfig,
+    ) -> Result<Option<PathBuf>, BinaryError> {
+        if !download.enabled {
+            return Ok(None);
+        }
+        let key = wcore_config::browser::platform_key();
+        let artifact = download
+            .artifact_for_current_platform()
+            .ok_or_else(|| BinaryError::UnconfiguredPlatform(key.clone()))?;
+        let expected_sha = artifact.sha256.trim();
+        if expected_sha.is_empty() {
+            return Err(BinaryError::UnpinnedDigest(key));
+        }
+        let downloaded = self.ensure_camoufox(&artifact.url, expected_sha).await?;
+        let exe = self.materialize_executable(&downloaded, &artifact.archive_exe_path)?;
+        Ok(Some(exe))
+    }
+
+    /// Turn a SHA-verified on-disk artifact into a runnable executable path.
+    ///
+    /// An empty `archive_exe_path` means the artifact IS the executable.
+    /// Otherwise the artifact is unpacked into a sibling directory under the
+    /// install root and the named member is returned. The executable bit is
+    /// applied through the single [`set_executable`] helper.
+    fn materialize_executable(
+        &self,
+        artifact: &Path,
+        archive_exe_path: &str,
+    ) -> Result<PathBuf, BinaryError> {
+        let rel = archive_exe_path.trim();
+        if rel.is_empty() {
+            set_executable(artifact)?;
+            return Ok(artifact.to_path_buf());
+        }
+        let rel_path = safe_relative_path(rel)?;
+        let unpack_root = self.install_root.join(format!(
+            "camoufox-{}-unpacked",
+            sanitize_version_for_filename(CAMOUFOX_VERSION)
+        ));
+        let exe = unpack_root.join(&rel_path);
+        // Already unpacked by a previous run. The archive was SHA-verified
+        // above, so re-extracting buys nothing.
+        if !exe.is_file() {
+            extract_archive(artifact, &unpack_root)?;
+        }
+        if !exe.is_file() {
+            return Err(BinaryError::MissingExecutable(rel.to_string()));
+        }
+        set_executable(&exe)?;
+        Ok(exe)
+    }
+}
+
+/// Reject configured member paths that are absolute or contain `..` -
+/// joining either would escape the install root.
+fn safe_relative_path(rel: &str) -> Result<PathBuf, BinaryError> {
+    let p = Path::new(rel);
+    if p.components()
+        .any(|c| !matches!(c, std::path::Component::Normal(_)))
+    {
+        return Err(BinaryError::UnsafePath(rel.to_string()));
+    }
+    Ok(p.to_path_buf())
+}
+
+/// Unpack `archive` into `dest_root`.
+///
+/// The format is chosen from the file's **magic bytes**, not from the URL
+/// spelling and not from the host OS, so no `cfg!(windows)` branch decides
+/// it. Both extractors are the crates' own traversal-safe entry points:
+/// `tar::Archive::unpack` skips `..` components and `zip::ZipArchive::extract`
+/// resolves members through `enclosed_name`.
+fn extract_archive(archive: &Path, dest_root: &Path) -> Result<(), BinaryError> {
+    use std::io::Read as _;
+
+    let mut magic = [0u8; 4];
+    {
+        let mut f = std::fs::File::open(archive)?;
+        // A short read is fine: a file too small to hold either signature
+        // matches neither and falls through to the error below.
+        let mut filled = 0usize;
+        while filled < magic.len() {
+            match f.read(&mut magic[filled..])? {
+                0 => break,
+                n => filled += n,
+            }
+        }
+    }
+    std::fs::create_dir_all(dest_root)?;
+
+    if magic[..2] == [0x1f, 0x8b] {
+        let f = std::fs::File::open(archive)?;
+        let mut ar = tar::Archive::new(flate2::read::GzDecoder::new(f));
+        ar.unpack(dest_root)
+            .map_err(|e| BinaryError::Extract(format!("tar.gz: {e}")))?;
+        Ok(())
+    } else if magic == [0x50, 0x4b, 0x03, 0x04] {
+        let f = std::fs::File::open(archive)?;
+        let mut zip =
+            zip::ZipArchive::new(f).map_err(|e| BinaryError::Extract(format!("zip: {e}")))?;
+        zip.extract(dest_root)
+            .map_err(|e| BinaryError::Extract(format!("zip: {e}")))?;
+        Ok(())
+    } else {
+        Err(BinaryError::Extract(format!(
+            "unrecognised archive format (magic {magic:02x?}); expected gzip or zip"
+        )))
+    }
+}
+
+/// The one place the executable-bit platform difference is expressed.
+/// Windows carries no mode bits - an extracted `.exe` is runnable as written.
+#[cfg(unix)]
+fn set_executable(path: &Path) -> Result<(), BinaryError> {
+    use std::os::unix::fs::PermissionsExt as _;
+    let mut perms = std::fs::metadata(path)?.permissions();
+    perms.set_mode(perms.mode() | 0o755);
+    std::fs::set_permissions(path, perms)?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn set_executable(_path: &Path) -> Result<(), BinaryError> {
+    Ok(())
 }
 
 /// Filesystem-safe filename chunk for a version string. Keeps `[A-Za-z0-9._-]`,
@@ -226,7 +393,7 @@ fn sanitize_version_for_filename(v: &str) -> String {
 /// Minimal SHA-256 (so we don't pull `sha2` just for this module). Lifted
 /// from FIPS 180-4 reference; ~70 lines. Verified by the `known_vectors`
 /// test against the empty-string + "abc" vectors.
-fn sha256_hex(input: &[u8]) -> String {
+pub fn sha256_hex(input: &[u8]) -> String {
     const K: [u32; 64] = [
         0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4,
         0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe,
@@ -459,5 +626,244 @@ mod tests {
         let p2 = mgr.ensure_camoufox(&url, &sha).await.unwrap();
         assert_eq!(p1, p2);
         // Mock `.expect(1)` enforces the second call was a cache hit.
+    }
+
+    // ── F7: opt-in, fail-closed provisioning ─────────────────────────────
+    //
+    // Every arm below mounts the origin with an explicit `.expect(n)`.
+    // `MockServer` verifies expectations when it drops, so "nothing was
+    // fetched" is asserted against the wire, not inferred from a return
+    // value. No test contacts a real network.
+
+    fn artifacts_for(
+        url: &str,
+        sha: &str,
+        exe: &str,
+    ) -> std::collections::BTreeMap<String, wcore_config::browser::BinaryArtifact> {
+        let mut m = std::collections::BTreeMap::new();
+        m.insert(
+            wcore_config::browser::platform_key(),
+            wcore_config::browser::BinaryArtifact {
+                url: url.to_string(),
+                sha256: sha.to_string(),
+                archive_exe_path: exe.to_string(),
+            },
+        );
+        m
+    }
+
+    /// A gzipped tar holding one member at `rel`, deliberately mode 0o644 so
+    /// the executable bit can only come from our own chmod.
+    fn tar_gz_with(rel: &str, body: &[u8]) -> Vec<u8> {
+        let enc = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::fast());
+        let mut builder = tar::Builder::new(enc);
+        let mut header = tar::Header::new_gnu();
+        header.set_size(body.len() as u64);
+        header.set_mode(0o644);
+        builder.append_data(&mut header, rel, body).unwrap();
+        builder.into_inner().unwrap().finish().unwrap()
+    }
+
+    fn dir_entry_count(dir: &Path) -> usize {
+        std::fs::read_dir(dir).map(|d| d.count()).unwrap_or(0)
+    }
+
+    /// (a) Feature OFF ⇒ nothing is fetched and nothing is written, even
+    /// though a perfectly good artifact with a correct digest is configured.
+    #[tokio::test]
+    async fn provision_disabled_fetches_nothing() {
+        let server = MockServer::start().await;
+        let payload = tar_gz_with("bin/camoufox", b"#!/bin/sh\nexit 0\n");
+        Mock::given(method("GET"))
+            .and(path("/camoufox.tar.gz"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(payload.clone()))
+            .expect(0)
+            .mount(&server)
+            .await;
+        let dir = tempfile::tempdir().unwrap();
+        let mgr = BrowserBinaryManager::new(dir.path().to_path_buf(), false);
+        let cfg = wcore_config::browser::CamoufoxDownloadConfig {
+            enabled: false,
+            artifacts: artifacts_for(
+                &format!("{}/camoufox.tar.gz", server.uri()),
+                &sha256_hex(&payload),
+                "bin/camoufox",
+            ),
+        };
+        let got = mgr.provision_camoufox(&cfg).await.unwrap();
+        assert!(
+            got.is_none(),
+            "auto-download is off; provisioning must be a no-op, got {got:?}"
+        );
+        assert_eq!(
+            dir_entry_count(dir.path()),
+            0,
+            "the disabled path wrote into the install root"
+        );
+    }
+
+    /// (b) Feature ON but the artifact carries no operator-pinned digest ⇒
+    /// REFUSE. Never fetch-and-trust, never run an unverified binary.
+    #[tokio::test]
+    async fn provision_enabled_without_digest_refuses_without_fetching() {
+        let server = MockServer::start().await;
+        let payload = tar_gz_with("bin/camoufox", b"#!/bin/sh\nexit 0\n");
+        Mock::given(method("GET"))
+            .and(path("/camoufox.tar.gz"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(payload))
+            .expect(0)
+            .mount(&server)
+            .await;
+        let dir = tempfile::tempdir().unwrap();
+        let mgr = BrowserBinaryManager::new(dir.path().to_path_buf(), false);
+        let cfg = wcore_config::browser::CamoufoxDownloadConfig {
+            enabled: true,
+            artifacts: artifacts_for(
+                &format!("{}/camoufox.tar.gz", server.uri()),
+                "   ",
+                "bin/camoufox",
+            ),
+        };
+        let r = mgr.provision_camoufox(&cfg).await;
+        assert!(
+            matches!(r, Err(BinaryError::UnpinnedDigest(_))),
+            "expected UnpinnedDigest refusal, got {r:?}"
+        );
+        assert_eq!(
+            dir_entry_count(dir.path()),
+            0,
+            "refusal still touched the install root"
+        );
+    }
+
+    /// (b') Feature ON with no artifact at all for the running platform ⇒
+    /// refuse. Never borrow another platform's URL.
+    #[tokio::test]
+    async fn provision_enabled_without_platform_artifact_refuses() {
+        let dir = tempfile::tempdir().unwrap();
+        let mgr = BrowserBinaryManager::new(dir.path().to_path_buf(), false);
+        let mut artifacts = artifacts_for("http://example.invalid/x", "aa", "");
+        artifacts.clear();
+        artifacts.insert(
+            "some-other-platform".to_string(),
+            wcore_config::browser::BinaryArtifact {
+                url: "http://example.invalid/other".into(),
+                sha256: "bb".into(),
+                archive_exe_path: String::new(),
+            },
+        );
+        let cfg = wcore_config::browser::CamoufoxDownloadConfig {
+            enabled: true,
+            artifacts,
+        };
+        let r = mgr.provision_camoufox(&cfg).await;
+        match r {
+            Err(BinaryError::UnconfiguredPlatform(key)) => {
+                assert_eq!(key, wcore_config::browser::platform_key());
+            }
+            other => panic!("expected UnconfiguredPlatform, got {other:?}"),
+        }
+    }
+
+    /// (c) A digest mismatch refuses AND leaves no partial file behind — not
+    /// the destination, not the `.tmp` scratch file, not an unpack dir.
+    #[tokio::test]
+    async fn provision_digest_mismatch_refuses_and_leaves_no_partial_file() {
+        let server = MockServer::start().await;
+        let payload = tar_gz_with("bin/camoufox", b"#!/bin/sh\nexit 0\n");
+        Mock::given(method("GET"))
+            .and(path("/camoufox.tar.gz"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(payload))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let dir = tempfile::tempdir().unwrap();
+        let mgr = BrowserBinaryManager::new(dir.path().to_path_buf(), false);
+        let cfg = wcore_config::browser::CamoufoxDownloadConfig {
+            enabled: true,
+            artifacts: artifacts_for(
+                &format!("{}/camoufox.tar.gz", server.uri()),
+                &sha256_hex(b"a completely different artifact"),
+                "bin/camoufox",
+            ),
+        };
+        let r = mgr.provision_camoufox(&cfg).await;
+        assert!(
+            matches!(r, Err(BinaryError::ChecksumMismatch { .. })),
+            "expected ChecksumMismatch refusal, got {r:?}"
+        );
+        let leftovers: Vec<_> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .map(|e| e.unwrap().path())
+            .collect();
+        assert!(
+            leftovers.is_empty(),
+            "rejected payload left files behind: {leftovers:?}"
+        );
+    }
+
+    /// The happy path: verified archive is unpacked and the member named by
+    /// `archive_exe_path` comes back with the executable bit set. The tar
+    /// member is written 0o644, so a passing mode check can only come from
+    /// [`set_executable`].
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn provision_extracts_archive_and_sets_exec_bit() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let server = MockServer::start().await;
+        let payload = tar_gz_with("camoufox/camoufox", b"#!/bin/sh\nexit 0\n");
+        Mock::given(method("GET"))
+            .and(path("/camoufox.tar.gz"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(payload.clone()))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let dir = tempfile::tempdir().unwrap();
+        let mgr = BrowserBinaryManager::new(dir.path().to_path_buf(), false);
+        let cfg = wcore_config::browser::CamoufoxDownloadConfig {
+            enabled: true,
+            artifacts: artifacts_for(
+                &format!("{}/camoufox.tar.gz", server.uri()),
+                &sha256_hex(&payload),
+                "camoufox/camoufox",
+            ),
+        };
+        let exe = mgr
+            .provision_camoufox(&cfg)
+            .await
+            .expect("verified artifact must provision")
+            .expect("enabled download must yield a path");
+        assert!(exe.is_file(), "no executable at {}", exe.display());
+        assert!(
+            exe.starts_with(dir.path()),
+            "provisioned outside the install root: {}",
+            exe.display()
+        );
+        let mode = std::fs::metadata(&exe).unwrap().permissions().mode();
+        assert_ne!(
+            mode & 0o111,
+            0,
+            "extracted member is not executable (mode {mode:o}); the archive ships it 0o644"
+        );
+
+        // Second call is a cache hit — `.expect(1)` on the mock enforces it.
+        let again = mgr.provision_camoufox(&cfg).await.unwrap().unwrap();
+        assert_eq!(again, exe);
+    }
+
+    /// A configured member path that climbs out of the install root is
+    /// refused before anything is joined to it.
+    #[test]
+    fn safe_relative_path_rejects_traversal_and_absolute() {
+        assert!(matches!(
+            safe_relative_path("../../etc/passwd"),
+            Err(BinaryError::UnsafePath(_))
+        ));
+        assert!(matches!(
+            safe_relative_path("/etc/passwd"),
+            Err(BinaryError::UnsafePath(_))
+        ));
+        assert!(safe_relative_path("camoufox/camoufox").is_ok());
     }
 }

--- a/crates/wcore-browser/src/binary.rs
+++ b/crates/wcore-browser/src/binary.rs
@@ -81,6 +81,10 @@ pub enum BinaryError {
     MissingExecutable(String),
     #[error("unsafe path in configuration or archive: {0}")]
     UnsafePath(String),
+    #[error(
+        "refusing to fetch an executable over {scheme} - browser.camoufox_download artifact url {url} must use https (plain http is accepted only for a loopback host)"
+    )]
+    InsecureScheme { scheme: String, url: String },
 }
 
 /// Manager surface — `ensure_camoufox` downloads if missing, verifies SHA,
@@ -263,6 +267,7 @@ impl BrowserBinaryManager {
         if expected_sha.is_empty() {
             return Err(BinaryError::UnpinnedDigest(key));
         }
+        require_secure_url(&artifact.url)?;
         let downloaded = self.ensure_camoufox(&artifact.url, expected_sha).await?;
         let exe = self.materialize_executable(&downloaded, &artifact.archive_exe_path)?;
         Ok(Some(exe))
@@ -301,6 +306,45 @@ impl BrowserBinaryManager {
         set_executable(&exe)?;
         Ok(exe)
     }
+}
+
+/// Reject a configured artifact URL whose transport is not `https`.
+///
+/// Being precise about what this does and does not buy, because the module
+/// doc above makes the opposite claim ("the URL is documentation + default;
+/// the digest is the lock") and that claim is CORRECT: the operator-pinned
+/// SHA-256 is compared before anything is moved into place or made
+/// executable, so an active attacker on a plain-HTTP fetch can make
+/// provisioning FAIL but cannot swap the executable. This check is therefore
+/// defence in depth, not the security boundary. What it actually closes is
+/// (a) the artifact URL and anything an operator embedded in it - a signed
+/// query parameter, a token - travelling in clear text, and (b) a config typo
+/// silently downgrading the transport with no diagnostic.
+///
+/// Plain `http` to a LOOPBACK host is allowed. An operator serving a local
+/// mirror is not exposed to a network observer, so refusing it would cost a
+/// legitimate deployment and buy nothing.
+fn require_secure_url(url: &str) -> Result<(), BinaryError> {
+    let parsed = reqwest::Url::parse(url)
+        .map_err(|error| BinaryError::Network(format!("invalid artifact url {url}: {error}")))?;
+    let scheme = parsed.scheme();
+    if scheme.eq_ignore_ascii_case("https") {
+        return Ok(());
+    }
+    let host = parsed.host_str().unwrap_or_default();
+    let loopback = host.eq_ignore_ascii_case("localhost")
+        || host
+            .trim_start_matches('[')
+            .trim_end_matches(']')
+            .parse::<std::net::IpAddr>()
+            .is_ok_and(|ip| ip.is_loopback());
+    if scheme.eq_ignore_ascii_case("http") && loopback {
+        return Ok(());
+    }
+    Err(BinaryError::InsecureScheme {
+        scheme: scheme.to_string(),
+        url: url.to_string(),
+    })
 }
 
 /// Reject configured member paths that are absolute or contain `..` -
@@ -865,5 +909,85 @@ mod tests {
             Err(BinaryError::UnsafePath(_))
         ));
         assert!(safe_relative_path("camoufox/camoufox").is_ok());
+    }
+
+    /// The transport check, both directions. The negative cases are the
+    /// point, but the positive ones are here too: a rule that refuses every
+    /// URL would pass the refusals and break every real deployment.
+    #[test]
+    fn require_secure_url_refuses_non_https_transports() {
+        for url in [
+            "http://mirror.example.com/camoufox.tar.gz",
+            "http://203.0.113.7:8080/camoufox.tar.gz",
+            "ftp://mirror.example.com/camoufox.tar.gz",
+            "file:///tmp/camoufox.tar.gz",
+        ] {
+            assert!(
+                matches!(
+                    require_secure_url(url),
+                    Err(BinaryError::InsecureScheme { .. })
+                ),
+                "{url} was accepted; an executable would be fetched over an \
+                 unauthenticated transport"
+            );
+        }
+    }
+
+    /// Positive control for the arm above: https anywhere, and plain http
+    /// only to a loopback host (the local-mirror carve-out the doc comment
+    /// justifies, and the transport the provisioning wiring tests use).
+    #[test]
+    fn require_secure_url_accepts_https_and_loopback_http() {
+        for url in [
+            "https://mirror.example.com/camoufox.tar.gz",
+            "HTTPS://mirror.example.com/camoufox.tar.gz",
+            "http://127.0.0.1:8080/camoufox.tar.gz",
+            "http://localhost:8080/camoufox.tar.gz",
+            "http://[::1]:8080/camoufox.tar.gz",
+        ] {
+            assert!(
+                require_secure_url(url).is_ok(),
+                "{url} was refused; the rule is stricter than intended"
+            );
+        }
+    }
+
+    /// The refusal must happen at the CONFIG surface, before any client is
+    /// built or any request is issued. Asserting on the returned error alone
+    /// would not distinguish "refused" from "tried and failed".
+    #[tokio::test]
+    async fn provision_camoufox_refuses_a_plain_http_artifact() {
+        let dir = tempfile::tempdir().unwrap();
+        let mgr = BrowserBinaryManager::new(dir.path().to_path_buf(), false);
+        let mut artifacts = std::collections::BTreeMap::new();
+        artifacts.insert(
+            wcore_config::browser::platform_key(),
+            wcore_config::browser::BinaryArtifact {
+                url: "http://mirror.example.com/camoufox.tar.gz".to_string(),
+                sha256: sha256_hex(b"payload"),
+                archive_exe_path: "camoufox/camoufox".to_string(),
+            },
+        );
+        let cfg = wcore_config::browser::CamoufoxDownloadConfig {
+            enabled: true,
+            artifacts,
+        };
+
+        let err = mgr
+            .provision_camoufox(&cfg)
+            .await
+            .expect_err("a plain-http artifact url must be refused, not fetched");
+        assert!(
+            matches!(err, BinaryError::InsecureScheme { .. }),
+            "expected an InsecureScheme refusal, got: {err}"
+        );
+        assert!(
+            err.to_string().contains("https"),
+            "the refusal must name the transport the operator has to switch to, got: {err}"
+        );
+        assert!(
+            !dir.path().join("camoufox.tar.gz").exists(),
+            "the refused path still wrote into the install root"
+        );
     }
 }

--- a/crates/wcore-browser/src/supervisor.rs
+++ b/crates/wcore-browser/src/supervisor.rs
@@ -4,6 +4,11 @@
 //!
 //!   * **Launch:** `launch_camoufox` spawns the sidecar binary with
 //!     `kill_on_drop(true)` so a panic in the host kills the child.
+//!   * **Provisioning:** when the configured sidecar program does not resolve
+//!     and the operator opted in via `[browser.camoufox_download]`,
+//!     `ensure_ready` calls
+//!     `BrowserBinaryManager::provision_camoufox` to download + SHA-verify +
+//!     unpack it. Off by default; fail-closed without a pinned digest.
 //!   * **PID tracking:** `register` records the live child + parent PID.
 //!   * **Healthcheck:** `healthcheck` issues `GET /health` and returns
 //!     `Ok(true)` on 2xx.
@@ -44,6 +49,13 @@ pub struct SupervisorConfig {
     pub sidecar_program: Option<String>,
     /// Maximum time to wait for a newly spawned sidecar to become healthy.
     pub startup_timeout: Duration,
+    /// Opt-in auto-provisioning of the Camoufox binary. Default: **disabled**
+    /// (`CamoufoxDownloadConfig::default()`), so the supervisor fetches
+    /// nothing unless an operator turns it on in `[browser.camoufox_download]`
+    /// and pins a SHA-256 for their platform.
+    pub camoufox_download: wcore_config::browser::CamoufoxDownloadConfig,
+    /// Install root for auto-provisioned browser binaries.
+    pub binary_install_root: PathBuf,
 }
 
 impl Default for SupervisorConfig {
@@ -55,14 +67,21 @@ impl Default for SupervisorConfig {
             healthcheck_url: "http://localhost:9377/health".to_string(),
             sidecar_program: None,
             startup_timeout: Duration::from_secs(15),
+            camoufox_download: wcore_config::browser::CamoufoxDownloadConfig::default(),
+            binary_install_root: home_bin_dir(),
         }
     }
 }
 
 impl SupervisorConfig {
     /// Production configuration for the locally managed Camoufox sidecar.
-    /// The command may be overridden by Desktop or an operator; Core never
-    /// invokes a package manager or downloads executable code at runtime.
+    /// The command may be overridden by Desktop or an operator.
+    ///
+    /// Core still invokes no package manager. It downloads executable code
+    /// only when the operator has explicitly enabled
+    /// `[browser.camoufox_download]` AND pinned a SHA-256 for their platform;
+    /// the default config leaves that switch off, which is the pre-existing
+    /// "never downloads" behaviour verbatim.
     pub fn local_camoufox(base_url: &str) -> Self {
         let base_url = base_url.trim_end_matches('/');
         Self {
@@ -71,9 +90,34 @@ impl SupervisorConfig {
                 std::env::var("WAYLAND_CAMOUFOX_BIN")
                     .unwrap_or_else(|_| "camofox-browser".to_string()),
             ),
+            camoufox_download: configured_camoufox_download(),
             ..Self::default()
         }
     }
+}
+
+/// The operator's `[browser.camoufox_download]` block, read once per process.
+///
+/// `local_camoufox` is the only production constructor of the Camoufox
+/// supervisor (`adapter::from_spec`), and it already resolves the sidecar
+/// program from the environment, so config resolution belongs here too. A
+/// config that cannot be read yields the default - which is *disabled*, so
+/// the failure mode is "no auto-download", never "unverified download".
+fn configured_camoufox_download() -> wcore_config::browser::CamoufoxDownloadConfig {
+    static CACHE: OnceLock<wcore_config::browser::CamoufoxDownloadConfig> = OnceLock::new();
+    CACHE
+        .get_or_init(|| {
+            wcore_config::config::load_merged_config_file(None)
+                .map(|file| file.browser.camoufox_download)
+                .unwrap_or_default()
+        })
+        .clone()
+}
+
+fn home_bin_dir() -> PathBuf {
+    wcore_config::config::profile_home()
+        .join("browser")
+        .join("bin")
 }
 
 fn home_pid_dir() -> PathBuf {
@@ -280,7 +324,7 @@ impl BrowserSupervisor {
     /// externally managed service is reused. Otherwise Core starts only the
     /// already-installed command and waits under a fixed deadline.
     pub async fn ensure_ready(self: &Arc<Self>) -> Result<(), String> {
-        let Some(program) = self.config.sidecar_program.as_deref() else {
+        let Some(configured_program) = self.config.sidecar_program.clone() else {
             return Ok(());
         };
 
@@ -292,6 +336,9 @@ impl BrowserSupervisor {
         {
             return Ok(());
         }
+
+        let resolved_program = self.resolve_sidecar_program(&configured_program).await?;
+        let program = resolved_program.as_str();
 
         let session_id = format!("camoufox-sidecar-{}", std::process::id());
         // A prior owned sidecar may be alive but unhealthy. Remove it before
@@ -335,6 +382,45 @@ Install @askjo/camofox-browser or set WAYLAND_CAMOUFOX_BIN to its executable",
                 ));
             }
             tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    }
+
+    /// The executable [`Self::ensure_ready`] will actually spawn.
+    ///
+    /// Returns the configured program unchanged when it already resolves
+    /// (PATHEXT-aware via `which`, resolve-only - nothing is executed), and
+    /// unchanged when auto-download is off, which is the default. Only when
+    /// the program is missing AND the operator enabled
+    /// `[browser.camoufox_download]` does this reach the network, and then
+    /// only through the fail-closed
+    /// [`crate::binary::BrowserBinaryManager::provision_camoufox`]: an
+    /// unconfigured platform or an unpinned digest is an error here, never a
+    /// silent unverified fetch.
+    async fn resolve_sidecar_program(&self, program: &str) -> Result<String, String> {
+        if which::which(program).is_ok() {
+            return Ok(program.to_string());
+        }
+        if !self.config.camoufox_download.enabled {
+            // Unchanged pre-existing behaviour: let the spawn below fail with
+            // the actionable "install it / set WAYLAND_CAMOUFOX_BIN" message.
+            return Ok(program.to_string());
+        }
+        let manager = crate::binary::BrowserBinaryManager::new(
+            self.config.binary_install_root.clone(),
+            false,
+        );
+        match manager
+            .provision_camoufox(&self.config.camoufox_download)
+            .await
+        {
+            Ok(Some(path)) => path
+                .to_str()
+                .map(str::to_string)
+                .ok_or_else(|| "provisioned Camoufox path is not valid UTF-8".to_string()),
+            Ok(None) => Ok(program.to_string()),
+            Err(error) => Err(format!(
+                "Camoufox auto-download failed while provisioning `{program}`: {error}"
+            )),
         }
     }
 

--- a/crates/wcore-browser/tests/camoufox_provisioning_wiring_test.rs
+++ b/crates/wcore-browser/tests/camoufox_provisioning_wiring_test.rs
@@ -1,0 +1,277 @@
+//! F7 — the supervisor's readiness path must actually *invoke* binary
+//! provisioning.
+//!
+//! `BrowserBinaryManager::ensure_camoufox` shipped complete — SHA-256
+//! verification, atomic move, bounded redirects, wiremock coverage — and had
+//! **zero production callers**: its only other references were two doc
+//! comments and one unit test. A host without `camofox-browser` on PATH
+//! therefore failed, with a working downloader sitting one call away. Unit
+//! tests of the downloader cannot detect that, because the downloader was
+//! never broken. Only a test that drives `BrowserSupervisor::ensure_ready`
+//! can.
+//!
+//! Both arms are paired, and the wire is the instrument. The origin is a
+//! `wiremock` server mounted with an explicit `.expect(n)`; `MockServer`
+//! verifies expectations on drop, so "it downloaded" and "it did not
+//! download" are both measured against real HTTP rather than inferred from a
+//! return value. No test contacts a real network.
+//!
+//! The configured sidecar program is a name that provably does not resolve on
+//! PATH, so a successful `ensure_ready` is attributable to provisioning and
+//! nothing else — and the disabled arm is the control that stops
+//! "provisioning ran" from being satisfied by a supervisor that would have
+//! succeeded anyway.
+//!
+//! **Unix only** (the stand-in sidecar is a `#!`-script and the executable
+//! bit is a Unix concept). Windows is not covered here; that is a gap, not a
+//! pass.
+
+#![cfg(unix)]
+
+use std::collections::BTreeMap;
+use std::os::unix::fs::PermissionsExt as _;
+use std::sync::Arc;
+use std::time::Duration;
+
+use wcore_browser::binary::{CAMOUFOX_VERSION, sha256_hex};
+use wcore_browser::supervisor::{BrowserSupervisor, SupervisorConfig};
+use wcore_config::browser::{BinaryArtifact, CamoufoxDownloadConfig, platform_key};
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// A name no PATH entry can satisfy. `which` must fail on it, otherwise the
+/// arms below measure a pre-installed binary instead of the download.
+const ABSENT_PROGRAM: &str = "wcore-f7-camoufox-that-does-not-exist";
+
+/// Gzipped tar holding one member at `rel`. Written mode 0o644 on purpose:
+/// if the spawned sidecar runs, the executable bit came from the
+/// provisioning path, not from the archive.
+fn tar_gz_with(rel: &str, body: &[u8]) -> Vec<u8> {
+    let enc = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::fast());
+    let mut builder = tar::Builder::new(enc);
+    let mut header = tar::Header::new_gnu();
+    header.set_size(body.len() as u64);
+    header.set_mode(0o644);
+    builder.append_data(&mut header, rel, body).unwrap();
+    builder.into_inner().unwrap().finish().unwrap()
+}
+
+/// An argument-free HTTP health server. `launch_camoufox_program` passes NO
+/// args, so the stand-in sidecar has to be self-contained.
+fn stub_sidecar_script(port: u16) -> String {
+    format!(
+        r#"#!/usr/bin/env python3
+import http.server, socketserver
+class H(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200); self.send_header("Content-Length","2"); self.end_headers()
+        self.wfile.write(b"ok")
+    def log_message(self, *a): pass
+socketserver.TCPServer.allow_reuse_address = True
+socketserver.TCPServer(("127.0.0.1", {port}), H).serve_forever()
+"#
+    )
+}
+
+fn free_port() -> u16 {
+    let l = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    l.local_addr().unwrap().port()
+}
+
+fn artifacts(url: &str, sha: &str, exe: &str) -> BTreeMap<String, BinaryArtifact> {
+    let mut m = BTreeMap::new();
+    m.insert(
+        platform_key(),
+        BinaryArtifact {
+            url: url.to_string(),
+            sha256: sha.to_string(),
+            archive_exe_path: exe.to_string(),
+        },
+    );
+    m
+}
+
+fn cfg(port: u16, tmp: &std::path::Path, download: CamoufoxDownloadConfig) -> SupervisorConfig {
+    SupervisorConfig {
+        pid_dir: tmp.join("pids"),
+        reaper_interval: Duration::from_millis(200),
+        healthcheck_interval: Duration::from_secs(30),
+        healthcheck_url: format!("http://127.0.0.1:{port}/health"),
+        sidecar_program: Some(ABSENT_PROGRAM.to_string()),
+        startup_timeout: Duration::from_secs(20),
+        camoufox_download: download,
+        binary_install_root: tmp.join("bin"),
+    }
+}
+
+/// Precondition shared by both arms: the configured program really is absent.
+/// Without this the "download happened" arm could be satisfied by a machine
+/// that happened to have the binary, and the control arm proves nothing.
+#[test]
+fn configured_program_is_genuinely_unresolvable() {
+    assert!(
+        which::which(ABSENT_PROGRAM).is_err(),
+        "{ABSENT_PROGRAM} resolves on this host; both arms below would be vacuous"
+    );
+}
+
+/// ARM 1 — enabled + pinned digest ⇒ `ensure_ready` downloads, verifies,
+/// unpacks, chmods, and spawns the provisioned executable, which then
+/// answers the healthcheck.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn ensure_ready_provisions_camoufox_when_enabled() {
+    let port = free_port();
+    let payload = tar_gz_with("camoufox/camoufox", stub_sidecar_script(port).as_bytes());
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/camoufox.tar.gz"))
+        .respond_with(ResponseTemplate::new(200).set_body_bytes(payload.clone()))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let download = CamoufoxDownloadConfig {
+        enabled: true,
+        artifacts: artifacts(
+            &format!("{}/camoufox.tar.gz", server.uri()),
+            &sha256_hex(&payload),
+            "camoufox/camoufox",
+        ),
+    };
+    let sup = Arc::new(BrowserSupervisor::with_config(cfg(
+        port,
+        tmp.path(),
+        download,
+    )));
+
+    sup.ensure_ready().await.expect(
+        "ensure_ready must provision the sidecar; the configured program is not on PATH, \
+         so this can only succeed via the download path",
+    );
+
+    // The supervisor spawned something and is tracking it.
+    let live = sup.live_sessions();
+    assert_eq!(
+        live.len(),
+        1,
+        "exactly one sidecar session must be tracked, got {live:?}"
+    );
+
+    // The thing it spawned is the artifact we served, on disk, executable.
+    let exe = tmp
+        .path()
+        .join("bin")
+        .join(format!("camoufox-{CAMOUFOX_VERSION}-unpacked"))
+        .join("camoufox")
+        .join("camoufox");
+    assert!(
+        exe.is_file(),
+        "provisioned executable missing at {}",
+        exe.display()
+    );
+    let mode = std::fs::metadata(&exe).unwrap().permissions().mode();
+    assert_ne!(
+        mode & 0o111,
+        0,
+        "provisioned executable is not executable (mode {mode:o}); the archive ships it 0o644"
+    );
+
+    // Mock `.expect(1)`, verified on drop, is the wire-level proof that
+    // ensure_ready reached the downloader exactly once.
+    drop(server);
+}
+
+/// ARM 2 (control) — the SAME setup with the switch off. Nothing is fetched,
+/// and the operator still gets the pre-existing actionable install message.
+/// Without this arm, ARM 1 is satisfied by an implementation that downloads
+/// unconditionally, which is exactly the behaviour the policy forbids.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn ensure_ready_fetches_nothing_when_download_disabled() {
+    let port = free_port();
+    let payload = tar_gz_with("camoufox/camoufox", stub_sidecar_script(port).as_bytes());
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/camoufox.tar.gz"))
+        .respond_with(ResponseTemplate::new(200).set_body_bytes(payload.clone()))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let download = CamoufoxDownloadConfig {
+        enabled: false,
+        artifacts: artifacts(
+            &format!("{}/camoufox.tar.gz", server.uri()),
+            &sha256_hex(&payload),
+            "camoufox/camoufox",
+        ),
+    };
+    let sup = Arc::new(BrowserSupervisor::with_config(cfg(
+        port,
+        tmp.path(),
+        download,
+    )));
+
+    let err = sup
+        .ensure_ready()
+        .await
+        .expect_err("with auto-download off there is no binary, so readiness must fail");
+    assert!(
+        err.contains("Install @askjo/camofox-browser"),
+        "the disabled path must keep the actionable install message, got: {err}"
+    );
+    assert!(
+        !tmp.path().join("bin").exists(),
+        "the disabled path created an install root"
+    );
+    assert!(sup.live_sessions().is_empty());
+    drop(server);
+}
+
+/// ARM 3 — enabled but the operator pinned no digest. `ensure_ready` must
+/// REFUSE with an actionable message and never touch the origin. This is the
+/// fail-closed rule stated at the supervisor boundary rather than only at the
+/// downloader's.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn ensure_ready_refuses_when_no_digest_is_pinned() {
+    let port = free_port();
+    let payload = tar_gz_with("camoufox/camoufox", stub_sidecar_script(port).as_bytes());
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/camoufox.tar.gz"))
+        .respond_with(ResponseTemplate::new(200).set_body_bytes(payload))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let download = CamoufoxDownloadConfig {
+        enabled: true,
+        artifacts: artifacts(
+            &format!("{}/camoufox.tar.gz", server.uri()),
+            "",
+            "camoufox/camoufox",
+        ),
+    };
+    let sup = Arc::new(BrowserSupervisor::with_config(cfg(
+        port,
+        tmp.path(),
+        download,
+    )));
+
+    let err = sup
+        .ensure_ready()
+        .await
+        .expect_err("an unpinned artifact must be refused, not fetched");
+    assert!(
+        err.contains("no sha256 is pinned"),
+        "refusal must name the missing digest, got: {err}"
+    );
+    assert!(
+        err.contains("browser.camoufox_download.artifacts"),
+        "refusal must name the config key the operator has to set, got: {err}"
+    );
+    assert!(sup.live_sessions().is_empty());
+    drop(server);
+}

--- a/crates/wcore-browser/tests/process_count_reaper_baseline_test.rs
+++ b/crates/wcore-browser/tests/process_count_reaper_baseline_test.rs
@@ -350,6 +350,7 @@ fn cfg_for(program: &std::path::Path, port: u16, pid_dir: PathBuf) -> Supervisor
         healthcheck_url: format!("http://127.0.0.1:{port}/health"),
         sidecar_program: Some(program.to_string_lossy().into_owned()),
         startup_timeout: Duration::from_secs(20),
+        ..SupervisorConfig::default()
     }
 }
 
@@ -482,6 +483,7 @@ async fn baseline_reaper_one_interval_both_directions() {
         healthcheck_url: "http://127.0.0.1:1/health".into(),
         sidecar_program: None,
         startup_timeout: Duration::from_secs(1),
+        ..SupervisorConfig::default()
     }));
     let (mut orphan_child, orphan_pid) = spawn_real_child();
     // Participant-started check (§6a-i).
@@ -545,6 +547,7 @@ async fn baseline_reaper_one_interval_both_directions() {
         healthcheck_url: "http://127.0.0.1:1/health".into(),
         sidecar_program: None,
         startup_timeout: Duration::from_secs(1),
+        ..SupervisorConfig::default()
     }));
     let (mut keep_child, keep_pid) = spawn_real_child();
     assert!(alive(keep_pid), "ARM 2: the child never started");

--- a/crates/wcore-config/src/browser.rs
+++ b/crates/wcore-config/src/browser.rs
@@ -6,7 +6,63 @@
 //! facing fields here so config loading stays in `wcore-config` (which
 //! already owns the cascade + profile system).
 
+use std::collections::BTreeMap;
+
 use serde::{Deserialize, Serialize};
+
+/// Key identifying the platform an artifact is built for: `"<os>-<arch>"`
+/// from `std::env::consts` — e.g. `linux-x86_64`, `macos-aarch64`,
+/// `windows-x86_64`.
+///
+/// Centralised here rather than spelled out at each consumer. Per the
+/// architecture rule "Centralize Platform Differences", the platform is a
+/// **lookup key into configuration**, not a `cfg!`/`if` ladder that hardcodes
+/// one vendor's URL per target.
+pub fn platform_key() -> String {
+    format!("{}-{}", std::env::consts::OS, std::env::consts::ARCH)
+}
+
+/// One downloadable artifact, for one platform.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct BinaryArtifact {
+    /// Where the artifact is fetched from.
+    pub url: String,
+    /// Operator-supplied SHA-256 (hex) of the bytes at [`Self::url`].
+    ///
+    /// **There is no built-in digest and none is ever guessed.** An empty
+    /// value means *unpinned*, and an unpinned artifact is refused, never
+    /// fetched — see `wcore_browser::binary::BrowserBinaryManager::provision_camoufox`.
+    pub sha256: String,
+    /// Path of the executable *inside* the archive, relative to the archive
+    /// root (e.g. `camoufox/camoufox`). Empty means the artifact is itself a
+    /// bare executable and no extraction is performed.
+    pub archive_exe_path: String,
+}
+
+/// Opt-in auto-provisioning of the Camoufox sidecar binary.
+///
+/// [`Self::enabled`] defaults to **false**: Core does not fetch executable
+/// code from the network unless an operator explicitly turns it on *and*
+/// pins a digest for the platform being provisioned. Enabling it without a
+/// digest is an error, not a permission to fetch-and-trust.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct CamoufoxDownloadConfig {
+    /// Master switch. OFF by default.
+    pub enabled: bool,
+    /// Artifacts keyed by [`platform_key`].
+    pub artifacts: BTreeMap<String, BinaryArtifact>,
+}
+
+impl CamoufoxDownloadConfig {
+    /// The artifact configured for the platform this process is running on,
+    /// if any. `None` is a refusal condition for the download path, never a
+    /// cue to fall back to some other platform's artifact.
+    pub fn artifact_for_current_platform(&self) -> Option<&BinaryArtifact> {
+        self.artifacts.get(&platform_key())
+    }
+}
 
 /// Preferred provider. Mirrors `wcore_browser::ProviderHint`.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, Default, PartialEq, Eq)]
@@ -63,6 +119,9 @@ pub struct BrowserConfig {
     pub download_dir: Option<String>,
     /// When true, the same on-disk profile is reused across sessions.
     pub persist_profile: bool,
+    /// Opt-in auto-download of the Camoufox sidecar binary
+    /// (`[browser.camoufox_download]`). Disabled by default.
+    pub camoufox_download: CamoufoxDownloadConfig,
 }
 
 #[cfg(test)]
@@ -88,6 +147,7 @@ mod tests {
             },
             download_dir: Some("/tmp/downloads".into()),
             persist_profile: false,
+            camoufox_download: CamoufoxDownloadConfig::default(),
         };
         let s = toml::to_string(&cfg).unwrap();
         let parsed: BrowserConfig = toml::from_str(&s).unwrap();
@@ -102,5 +162,61 @@ mod tests {
         assert_eq!(cfg.stealth.preferred_provider, BrowserProvider::Auto);
         assert!(!cfg.stealth.allow_cloud_fallback);
         assert!(!cfg.persist_profile);
+    }
+
+    /// The auto-download switch must be OFF for a config that never mentions
+    /// it — a default-on network fetch of an executable is not acceptable.
+    #[test]
+    fn camoufox_download_is_off_by_default() {
+        let cfg: BrowserConfig = toml::from_str("").unwrap();
+        assert!(
+            !cfg.camoufox_download.enabled,
+            "auto-download must default to disabled"
+        );
+        assert!(cfg.camoufox_download.artifacts.is_empty());
+        assert!(
+            cfg.camoufox_download
+                .artifact_for_current_platform()
+                .is_none()
+        );
+    }
+
+    /// The operator-facing TOML path is `[browser.camoufox_download]` with a
+    /// per-platform artifacts table keyed by [`platform_key`]. Parsing it
+    /// through the real serde types is what stops the documented key and the
+    /// loaded key from drifting apart (cf. `config_hint.rs`).
+    #[test]
+    fn camoufox_download_round_trips_per_platform_artifacts() {
+        let key = platform_key();
+        let toml_src = format!(
+            r#"
+[camoufox_download]
+enabled = true
+
+[camoufox_download.artifacts."{key}"]
+url = "https://example.test/camoufox.tar.gz"
+sha256 = "aa"
+archive_exe_path = "camoufox/camoufox"
+"#
+        );
+        let cfg: BrowserConfig = toml::from_str(&toml_src).unwrap();
+        assert!(cfg.camoufox_download.enabled);
+        let a = cfg
+            .camoufox_download
+            .artifact_for_current_platform()
+            .expect("artifact must resolve for the running platform");
+        assert_eq!(a.url, "https://example.test/camoufox.tar.gz");
+        assert_eq!(a.sha256, "aa");
+        assert_eq!(a.archive_exe_path, "camoufox/camoufox");
+    }
+
+    /// The platform key must be the `<os>-<arch>` pair, not one or the other:
+    /// macOS arm64 and macOS x86_64 are different artifacts.
+    #[test]
+    fn platform_key_pairs_os_and_arch() {
+        let k = platform_key();
+        assert!(k.starts_with(std::env::consts::OS), "{k}");
+        assert!(k.ends_with(std::env::consts::ARCH), "{k}");
+        assert!(k.contains('-'), "{k}");
     }
 }

--- a/crates/wcore-config/src/config.rs
+++ b/crates/wcore-config/src/config.rs
@@ -5221,6 +5221,11 @@ fn merge_config_files_with_trust(
     let browser = if project.browser.policy.default_action != default_browser_policy.default_action
         || !project.browser.policy.allowed_origins.is_empty()
         || !project.browser.policy.denied_origins.is_empty()
+        // A project block that configures ONLY [browser.camoufox_download]
+        // leaves every policy field at its default; without this term the
+        // whole block loses to global and the operator gets no diagnostic —
+        // the silent-drop failure mode config_hint.rs documents.
+        || project.browser.camoufox_download != crate::browser::CamoufoxDownloadConfig::default()
     {
         project.browser
     } else {

--- a/crates/wcore-config/src/config.rs
+++ b/crates/wcore-config/src/config.rs
@@ -5212,24 +5212,58 @@ fn merge_config_files_with_trust(
         global.inbound_webhook
     };
 
-    // FleetDispatcher-class fix (audit 2026-05-24 §3) — browser section:
-    // project overrides global if any policy field differs from
-    // `BrowserPolicyConfig::default()`. Mirrors the memory/budget strategy
-    // above; conservative — preserves the deny-all default when neither
-    // block exists.
+    // FleetDispatcher-class fix (audit 2026-05-24 §3) — browser section.
+    //
+    // Merged FIELD-WISE, the same shape as the `[anvil]` block below, and for
+    // the same reason: a project config travels with a cloned repo, so a
+    // setting it never mentions must not disappear because of one it did.
+    //
+    // The whole-block form this replaces resolved `[browser]` as a single
+    // all-or-nothing choice. `[browser.camoufox_download]` then became a
+    // trigger for that choice, so a project configuring ONLY a download — a
+    // network-fetch-and-execute surface — replaced the operator's
+    // `[browser.policy]` with `BrowserPolicyConfig::default()`, silently
+    // dropping the origin allowlist that bounds where the browser may go.
+    // Enabling a download must not be able to drop the operator's policy.
+    // Locked by `tests/browser_merge_trust_test.rs`.
+    //
+    // Every field keeps the presence-over-default resolution it had before, so
+    // the only behaviour that changes is the cross-field clobbering. `policy`
+    // is resolved as a UNIT under exactly its previous predicate rather than
+    // split per field: `default_action` and the two origin lists are one
+    // decision — an allowlist only means anything alongside the action it
+    // qualifies — and merging them separately would synthesise a
+    // project-denies/operator-allows pairing that neither layer wrote.
     let default_browser_policy = crate::browser::BrowserPolicyConfig::default();
-    let browser = if project.browser.policy.default_action != default_browser_policy.default_action
-        || !project.browser.policy.allowed_origins.is_empty()
-        || !project.browser.policy.denied_origins.is_empty()
-        // A project block that configures ONLY [browser.camoufox_download]
-        // leaves every policy field at its default; without this term the
-        // whole block loses to global and the operator gets no diagnostic —
-        // the silent-drop failure mode config_hint.rs documents.
-        || project.browser.camoufox_download != crate::browser::CamoufoxDownloadConfig::default()
-    {
-        project.browser
-    } else {
-        global.browser
+    let browser = crate::browser::BrowserConfig {
+        policy: if project.browser.policy.default_action != default_browser_policy.default_action
+            || !project.browser.policy.allowed_origins.is_empty()
+            || !project.browser.policy.denied_origins.is_empty()
+        {
+            project.browser.policy
+        } else {
+            global.browser.policy
+        },
+        stealth: crate::browser::StealthConfig {
+            preferred_provider: if project.browser.stealth.preferred_provider
+                != crate::browser::BrowserProvider::default()
+            {
+                project.browser.stealth.preferred_provider
+            } else {
+                global.browser.stealth.preferred_provider
+            },
+            allow_cloud_fallback: project.browser.stealth.allow_cloud_fallback
+                || global.browser.stealth.allow_cloud_fallback,
+        },
+        download_dir: project.browser.download_dir.or(global.browser.download_dir),
+        persist_profile: project.browser.persist_profile || global.browser.persist_profile,
+        camoufox_download: if project.browser.camoufox_download
+            != crate::browser::CamoufoxDownloadConfig::default()
+        {
+            project.browser.camoufox_download
+        } else {
+            global.browser.camoufox_download
+        },
     };
 
     // Crucible: project overrides global when it set a non-default council

--- a/crates/wcore-config/tests/browser_merge_trust_test.rs
+++ b/crates/wcore-config/tests/browser_merge_trust_test.rs
@@ -1,0 +1,344 @@
+//! `[browser]` merge — trust polarity and cross-field clobbering.
+//!
+//! Two separate properties, both about the same block, both driven through the
+//! **real** load path (`Config::resolve_with_provenance` over a global
+//! `config.toml` and a project `.wayland-core.toml` on disk) rather than by
+//! calling the merge or the trust filter with a hand-built struct. A fixture
+//! that cannot carry the defect proves nothing, so every arm here writes the
+//! attacker-shaped TOML a cloned repository would actually ship.
+//!
+//! ## 1. Enabling a download must not drop the operator's policy
+//!
+//! `[browser]` used to merge as one all-or-nothing block, and
+//! `[browser.camoufox_download]` — a network-fetch-and-execute surface — was
+//! added as a trigger for that choice. A project configuring only a download
+//! therefore replaced the operator's `[browser.policy]` with
+//! `BrowserPolicyConfig::default()`, silently deleting the origin allowlist
+//! that bounds where the browser may go. The merge is now field-wise.
+//!
+//! ## 2. An untrusted project cannot reach `[browser]` at all
+//!
+//! `restrict_untrusted_project_config` is an ALLOWLIST — it starts from
+//! `ConfigFile::default()` and forwards a named handful of narrowing fields —
+//! so `[browser]` from an untrusted workspace is dropped whole. That is a load-
+//! bearing property of the download surface (an untrusted repo naming its own
+//! URL and its own digest would otherwise be fetched, verified against the
+//! attacker's digest, chmod'd and spawned), and nothing in the function names
+//! `browser`, so nothing in the function would break if a future edit started
+//! forwarding it. These arms pin the property from the outside.
+//!
+//! Both untrusted arms are paired with a TRUSTED control using the identical
+//! project body. Without the control, "the untrusted config did not take
+//! effect" is satisfiable by a fixture that never took effect anywhere.
+
+use std::ffi::{OsStr, OsString};
+
+use serial_test::serial;
+use wcore_config::browser::{CamoufoxDownloadConfig, platform_key};
+use wcore_config::config::{CliArgs, Config};
+use wcore_config::resolution_provenance::{ConfigSourceDisposition, ConfigSourceRole};
+use wcore_config::workspace_trust::WorkspaceTrustStore;
+
+/// Written into every temp GLOBAL config and read back out of the merged
+/// result. This host injects provider credentials into a process regardless of
+/// the shell environment, and a stale real `~/.wayland` would silently supply a
+/// different `[browser]` block — so each arm proves it read *its own* global
+/// file before it trusts anything else the merge produced.
+const GLOBAL_SENTINEL_MAX_TOKENS: u32 = 4321;
+
+/// The operator's allowlisted origin. Its survival (or disappearance) is the
+/// symptom under test in the clobbering arms.
+const OPERATOR_ORIGIN: &str = "https://ops.example.com";
+
+struct EnvGuard {
+    saved: Vec<(&'static str, Option<OsString>)>,
+}
+
+impl EnvGuard {
+    fn set(values: &[(&'static str, Option<&OsStr>)]) -> Self {
+        let saved = values
+            .iter()
+            .map(|(key, _)| (*key, std::env::var_os(key)))
+            .collect();
+        for (key, value) in values {
+            // SAFETY: every test in this binary that mutates the environment is
+            // in the same `serial` group and restores through this guard.
+            unsafe {
+                match value {
+                    Some(value) => std::env::set_var(key, value),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
+        Self { saved }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        for (key, value) in self.saved.drain(..).rev() {
+            // SAFETY: see `EnvGuard::set`.
+            unsafe {
+                match value {
+                    Some(value) => std::env::set_var(key, value),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
+    }
+}
+
+/// Whether the workspace fingerprint is granted before the config is resolved.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum Trust {
+    Granted,
+    /// The DEFAULT state of any freshly cloned or freshly created project.
+    Untrusted,
+}
+
+/// Drive the real load + merge and hand back the resolved config.
+fn load(global_browser: &str, project_body: &str, trust: Trust) -> Config {
+    let home = tempfile::tempdir().unwrap();
+    let project = tempfile::tempdir().unwrap();
+
+    std::fs::write(
+        home.path().join("config.toml"),
+        format!("[default]\nmax_tokens = {GLOBAL_SENTINEL_MAX_TOKENS}\n\n{global_browser}"),
+    )
+    .unwrap();
+    std::fs::write(project.path().join(".wayland-core.toml"), project_body).unwrap();
+
+    let _env = EnvGuard::set(&[
+        ("WAYLAND_HOME", Some(home.path().as_os_str())),
+        ("WAYLAND_CONFIG_PATH", None),
+        ("XDG_DATA_HOME", None),
+    ]);
+
+    if trust == Trust::Granted {
+        // The trust store lives under WAYLAND_HOME, so the grant must happen
+        // with the guard already installed.
+        WorkspaceTrustStore::for_current_home()
+            .grant(project.path())
+            .expect("granting workspace trust");
+    }
+
+    let cli = CliArgs {
+        provider: Some("anthropic".to_string()),
+        api_key: Some("test-key-not-a-real-credential".to_string()),
+        project_dir: Some(project.path().to_path_buf()),
+        ..CliArgs::default()
+    };
+    let resolved = Config::resolve_with_provenance(&cli).expect("resolving config");
+
+    let project_sources: Vec<_> = resolved
+        .provenance
+        .sources
+        .iter()
+        .filter(|source| source.role == ConfigSourceRole::Project)
+        .collect();
+    assert!(
+        !project_sources.is_empty(),
+        "a Project config source must appear in the provenance; the project \
+         .wayland-core.toml was never read and every arm here is vacuous"
+    );
+    let project_restricted = project_sources.iter().any(|source| {
+        source
+            .dispositions
+            .contains(&ConfigSourceDisposition::Restricted)
+    });
+
+    // Instrument-alive check: the merge really read the temp global file.
+    assert_eq!(
+        resolved.value.max_tokens, GLOBAL_SENTINEL_MAX_TOKENS,
+        "the merged config did not carry the temp global config's sentinel \
+         max_tokens — this test read some OTHER global config, so nothing it \
+         measures about [browser] can be trusted"
+    );
+    // And the trust arm actually under test was the one exercised.
+    assert_eq!(
+        project_restricted,
+        trust == Trust::Untrusted,
+        "workspace trust arm mismatch: wanted {trust:?}, but the resolver \
+         reported project_restricted={project_restricted}"
+    );
+
+    resolved.value
+}
+
+/// An operator global that allows exactly one origin. Anything that replaces
+/// this block with `BrowserPolicyConfig::default()` produces a deny-all with an
+/// empty allowlist, which is a visibly different value.
+fn operator_global_policy() -> String {
+    format!(
+        "[browser.policy]\ndefault_action = \"allow\"\nallowed_origins = [\"{OPERATOR_ORIGIN}\"]\n"
+    )
+}
+
+/// A project block that configures ONLY a Camoufox download — it says nothing
+/// whatsoever about `[browser.policy]`.
+fn download_only_project_body() -> String {
+    let key = platform_key();
+    format!(
+        "[browser.camoufox_download]\nenabled = true\n\n\
+         [browser.camoufox_download.artifacts.\"{key}\"]\n\
+         url = \"https://repo-supplied.example.com/camoufox.tar.gz\"\n\
+         sha256 = \"{}\"\n\
+         archive_exe_path = \"camoufox/camoufox\"\n",
+        "a".repeat(64)
+    )
+}
+
+// ── 1. Cross-field clobbering (trusted path) ─────────────────────────────────
+
+/// A trusted project that configures only `[browser.camoufox_download]` must
+/// keep the operator's `[browser.policy]`. Both values must survive: the
+/// download the project asked for AND the allowlist it never mentioned.
+///
+/// Red arm: with the whole-block merge, `project.browser` wins outright and the
+/// operator's `allowed_origins` comes back empty with `default_action = "deny"`.
+#[test]
+#[serial(browser_merge_trust_env)]
+fn enabling_a_download_does_not_drop_the_operator_browser_policy() {
+    let config = load(
+        &operator_global_policy(),
+        &download_only_project_body(),
+        Trust::Granted,
+    );
+
+    assert_eq!(
+        config.browser.policy.allowed_origins,
+        vec![OPERATOR_ORIGIN.to_string()],
+        "the operator's browser origin allowlist was dropped by a project \
+         config that configured only [browser.camoufox_download] and never \
+         mentioned [browser.policy]"
+    );
+    assert_eq!(
+        config.browser.policy.default_action, "allow",
+        "the operator's browser default_action was dropped by a project config \
+         that never mentioned [browser.policy]"
+    );
+    // The other half of field-wise: the project's own block still applies.
+    assert!(
+        config.browser.camoufox_download.enabled,
+        "the trusted project's [browser.camoufox_download] was itself dropped; \
+         this arm would then pass for the wrong reason"
+    );
+}
+
+/// Opposite control — the merge must still be able to reach the project's
+/// policy. Without this, a "fix" that hard-wired `global.browser` would pass
+/// the arm above while deleting the trusted-project override entirely.
+#[test]
+#[serial(browser_merge_trust_env)]
+fn a_trusted_project_can_still_replace_the_browser_policy() {
+    let config = load(
+        &operator_global_policy(),
+        "[browser.policy]\ndefault_action = \"deny\"\n\
+         denied_origins = [\"https://blocked.example.com\"]\n",
+        Trust::Granted,
+    );
+
+    assert_eq!(config.browser.policy.default_action, "deny");
+    assert_eq!(
+        config.browser.policy.denied_origins,
+        vec!["https://blocked.example.com".to_string()]
+    );
+    assert!(
+        config.browser.policy.allowed_origins.is_empty(),
+        "policy merges as a unit: a project that wrote a policy owns the whole \
+         policy, so the operator's allowed_origins must not be spliced into it"
+    );
+}
+
+// ── 2. Untrusted project cannot reach [browser] ──────────────────────────────
+
+/// An untrusted workspace — the default state of any freshly cloned repo — must
+/// not be able to configure the download surface. The fixture names its own URL
+/// and its own digest, which is exactly the shape that would otherwise be
+/// fetched, verified against the attacker's digest, chmod'd and spawned.
+#[test]
+#[serial(browser_merge_trust_env)]
+fn an_untrusted_project_cannot_configure_a_camoufox_download() {
+    let config = load(
+        &operator_global_policy(),
+        &download_only_project_body(),
+        Trust::Untrusted,
+    );
+
+    assert_eq!(
+        config.browser.camoufox_download,
+        CamoufoxDownloadConfig::default(),
+        "an untrusted project config reached [browser.camoufox_download]: \
+         enabled={} artifacts={:?} — a cloned repository can now name the URL \
+         and the digest of an executable Core will fetch and run",
+        config.browser.camoufox_download.enabled,
+        config
+            .browser
+            .camoufox_download
+            .artifacts
+            .keys()
+            .collect::<Vec<_>>(),
+    );
+}
+
+/// Same block, WIDENING direction: an untrusted project must not be able to
+/// relax the operator's origin policy either.
+#[test]
+#[serial(browser_merge_trust_env)]
+fn an_untrusted_project_cannot_widen_the_browser_policy() {
+    let config = load(
+        "[browser.policy]\ndefault_action = \"deny\"\n",
+        "[browser.policy]\ndefault_action = \"allow\"\n\
+         allowed_origins = [\"https://collector.attacker-example.com\"]\n",
+        Trust::Untrusted,
+    );
+
+    assert_eq!(
+        config.browser.policy.default_action, "deny",
+        "an untrusted project flipped the browser policy from deny to allow"
+    );
+    assert!(
+        config.browser.policy.allowed_origins.is_empty(),
+        "an untrusted project added a browser origin to the operator's \
+         allowlist: {:?}",
+        config.browser.policy.allowed_origins
+    );
+}
+
+/// Control for BOTH untrusted arms: the identical project bodies DO take effect
+/// once the workspace is trusted. This is what makes the two arms above
+/// measurements rather than a fixture that never worked.
+#[test]
+#[serial(browser_merge_trust_env)]
+fn the_same_project_bodies_do_take_effect_when_the_workspace_is_trusted() {
+    let download = load(
+        &operator_global_policy(),
+        &download_only_project_body(),
+        Trust::Granted,
+    );
+    assert!(
+        download.browser.camoufox_download.enabled,
+        "control failed: the download fixture does not take effect even when \
+         trusted, so the untrusted arm proves nothing"
+    );
+    assert_eq!(
+        download
+            .browser
+            .camoufox_download
+            .artifact_for_current_platform()
+            .map(|artifact| artifact.url.as_str()),
+        Some("https://repo-supplied.example.com/camoufox.tar.gz"),
+    );
+
+    let widened = load(
+        "[browser.policy]\ndefault_action = \"deny\"\n",
+        "[browser.policy]\ndefault_action = \"allow\"\n\
+         allowed_origins = [\"https://collector.attacker-example.com\"]\n",
+        Trust::Granted,
+    );
+    assert_eq!(
+        widened.browser.policy.default_action, "allow",
+        "control failed: the policy-widening fixture does not take effect even \
+         when trusted, so the untrusted arm proves nothing"
+    );
+}


### PR DESCRIPTION
Wires up Camoufox binary provisioning that existed but was never called.

## Confirmed, positive-controlled
`ensure_camoufox` — 5 hits, all non-production: `binary.rs:10` and `:65` (doc comments), `:445`/`:458`/`:459` (one unit test). **Zero production callers.** Positive control on the same grep: `launch_camoufox` has production sites at `supervisor.rs:304`/`:348`/`:357`. The search worked; the function really was dead.

The downloader itself was complete (SHA verification, atomic move, bounded redirects, wiremock tests). What was missing: any caller, a per-platform URL (it hardcoded macos-arm64), archive extraction, the exec bit, and a config surface for the digest.

## Policy implemented as decided
- **Auto-download is OPT-IN and OFF by default.** A default-on network fetch of an executable is not acceptable.
- **Fail closed with no verified digest.** `provision_camoufox` has exactly three outcomes: `Ok(None)` (disabled — nothing fetched, nothing written), `Ok(Some(path))` (bytes matched the operator-pinned SHA-256), `Err`. No artifact for the running platform → `UnconfiguredPlatform`. Empty/whitespace `sha256` → `UnpinnedDigest`, **before any network call**. No fetch-and-trust path, no fallback to an unverified binary.
- **No digest values were invented, guessed, or hardcoded.**

## Config (`[browser.camoufox_download]`)

| key | default |
|---|---|
| `enabled` | **`false`** |
| `artifacts` | empty map, keyed `<os>-<arch>` |
| `artifacts.<key>.url` | `""` |
| `artifacts.<key>.sha256` | `""` (= unpinned = refuse) |
| `artifacts.<key>.archive_exe_path` | `""` (= bare executable) |

Platform selection is a **lookup key into config**, not a `cfg!` ladder — one centralised `platform_key()`. Archive format comes from **magic bytes** (gzip vs zip), so no `cfg!(windows)` decides that either. The exec bit goes through one `set_executable` helper with the `#[cfg(unix)]`/`#[cfg(not(unix))]` pair.

Also extended the project↔global browser-block merge predicate — otherwise a project config setting *only* `[browser.camoufox_download]` is silently dropped, which is the exact trap `config_hint.rs` documents.

## Layering — `cargo metadata`
```
wcore-config  -> [wcore-budget, wcore-compact, wcore-types]
wcore-browser -> [wcore-config, wcore-egress, wcore-protocol, wcore-sandbox, wcore-tools, wcore-types]
```
`wcore-browser → wcore-config` already existed. **No new internal dependency edge, no upward or circular reference.** The three added deps (`tar`, `flate2`, `zip`) are existing workspace deps; `Cargo.lock` gained no new packages.

## Verification
`wcore-browser` lib **99 passed / 0 failed**, wiring suite **4 / 0**, `wcore-config` lib **670 / 0**; 26 result lines, all `ok`, exit 0. No test touches a real network.

Red arms (mutate → `touch` → run → restore → `touch`; each grep-confirmed on code):
- **A — the row's defect verbatim** (delete the provisioning call from `ensure_ready`): wiring suite **2 failed**; the disabled control stayed green.
- **B** opt-in gate deleted from the downloader → unit test FAILED.
- **C** unpinned-digest refusal deleted → unit **and** supervisor-level tests FAILED.
- **D** `set_executable` neutered → exec-bit test **and** the provisioning test FAILED (the tar member ships 0o644, so the spawn only works via our chmod).
- **E — a vacuity I found and closed.** With only the downloader's gate removed, the supervisor-level disabled test still passed, because the gate is **doubled** (the supervisor short-circuits first). Arm E removes *both*, and that test then FAILED. Each gate now has a test that can see it.

`check --workspace --all-targets` clean — it caught the known shared-type trap (three `SupervisorConfig` literals in a baseline test broke on the new fields). `clippy --workspace -- -D warnings` exit 0, **and** `--target x86_64-pc-windows-gnu` clean for the `#[cfg(not(unix))]` code host clippy is blind to. `fmt` clean.

## To enable this, an operator must
Set `enabled = true`, add an `artifacts."<os>-<arch>"` entry with the real URL, **compute the SHA-256 themselves** (`wcore_browser::binary::sha256_hex` is now public for this), and name the executable's path inside the archive.

## Two things to flag
1. `CAMOUFOX_DOWNLOAD_URL` (the hardcoded macos-arm64 constant) and `CAMOUFOX_SHA256_PLACEHOLDER` remain, still `#[allow(dead_code)]`, now superseded. Left per "don't delete pre-existing dead code unless asked" — but a follow-up should remove the URL constant, since it now reads as a default it isn't.
2. `[browser.camoufox_download]` merges through the existing project-overrides-global rule, so a project-local `.wayland-core.toml` can enable download and name both URL and digest. **The digest is therefore not a defence against a hostile project config** — the same trust posture `[browser.policy]` already has. Naming it in case you want this block global-only.
