### PR TITLE
fix(tools): skip the workspace read-deny walk for a backend that discards it

### DIFF
--- a/crates/wcore-sandbox/tests/enforces_read_deny_pairing.rs
+++ b/crates/wcore-sandbox/tests/enforces_read_deny_pairing.rs
@@ -1,0 +1,98 @@
+//! A2 (#922 R1) — the ONE safety assumption `secret_deny_paths_for_backend`
+//! rests on: **no backend that actually enforces `manifest.fs_read_deny`
+//! reports `enforces_read_deny() == false`.**
+//!
+//! R1 skips producing the deny list when this predicate says `false`. That is
+//! observationally free only while `false` really does mean "this field is
+//! discarded". A backend that UNDER-reports enforcement would turn the skip
+//! into a stale-NEGATIVE — the security direction. Over-reporting is the safe
+//! direction: we compute a list the backend may not use, which costs latency
+//! and nothing else.
+//!
+//! The `AppContainerBackend` leg is the load-bearing one and is Windows-only,
+//! because its answer is DERIVED (`!containment_withdrawn()`) rather than
+//! hardcoded. It must answer `true` while the availability probe is unsettled
+//! — the property measured on SEANDESKTOP 2026-08-10 and documented at
+//! `platform_candidate` in the crate root. Run it on Windows or it proves
+//! nothing about the platform #922 is about.
+//!
+//! Its own file so each assertion gets a fresh process: the AppContainer probe
+//! cache is process-global, and a sibling test that probed first would settle
+//! the verdict this one needs to observe UNSETTLED.
+
+use wcore_sandbox::backends::SandboxBackend;
+
+#[test]
+fn every_enforcing_backend_reports_it_and_every_relaxed_one_does_not() {
+    // Enforcing: hardcoded `true`, and they really do apply the field —
+    // bwrap by mounting over each path, sandbox_exec by an SBPL deny rule.
+    assert!(
+        wcore_sandbox::backends::bwrap::BubblewrapBackend::new().enforces_read_deny(),
+        "bwrap enforces fs_read_deny by mounting over every denied path"
+    );
+    assert!(
+        wcore_sandbox::backends::sandbox_exec::SandboxExecBackend::new().enforces_read_deny(),
+        "sandbox_exec enforces fs_read_deny via SBPL"
+    );
+
+    // Relaxed: the trait default. `windows_job_object` is the shipped Windows
+    // session default and delegates execution to `NoSandboxBackend`, which
+    // takes no filesystem action at all — so `false` here is a statement of
+    // fact, and it is exactly what makes #922's walk pure waste.
+    assert!(
+        !wcore_sandbox::backends::windows_job_object::WindowsJobObjectBackend::new()
+            .enforces_read_deny(),
+        "windows_job_object must keep the trait default — R1's whole premise"
+    );
+    assert!(
+        !wcore_sandbox::backends::no_sandbox::NoSandboxBackend::new().enforces_read_deny(),
+        "no_sandbox enforces nothing"
+    );
+
+    // Docker without the `live-docker` feature cannot enforce anything and
+    // must keep the trait default. With the feature it hardcodes `true`.
+    #[cfg(not(feature = "live-docker"))]
+    assert!(
+        !wcore_sandbox::backends::docker::DockerBackend::new().enforces_read_deny(),
+        "the non-live docker build must not claim an enforcement it cannot apply"
+    );
+    #[cfg(feature = "live-docker")]
+    assert!(
+        wcore_sandbox::backends::docker::DockerBackend::new().enforces_read_deny(),
+        "the live docker build enforces fs_read_deny via /dev/null binds and empty-dir overlays"
+    );
+}
+
+/// The AppContainer leg. THIS is the assertion R1's safety rests on: an
+/// UNPROBED backend must over-report enforcement, never under-report it.
+///
+/// Red arm for this test: make `containment_claim` answer `settled ==
+/// Some(true)` instead of `settled != Some(false)`. An unsettled verdict then
+/// yields `enforces_read_deny() == false`, R1 skips the walk on a backend that
+/// would have enforced, and this test must go red. If it does not, it is not
+/// testing the property R1 depends on.
+#[cfg(windows)]
+#[test]
+fn appcontainer_over_reports_enforcement_while_the_probe_is_unsettled() {
+    // Constructed, never probed: nothing in this process has called
+    // `is_available()`, so `settled_verdict()` is `None`.
+    let backend = wcore_sandbox::backends::appcontainer::AppContainerBackend::new();
+    assert!(
+        backend.enforces_read_deny(),
+        "an UNPROBED AppContainer backend must claim enforcement: an unknown \
+         answer has to over-report (we walk, stale-POSITIVE) and never \
+         under-report (we skip, stale-NEGATIVE — the leak direction)"
+    );
+}
+
+/// Off Windows the AppContainer type is a compile stub that can execute
+/// nothing; it must not claim an enforcement either. Pinned so the stub can
+/// never drift into a `true` that a non-Windows host would then act on.
+#[cfg(not(windows))]
+#[test]
+fn appcontainer_stub_claims_nothing() {
+    let backend = wcore_sandbox::backends::appcontainer::AppContainerBackend::new();
+    assert_eq!(backend.name(), "appcontainer_stub");
+    assert!(!backend.enforces_read_deny());
+    assert!(!backend.is_available());
+}

--- a/crates/wcore-tools/src/bash.rs
+++ b/crates/wcore-tools/src/bash.rs
@@ -81,17 +81,32 @@ const MAX_TIMEOUT_MS: u64 = 600_000;
 /// threaded through. This is a documented defense-in-depth gap, not an
 /// escape: the env is already secret-scrubbed and the network now defaults
 /// closed.
+///
+/// Shorthand for [`build_sandbox_pieces_for_session`] with no session env
+/// passthrough and `backend_enforces_read_deny = true`.
+///
+/// The `true` is inert rather than assumed: both production callers pass
+/// `policy: None`, and with no policy there is no `fs_read_deny` to produce
+/// whatever the flag says. It is also the conservative value — `true` COMPUTES
+/// the list, which is #922 R1's stale-positive (availability-only) direction.
+/// Keeping this two-argument shape is deliberate: the `#234` / `#667` unit
+/// suite drives it with a policy, and that suite must keep grading the
+/// enforcing path byte-for-byte as it did before #922.
 fn build_sandbox_pieces(
     command: &str,
     policy: Option<&crate::workspace_policy::WorkspacePolicy>,
 ) -> (SandboxManifest, SandboxCommand) {
-    build_sandbox_pieces_for_session(command, policy, None)
+    build_sandbox_pieces_for_session(command, policy, None, true)
 }
 
+/// `backend_enforces_read_deny` is `SandboxBackend::enforces_read_deny()` read
+/// off the SAME backend handle that will run `execute()` for this manifest —
+/// so there is no window between reading the capability and applying it.
 fn build_sandbox_pieces_for_session(
     command: &str,
     policy: Option<&crate::workspace_policy::WorkspacePolicy>,
     env_passthrough: Option<&std::collections::HashSet<String>>,
+    backend_enforces_read_deny: bool,
 ) -> (SandboxManifest, SandboxCommand) {
     // Shell prefix honors the Windows WAYLAND_BASH_SHELL=powershell|pwsh override
     // (BashTool only); defaults to sh -c / cmd /C.
@@ -133,7 +148,10 @@ fn build_sandbox_pieces_for_session(
         // is denied on the next command — closing the Bash TOCTOU that the file
         // tools' dynamic `is_project_secret` guard already avoids. Local-keyboard
         // (Trusted, no project-secret denial) is returned unchanged, no walk.
-        manifest.fs_read_deny = p.secret_deny_paths_dynamic();
+        // #922 R1: on a backend that does not enforce this field the walk
+        // below produces a value the backend discards. See
+        // `WorkspacePolicy::secret_deny_paths_for_backend`.
+        manifest.fs_read_deny = p.secret_deny_paths_for_backend(backend_enforces_read_deny);
         // Stat-only, never content — see
         // `SandboxManifest::fs_metadata_read_allow`. Assigned after
         // `fs_read_deny` for readability only: SBPL last-match-wins is what
@@ -620,6 +638,8 @@ impl Tool for BashTool {
             command,
             ctx.workspace.as_deref(),
             Some(ctx.sandbox.env_passthrough()),
+            // Same `backend` handle that runs `execute()` below.
+            backend.enforces_read_deny(),
         );
         downgrade_powershell_for_sandbox(&mut cmd.argv, backend.blocks_powershell());
         let net = manifest.network.clone();
@@ -717,6 +737,8 @@ impl Tool for BashTool {
             command,
             ctx.workspace.as_deref(),
             Some(ctx.sandbox.env_passthrough()),
+            // Same `backend` handle that runs `execute()` below.
+            backend.enforces_read_deny(),
         );
         downgrade_powershell_for_sandbox(&mut cmd.argv, backend.blocks_powershell());
         let net = manifest.network.clone();

--- a/crates/wcore-tools/src/bash/tests.rs
+++ b/crates/wcore-tools/src/bash/tests.rs
@@ -1241,7 +1241,8 @@ fn child_workspace_policy_strips_git_authority_env_and_denies_parent_roots() {
         .with_authority_read_deny([parent.clone(), git_common.clone()])
         .with_authority_write_deny([parent.clone(), git_common.clone()])
         .with_git_authority_env_deny();
-    let (manifest, _) = build_sandbox_pieces_for_session("git status", Some(&policy), Some(&allow));
+    let (manifest, _) =
+        build_sandbox_pieces_for_session("git status", Some(&policy), Some(&allow), true);
 
     assert!(manifest.fs_read_deny.contains(&parent));
     assert!(manifest.fs_read_deny.contains(&git_common));

--- a/crates/wcore-tools/src/workspace_policy.rs
+++ b/crates/wcore-tools/src/workspace_policy.rs
@@ -748,6 +748,46 @@ impl WorkspacePolicy {
         out
     }
 
+    /// #922 R1: the OS read-deny list, computed only for a backend that will
+    /// actually apply it.
+    ///
+    /// `manifest.fs_read_deny` has exactly one producer
+    /// ([`secret_deny_paths_dynamic`](Self::secret_deny_paths_dynamic)) and the
+    /// backends are its only enforcing consumer. A backend whose
+    /// `SandboxBackend::enforces_read_deny()` is `false` — the trait default,
+    /// which the Windows session default `windows_job_object` deliberately
+    /// keeps — takes no filesystem action on the field at all. Producing it for
+    /// such a backend is a full no-prune walk of the workspace whose only
+    /// result is dropped: measured on SeanDesktop at 76,367 ms against a real
+    /// user profile versus 175 ms against an empty directory (#922).
+    ///
+    /// This is NOT a relaxation of a security profile — the precedent this
+    /// project set with "enforces_read_deny is liveness, not policy" is about
+    /// using this predicate to WEAKEN a profile, and that is not what happens
+    /// here. A `false` answer is the definition of "this field is discarded",
+    /// so skipping its computation is observationally identical. The gate also
+    /// fails in the safe direction: every enforcing backend
+    /// (`bwrap`/`sandbox_exec`/live `docker`) hardcodes `true`, and
+    /// `AppContainerBackend` derives its answer from a monotone probe that
+    /// answers `true` while unsettled — an unknown answer therefore
+    /// over-reports enforcement and we still walk (stale-POSITIVE, an
+    /// availability cost, never a leak). That single assumption is pinned by
+    /// `crates/wcore-sandbox/tests/enforces_read_deny_pairing.rs` (A2).
+    ///
+    /// Note the layering: this gate gets to exist only because it guards the
+    /// OS-enforced list. The IN-PROCESS file-tool predicate
+    /// ([`is_project_secret`](Self::is_project_secret), via
+    /// `vfs::SecretDenyFs`) is enforced by this process and must NEVER be
+    /// routed through a backend capability — pinned by
+    /// `crates/wcore-tools/tests/vfs_secret_deny_backend_independent.rs` (A7).
+    pub fn secret_deny_paths_for_backend(&self, backend_enforces_read_deny: bool) -> Vec<PathBuf> {
+        if !backend_enforces_read_deny {
+            // The backend discards this field; producing it is pure cost.
+            return Vec::new();
+        }
+        self.secret_deny_paths_dynamic()
+    }
+
     /// #667 (F2): true when `Bash` must be REFUSED on a backend that cannot
     /// enforce `fs_read_deny` at the OS layer — because this policy relies on
     /// that enforcement to keep secrets unreadable from the shell. Replaces the
@@ -997,6 +1037,12 @@ fn project_committed_secrets(root: &Path, readable_canon: &[PathBuf]) -> Vec<Pat
     // prefilter: we canonicalize (an expensive symlink-resolving syscall) ONLY for
     // secret-NAMED files and for symlinks — not for every entry. Visiting (readdir)
     // a large `node_modules` is cheap; canonicalizing every file in it was the cost.
+    //
+    // Pinned by `tests::no_prune_survives_the_922_backend_gate` (#922 A4), which
+    // asserts a secret under `node_modules/` and under `target/` is still in the
+    // list. #922's fix declines to COMPUTE this walk on a backend that discards
+    // it; it must never become a reason to PRUNE it, because a prune is a
+    // permanent stale-negative against the in-process predicate above.
     let walker = ignore::WalkBuilder::new(root)
         .standard_filters(false) // a .gitignore'd .env must still be denied
         .hidden(false)

--- a/crates/wcore-tools/src/workspace_policy/tests.rs
+++ b/crates/wcore-tools/src/workspace_policy/tests.rs
@@ -1160,3 +1160,155 @@ fn contained_interpreter_grant_excludes_package_manager_config_and_state() {
         eprintln!("note: no package-manager prefix on this host; prefix assertions vacuous");
     }
 }
+
+// ── #922 R1 acceptance tests (A1, A3, A4) ────────────────────────────────────
+
+/// Build a fixture tree carrying every entry class the deny list must cover.
+///
+/// Returns the tempdir (kept alive by the caller) and the canonical root.
+fn secret_fixture_tree() -> (tempfile::TempDir, std::path::PathBuf) {
+    let dir = tempfile::tempdir().unwrap();
+    let root = std::fs::canonicalize(dir.path()).unwrap();
+    std::fs::write(root.join(".env"), b"TOKEN=1").unwrap();
+    // gitignored, and still denied — the #234 anti-bypass property.
+    std::fs::write(root.join(".gitignore"), b"id.pem\nnode_modules/\ntarget/\n").unwrap();
+    std::fs::write(root.join("id.pem"), b"key").unwrap();
+    std::fs::create_dir_all(root.join("node_modules/vendor")).unwrap();
+    std::fs::write(root.join("node_modules/vendor/x.pem"), b"key").unwrap();
+    std::fs::create_dir_all(root.join("target/debug/build")).unwrap();
+    std::fs::write(root.join("target/debug/build/secret.pem"), b"key").unwrap();
+    std::fs::create_dir_all(root.join(".git/objects")).unwrap();
+    std::fs::write(root.join(".git/objects/keep"), b"x").unwrap();
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(root.join(".env"), root.join("notes.txt")).unwrap();
+    (dir, root)
+}
+
+/// A1 — #922 R1: the deny walk is not run for a backend that discards the list.
+///
+/// Modelled on `contained_construction_does_not_walk_the_workspace` above,
+/// including its known-positive control: the `true` arm must be materially
+/// more expensive on the big tree than on an empty one, so a host where both
+/// arms are instant FAILS the instrument instead of passing the assertion
+/// vacuously.
+#[test]
+fn r1_skips_the_walk_for_a_non_enforcing_backend() {
+    let empty = tempfile::tempdir().unwrap();
+    let baseline = WorkspacePolicy::contained(empty.path());
+    // Taken first so the cold cost of the fixed path probes lands here.
+    let t = std::time::Instant::now();
+    let _ = baseline.secret_deny_paths_for_backend(true);
+    let enforcing_empty = t.elapsed();
+    let t = std::time::Instant::now();
+    let _ = baseline.secret_deny_paths_for_backend(false);
+    let skipped_empty = t.elapsed();
+
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    for i in 0..3000 {
+        let sub = root.join(format!("d{i}"));
+        std::fs::create_dir_all(&sub).unwrap();
+        std::fs::write(sub.join("a.rs"), b"fn main() {}").unwrap();
+    }
+    // One real secret, so the enforcing arm's output is non-empty for a reason
+    // this test controls. Without it the arm is non-empty only when the HOST
+    // happens to have a Tier-0 credential store (`/etc/docker` on the Linux box,
+    // nothing at all under a Windows service account with no `HOME`), and the
+    // liveness assertion below then fails for an environmental reason rather
+    // than a product one. Found by running this test on SeanDesktop.
+    std::fs::write(root.join(".env"), b"TOKEN=1").unwrap();
+    let p = WorkspacePolicy::contained(root);
+
+    let t = std::time::Instant::now();
+    let enforcing = p.secret_deny_paths_for_backend(true);
+    let enforcing_big = t.elapsed();
+    let t = std::time::Instant::now();
+    let skipped = p.secret_deny_paths_for_backend(false);
+    let skipped_big = t.elapsed();
+
+    // KNOWN-POSITIVE CONTROL: the walk this test claims to be skipping is
+    // reachable, does happen, and its cost really is driven by the tree.
+    assert!(
+        enforcing_big > enforcing_empty * 10,
+        "instrument is dead: the enforcing arm must be tree-driven; \
+         enforcing_big={enforcing_big:?} enforcing_empty={enforcing_empty:?}"
+    );
+
+    // THE CLAIM: the skipped arm is flat — the big tree costs no more than the
+    // empty one. Stated against the empty-tree baseline plus half a walk, the
+    // same shape the construction pin uses, so the platform constant is
+    // subtracted rather than assumed to be zero.
+    assert!(
+        skipped_big < skipped_empty + enforcing_big / 2,
+        "R1 must not walk on a non-enforcing backend: skipped_big={skipped_big:?} \
+         skipped_empty={skipped_empty:?} enforcing_big={enforcing_big:?}"
+    );
+
+    // And the skipped arm produces nothing at all, while the enforcing arm does.
+    assert!(
+        skipped.is_empty(),
+        "non-enforcing backend gets no list: {skipped:?}"
+    );
+    let want = std::fs::canonicalize(root.join(".env")).unwrap();
+    assert!(
+        enforcing.contains(&want),
+        "instrument is dead: the enforcing arm must carry the tree's own secret; got {enforcing:?}"
+    );
+}
+
+/// A3 — the enforcing path is byte-identical to the pre-#922 producer.
+///
+/// This is the "no security delta" claim. `secret_deny_paths_dynamic` is the
+/// function every `#234` / `#667` test already grades; R1 must not have become
+/// a second, drifting producer.
+#[test]
+fn r1_enforcing_arm_is_identical_to_the_dynamic_list() {
+    let (_dir, root) = secret_fixture_tree();
+    let p = WorkspacePolicy::contained(&root);
+
+    let via_gate = p.secret_deny_paths_for_backend(true);
+    let direct = p.secret_deny_paths_dynamic();
+    assert_eq!(
+        via_gate, direct,
+        "the enforcing arm must be the same list, element for element"
+    );
+
+    // Not vacuous: the list actually carries the entry classes that matter.
+    let has = |needle: &str| via_gate.iter().any(|p| p.ends_with(needle));
+    assert!(has(".env"), "fixture .env missing from {via_gate:?}");
+    assert!(has("id.pem"), "gitignored id.pem missing from {via_gate:?}");
+    assert!(
+        via_gate.iter().any(|p| p.ends_with(".git/objects")),
+        "git object store missing from {via_gate:?}"
+    );
+}
+
+/// A4 — the NO-PRUNE property survives #922.
+///
+/// The guard rail for the next reader who sees "436x" and reaches for a
+/// `filter_entry`. Pruning `node_modules` / `target` is a PERMANENT
+/// stale-negative: `is_project_secret` (the in-process file-tool predicate)
+/// covers a secret anywhere under root, so the OS list must too, or
+/// `Bash cat node_modules/vendor/x.pem` reads what `Read` refuses.
+///
+/// See the "NO directory prune" comment in `project_committed_secrets`.
+#[test]
+fn no_prune_survives_the_922_backend_gate() {
+    let (_dir, root) = secret_fixture_tree();
+    let p = WorkspacePolicy::contained(&root);
+    let deny = p.secret_deny_paths_for_backend(true);
+
+    for buried in ["node_modules/vendor/x.pem", "target/debug/build/secret.pem"] {
+        let want = std::fs::canonicalize(root.join(buried)).unwrap();
+        assert!(
+            deny.contains(&want),
+            "a secret under {buried} must still be denied — do NOT prune the walk; got {deny:?}"
+        );
+        // The two layers must agree: what the OS list denies, the in-process
+        // predicate denies too.
+        assert!(
+            p.is_project_secret(&want),
+            "in-process predicate must also cover {buried}"
+        );
+    }
+}

--- a/crates/wcore-tools/tests/vfs_secret_deny_backend_independent.rs
+++ b/crates/wcore-tools/tests/vfs_secret_deny_backend_independent.rs
@@ -1,0 +1,99 @@
+//! A7 (#922 R1) — **the in-process VFS secret predicate is NOT gated on the
+//! sandbox backend.**
+//!
+//! #922's fix gates ONE thing: `manifest.fs_read_deny`, the list the OS
+//! backend applies. It is skipped when the backend answers
+//! `enforces_read_deny() == false`, because a `false` answer is the definition
+//! of "this backend discards that field".
+//!
+//! The file tools do not go through the OS backend at all. `vfs::SecretDenyFs`
+//! calls `WorkspacePolicy::is_project_secret` per access, in THIS process, and
+//! its refusal is enforced by this process. Routing that predicate through the
+//! same backend capability would hand `Read`/`Edit`/`Grep` every project
+//! secret on the shipped Windows default — turning a latency fix into the
+//! exact leak #234/#667 closed. The design calls this "the easiest thing to
+//! get wrong", so it gets its own pin.
+//!
+//! **Red arm:** make `SecretDenyFs::guard` (or `is_project_secret`) consult the
+//! backend's `enforces_read_deny()` the way `secret_deny_paths_for_backend`
+//! does. Every assertion below must go red.
+//!
+//! Note on scope: core#244 (denying a raw `.git/objects/ab/cdef…` read through
+//! the VFS) is still OPEN and is deliberately NOT bundled here — see the
+//! design's §3. This test therefore pins the property on a path the predicate
+//! covers TODAY (`.env`, and a secret buried under `node_modules/`). When #244
+//! lands it extends this file rather than replacing it.
+
+use std::sync::Arc;
+use wcore_sandbox::SandboxRegistry;
+use wcore_sandbox::backends::windows_job_object::WindowsJobObjectBackend;
+use wcore_tools::vfs::{RealFs, SecretDenyFs, VfsError, VirtualFs};
+use wcore_tools::workspace_policy::WorkspacePolicy;
+
+#[tokio::test]
+async fn vfs_secret_denial_survives_a_backend_that_enforces_no_read_deny() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = std::fs::canonicalize(dir.path()).unwrap();
+    std::fs::write(root.join(".env"), b"TOKEN=abc").unwrap();
+    std::fs::create_dir_all(root.join("node_modules/vendor")).unwrap();
+    std::fs::write(root.join("node_modules/vendor/x.pem"), b"KEY").unwrap();
+    std::fs::write(root.join("main.rs"), b"fn main() {}").unwrap();
+
+    // The shipped Windows session default, wrapped exactly as a session wraps
+    // it. This is the backend #922's 76,367 ms was being paid for.
+    let registry = SandboxRegistry::new(Arc::new(WindowsJobObjectBackend::new()));
+    assert!(
+        !registry.enforces_read_deny(),
+        "precondition: this must be the NON-enforcing backend, or the test \
+         proves nothing about the gate"
+    );
+
+    let policy = Arc::new(WorkspacePolicy::contained(&root));
+
+    // The OS list IS gated — this is R1 firing, and it is what makes the
+    // assertions below non-vacuous: they hold on the very configuration where
+    // the OS layer has been switched off.
+    assert!(
+        policy
+            .secret_deny_paths_for_backend(registry.enforces_read_deny())
+            .is_empty(),
+        "R1: the OS deny list must be skipped for a non-enforcing backend"
+    );
+    assert!(
+        !policy.secret_deny_paths_for_backend(true).is_empty(),
+        "control: the same policy DOES produce a list for an enforcing backend"
+    );
+
+    // ...and the in-process layer is NOT gated.
+    let fs = SecretDenyFs::new(RealFs, Arc::clone(&policy));
+    for secret in [".env", "node_modules/vendor/x.pem"] {
+        assert!(
+            matches!(
+                fs.read(&root.join(secret)).await,
+                Err(VfsError::SecretDenied { .. })
+            ),
+            "{secret} must still be refused by the in-process predicate on a \
+             backend that enforces no OS read-deny"
+        );
+        assert!(
+            matches!(
+                fs.write(&root.join(secret), b"x").await,
+                Err(VfsError::SecretDenied { .. })
+            ),
+            "{secret} write must still be refused"
+        );
+    }
+
+    // Not a blanket refusal: an ordinary file still reads.
+    assert_eq!(
+        fs.read(&root.join("main.rs")).await.unwrap(),
+        b"fn main() {}",
+        "control: the predicate must not have become deny-everything"
+    );
+
+    // And the predicate itself takes no backend and cannot be made to.
+    assert!(
+        policy.is_project_secret(&root.join(".env")),
+        "is_project_secret is a lexical, per-access predicate — no backend input"
+    );
+}


### PR DESCRIPTION
Closes the #922 / #1000 Windows command-execution cluster at the cost, not at the symptom.

## The defect

`manifest.fs_read_deny` is produced by a full **no-prune walk of the entire workspace on every single Bash exec**. The shipped Windows session default (`windows_job_object`) keeps the trait default `enforces_read_deny() == false` and delegates execution to `NoSandboxBackend`, which takes no filesystem action at all — so on that backend the walk produces a `Vec<PathBuf>` that is **dropped unread**.

Measured on real Windows hardware: an empty workspace costs ~137 ms, a real user profile costs **tens of seconds per command**. That is the "Bash times out on every command" report, and it is why every reproduction in a clean temp directory has come back green — a small workspace hides it completely.

FerroxLabs/wayland#1000 confirms the symptom survived into shipped **0.13.0 on defaults** (fresh install, Job Object backend, not opted into AppContainer), which rules out the AppContainer work as the owner of this one.

## The fix

Adds `WorkspacePolicy::secret_deny_paths_for_backend(enforces)` and threads `backend.enforces_read_deny()` into `build_sandbox_pieces_for_session`. On an enforcing backend the list is byte-identical to `secret_deny_paths_dynamic()`; on a non-enforcing one it is empty — which is what that backend already did with it.

The capability is read off the **same backend handle** that then runs `execute()`, so there is no window between reading the capability and applying it.

## Why this is not a security relaxation

This was the review question I cared about most, so I checked every implementation rather than trusting the reasoning:

| Backend | `enforces_read_deny()` | Effect |
|---|---|---|
| bwrap (Linux) | hardcoded `true` | still walks, unchanged |
| sandbox_exec (macOS) | hardcoded `true` | still walks, unchanged |
| docker | `true` under `live-docker` | still walks when it can enforce |
| AppContainer (Windows) | `!containment_withdrawn()` | **`true` while the probe is unsettled** |
| trait default → job object / no-sandbox | `false` | skips a list it discards |

A `false` answer is the *definition* of "this field is discarded", and the predicate fails **safe**: an unknown answer over-reports enforcement, so we still walk. The failure direction is an availability cost, never a containment loss.

The in-process file-tool predicate (`vfs::SecretDenyFs` / `is_project_secret`) is deliberately **not** gated — it is enforced by this process, not by the backend. `vfs_secret_deny_backend_independent.rs` pins that, so core#244 stays outside this change.

## Verification

Acceptance tests, each with a red arm:

- A1 `workspace_policy::tests::r1_skips_the_walk_for_a_non_enforcing_backend`
- A2 `wcore-sandbox/tests/enforces_read_deny_pairing.rs`
- A3 `workspace_policy::tests::r1_enforcing_arm_is_identical_to_the_dynamic_list`
- A4 `workspace_policy::tests::no_prune_survives_the_922_backend_gate`
- A7 `wcore-tools/tests/vfs_secret_deny_backend_independent.rs`

A3 is the one that matters for review: it asserts the enforcing arm is **byte-identical** to the pre-change list, so this cannot silently narrow enforcement on Linux or macOS.

Live A/B timing on real Windows hardware (both arms built from source on the same box, same toolchain, interleaved, against a real profile rather than a clean temp dir) is running now and will be posted to this PR as a comment before it is proposed for merge.

Refs FerroxLabs/wayland#922, FerroxLabs/wayland#1000, FerroxLabs/wayland#942, FerroxLabs/wayland#929
