### PR TITLE
fix(matrix): renew expired tokens and stop latching authz refusals as auth failure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9487,6 +9487,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "toml",

--- a/crates/wcore-channel-matrix/Cargo.toml
+++ b/crates/wcore-channel-matrix/Cargo.toml
@@ -22,4 +22,5 @@ wcore-config = { workspace = true }
 
 [dev-dependencies]
 mockito = "1"
+tempfile = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }

--- a/crates/wcore-channel-matrix/src/config.rs
+++ b/crates/wcore-channel-matrix/src/config.rs
@@ -11,6 +11,16 @@ pub struct MatrixConfig {
     pub credential_handle_access_token: String,
     /// Full Matrix user ID of the bot (e.g. `@bot:matrix.org`).
     pub user_id: String,
+    /// Credentials-store key for the Matrix **refresh** token, if the login
+    /// that produced the access token asked for one (`"refresh_token": true`).
+    ///
+    /// Optional because a homeserver on the legacy `m.login.password` flow
+    /// issues access tokens that live until logout, and configuring a handle
+    /// with nothing behind it would be worse than declaring none. When it IS
+    /// set, an expired access token is renewed in place instead of taking the
+    /// channel down — see [`crate::token`].
+    #[serde(default)]
+    pub credential_handle_refresh_token: Option<String>,
 }
 
 #[cfg(test)]
@@ -28,6 +38,30 @@ user_id = "@wayland-bot:matrix.org"
         assert_eq!(cfg.homeserver_url, "https://matrix.org");
         assert_eq!(cfg.credential_handle_access_token, "matrix.prod.token");
         assert_eq!(cfg.user_id, "@wayland-bot:matrix.org");
+        assert_eq!(
+            cfg.credential_handle_refresh_token, None,
+            "a config written before refresh support must still parse",
+        );
+    }
+
+    /// The refresh handle is optional but must be REACHABLE. `deny_unknown_fields`
+    /// means a typo'd or unregistered key is rejected outright, so a config
+    /// that sets it and silently gets no refresh support is not possible.
+    #[test]
+    fn refresh_token_handle_round_trips() {
+        let cfg: MatrixConfig = toml::from_str(
+            r#"
+homeserver_url = "https://matrix.org"
+credential_handle_access_token = "matrix.prod.token"
+credential_handle_refresh_token = "matrix.prod.refresh"
+user_id = "@wayland-bot:matrix.org"
+"#,
+        )
+        .unwrap();
+        assert_eq!(
+            cfg.credential_handle_refresh_token.as_deref(),
+            Some("matrix.prod.refresh"),
+        );
     }
 
     #[test]

--- a/crates/wcore-channel-matrix/src/lib.rs
+++ b/crates/wcore-channel-matrix/src/lib.rs
@@ -173,13 +173,9 @@ impl MatrixChannel {
             Ok(value) => return Ok(value),
             Err(e) => e,
         };
-        if !matches!(
-            rejection,
-            MatrixError::Http {
-                status: 401 | 403,
-                ..
-            }
-        ) {
+        // The errcode, not the bare status: a 403 `M_FORBIDDEN` is the bot's
+        // power level and must not be reported as a dead credential.
+        if !token::is_credential_rejection(&rejection) {
             return Err(ChannelError::Transport(rejection.to_string()));
         }
         // Secret-free from here on: the homeserver's error body is an echo of
@@ -848,6 +844,90 @@ user_id = "@bot:matrix.example.org"
             "the homeserver's own errcode must reach the operator, got {err}"
         );
         ch.stop().await.unwrap();
+    }
+
+    /// A PERMISSION error must not be reported as a dead credential.
+    ///
+    /// `with_access_token` funnels every outbound call through one 401/403
+    /// decision, which is what stops the send path having its own opinion about
+    /// expiry. But Matrix uses those two statuses for two different things:
+    /// `M_UNKNOWN_TOKEN` says *who you are* is no longer accepted, while
+    /// `M_FORBIDDEN` says *what you asked for* is not allowed — an
+    /// under-privileged bot asked to redact someone else's event, with a
+    /// perfectly live token.
+    ///
+    /// Collapsing them publishes `AuthExpired`, which the channel manager
+    /// projects onto `HealthState::Unauthenticated` and which `TokenSource`
+    /// latches so it can never be walked back. One refused redaction would
+    /// therefore mark the channel permanently unauthenticated while every
+    /// subsequent send kept succeeding — health lying, in the direction the
+    /// operator acts on, because `channel reload` cannot fix a power level.
+    ///
+    /// **The negative half is paired with a known-positive on purpose.** An
+    /// "no `AuthExpired` was published" assertion passes just as happily if the
+    /// event can never be published at all, so the same shape is run against a
+    /// genuine `M_UNKNOWN_TOKEN` revocation, which must still fail closed.
+    #[tokio::test]
+    async fn a_permission_error_is_not_a_dead_credential() {
+        async fn auth_expired_after_a_refused_redaction(status: usize, body: &str) -> Vec<String> {
+            let mut server = mockito::Server::new_async().await;
+            let _m = server
+                .mock(
+                    "PUT",
+                    mockito::Matcher::Regex(
+                        r"/_matrix/client/v3/rooms/[^/]+/redact/.*".to_string(),
+                    ),
+                )
+                .with_status(status)
+                .with_header("content-type", "application/json")
+                .with_body(body)
+                .create_async()
+                .await;
+
+            let creds = MemCreds::with_token("matrix.test.token", TEST_TOKEN);
+            let mut ch = MatrixChannel::with_base("test", cfg(), creds, server.url());
+            ch.start().await.unwrap();
+            let err = ch.delete_message(TEST_ROOM, "$orig123").await.unwrap_err();
+            assert!(
+                err.to_string().contains("M_"),
+                "the homeserver's errcode must reach the operator, got {err}"
+            );
+            let events = ch.poll_events().await.unwrap();
+            ch.stop().await.unwrap();
+            events
+                .into_iter()
+                .filter_map(|e| match e {
+                    ChannelEvent::AuthExpired { reason } => Some(reason),
+                    _ => None,
+                })
+                .collect()
+        }
+
+        // Known-positive: a real revocation on the same route, same shape.
+        let revoked = auth_expired_after_a_refused_redaction(
+            401,
+            r#"{"errcode":"M_UNKNOWN_TOKEN","error":"Token is not active"}"#,
+        )
+        .await;
+        assert_eq!(
+            revoked.len(),
+            1,
+            "a revoked token must still fail closed on the send path, or the \
+             assertion below proves nothing: {revoked:?}"
+        );
+
+        // The case under test: a live token, an operation the bot may not do.
+        let forbidden = auth_expired_after_a_refused_redaction(
+            403,
+            r#"{"errcode":"M_FORBIDDEN","error":"You don't have permission to redact this event"}"#,
+        )
+        .await;
+        assert!(
+            forbidden.is_empty(),
+            "a permission error marked the credential dead; health would read \
+             Unauthenticated for a live token and `channel reload` cannot fix a \
+             power level: {forbidden:?}"
+        );
     }
 
     /// Declaration ↔ behaviour, both directions.

--- a/crates/wcore-channel-matrix/src/lib.rs
+++ b/crates/wcore-channel-matrix/src/lib.rs
@@ -18,6 +18,7 @@ pub mod error;
 mod rest;
 mod sync;
 mod sync_store;
+mod token;
 
 /// The single source of this adapter's inbound media bounds.
 ///
@@ -51,12 +52,19 @@ use wcore_config::credentials::CredentialsStore;
 pub use config::MatrixConfig;
 pub use error::MatrixError;
 
+use token::{Renewal, TokenSource, TokenSourceParams};
+
 /// Production Matrix channel adapter.
 pub struct MatrixChannel {
     name: String,
     config: MatrixConfig,
     state: ConnectionState,
-    access_token: Option<String>,
+    /// The live access token and the only path that renews it, shared with the
+    /// `/sync` task. A plain `String` here was the whole of #936: the token was
+    /// read once in `start()` and could never be replaced, so an expiring
+    /// credential (the OIDC / Matrix Authentication Service default) took the
+    /// channel down permanently. `None` until started.
+    tokens: Option<Arc<TokenSource>>,
     http: wcore_egress::EgressClient,
     /// Background `/sync` task pushes into this; `poll_events` drains it.
     inbox: Arc<Mutex<VecDeque<ChannelEvent>>>,
@@ -95,7 +103,7 @@ impl MatrixChannel {
             name: name.into(),
             config,
             state: ConnectionState::Disconnected,
-            access_token: None,
+            tokens: None,
             http,
             inbox: Arc::new(Mutex::new(VecDeque::new())),
             poll_handle: None,
@@ -116,31 +124,79 @@ impl MatrixChannel {
     /// keyed one drift away from the unkeyed one and quietly stop transmitting
     /// the key while `supports_outbound_idempotency` still claimed it did.
     async fn put_message(
-        &mut self,
+        &self,
         msg: OutgoingMessage,
         delivery_key: Option<&str>,
     ) -> Result<MessageReceipt, ChannelError> {
-        let token = self
-            .access_token
-            .as_deref()
-            .ok_or(ChannelError::NotStarted)?;
-
-        let event_id = rest::send_text_message(
-            &self.http,
-            &self.api_base,
-            token,
-            &msg.conversation_id,
-            &msg.text,
-            delivery_key,
-        )
-        .await
-        .map_err(|e| ChannelError::Transport(e.to_string()))?;
+        let room: &str = &msg.conversation_id;
+        let text: &str = &msg.text;
+        let event_id = self
+            .with_access_token(|token| async move {
+                rest::send_text_message(
+                    &self.http,
+                    &self.api_base,
+                    &token,
+                    room,
+                    text,
+                    delivery_key,
+                )
+                .await
+            })
+            .await?;
 
         Ok(MessageReceipt {
             id: event_id,
             conversation_id: msg.conversation_id.clone(),
             ts_secs: chrono::Utc::now().timestamp(),
         })
+    }
+
+    /// Run one authenticated call, renewing the credential once if the
+    /// homeserver rejects it.
+    ///
+    /// **Every** outbound call goes through here, so there is exactly one
+    /// place that decides what a 401 means on the send side — and it is the
+    /// same decision the `/sync` loop takes, because both delegate to
+    /// [`TokenSource`]. A send path with its own opinion is how "the channel
+    /// reports healthy and every message fails" gets built.
+    ///
+    /// Retrying is safe: a call the homeserver answered 401 was never applied,
+    /// so the second attempt cannot duplicate a delivery.
+    async fn with_access_token<T, F, Fut>(&self, op: F) -> Result<T, ChannelError>
+    where
+        F: Fn(String) -> Fut,
+        Fut: std::future::Future<Output = Result<T, MatrixError>>,
+    {
+        let tokens = self.tokens.as_ref().ok_or(ChannelError::NotStarted)?;
+        let presented = tokens.access();
+        let rejection = match op(presented.clone()).await {
+            Ok(value) => return Ok(value),
+            Err(e) => e,
+        };
+        if !matches!(
+            rejection,
+            MatrixError::Http {
+                status: 401 | 403,
+                ..
+            }
+        ) {
+            return Err(ChannelError::Transport(rejection.to_string()));
+        }
+        // Secret-free from here on: the homeserver's error body is an echo of
+        // a request we authenticated, so only the errcode label travels.
+        let label = token::auth_rejection_label(&rejection);
+        match tokens.renew_after_rejection(&presented, &rejection).await {
+            Renewal::Renewed => op(tokens.access())
+                .await
+                .map_err(|e| ChannelError::Transport(e.to_string())),
+            Renewal::Deferred(why) => Err(ChannelError::Transport(format!(
+                "{label}; could not renew it yet: {why}"
+            ))),
+            // `TokenSource` has already published `AuthExpired`, so health
+            // reads `Unauthenticated` even though a SEND — not the `/sync`
+            // loop — is what discovered the dead credential.
+            Renewal::Fatal => Err(ChannelError::Auth(label)),
+        }
     }
 }
 
@@ -186,7 +242,20 @@ impl Channel for MatrixChannel {
                 ))
             })?;
 
-        self.access_token = Some(token.clone());
+        // One shared token for the send path and the `/sync` task: a renewal
+        // driven by either is immediately visible to the other, so the
+        // outbound half never keeps authenticating with a token the loop has
+        // already replaced.
+        let tokens = Arc::new(TokenSource::new(TokenSourceParams {
+            creds: Arc::clone(&self.creds),
+            access_handle: self.config.credential_handle_access_token.clone(),
+            refresh_handle: self.config.credential_handle_refresh_token.clone(),
+            access_token: token,
+            http: self.http.clone(),
+            api_base: self.api_base.clone(),
+            inbox: Arc::clone(&self.inbox),
+        }));
+        self.tokens = Some(Arc::clone(&tokens));
 
         // Emit a Connected state-change so subscribers know the channel
         // went live (the manager will tag and broadcast it).
@@ -202,7 +271,7 @@ impl Channel for MatrixChannel {
         let args = sync::SyncArgs {
             http: self.http.clone(),
             api_base: self.api_base.clone(),
-            access_token: token,
+            tokens,
             user_id: self.config.user_id.clone(),
             inbox: Arc::clone(&self.inbox),
             shutdown: rx,
@@ -246,7 +315,7 @@ impl Channel for MatrixChannel {
                 }
             }
         }
-        self.access_token = None;
+        self.tokens = None;
         self.state = ConnectionState::Disconnected;
         self.inbox
             .lock()
@@ -303,20 +372,18 @@ impl Channel for MatrixChannel {
     /// config field) is the path subject. 30s server-side timeout; the
     /// subscriber re-sends on a shorter cadence while a turn runs.
     async fn send_typing(&self, conversation_id: &str) -> Result<(), ChannelError> {
-        let token = self
-            .access_token
-            .as_deref()
-            .ok_or(ChannelError::NotStarted)?;
-        rest::send_typing(
-            &self.http,
-            &self.api_base,
-            token,
-            conversation_id,
-            &self.config.user_id,
-            30_000,
-        )
+        self.with_access_token(|token| async move {
+            rest::send_typing(
+                &self.http,
+                &self.api_base,
+                &token,
+                conversation_id,
+                &self.config.user_id,
+                30_000,
+            )
+            .await
+        })
         .await
-        .map_err(|e| ChannelError::Transport(e.to_string()))
     }
 
     /// `m.reaction` annotation relating to the inbound event — the ack
@@ -327,20 +394,18 @@ impl Channel for MatrixChannel {
         message_id: &str,
         emoji: &str,
     ) -> Result<(), ChannelError> {
-        let token = self
-            .access_token
-            .as_deref()
-            .ok_or(ChannelError::NotStarted)?;
-        rest::send_reaction(
-            &self.http,
-            &self.api_base,
-            token,
-            conversation_id,
-            message_id,
-            emoji,
-        )
+        self.with_access_token(|token| async move {
+            rest::send_reaction(
+                &self.http,
+                &self.api_base,
+                &token,
+                conversation_id,
+                message_id,
+                emoji,
+            )
+            .await
+        })
         .await
-        .map_err(|e| ChannelError::Transport(e.to_string()))
     }
 
     /// Download unencrypted inbound media by its `mxc://` URI via the
@@ -350,13 +415,11 @@ impl Channel for MatrixChannel {
         &self,
         attachment: &wcore_channels::Attachment,
     ) -> Result<Vec<u8>, ChannelError> {
-        let token = self
-            .access_token
-            .as_deref()
-            .ok_or(ChannelError::NotStarted)?;
-        rest::download_media(&self.http, &self.api_base, token, &attachment.url)
-            .await
-            .map_err(|e| ChannelError::Transport(e.to_string()))
+        let url: &str = &attachment.url;
+        self.with_access_token(|token| async move {
+            rest::download_media(&self.http, &self.api_base, &token, url).await
+        })
+        .await
     }
 
     /// This adapter's inbound intake policy — see [`MEDIA_BOUNDS`], from which
@@ -396,20 +459,19 @@ impl Channel for MatrixChannel {
         message_id: &str,
         new_text: &str,
     ) -> Result<MessageReceipt, ChannelError> {
-        let token = self
-            .access_token
-            .as_deref()
-            .ok_or(ChannelError::NotStarted)?;
-        let new_event_id = rest::edit_message(
-            &self.http,
-            &self.api_base,
-            token,
-            conversation_id,
-            message_id,
-            new_text,
-        )
-        .await
-        .map_err(|e| ChannelError::Transport(e.to_string()))?;
+        let new_event_id = self
+            .with_access_token(|token| async move {
+                rest::edit_message(
+                    &self.http,
+                    &self.api_base,
+                    &token,
+                    conversation_id,
+                    message_id,
+                    new_text,
+                )
+                .await
+            })
+            .await?;
         Ok(MessageReceipt {
             id: new_event_id,
             conversation_id: conversation_id.to_string(),
@@ -423,20 +485,18 @@ impl Channel for MatrixChannel {
         conversation_id: &str,
         message_id: &str,
     ) -> Result<(), ChannelError> {
-        let token = self
-            .access_token
-            .as_deref()
-            .ok_or(ChannelError::NotStarted)?;
-        rest::redact_event(
-            &self.http,
-            &self.api_base,
-            token,
-            conversation_id,
-            message_id,
-        )
+        self.with_access_token(|token| async move {
+            rest::redact_event(
+                &self.http,
+                &self.api_base,
+                &token,
+                conversation_id,
+                message_id,
+            )
+            .await
+            .map(|_| ())
+        })
         .await
-        .map(|_| ())
-        .map_err(|e| ChannelError::Transport(e.to_string()))
     }
 }
 
@@ -447,50 +507,15 @@ impl Channel for MatrixChannel {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex as StdMutex;
-    use wcore_config::credentials::{CredentialsError, CredentialsStore as CredsTrait};
-
-    struct MemCreds {
-        inner: StdMutex<std::collections::HashMap<String, String>>,
-    }
-    impl MemCreds {
-        fn with_token(handle: &str, token: &str) -> Arc<dyn CredsTrait> {
-            let s = Self {
-                inner: StdMutex::new(std::collections::HashMap::new()),
-            };
-            s.inner
-                .lock()
-                .unwrap()
-                .insert(handle.to_string(), token.to_string());
-            Arc::new(s)
-        }
-        fn empty() -> Arc<dyn CredsTrait> {
-            Arc::new(Self {
-                inner: StdMutex::new(std::collections::HashMap::new()),
-            })
-        }
-    }
-    impl CredsTrait for MemCreds {
-        fn get(&self, key: &str) -> Result<Option<String>, CredentialsError> {
-            Ok(self.inner.lock().unwrap().get(key).cloned())
-        }
-        fn put(&self, key: &str, value: &str) -> Result<(), CredentialsError> {
-            self.inner
-                .lock()
-                .unwrap()
-                .insert(key.to_string(), value.to_string());
-            Ok(())
-        }
-        fn delete(&self, key: &str) -> Result<(), CredentialsError> {
-            self.inner.lock().unwrap().remove(key);
-            Ok(())
-        }
-    }
+    // One in-memory credentials store for the whole crate's tests; it lives
+    // beside the token source because that is what reads and rotates it.
+    use crate::token::tests::MemCreds;
 
     fn cfg() -> MatrixConfig {
         MatrixConfig {
             homeserver_url: "https://matrix.example.org".to_string(),
             credential_handle_access_token: "matrix.test.token".to_string(),
+            credential_handle_refresh_token: None,
             user_id: "@bot:matrix.example.org".to_string(),
         }
     }

--- a/crates/wcore-channel-matrix/src/rest.rs
+++ b/crates/wcore-channel-matrix/src/rest.rs
@@ -165,6 +165,59 @@ pub async fn send_text_message(
     Ok(result.event_id)
 }
 
+/// The token pair `POST /_matrix/client/v3/refresh` returns.
+#[derive(Debug, Deserialize)]
+pub(crate) struct RefreshedTokens {
+    pub access_token: String,
+    /// Matrix refresh tokens ROTATE. When this is present the token we
+    /// presented is SPENT, and persisting the replacement is not optional:
+    /// a later process that replays the spent one can have the whole grant
+    /// revoked (RFC 6819 §5.2.2.3).
+    #[serde(default)]
+    pub refresh_token: Option<String>,
+    /// Lifetime of the new access token. Absent means the homeserver did not
+    /// state one, so no proactive renewal is scheduled — the reactive 401 path
+    /// still covers it.
+    #[serde(default)]
+    pub expires_in_ms: Option<u64>,
+}
+
+#[derive(Serialize)]
+struct RefreshRequest<'a> {
+    refresh_token: &'a str,
+}
+
+/// Exchange a refresh token for a fresh access token.
+///
+/// **Deliberately unauthenticated.** The refresh token IS the credential here
+/// and rides in the body; attaching the (expired) access token as a bearer
+/// would hand the homeserver a reason to 401 a call that must succeed, and
+/// would make the dead credential a precondition for replacing itself.
+pub(crate) async fn refresh_access_token(
+    http: &wcore_egress::EgressClient,
+    api_base: &str,
+    refresh_token: &str,
+) -> Result<RefreshedTokens, MatrixError> {
+    let url = format!("{api_base}/_matrix/client/v3/refresh");
+    let resp = http
+        .post(&url)
+        .json(&RefreshRequest { refresh_token })
+        .timeout(crate::token::REFRESH_POST_TIMEOUT)
+        .send()
+        .await
+        .map_err(|e| MatrixError::Network(e.to_string()))?;
+
+    let status = resp.status().as_u16();
+    if !resp.status().is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        return Err(MatrixError::Http { status, body });
+    }
+
+    resp.json()
+        .await
+        .map_err(|e| MatrixError::Parse(e.to_string()))
+}
+
 #[derive(Serialize)]
 struct TypingBody {
     typing: bool,

--- a/crates/wcore-channel-matrix/src/schemas/matrix.json
+++ b/crates/wcore-channel-matrix/src/schemas/matrix.json
@@ -14,6 +14,10 @@
       "type": "string",
       "description": "Credentials-store key for the Matrix access token."
     },
+    "credential_handle_refresh_token": {
+      "type": "string",
+      "description": "Credentials-store key for the Matrix refresh token, if the login requested one. Set it when the homeserver issues expiring access tokens (OIDC / Matrix Authentication Service) so the channel renews in place instead of going unauthenticated at expiry."
+    },
     "user_id": {
       "type": "string",
       "description": "Full Matrix user ID of the bot (e.g. @bot:matrix.org).",

--- a/crates/wcore-channel-matrix/src/sync.rs
+++ b/crates/wcore-channel-matrix/src/sync.rs
@@ -34,7 +34,7 @@ use wcore_channels::event::{Attachment, ChannelEvent, ChatType, IncomingMessage,
 
 use crate::error::MatrixError;
 use crate::sync_store::{self, Loaded};
-use crate::token::{Renewal, TokenSource};
+use crate::token::{self, Renewal, TokenSource};
 
 /// Long-poll timeout (ms) handed to the homeserver's `/sync`. The HTTP read
 /// timeout is this plus a buffer so a wedged proxy can't park us forever.
@@ -364,13 +364,7 @@ pub(crate) async fn sync_loop(args: SyncArgs) {
                 // `AuthExpired` (exactly once, from the token source) and stops
                 // — because a refresh path that papers over a real revocation
                 // is worse than no refresh path.
-                if matches!(
-                    e,
-                    MatrixError::Http {
-                        status: 401 | 403,
-                        ..
-                    }
-                ) {
+                if token::is_credential_rejection(&e) {
                     match tokens.renew_after_rejection(&presented, &e).await {
                         Renewal::Renewed => {
                             consecutive_failures = 0;
@@ -1324,44 +1318,72 @@ mod tests {
         let _ = std::fs::remove_file(&state);
     }
 
-    /// The 400 cursor-rejection path predates this change and must keep its own
-    /// behaviour: re-seed, do NOT classify as an auth rejection. Without this,
-    /// a broad `4xx` classification would silently convert a recoverable cursor
-    /// fault into a terminal "rotate your token".
+    /// What counts as a CREDENTIAL rejection, asserted against the production
+    /// predicate.
+    ///
+    /// This test used to build a `MatrixError` and then `matches!` it against
+    /// the same `status: 401 | 403` pattern written inline — it asserted a fact
+    /// about `matches!`, referenced no production code, and would have stayed
+    /// green through any change to the real classification. It now calls
+    /// [`token::is_credential_rejection`], the one predicate both this loop and
+    /// the send path gate on.
+    ///
+    /// Three obligations, and each row can fail on its own:
+    ///
+    /// * The 400 cursor-rejection path predates #936 and must keep re-seeding
+    ///   rather than becoming a terminal "rotate your token".
+    /// * A token errcode IS the credential, on either status.
+    /// * `M_FORBIDDEN` on 403 is the bot's POWER LEVEL, not its identity.
+    ///   Classifying it as a credential rejection latches the channel
+    ///   `Unauthenticated` for a token that still works.
     #[test]
-    fn only_401_and_403_are_auth_rejections() {
+    fn credential_rejection_is_the_errcode_not_the_bare_status() {
         for status in [400_u16, 404, 429, 500, 502] {
-            let e = MatrixError::Http {
-                status,
-                body: r#"{"errcode":"M_UNKNOWN"}"#.to_string(),
-            };
             assert!(
-                !matches!(
-                    e,
-                    MatrixError::Http {
-                        status: 401 | 403,
-                        ..
-                    }
-                ),
+                !token::is_credential_rejection(&MatrixError::Http {
+                    status,
+                    body: r#"{"errcode":"M_UNKNOWN"}"#.to_string(),
+                }),
                 "HTTP {status} must not be classified as a credential rejection"
             );
         }
         for status in [401_u16, 403] {
-            let e = MatrixError::Http {
-                status,
-                body: r#"{"errcode":"M_UNKNOWN_TOKEN"}"#.to_string(),
-            };
             assert!(
-                matches!(
-                    e,
-                    MatrixError::Http {
-                        status: 401 | 403,
-                        ..
-                    }
-                ),
-                "HTTP {status} IS a credential rejection"
+                token::is_credential_rejection(&MatrixError::Http {
+                    status,
+                    body: r#"{"errcode":"M_UNKNOWN_TOKEN"}"#.to_string(),
+                }),
+                "HTTP {status} M_UNKNOWN_TOKEN IS a credential rejection"
             );
         }
+        // A gateway that stripped the Matrix body still refused our identity.
+        assert!(
+            token::is_credential_rejection(&MatrixError::Http {
+                status: 401,
+                body: "<html>Unauthorized</html>".to_string(),
+            }),
+            "a bare 401 is still a credential rejection; no retry fixes it"
+        );
+        // The row this predicate exists for.
+        assert!(
+            !token::is_credential_rejection(&MatrixError::Http {
+                status: 403,
+                body: r#"{"errcode":"M_FORBIDDEN","error":"no permission to redact"}"#.to_string(),
+            }),
+            "M_FORBIDDEN is a power level, not a dead token; classifying it \
+             latches the channel Unauthenticated while every send still works"
+        );
+        assert!(
+            !token::is_credential_rejection(&MatrixError::Http {
+                status: 403,
+                body: "blocked by upstream proxy".to_string(),
+            }),
+            "a bare 403 is an upstream block, not a credential verdict"
+        );
+        assert!(
+            !token::is_credential_rejection(&MatrixError::Network("timeout".to_string())),
+            "a network fault is not a credential verdict"
+        );
     }
 
     /// **Quadrant 2 — the token merely EXPIRED (#936).**

--- a/crates/wcore-channel-matrix/src/sync.rs
+++ b/crates/wcore-channel-matrix/src/sync.rs
@@ -34,10 +34,11 @@ use wcore_channels::event::{Attachment, ChannelEvent, ChatType, IncomingMessage,
 
 use crate::error::MatrixError;
 use crate::sync_store::{self, Loaded};
+use crate::token::{Renewal, TokenSource};
 
 /// Long-poll timeout (ms) handed to the homeserver's `/sync`. The HTTP read
 /// timeout is this plus a buffer so a wedged proxy can't park us forever.
-const SYNC_TIMEOUT_MS: u64 = 30_000;
+pub(crate) const SYNC_TIMEOUT_MS: u64 = 30_000;
 
 /// Hard cap on a single `/sync` response body. The body is buffered fully to
 /// parse `SyncResponse`, so without a cap a homeserver (or a wedged proxy)
@@ -53,7 +54,11 @@ const MAX_ERROR_BODY_BYTES: usize = 4 * 1024;
 pub(crate) struct SyncArgs {
     pub http: wcore_egress::EgressClient,
     pub api_base: String,
-    pub access_token: String,
+    /// The live access token and the only path that renews it. Shared with
+    /// `MatrixChannel`, so a renewal driven from here is immediately visible
+    /// to the send path (and vice versa) rather than leaving the outbound
+    /// half authenticating with a token this loop already replaced.
+    pub tokens: Arc<TokenSource>,
     pub user_id: String,
     pub inbox: Arc<Mutex<VecDeque<ChannelEvent>>>,
     pub shutdown: watch::Receiver<bool>,
@@ -196,7 +201,7 @@ pub(crate) async fn sync_loop(args: SyncArgs) {
     let SyncArgs {
         http,
         api_base,
-        access_token,
+        tokens,
         user_id,
         inbox,
         mut shutdown,
@@ -246,6 +251,31 @@ pub(crate) async fn sync_loop(args: SyncArgs) {
             break;
         }
 
+        // Proactive renewal. The homeserver states `expires_in_ms` on every
+        // refresh, so once this adapter has renewed once it knows the deadline
+        // and replaces the token BEFORE a call fails. Without this the only
+        // trigger is a 401, i.e. at least one rejected `/sync` per expiry.
+        if tokens.renewal_due() {
+            match tokens.renew_before_expiry().await {
+                Renewal::Renewed => {}
+                Renewal::Deferred(why) => {
+                    tracing::warn!(
+                        target: "wcore_channel_matrix::sync",
+                        reason = %why,
+                        "could not renew the Matrix access token ahead of expiry; continuing on the current one",
+                    );
+                }
+                // `AuthExpired` is already published by the token source.
+                Renewal::Fatal => break,
+            }
+        }
+
+        // The token this iteration authenticates with. Captured before the
+        // call so the 401 handler can tell "the token I presented" from "the
+        // token in the store now", which is how a peer process's refresh is
+        // detected without POSTing.
+        let presented = tokens.access();
+
         // Race the next API call against a shutdown signal so we don't get
         // stuck for ~SYNC_TIMEOUT_MS after stop() flips the flag.
         let result = tokio::select! {
@@ -254,12 +284,15 @@ pub(crate) async fn sync_loop(args: SyncArgs) {
                 if *shutdown.borrow() { break; }
                 continue;
             }
-            r = sync_once(&http, &api_base, &access_token, since.as_deref()) => r,
+            r = sync_once(&http, &api_base, &presented, since.as_deref()) => r,
         };
 
         match result {
             Ok(resp) => {
                 consecutive_failures = 0;
+                // A served `/sync` proves the token in play is live, which
+                // releases the renewal-loop guard.
+                tokens.mark_progress();
                 // The homeserver accepted whatever cursor we presented, so a
                 // resumed one is now proven good.
                 resumed_unverified = false;
@@ -315,16 +348,22 @@ pub(crate) async fn sync_loop(args: SyncArgs) {
                 }
                 // A 401/403 is the homeserver REJECTING the access token
                 // (`M_UNKNOWN_TOKEN` on a revoked one), not a transient fault.
-                // Backoff cannot recover a dead credential, and — this is the
-                // defect — the manager cannot infer it either: this loop owns
-                // `consecutive_failures` privately, `poll_events()` drains an
-                // empty inbox and returns `Ok(vec![])`, and the manager's Ok arm
-                // RESETS its error count. So the channel reported `Healthy` while
-                // every single sync 401'd, measured live at 21 consecutive
-                // failures. Publish the rejection as the event the health
-                // projection already understands, and stop: the manager records
-                // `Unauthenticated` and ends the poll loop rather than reconnect-
-                // looping against a token that will never be accepted.
+                // Backoff cannot recover a dead credential, and — this was the
+                // original defect — the manager cannot infer it either: this
+                // loop owns `consecutive_failures` privately, `poll_events()`
+                // drains an empty inbox and returns `Ok(vec![])`, and the
+                // manager's Ok arm RESETS its error count. So the channel
+                // reported `Healthy` while every single sync 401'd, measured
+                // live at 21 consecutive failures.
+                //
+                // #936 splits that one verdict into three. A token the
+                // homeserver says is merely EXPIRED (`soft_logout: true`) is
+                // renewed in place and the loop continues; a transient fault on
+                // the refresh endpoint backs off WITHOUT accusing the
+                // credential; and a genuine revocation still publishes
+                // `AuthExpired` (exactly once, from the token source) and stops
+                // — because a refresh path that papers over a real revocation
+                // is worse than no refresh path.
                 if matches!(
                     e,
                     MatrixError::Http {
@@ -332,23 +371,33 @@ pub(crate) async fn sync_loop(args: SyncArgs) {
                         ..
                     }
                 ) {
-                    let reason = auth_rejection_label(&e);
-                    tracing::error!(
+                    match tokens.renew_after_rejection(&presented, &e).await {
+                        Renewal::Renewed => {
+                            consecutive_failures = 0;
+                            continue;
+                        }
+                        Renewal::Deferred(why) => {
+                            tracing::warn!(
+                                target: "wcore_channel_matrix::sync",
+                                reason = %why,
+                                "the Matrix access token was rejected and could not be renewed yet; backing off",
+                            );
+                        }
+                        Renewal::Fatal => {
+                            tracing::error!(
+                                target: "wcore_channel_matrix::sync",
+                                "homeserver rejected the access token and it cannot be renewed; stopping /sync",
+                            );
+                            break;
+                        }
+                    }
+                } else {
+                    tracing::warn!(
                         target: "wcore_channel_matrix::sync",
-                        reason = %reason,
-                        "homeserver rejected the access token; stopping /sync. Rotate the token and run `channel reload`"
+                        error = %e,
+                        "/sync failed; backing off"
                     );
-                    inbox
-                        .lock()
-                        .await
-                        .push_back(ChannelEvent::AuthExpired { reason });
-                    break;
                 }
-                tracing::warn!(
-                    target: "wcore_channel_matrix::sync",
-                    error = %e,
-                    "/sync failed; backing off"
-                );
                 consecutive_failures = consecutive_failures.saturating_add(1);
                 let sleep_secs = (2_u64.saturating_mul(consecutive_failures as u64)).min(30);
                 tokio::select! {
@@ -360,30 +409,6 @@ pub(crate) async fn sync_loop(args: SyncArgs) {
                 }
             }
         }
-    }
-}
-
-/// A short, SECRET-FREE label for a credential rejection, suitable for the
-/// health surface's operator-facing `reason`.
-///
-/// Only the homeserver's `errcode` — a fixed spec vocabulary such as
-/// `M_UNKNOWN_TOKEN` — is surfaced, never the raw response body. The body is an
-/// echo of a request we authenticated, so treating it as printable would make
-/// the health surface a place a token could appear; `ProbeReport` holds the same
-/// line ("the NAME of a rejected item, never its value") and this must not be the
-/// weaker of the two. A body we cannot parse yields the status alone.
-fn auth_rejection_label(e: &MatrixError) -> String {
-    let MatrixError::Http { status, body } = e else {
-        return "platform rejected the credential".to_string();
-    };
-    match serde_json::from_str::<serde_json::Value>(body)
-        .ok()
-        .as_ref()
-        .and_then(|v| v.get("errcode"))
-        .and_then(|c| c.as_str())
-    {
-        Some(errcode) => format!("homeserver rejected the access token: HTTP {status} {errcode}"),
-        None => format!("homeserver rejected the access token: HTTP {status}"),
     }
 }
 
@@ -825,7 +850,7 @@ mod tests {
         let handle = tokio::spawn(sync_loop(SyncArgs {
             http,
             api_base: server_url.to_string(),
-            access_token: "syt_test".to_string(),
+            tokens: crate::token::tests::plain_source(server_url, "syt_test", &inbox),
             user_id: BOT.to_string(),
             inbox: Arc::clone(&inbox),
             shutdown: rx,
@@ -1152,7 +1177,7 @@ mod tests {
         let handle = tokio::spawn(sync_loop(SyncArgs {
             http,
             api_base: server_url.to_string(),
-            access_token: TOKEN_CANARY.to_string(),
+            tokens: crate::token::tests::plain_source(server_url, TOKEN_CANARY, &inbox),
             user_id: BOT.to_string(),
             inbox: Arc::clone(&inbox),
             shutdown: rx,
@@ -1339,32 +1364,132 @@ mod tests {
         }
     }
 
-    /// The label is the string an operator reads on the health surface. It must
-    /// carry the errcode and never the response body, which is an echo of a
-    /// request we authenticated.
-    #[test]
-    fn the_auth_label_names_the_errcode_and_never_the_body() {
-        let label = auth_rejection_label(&MatrixError::Http {
-            status: 401,
-            body: format!(r#"{{"errcode":"M_UNKNOWN_TOKEN","error":"{TOKEN_CANARY}"}}"#),
-        });
-        assert!(label.contains("M_UNKNOWN_TOKEN"), "got {label:?}");
-        assert!(label.contains("401"), "got {label:?}");
-        assert!(
-            !label.contains(TOKEN_CANARY),
-            "the label echoed the response body verbatim: {label:?}"
-        );
+    /// **Quadrant 2 — the token merely EXPIRED (#936).**
+    ///
+    /// This is the case the adapter had no answer for: a homeserver on the
+    /// OIDC / Matrix Authentication Service path answers `M_UNKNOWN_TOKEN`
+    /// with `soft_logout: true` when a short-lived access token ages out. The
+    /// loop must refresh in place and keep delivering — no `AuthExpired`, no
+    /// exit. Before the fix the identical response took the channel down
+    /// permanently.
+    ///
+    /// It is deliberately paired with the hard-revocation test above, which
+    /// still exits: a refresh path that recovered from BOTH would be worse
+    /// than no refresh path.
+    #[tokio::test]
+    async fn a_soft_logout_is_refreshed_in_place_and_delivery_continues() {
+        let mut server = mockito::Server::new_async().await;
+        let state = tmp_state_path("softlogout");
+        let _ = std::fs::remove_file(&state);
 
-        // An unparseable body must degrade to the status alone, never to the
-        // raw bytes.
-        let label = auth_rejection_label(&MatrixError::Http {
-            status: 403,
-            body: TOKEN_CANARY.to_string(),
-        });
-        assert!(label.contains("403"), "got {label:?}");
-        assert!(
-            !label.contains(TOKEN_CANARY),
-            "an unparseable body must not be echoed: {label:?}"
+        // The aged-out token is refused ...
+        let refused = server
+            .mock("GET", "/_matrix/client/v3/sync")
+            .match_header("authorization", "Bearer syt_expired")
+            .match_query(mockito::Matcher::Any)
+            .with_status(401)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"errcode":"M_UNKNOWN_TOKEN","soft_logout":true}"#)
+            .expect_at_least(1)
+            .create_async()
+            .await;
+        // ... the refresh endpoint mints a replacement pair, exactly once ...
+        let refreshed = server
+            .mock("POST", "/_matrix/client/v3/refresh")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"access_token":"syt_renewed","refresh_token":"rot_next","expires_in_ms":3600000}"#,
+            )
+            .expect(1)
+            .create_async()
+            .await;
+        // ... and only the replacement is served.
+        server
+            .mock("GET", "/_matrix/client/v3/sync")
+            .match_header("authorization", "Bearer syt_renewed")
+            .match_query(initial_query())
+            .with_status(200)
+            .with_body(body_empty("g1"))
+            .create_async()
+            .await;
+        server
+            .mock("GET", "/_matrix/client/v3/sync")
+            .match_header("authorization", "Bearer syt_renewed")
+            .match_query(resume_query("g1"))
+            .with_status(200)
+            .with_body(body_with_event("g2", "$after_refresh", "delivered anyway"))
+            .create_async()
+            .await;
+
+        let lock_dir = tempfile::tempdir().unwrap();
+        let inbox: Arc<Mutex<VecDeque<ChannelEvent>>> = Arc::new(Mutex::new(VecDeque::new()));
+        let creds = crate::token::tests::MemCreds::new(&[
+            ("matrix.test.access", "syt_expired"),
+            ("matrix.test.refresh", "rot_first"),
+        ]);
+        let tokens = crate::token::tests::refreshing_source(
+            &server.url(),
+            "syt_expired",
+            creds.clone(),
+            lock_dir.path(),
+            &inbox,
         );
+        let (tx, rx) = watch::channel(false);
+        let handle = tokio::spawn(sync_loop(SyncArgs {
+            http: wcore_egress::EgressClient::builder()
+                .user_agent("wcore-matrix-936-test")
+                .build()
+                .unwrap_or_default(),
+            api_base: server.url(),
+            tokens: Arc::clone(&tokens),
+            user_id: BOT.to_string(),
+            inbox: Arc::clone(&inbox),
+            shutdown: rx,
+            state_path: state.clone(),
+        }));
+
+        // Bounded wait for the post-refresh cursor; the loop persists it only
+        // after the message it accompanied is already in the inbox.
+        let mut reached = false;
+        for _ in 0..200 {
+            if matches!(sync_store::load_from(&state), Loaded::Cursor(ref c) if c == "g2") {
+                reached = true;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+        let _ = tx.send(true);
+        let _ = tokio::time::timeout(Duration::from_secs(5), handle).await;
+        let events: Vec<ChannelEvent> = inbox.lock().await.drain(..).collect();
+
+        assert!(
+            reached,
+            "the loop never got past the expired token: {:?}",
+            auth_events(&events),
+        );
+        refused.assert_async().await;
+        refreshed.assert_async().await;
+        assert_eq!(
+            message_ids(&events),
+            vec!["$after_refresh".to_string()],
+            "the message that arrived after the renewal must be delivered",
+        );
+        assert!(
+            auth_events(&events).is_empty(),
+            "a credential that was RECOVERED must not be reported unauthenticated: {:?}",
+            auth_events(&events),
+        );
+        assert_eq!(
+            tokens.access(),
+            "syt_renewed",
+            "the renewed token must be the one in play",
+        );
+        assert_eq!(
+            creds.peek("matrix.test.refresh").as_deref(),
+            Some("rot_next"),
+            "the rotated refresh token must be persisted for the next process",
+        );
+        let _ = std::fs::remove_file(&state);
     }
 }

--- a/crates/wcore-channel-matrix/src/token.rs
+++ b/crates/wcore-channel-matrix/src/token.rs
@@ -1,0 +1,992 @@
+//! The adapter's live access token, and the one place it is renewed (#936).
+//!
+//! # The defect this closes
+//!
+//! The adapter held a `String` access token read once in `start()`. Matrix
+//! access tokens issued through the Matrix Authentication Service (the OIDC
+//! path `matrix.org` is moving accounts onto) are **short-lived by design**,
+//! and a client is expected to hold a refresh token alongside them. With no
+//! refresh support the adapter's entire response to expiry was to publish
+//! `AuthExpired` and stop — it could *report* a dead token and never *recover*
+//! from one.
+//!
+//! # Cross-process safety is the bar, not in-process single-flight
+//!
+//! A Matrix refresh token ROTATES: `POST /_matrix/client/v3/refresh` may return
+//! a new one, and the presented one is then spent. Two Wayland processes
+//! sharing one credentials store that both POST the same refresh token get one
+//! winner and one `M_UNKNOWN_TOKEN`, and under RFC 6819 §5.2.2.3 a server is
+//! sanctioned to revoke the whole grant — i.e. BOTH processes logged out, not
+//! one poll failed. An in-process mutex cannot see a sibling process, so this
+//! module takes [`ExclusiveFileLock`] — the same cross-process primitive
+//! `wcore_agent::oauth::refresh_lock` takes, from the same `wcore-config`
+//! layer — around the whole load → decide → POST → store critical section.
+//!
+//! The lock releases in `Drop` (never on a timer, never on an explicit
+//! unlock this code could skip on an early return), so every `?` and every
+//! error arm below frees it.
+//!
+//! # What "fail closed" means here
+//!
+//! A refresh path that papers over a real revocation is worse than none, so
+//! the outcomes are three, not two:
+//!
+//! * [`Renewal::Renewed`] — a usable access token is installed.
+//! * [`Renewal::Deferred`] — transient (network, lock contention, store I/O).
+//!   The caller backs off. This is explicitly NOT a credential verdict: a
+//!   blip on the refresh endpoint must not read as "your token was revoked".
+//! * [`Renewal::Fatal`] — the credential is dead. `AuthExpired` is published
+//!   exactly once, so the health surface says `Unauthenticated` no matter
+//!   which call site discovered it.
+
+use std::collections::VecDeque;
+use std::hash::{Hash, Hasher};
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::{Arc, RwLock};
+use std::time::{Duration, Instant};
+
+use tokio::sync::Mutex;
+
+use wcore_channels::event::ChannelEvent;
+use wcore_config::credentials::{CredentialsStore, ExclusiveFileLock, LockPolicy};
+
+use crate::error::MatrixError;
+use crate::rest;
+
+/// Outer wall-clock cap on one refresh round-trip. Every lock timing below is
+/// derived from it, so the two cannot drift apart silently.
+pub(crate) const REFRESH_POST_TIMEOUT: Duration = Duration::from_secs(POST_TIMEOUT_SECS);
+const POST_TIMEOUT_SECS: u64 = 20;
+
+/// Budget for the credential-store reads and writes the critical section does
+/// around the POST.
+const STORE_BUDGET_SECS: u64 = 5;
+
+/// The most time a healthy holder can occupy the lock.
+const MAX_HOLD_SECS: u64 = POST_TIMEOUT_SECS + STORE_BUDGET_SECS;
+
+/// How often a holder re-stamps the lockfile. With a heartbeat the lockfile's
+/// mtime tracks LIVENESS rather than acquisition, so staleness is sized against
+/// the beat and a crashed holder is detected in seconds regardless of how long
+/// the held work takes.
+const HEARTBEAT_SECS: u64 = 2;
+
+/// How long an un-refreshed lockfile may sit before a waiter treats its holder
+/// as crashed. Five missed beats of slack, so a LIVE holder is never stolen
+/// from — a steal from a live holder is the exact double-POST this lock exists
+/// to prevent.
+const STALE_AFTER_SECS: u64 = HEARTBEAT_SECS * 5;
+
+/// How long a waiter keeps trying. Above `MAX_HOLD_SECS` so healthy contention
+/// never times out, and above `STALE_AFTER_SECS` so a crashed holder is always
+/// reached by the steal within the wait.
+const WAIT_CEILING_SECS: u64 = MAX_HOLD_SECS + STALE_AFTER_SECS + 5;
+
+const _: () = assert!(
+    WAIT_CEILING_SECS > MAX_HOLD_SECS,
+    "a waiter that gives up before a healthy holder can finish fires the \
+     contention path on the happy path"
+);
+const _: () = assert!(
+    WAIT_CEILING_SECS > STALE_AFTER_SECS,
+    "a ceiling below staleness means a crashed holder is never stolen from"
+);
+const _: () = assert!(
+    STALE_AFTER_SECS >= HEARTBEAT_SECS * 3,
+    "staleness must leave a live holder several missed heartbeats of slack"
+);
+
+/// Renew this long before the homeserver's stated expiry.
+///
+/// Derived from the `/sync` long-poll, not picked: a renewal decision is taken
+/// once per loop iteration, and an iteration can be parked in a long poll for
+/// [`crate::sync::SYNC_TIMEOUT_MS`] plus its read-timeout buffer. A margin
+/// below that would let a token die *inside* a poll that had already started,
+/// which converts the proactive path back into the reactive one it exists to
+/// avoid.
+pub(crate) const RENEW_MARGIN: Duration = Duration::from_secs(120);
+
+const _: () = assert!(
+    RENEW_MARGIN.as_millis() as u64 > crate::sync::SYNC_TIMEOUT_MS + 10_000,
+    "the renewal margin must exceed one full long-poll plus its read-timeout \
+     buffer, or the token can expire inside a poll already in flight"
+);
+
+/// Consecutive renewals with no successful `/sync` in between before the
+/// credential is declared dead.
+///
+/// Without this a homeserver that keeps answering 401 `soft_logout` *after* a
+/// successful refresh turns this module into an unbounded refresh loop: every
+/// iteration spends a rotating refresh token and POSTs again. Three attempts
+/// is enough to ride out a genuine race with a peer process and far short of
+/// a self-inflicted denial of service.
+const MAX_RENEWALS_WITHOUT_PROGRESS: u32 = 3;
+
+/// What a renewal attempt produced. See the module docs for why there are
+/// three of these and not two.
+#[derive(Debug)]
+pub(crate) enum Renewal {
+    /// A usable access token is installed; retry the call that failed.
+    Renewed,
+    /// Transient. Back off and try again later; the credential is NOT accused.
+    Deferred(String),
+    /// The credential is dead. `AuthExpired` has been published exactly once.
+    Fatal,
+}
+
+/// The access token currently in play, and what we know about its lifetime.
+struct Snapshot {
+    access: String,
+    /// When the homeserver said this token expires. `None` means "not stated"
+    /// — a token read from the credentials store carries no expiry, so no
+    /// proactive renewal is scheduled until this adapter has done one refresh
+    /// and been told `expires_in_ms`.
+    expires_at: Option<Instant>,
+}
+
+/// Everything [`TokenSource::new`] needs. A struct rather than nine positional
+/// arguments.
+pub(crate) struct TokenSourceParams {
+    pub creds: Arc<dyn CredentialsStore>,
+    pub access_handle: String,
+    pub refresh_handle: Option<String>,
+    pub access_token: String,
+    pub http: wcore_egress::EgressClient,
+    pub api_base: String,
+    pub inbox: Arc<Mutex<VecDeque<ChannelEvent>>>,
+}
+
+/// The adapter's live access token and the only path that replaces it.
+pub(crate) struct TokenSource {
+    creds: Arc<dyn CredentialsStore>,
+    access_handle: String,
+    refresh_handle: Option<String>,
+    http: wcore_egress::EgressClient,
+    api_base: String,
+    lock_path: PathBuf,
+    inbox: Arc<Mutex<VecDeque<ChannelEvent>>>,
+    current: RwLock<Snapshot>,
+    /// `AuthExpired` is published at most once per channel start, so a send
+    /// path and the `/sync` loop discovering the same dead credential do not
+    /// produce two health events.
+    reported: AtomicBool,
+    renewals_without_progress: AtomicU32,
+}
+
+impl TokenSource {
+    pub(crate) fn new(params: TokenSourceParams) -> Self {
+        let lock_path = refresh_lock_path(&params.api_base, &params.access_handle);
+        Self {
+            creds: params.creds,
+            access_handle: params.access_handle,
+            refresh_handle: params.refresh_handle,
+            http: params.http,
+            api_base: params.api_base,
+            lock_path,
+            inbox: params.inbox,
+            current: RwLock::new(Snapshot {
+                access: params.access_token,
+                expires_at: None,
+            }),
+            reported: AtomicBool::new(false),
+            renewals_without_progress: AtomicU32::new(0),
+        }
+    }
+
+    /// The access token to authenticate the next call with.
+    pub(crate) fn access(&self) -> String {
+        self.read().access.clone()
+    }
+
+    /// Whether this adapter can renew at all. Reported on the health reason
+    /// when it cannot, because "no refresh token is configured" and "the
+    /// homeserver revoked you" are different operator actions.
+    pub(crate) fn can_renew(&self) -> bool {
+        self.refresh_handle.is_some()
+    }
+
+    /// A `/sync` succeeded: the token in play is live, so the renewal-loop
+    /// guard resets.
+    pub(crate) fn mark_progress(&self) {
+        self.renewals_without_progress.store(0, Ordering::Relaxed);
+    }
+
+    /// True when the homeserver's stated expiry is inside [`RENEW_MARGIN`].
+    pub(crate) fn renewal_due(&self) -> bool {
+        match self.read().expires_at {
+            Some(at) => at <= Instant::now() + RENEW_MARGIN,
+            None => false,
+        }
+    }
+
+    /// Proactive renewal, ahead of a stated `expires_in_ms`.
+    pub(crate) async fn renew_before_expiry(&self) -> Renewal {
+        let presented = self.access();
+        self.renew(&presented, "access token is about to expire")
+            .await
+    }
+
+    /// Reactive renewal, after the homeserver rejected a call.
+    ///
+    /// **`soft_logout` is the decision.** Matrix distinguishes a token that
+    /// merely expired (401 `M_UNKNOWN_TOKEN` with `soft_logout: true` — the
+    /// device survives and the refresh token is still good) from a genuine
+    /// revocation (a hard logout, a destroyed device, a 403). Before this,
+    /// both looked identical and both were fatal. Only the first is renewed
+    /// here; the second still fails closed, which is the half of #936 that a
+    /// refresh path could otherwise paper over.
+    pub(crate) async fn renew_after_rejection(
+        &self,
+        presented: &str,
+        cause: &MatrixError,
+    ) -> Renewal {
+        let label = auth_rejection_label(cause);
+        if !is_soft_logout(cause) {
+            self.publish_auth_expired(format!(
+                "{label} — a hard revocation (no soft_logout), which a refresh token cannot \
+                 recover; re-authenticate the bot and run `channel reload`"
+            ))
+            .await;
+            return Renewal::Fatal;
+        }
+        if !self.can_renew() {
+            self.publish_auth_expired(format!(
+                "{label} — the homeserver reports soft_logout, so this token is refreshable, \
+                 but no refresh token is configured; set `credential_handle_refresh_token` on \
+                 this channel and run `channel reload`"
+            ))
+            .await;
+            return Renewal::Fatal;
+        }
+        self.renew(presented, &label).await
+    }
+
+    /// Load → decide → POST → store, all under the cross-process lock.
+    async fn renew(&self, presented: &str, why: &str) -> Renewal {
+        let Some(refresh_handle) = self.refresh_handle.clone() else {
+            return Renewal::Deferred("no refresh token is configured".to_string());
+        };
+
+        if self
+            .renewals_without_progress
+            .fetch_add(1, Ordering::Relaxed)
+            >= MAX_RENEWALS_WITHOUT_PROGRESS
+        {
+            self.publish_auth_expired(format!(
+                "{why} — refreshed {MAX_RENEWALS_WITHOUT_PROGRESS} times with no successful \
+                 call in between, so the homeserver is rejecting freshly issued tokens; \
+                 re-authenticate the bot and run `channel reload`"
+            ))
+            .await;
+            return Renewal::Fatal;
+        }
+
+        // The spin inside `acquire` sleeps a real thread and the wait ceiling
+        // sits above the POST timeout, so awaiting it inline would park a task
+        // worker for tens of seconds — on a small runtime, possibly the very
+        // worker that would have driven the POST that releases the lock.
+        let path = self.lock_path.clone();
+        let acquired = tokio::task::spawn_blocking(move || {
+            ExclusiveFileLock::acquire(path, lock_policy(), "matrix token refresh")
+        })
+        .await;
+        // The lock is held for the rest of this function and released by its
+        // `Drop` — on every arm below, including the early returns.
+        let _lock = match acquired {
+            Ok(Ok(lock)) => lock,
+            Ok(Err(error)) => {
+                return Renewal::Deferred(format!(
+                    "another process is refreshing this Matrix token and did not finish in \
+                     time; nothing was POSTed ({error})"
+                ));
+            }
+            // A panicked blocking task tells us nothing about the lock, so it
+            // is handled exactly like contention: no POST.
+            Err(error) => {
+                return Renewal::Deferred(format!("refresh lock task failed: {error}"));
+            }
+        };
+
+        // Double-check under the lock. A peer that refreshed while we queued
+        // has already written its new access token, so adopting it costs zero
+        // POSTs — and POSTing here would spend a refresh token the peer has
+        // already rotated away, which is the grant-revoking replay.
+        match self.creds.get(&self.access_handle) {
+            Ok(Some(stored)) if stored != presented => {
+                self.install(stored, None);
+                tracing::info!(
+                    target: "wcore_channel_matrix::token",
+                    "another process had already refreshed this Matrix token; adopted it without a refresh POST",
+                );
+                return Renewal::Renewed;
+            }
+            Ok(_) => {}
+            Err(error) => {
+                return Renewal::Deferred(format!("credentials lookup: {error}"));
+            }
+        }
+
+        let refresh_token = match self.creds.get(&refresh_handle) {
+            Ok(Some(t)) => t,
+            Ok(None) => {
+                self.publish_auth_expired(format!(
+                    "{why} — no refresh token is stored at {refresh_handle:?}; \
+                     re-authenticate the bot and run `channel reload`"
+                ))
+                .await;
+                return Renewal::Fatal;
+            }
+            Err(error) => {
+                return Renewal::Deferred(format!("credentials lookup: {error}"));
+            }
+        };
+
+        let renewed =
+            match rest::refresh_access_token(&self.http, &self.api_base, &refresh_token).await {
+                Ok(r) => r,
+                // The refresh token ITSELF was refused. That is the genuine
+                // revocation: there is no further credential to fall back on.
+                Err(
+                    e @ MatrixError::Http {
+                        status: 401 | 403, ..
+                    },
+                ) => {
+                    let refused = auth_rejection_label(&e);
+                    self.publish_auth_expired(format!(
+                        "{why}; the refresh token was refused too ({refused}) — \
+                     re-authenticate the bot and run `channel reload`"
+                    ))
+                    .await;
+                    return Renewal::Fatal;
+                }
+                Err(error) => {
+                    return Renewal::Deferred(format!("token refresh failed: {error}"));
+                }
+            };
+
+        // Persist the ROTATED REFRESH TOKEN FIRST, and the access token
+        // second. The order is the crash-recovery order, not a style choice:
+        //
+        // * refresh-then-access, interrupted → the store holds the new refresh
+        //   token and a stale access token. The next start 401s, refreshes
+        //   with the good refresh token, and recovers.
+        // * access-then-refresh, interrupted → the store holds a SPENT refresh
+        //   token. The next start's refresh POST replays it, and a spec-
+        //   compliant server may revoke the whole grant. Unrecoverable.
+        if let Some(rotated) = renewed.refresh_token.as_deref()
+            && let Err(error) = self.creds.put(&refresh_handle, rotated)
+        {
+            // Loud, because the store now holds a SPENT refresh token: this
+            // process keeps working on the access token below, but a restart
+            // will replay a dead token and need a re-authentication.
+            tracing::error!(
+                target: "wcore_channel_matrix::token",
+                error = %error,
+                handle = %refresh_handle,
+                "could not persist the rotated Matrix refresh token; the stored one is now spent and a restart will require re-authentication",
+            );
+        }
+        if let Err(error) = self.creds.put(&self.access_handle, &renewed.access_token) {
+            tracing::warn!(
+                target: "wcore_channel_matrix::token",
+                error = %error,
+                "could not persist the refreshed Matrix access token; this process holds it in memory only",
+            );
+        }
+
+        self.install(renewed.access_token, renewed.expires_in_ms);
+        Renewal::Renewed
+    }
+
+    fn install(&self, access: String, expires_in_ms: Option<u64>) {
+        let expires_at = expires_in_ms.map(|ms| Instant::now() + Duration::from_millis(ms));
+        let mut guard = self.current.write().unwrap_or_else(|e| e.into_inner());
+        *guard = Snapshot { access, expires_at };
+    }
+
+    fn read(&self) -> std::sync::RwLockReadGuard<'_, Snapshot> {
+        self.current.read().unwrap_or_else(|e| e.into_inner())
+    }
+
+    /// Publish the health event, at most once. The manager projects
+    /// `AuthExpired` onto `HealthState::Unauthenticated`, so this is what
+    /// stops the channel reporting `Healthy` against a dead credential.
+    async fn publish_auth_expired(&self, reason: String) {
+        if self.reported.swap(true, Ordering::SeqCst) {
+            return;
+        }
+        tracing::error!(
+            target: "wcore_channel_matrix::token",
+            reason = %reason,
+            "the Matrix credential is not recoverable; the channel is unauthenticated",
+        );
+        // Pushed inline rather than from a spawned task: a caller that breaks
+        // its loop the instant this returns must find the event already in the
+        // inbox, or the health surface learns about the dead credential only
+        // if a detached task happens to win a race.
+        self.inbox
+            .lock()
+            .await
+            .push_back(ChannelEvent::AuthExpired { reason });
+    }
+}
+
+/// The timing contract for the refresh lock.
+fn lock_policy() -> LockPolicy {
+    LockPolicy::new(
+        Duration::from_secs(STALE_AFTER_SECS),
+        Duration::from_secs(WAIT_CEILING_SECS),
+    )
+    .with_heartbeat(Duration::from_secs(HEARTBEAT_SECS))
+}
+
+/// Where the cross-process refresh lock for this credential lives.
+///
+/// Keyed on (homeserver × access-token handle) and NOT on the channel name:
+/// two channels configured against the same stored token share one rotating
+/// refresh token, so they must serialize against each other. A digest, so no
+/// credential handle appears in a filename.
+fn refresh_lock_path(api_base: &str, access_handle: &str) -> PathBuf {
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    api_base.hash(&mut h);
+    access_handle.hash(&mut h);
+    let key = h.finish();
+    wcore_config::config::wayland_config_dir()
+        .join("channel-state")
+        .join(format!("matrix-{key:016x}.refresh.lock"))
+}
+
+/// Whether the homeserver said this rejection is a SOFT logout — the access
+/// token is invalid but the device survives, so a refresh token can recover it.
+///
+/// Absent or `false` means a hard revocation. Defaulting to "refreshable" on a
+/// body we cannot read would convert a genuine revocation into an endless
+/// refresh loop against a dead grant, so absence fails closed.
+fn is_soft_logout(e: &MatrixError) -> bool {
+    let MatrixError::Http { status: 401, body } = e else {
+        return false;
+    };
+    serde_json::from_str::<serde_json::Value>(body)
+        .ok()
+        .as_ref()
+        .and_then(|v| v.get("soft_logout"))
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+}
+
+/// A short, SECRET-FREE label for a credential rejection, suitable for the
+/// health surface's operator-facing `reason`.
+///
+/// Only the homeserver's `errcode` — a fixed spec vocabulary such as
+/// `M_UNKNOWN_TOKEN` — is surfaced, never the raw response body. The body is an
+/// echo of a request we authenticated, so treating it as printable would make
+/// the health surface a place a token could appear; `ProbeReport` holds the same
+/// line ("the NAME of a rejected item, never its value") and this must not be the
+/// weaker of the two. A body we cannot parse yields the status alone.
+pub(crate) fn auth_rejection_label(e: &MatrixError) -> String {
+    let MatrixError::Http { status, body } = e else {
+        return "platform rejected the credential".to_string();
+    };
+    match serde_json::from_str::<serde_json::Value>(body)
+        .ok()
+        .as_ref()
+        .and_then(|v| v.get("errcode"))
+        .and_then(|c| c.as_str())
+    {
+        Some(errcode) => format!("homeserver rejected the access token: HTTP {status} {errcode}"),
+        None => format!("homeserver rejected the access token: HTTP {status}"),
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::sync::Mutex as StdMutex;
+    use wcore_config::credentials::CredentialsError;
+
+    /// A token value that must never reach the health surface.
+    const CANARY: &str = "syt_CANARY_2f9c41ab7de6_MUSTNOTLEAK";
+
+    /// The crate's one in-memory credentials store for tests. It lives here
+    /// because this module is what reads and rotates the pair it holds.
+    pub(crate) struct MemCreds {
+        inner: StdMutex<HashMap<String, String>>,
+    }
+
+    impl MemCreds {
+        pub(crate) fn new(pairs: &[(&str, &str)]) -> Arc<Self> {
+            let map = pairs
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect();
+            Arc::new(Self {
+                inner: StdMutex::new(map),
+            })
+        }
+        pub(crate) fn with_token(handle: &str, token: &str) -> Arc<dyn CredentialsStore> {
+            Self::new(&[(handle, token)])
+        }
+        pub(crate) fn empty() -> Arc<dyn CredentialsStore> {
+            Self::new(&[])
+        }
+        /// Read a stored value back — how a test proves a ROTATED token was
+        /// actually persisted rather than merely received.
+        pub(crate) fn peek(&self, key: &str) -> Option<String> {
+            self.inner.lock().unwrap().get(key).cloned()
+        }
+    }
+
+    impl CredentialsStore for MemCreds {
+        fn get(&self, key: &str) -> Result<Option<String>, CredentialsError> {
+            Ok(self.inner.lock().unwrap().get(key).cloned())
+        }
+        fn put(&self, key: &str, value: &str) -> Result<(), CredentialsError> {
+            self.inner
+                .lock()
+                .unwrap()
+                .insert(key.to_string(), value.to_string());
+            Ok(())
+        }
+        fn delete(&self, key: &str) -> Result<(), CredentialsError> {
+            self.inner.lock().unwrap().remove(key);
+            Ok(())
+        }
+    }
+
+    /// A `TokenSource` whose lock lives in a per-test directory, so parallel
+    /// tests never serialize against each other or against a real profile.
+    /// A source with NO refresh handle: the shape of a channel configured with
+    /// a bare access token, which is every pre-#936 config. It can never take
+    /// the refresh lock, so its lock path is never created.
+    pub(crate) fn plain_source(
+        api_base: &str,
+        access_token: &str,
+        inbox: &Arc<Mutex<VecDeque<ChannelEvent>>>,
+    ) -> Arc<TokenSource> {
+        Arc::new(source_with_lock_dir(
+            MemCreds::empty(),
+            None,
+            access_token,
+            api_base,
+            std::path::Path::new("unreachable-no-refresh-handle-is-configured"),
+            Arc::clone(inbox),
+        ))
+    }
+
+    /// A source that CAN refresh, with its lock confined to `lock_dir` so
+    /// parallel tests never serialize against each other or a real profile.
+    pub(crate) fn refreshing_source(
+        api_base: &str,
+        access_token: &str,
+        creds: Arc<MemCreds>,
+        lock_dir: &std::path::Path,
+        inbox: &Arc<Mutex<VecDeque<ChannelEvent>>>,
+    ) -> Arc<TokenSource> {
+        Arc::new(source_with_lock_dir(
+            creds,
+            Some("matrix.test.refresh"),
+            access_token,
+            api_base,
+            lock_dir,
+            Arc::clone(inbox),
+        ))
+    }
+
+    fn source_with_lock_dir(
+        creds: Arc<dyn CredentialsStore>,
+        refresh_handle: Option<&str>,
+        access_token: &str,
+        api_base: &str,
+        dir: &std::path::Path,
+        inbox: Arc<Mutex<VecDeque<ChannelEvent>>>,
+    ) -> TokenSource {
+        let mut src = TokenSource::new(TokenSourceParams {
+            creds,
+            access_handle: "matrix.test.access".to_string(),
+            refresh_handle: refresh_handle.map(str::to_string),
+            access_token: access_token.to_string(),
+            http: wcore_egress::EgressClient::builder()
+                .user_agent("wcore-matrix-token-test")
+                .build()
+                .unwrap_or_default(),
+            api_base: api_base.to_string(),
+            inbox,
+        });
+        src.lock_path = dir.join("refresh.lock");
+        src
+    }
+
+    fn inbox() -> Arc<Mutex<VecDeque<ChannelEvent>>> {
+        Arc::new(Mutex::new(VecDeque::new()))
+    }
+
+    async fn auth_reasons(inbox: &Arc<Mutex<VecDeque<ChannelEvent>>>) -> Vec<String> {
+        inbox
+            .lock()
+            .await
+            .iter()
+            .filter_map(|e| match e {
+                ChannelEvent::AuthExpired { reason } => Some(reason.clone()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn soft_logout_is_read_from_the_body_and_absence_fails_closed() {
+        let soft = MatrixError::Http {
+            status: 401,
+            body: r#"{"errcode":"M_UNKNOWN_TOKEN","soft_logout":true}"#.to_string(),
+        };
+        assert!(is_soft_logout(&soft), "an explicit soft_logout is soft");
+
+        for hard in [
+            // A hard logout: the device is gone, no refresh can recover it.
+            r#"{"errcode":"M_UNKNOWN_TOKEN"}"#,
+            r#"{"errcode":"M_UNKNOWN_TOKEN","soft_logout":false}"#,
+            // Unparseable — must NOT be optimistically treated as refreshable.
+            "not json at all",
+            r#"{"soft_logout":"true"}"#,
+        ] {
+            assert!(
+                !is_soft_logout(&MatrixError::Http {
+                    status: 401,
+                    body: hard.to_string(),
+                }),
+                "{hard} must not be classified refreshable",
+            );
+        }
+
+        // A 403 is never soft, whatever the body claims.
+        assert!(
+            !is_soft_logout(&MatrixError::Http {
+                status: 403,
+                body: r#"{"soft_logout":true}"#.to_string(),
+            }),
+            "a 403 is a hard refusal regardless of the body",
+        );
+    }
+
+    /// The half of #936 a refresh path could paper over: a genuinely revoked
+    /// token must still fail closed, with no refresh POST attempted at all.
+    #[tokio::test]
+    async fn a_hard_revocation_fails_closed_without_posting() {
+        let mut server = mockito::Server::new_async().await;
+        let refresh = server
+            .mock("POST", "/_matrix/client/v3/refresh")
+            .expect(0)
+            .create_async()
+            .await;
+        let dir = tempfile::tempdir().unwrap();
+        let inbox = inbox();
+        let creds = MemCreds::new(&[
+            ("matrix.test.access", CANARY),
+            ("matrix.test.refresh", "the-refresh-token"),
+        ]);
+        let src = source_with_lock_dir(
+            creds,
+            Some("matrix.test.refresh"),
+            CANARY,
+            &server.url(),
+            dir.path(),
+            Arc::clone(&inbox),
+        );
+
+        let outcome = src
+            .renew_after_rejection(
+                CANARY,
+                &MatrixError::Http {
+                    status: 401,
+                    body: r#"{"errcode":"M_UNKNOWN_TOKEN","error":"Token is not active"}"#
+                        .to_string(),
+                },
+            )
+            .await;
+
+        assert!(
+            matches!(outcome, Renewal::Fatal),
+            "a hard revocation must be fatal, got {outcome:?}",
+        );
+        refresh.assert_async().await;
+        let reasons = auth_reasons(&inbox).await;
+        assert_eq!(reasons.len(), 1, "expected one AuthExpired: {reasons:?}");
+        assert!(
+            reasons[0].contains("M_UNKNOWN_TOKEN"),
+            "the reason must name the errcode: {:?}",
+            reasons[0]
+        );
+        assert!(
+            !reasons[0].contains(CANARY),
+            "the health reason leaked the token: {:?}",
+            reasons[0]
+        );
+    }
+
+    /// The positive direction: a soft logout is refreshed, the rotated pair is
+    /// persisted, and no `AuthExpired` is published.
+    #[tokio::test]
+    async fn a_soft_logout_is_refreshed_and_the_rotated_pair_is_persisted() {
+        let mut server = mockito::Server::new_async().await;
+        let refresh = server
+            .mock("POST", "/_matrix/client/v3/refresh")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"access_token":"syt_new_access","refresh_token":"rot_new_refresh","expires_in_ms":300000}"#,
+            )
+            .expect(1)
+            .create_async()
+            .await;
+        let dir = tempfile::tempdir().unwrap();
+        let inbox = inbox();
+        let creds = MemCreds::new(&[
+            ("matrix.test.access", CANARY),
+            ("matrix.test.refresh", "rot_old_refresh"),
+        ]);
+        let src = source_with_lock_dir(
+            Arc::clone(&creds) as Arc<dyn CredentialsStore>,
+            Some("matrix.test.refresh"),
+            CANARY,
+            &server.url(),
+            dir.path(),
+            Arc::clone(&inbox),
+        );
+
+        let outcome = src
+            .renew_after_rejection(
+                CANARY,
+                &MatrixError::Http {
+                    status: 401,
+                    body: r#"{"errcode":"M_UNKNOWN_TOKEN","soft_logout":true}"#.to_string(),
+                },
+            )
+            .await;
+
+        assert!(
+            matches!(outcome, Renewal::Renewed),
+            "a soft logout with a refresh token must renew, got {outcome:?}",
+        );
+        refresh.assert_async().await;
+        assert_eq!(src.access(), "syt_new_access", "the new token must be live");
+        assert_eq!(
+            creds.peek("matrix.test.refresh").as_deref(),
+            Some("rot_new_refresh"),
+            "the ROTATED refresh token must be persisted, or the next process replays a spent one",
+        );
+        assert_eq!(
+            creds.peek("matrix.test.access").as_deref(),
+            Some("syt_new_access"),
+        );
+        assert!(
+            auth_reasons(&inbox).await.is_empty(),
+            "a recovered credential must not be reported unauthenticated",
+        );
+        assert!(
+            !src.renewal_due(),
+            "a 300s expiry is outside the renewal margin",
+        );
+    }
+
+    /// A refresh token the homeserver refuses is the end of the line: fatal,
+    /// and said so on the health surface.
+    #[tokio::test]
+    async fn a_refused_refresh_token_is_fatal() {
+        let mut server = mockito::Server::new_async().await;
+        server
+            .mock("POST", "/_matrix/client/v3/refresh")
+            .with_status(401)
+            .with_body(r#"{"errcode":"M_UNKNOWN_TOKEN","error":"Unrecognised refresh token"}"#)
+            .create_async()
+            .await;
+        let dir = tempfile::tempdir().unwrap();
+        let inbox = inbox();
+        let creds = MemCreds::new(&[
+            ("matrix.test.access", CANARY),
+            ("matrix.test.refresh", "rot_dead"),
+        ]);
+        let src = source_with_lock_dir(
+            creds,
+            Some("matrix.test.refresh"),
+            CANARY,
+            &server.url(),
+            dir.path(),
+            Arc::clone(&inbox),
+        );
+
+        let outcome = src
+            .renew_after_rejection(
+                CANARY,
+                &MatrixError::Http {
+                    status: 401,
+                    body: r#"{"errcode":"M_UNKNOWN_TOKEN","soft_logout":true}"#.to_string(),
+                },
+            )
+            .await;
+        assert!(matches!(outcome, Renewal::Fatal), "got {outcome:?}");
+        let reasons = auth_reasons(&inbox).await;
+        assert_eq!(reasons.len(), 1, "{reasons:?}");
+        assert!(
+            reasons[0].contains("refresh token was refused"),
+            "the reason must distinguish a dead refresh token: {:?}",
+            reasons[0]
+        );
+    }
+
+    /// A network failure on the refresh endpoint is NOT a credential verdict.
+    /// Without this split a blip would report `Unauthenticated` and send an
+    /// operator to re-authenticate a perfectly good bot.
+    #[tokio::test]
+    async fn a_transient_refresh_failure_is_deferred_not_fatal() {
+        let dir = tempfile::tempdir().unwrap();
+        let inbox = inbox();
+        let creds = MemCreds::new(&[
+            ("matrix.test.access", CANARY),
+            ("matrix.test.refresh", "rot_ok"),
+        ]);
+        let src = source_with_lock_dir(
+            creds,
+            Some("matrix.test.refresh"),
+            CANARY,
+            // A port nothing is listening on: a connection error, not an HTTP
+            // status.
+            "http://127.0.0.1:1",
+            dir.path(),
+            Arc::clone(&inbox),
+        );
+
+        let outcome = src
+            .renew_after_rejection(
+                CANARY,
+                &MatrixError::Http {
+                    status: 401,
+                    body: r#"{"errcode":"M_UNKNOWN_TOKEN","soft_logout":true}"#.to_string(),
+                },
+            )
+            .await;
+        assert!(
+            matches!(outcome, Renewal::Deferred(_)),
+            "a network fault must defer, not accuse the credential: {outcome:?}",
+        );
+        assert!(
+            auth_reasons(&inbox).await.is_empty(),
+            "a transient fault must not report the channel unauthenticated",
+        );
+    }
+
+    /// The lock path is scoped to the credential, not to the channel, and
+    /// carries no cleartext handle.
+    #[test]
+    fn the_lock_is_credential_scoped_and_names_no_handle() {
+        let a = refresh_lock_path("https://matrix.org", "matrix.prod.token");
+        assert_eq!(
+            a,
+            refresh_lock_path("https://matrix.org", "matrix.prod.token")
+        );
+        assert_ne!(
+            a,
+            refresh_lock_path("https://other.org", "matrix.prod.token"),
+            "a different homeserver is a different grant",
+        );
+        assert_ne!(
+            a,
+            refresh_lock_path("https://matrix.org", "matrix.staging.token"),
+            "a different stored token must not serialize against this one",
+        );
+        let name = a.file_name().unwrap().to_string_lossy().to_string();
+        assert!(
+            !name.contains("matrix.prod.token"),
+            "the lock name must be a digest, not the credential handle: {name}"
+        );
+    }
+
+    /// An unbounded refresh loop is a self-inflicted denial of service AND
+    /// burns a rotating token on every pass. After the cap the credential is
+    /// declared dead instead.
+    #[tokio::test]
+    async fn repeated_renewals_without_progress_stop_instead_of_looping() {
+        let mut server = mockito::Server::new_async().await;
+        // Always succeeds — so nothing but the cap can stop the loop.
+        server
+            .mock("POST", "/_matrix/client/v3/refresh")
+            .with_status(200)
+            .with_body(r#"{"access_token":"syt_again","refresh_token":"rot_again"}"#)
+            .create_async()
+            .await;
+        let dir = tempfile::tempdir().unwrap();
+        let inbox = inbox();
+        let creds = MemCreds::new(&[
+            ("matrix.test.access", CANARY),
+            ("matrix.test.refresh", "rot_ok"),
+        ]);
+        let src = source_with_lock_dir(
+            creds,
+            Some("matrix.test.refresh"),
+            CANARY,
+            &server.url(),
+            dir.path(),
+            Arc::clone(&inbox),
+        );
+
+        let soft = MatrixError::Http {
+            status: 401,
+            body: r#"{"errcode":"M_UNKNOWN_TOKEN","soft_logout":true}"#.to_string(),
+        };
+        let mut outcomes = Vec::new();
+        for _ in 0..6 {
+            let presented = src.access();
+            outcomes.push(src.renew_after_rejection(&presented, &soft).await);
+        }
+        assert!(
+            outcomes.iter().any(|o| matches!(o, Renewal::Fatal)),
+            "the renewal loop must terminate: {outcomes:?}",
+        );
+        let fatal_at = outcomes
+            .iter()
+            .position(|o| matches!(o, Renewal::Fatal))
+            .unwrap();
+        assert!(
+            fatal_at <= MAX_RENEWALS_WITHOUT_PROGRESS as usize,
+            "gave up after {fatal_at} renewals, cap is {MAX_RENEWALS_WITHOUT_PROGRESS}",
+        );
+
+        // And a successful call in between resets it, so a channel that is
+        // genuinely working is never capped out.
+        src.mark_progress();
+        assert_eq!(
+            src.renewals_without_progress.load(Ordering::Relaxed),
+            0,
+            "progress must clear the guard",
+        );
+    }
+
+    /// The label is the string an operator reads on the health surface. It must
+    /// carry the errcode and never the response body, which is an echo of a
+    /// request we authenticated.
+    #[test]
+    fn the_auth_label_names_the_errcode_and_never_the_body() {
+        let label = auth_rejection_label(&MatrixError::Http {
+            status: 401,
+            body: format!(r#"{{"errcode":"M_UNKNOWN_TOKEN","error":"{CANARY}"}}"#),
+        });
+        assert!(label.contains("M_UNKNOWN_TOKEN"), "got {label:?}");
+        assert!(label.contains("401"), "got {label:?}");
+        assert!(
+            !label.contains(CANARY),
+            "the label echoed the response body verbatim: {label:?}"
+        );
+
+        // An unparseable body must degrade to the status alone, never to the
+        // raw bytes.
+        let label = auth_rejection_label(&MatrixError::Http {
+            status: 403,
+            body: CANARY.to_string(),
+        });
+        assert!(label.contains("403"), "got {label:?}");
+        assert!(
+            !label.contains(CANARY),
+            "an unparseable body must not be echoed: {label:?}"
+        );
+    }
+}

--- a/crates/wcore-channel-matrix/src/token.rs
+++ b/crates/wcore-channel-matrix/src/token.rs
@@ -457,6 +457,58 @@ fn refresh_lock_path(api_base: &str, access_handle: &str) -> PathBuf {
         .join(format!("matrix-{key:016x}.refresh.lock"))
 }
 
+/// Whether this rejection is about the CREDENTIAL, as opposed to the operation.
+///
+/// The single predicate both the `/sync` loop and the send path gate on, so
+/// there is exactly one definition of "the homeserver refused who we are".
+///
+/// Matrix spends 401 and 403 on two different questions, and the status alone
+/// cannot tell them apart:
+///
+/// * **401** — authentication. The token is not accepted. Always a credential
+///   rejection, errcode or not: a bare 401 from a gateway that stripped the
+///   Matrix body is still something no retry can fix.
+/// * **403 with a token errcode** — a credential rejection too. The spec puts
+///   `M_UNKNOWN_TOKEN` on 401, but deployments (and reverse proxies in front of
+///   them) do return it on 403, and refusing to renew there would strand a
+///   channel that a refresh would have healed.
+/// * **403 with anything else** — authorization, NOT authentication.
+///   `M_FORBIDDEN` on a redaction means the bot's power level is too low; a
+///   bare 403 usually means something in front of the homeserver blocked the
+///   request. The token is fine.
+///
+/// The last row is why this exists. Folding it in publishes `AuthExpired`,
+/// which the manager projects onto `HealthState::Unauthenticated` and which
+/// `TokenSource` latches so it can never be walked back — so ONE refused
+/// redaction would mark the channel permanently unauthenticated while every
+/// later send kept succeeding. That is the health surface lying in the
+/// direction the operator acts on, and `channel reload` cannot raise a power
+/// level.
+pub(crate) fn is_credential_rejection(e: &MatrixError) -> bool {
+    let MatrixError::Http { status, body } = e else {
+        return false;
+    };
+    match status {
+        401 => true,
+        403 => matches!(
+            errcode_of(body),
+            Some("M_UNKNOWN_TOKEN" | "M_MISSING_TOKEN")
+        ),
+        _ => false,
+    }
+}
+
+/// The homeserver's `errcode`, when the body is a readable Matrix error.
+fn errcode_of(body: &str) -> Option<&str> {
+    // Borrowed out of `body` rather than through a `Value`, so the caller can
+    // match on `&str` without an allocation per rejection.
+    let rest = body.split_once("\"errcode\"")?.1;
+    let rest = rest.trim_start().strip_prefix(':')?.trim_start();
+    let rest = rest.strip_prefix('"')?;
+    let end = rest.find('"')?;
+    Some(&rest[..end])
+}
+
 /// Whether the homeserver said this rejection is a SOFT logout — the access
 /// token is invalid but the device survives, so a refresh token can recover it.
 ///

--- a/crates/wcore-channel-matrix/tests/refresh_cross_process.rs
+++ b/crates/wcore-channel-matrix/tests/refresh_cross_process.rs
@@ -21,16 +21,36 @@
 //! **The homeserver is local.** Never a real one: a burned grant is not a
 //! recoverable test failure.
 //!
-//! **On the red half.** This test is only worth anything if it can fail. It is
-//! deliberately NOT paired with a "skip the lock" switch in the shipping
-//! binary — a bypass of the control is a worse defect than the one it proves.
-//! The red control is a SOURCE MUTANT applied out of tree: make
-//! `TokenSource::renew` proceed without `ExclusiveFileLock::acquire` and this
-//! test observes two POSTs.
+//! **On the red half.** This test is only worth anything if it can fail, and
+//! the wall-clock barrier alone is NOT enough to make it fail. Measured: with
+//! `ExclusiveFileLock` removed from `TokenSource::renew`, a barrier-only
+//! version still observed ONE POST, because the winner completed its POST and
+//! its store write inside the few milliseconds of launch skew and the loser's
+//! double-check then adopted the result. The test passed for a reason that had
+//! nothing to do with the lock — indistinguishable from the "got lucky on
+//! timing" it claims to rule out.
+//!
+//! So the race window is held OPEN by [`RendezvousStore`]: the first read of
+//! the refresh-token handle — which production code performs inside the
+//! critical section, immediately before the POST — parks until a sibling
+//! process reaches the same point, or [`RENDEZVOUS_HOLD`] elapses.
+//!
+//! * Lock present: the loser is parked in `ExclusiveFileLock::acquire` and
+//!   never reaches the read, so the winner's rendezvous times out, POSTs, and
+//!   persists; the loser then adopts. ONE POST.
+//! * Lock absent: both reach the read together and are both released, so both
+//!   POST with neither having persisted yet. TWO POSTs, and the count is what
+//!   `expect(1)` names.
+//!
+//! The instrument only DELAYS a store read. It adds no bypass of the control to
+//! the shipping binary — a "skip the lock" switch would be a worse defect than
+//! the one this proves — so the red arm remains a source mutant applied out of
+//! tree.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use wcore_channel_matrix::{MatrixChannel, MatrixConfig};
 use wcore_channels::Channel;
@@ -72,6 +92,95 @@ fn store_at(root: &std::path::Path) -> Arc<dyn CredentialsStore> {
     ))
 }
 
+/// How long the first refresh-token read parks waiting for a sibling process.
+///
+/// Bounded on both sides, and neither bound is arbitrary:
+///
+/// * Above the launch skew of two cold test binaries, so the LOCK-ABSENT arm
+///   reliably gets both processes into the critical section at once. Milliseconds
+///   of skew is what made the barrier-only version of this test unable to fail.
+/// * Well below the refresh lock's wait ceiling and its stale-after window, so
+///   in the LOCK-PRESENT arm the parked winner is never mistaken for a crashed
+///   holder and stolen from. A steal there would produce the two POSTs this
+///   test reads as a defect, i.e. a false red.
+const RENDEZVOUS_HOLD: Duration = Duration::from_millis(1_500);
+
+/// Number of processes the rendezvous waits for.
+const PEERS: usize = 2;
+
+/// A [`CredentialsStore`] that holds the cross-process race window open.
+///
+/// Delegates everything, except that the FIRST read of the refresh-token handle
+/// parks until `PEERS` processes have reached that same read or
+/// [`RENDEZVOUS_HOLD`] elapses. That read sits inside `TokenSource::renew`'s
+/// critical section, immediately before the refresh POST, so parking there is
+/// what turns "did both processes try to POST?" from a timing coin-flip into a
+/// determinate question.
+///
+/// It does NOT weaken the thing under test: no lock is skipped, no code path is
+/// branched on a test flag, and a store read is the only thing delayed.
+struct RendezvousStore {
+    inner: Arc<dyn CredentialsStore>,
+    dir: PathBuf,
+    tag: String,
+    /// Fires once. A refresh that legitimately reads the handle again must not
+    /// park a second time and burn another hold.
+    armed: AtomicBool,
+}
+
+impl RendezvousStore {
+    fn new(root: &Path) -> Self {
+        Self {
+            inner: store_at(root),
+            dir: root.join("rendezvous"),
+            tag: std::process::id().to_string(),
+            armed: AtomicBool::new(true),
+        }
+    }
+
+    fn wait_for_peer(&self) {
+        // Announce arrival, then wait for the sibling's announcement. A
+        // directory of one file per process is the whole protocol: it needs no
+        // cleanup, and a crashed peer just means the hold expires.
+        let _ = std::fs::create_dir_all(&self.dir);
+        let _ = std::fs::write(self.dir.join(&self.tag), b"here");
+        let deadline = Instant::now() + RENDEZVOUS_HOLD;
+        loop {
+            let arrived = std::fs::read_dir(&self.dir)
+                .map(std::iter::Iterator::count)
+                .unwrap_or(0);
+            if arrived >= PEERS || Instant::now() >= deadline {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(5));
+        }
+    }
+}
+
+impl CredentialsStore for RendezvousStore {
+    fn get(
+        &self,
+        key: &str,
+    ) -> Result<Option<String>, wcore_config::credentials::CredentialsError> {
+        if key == REFRESH_HANDLE && self.armed.swap(false, Ordering::SeqCst) {
+            self.wait_for_peer();
+        }
+        self.inner.get(key)
+    }
+
+    fn put(
+        &self,
+        key: &str,
+        value: &str,
+    ) -> Result<(), wcore_config::credentials::CredentialsError> {
+        self.inner.put(key, value)
+    }
+
+    fn delete(&self, key: &str) -> Result<(), wcore_config::credentials::CredentialsError> {
+        self.inner.delete(key)
+    }
+}
+
 /// The child half. Runs in a SEPARATE OS PROCESS; the parent below spawns two.
 ///
 /// Named as a test so the harness will run it, but inert unless the parent set
@@ -91,7 +200,12 @@ async fn xproc_child_entrypoint() {
         .parse()
         .expect("start barrier is millis");
 
-    let mut channel = MatrixChannel::with_base("xproc", cfg(&base), store_at(&root), base);
+    let mut channel = MatrixChannel::with_base(
+        "xproc",
+        cfg(&base),
+        Arc::new(RendezvousStore::new(&root)),
+        base,
+    );
     channel.start().await.expect("start reads the seeded token");
 
     // Barrier. Both children have read the SAME expired access token by now,

--- a/crates/wcore-channel-matrix/tests/refresh_cross_process.rs
+++ b/crates/wcore-channel-matrix/tests/refresh_cross_process.rs
@@ -1,0 +1,230 @@
+//! #936: the cross-process half of the Matrix refresh proof.
+//!
+//! Everything else about #936 is provable inside one process. This is not.
+//! A Matrix refresh token ROTATES — `POST /_matrix/client/v3/refresh` hands
+//! back a replacement and the presented one is spent — so the failure being
+//! closed here is TWO OS PROCESSES both POSTing the same one. A spec-compliant
+//! server treats the replay as theft and may revoke the whole authorization
+//! grant (RFC 6819 §5.2.2.3): the cost is both processes logged out, not one
+//! message failed. An in-process mutex cannot see a sibling process, so only a
+//! test with two real processes can tell "coalesced" from "got lucky on
+//! timing".
+//!
+//! **Shape.** The parent seeds ONE profile directory with an expired access
+//! token and a live refresh token, stands up a local homeserver that refuses
+//! the old token with `soft_logout: true`, and spawns two copies of this test
+//! binary. Each child drives the PRODUCTION path — `MatrixChannel::start()`
+//! then `send_message()` — over a real on-disk credentials store rooted at
+//! that shared directory. The parent then counts how many refresh POSTs
+//! actually arrived.
+//!
+//! **The homeserver is local.** Never a real one: a burned grant is not a
+//! recoverable test failure.
+//!
+//! **On the red half.** This test is only worth anything if it can fail. It is
+//! deliberately NOT paired with a "skip the lock" switch in the shipping
+//! binary — a bypass of the control is a worse defect than the one it proves.
+//! The red control is a SOURCE MUTANT applied out of tree: make
+//! `TokenSource::renew` proceed without `ExclusiveFileLock::acquire` and this
+//! test observes two POSTs.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use wcore_channel_matrix::{MatrixChannel, MatrixConfig};
+use wcore_channels::Channel;
+use wcore_channels::outgoing::OutgoingMessage;
+use wcore_config::credentials::{CredentialsStore, PlaintextCredentialsStore};
+
+const ROLE_ENV: &str = "WL936_XPROC_ROLE";
+const ROOT_ENV: &str = "WL936_XPROC_ROOT";
+const BASE_ENV: &str = "WL936_XPROC_BASE";
+const START_ENV: &str = "WL936_XPROC_START_MS";
+
+const ACCESS_HANDLE: &str = "matrix.xproc.access";
+const REFRESH_HANDLE: &str = "matrix.xproc.refresh";
+const EXPIRED_ACCESS: &str = "syt_expired_xproc";
+const SEEDED_REFRESH: &str = "rot_seeded_xproc";
+const RENEWED_ACCESS: &str = "syt_renewed_xproc";
+const ROTATED_REFRESH: &str = "rot_rotated_xproc";
+const ROOM: &str = "!xproc:matrix.example.org";
+
+fn now_ms() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock")
+        .as_millis()
+}
+
+fn cfg(base: &str) -> MatrixConfig {
+    MatrixConfig {
+        homeserver_url: base.to_string(),
+        credential_handle_access_token: ACCESS_HANDLE.to_string(),
+        credential_handle_refresh_token: Some(REFRESH_HANDLE.to_string()),
+        user_id: "@xproc:matrix.example.org".to_string(),
+    }
+}
+
+fn store_at(root: &std::path::Path) -> Arc<dyn CredentialsStore> {
+    Arc::new(PlaintextCredentialsStore::new(
+        root.join("credentials.toml"),
+    ))
+}
+
+/// The child half. Runs in a SEPARATE OS PROCESS; the parent below spawns two.
+///
+/// Named as a test so the harness will run it, but inert unless the parent set
+/// `ROLE_ENV` — otherwise every ordinary `cargo nextest` run would try to reach
+/// a homeserver that is not there.
+#[tokio::test]
+async fn xproc_child_entrypoint() {
+    let Ok(role) = std::env::var(ROLE_ENV) else {
+        return;
+    };
+    assert_eq!(role, "child", "unexpected role");
+
+    let root = PathBuf::from(std::env::var(ROOT_ENV).expect("root"));
+    let base = std::env::var(BASE_ENV).expect("homeserver base");
+    let start_at: u128 = std::env::var(START_ENV)
+        .expect("start barrier")
+        .parse()
+        .expect("start barrier is millis");
+
+    let mut channel = MatrixChannel::with_base("xproc", cfg(&base), store_at(&root), base);
+    channel.start().await.expect("start reads the seeded token");
+
+    // Barrier. Both children have read the SAME expired access token by now,
+    // so releasing them together is what puts two live refreshes in flight at
+    // once — which is the only condition under which the cross-process lock is
+    // the thing doing the work rather than luck.
+    while now_ms() < start_at {
+        tokio::time::sleep(Duration::from_millis(2)).await;
+    }
+
+    // The production send path: 401 `soft_logout` -> renew -> retry.
+    let receipt = channel
+        .send_message(OutgoingMessage::text(ROOM, "cross-process refresh"))
+        .await;
+    let _ = channel.stop().await;
+
+    // A LOSER that could not take the lock is still required to end up
+    // authenticated by adopting the winner's token. Failing here is a real
+    // failure, not an acceptable outcome.
+    let receipt = receipt.expect("the send must succeed after the renewal");
+    println!("XPROC_CHILD_OK {}", receipt.id);
+}
+
+/// Two processes, one credentials store, one expired access token: exactly ONE
+/// refresh POST reaches the homeserver, and BOTH processes end up able to send.
+///
+/// The assertion that carries the obligation is the POST COUNT. Asserting only
+/// that both children "succeeded" would pass just as well if the loser quietly
+/// POSTed the spent refresh token a second time and got a fresh pair back —
+/// which is precisely the grant-burning replay the lock exists to prevent.
+#[tokio::test]
+async fn two_processes_issue_exactly_one_refresh_post() {
+    if std::env::var(ROLE_ENV).is_ok() {
+        return; // this process IS a child; the entrypoint above does the work
+    }
+
+    let profile = tempfile::tempdir().expect("profile dir");
+    let root = profile.path().to_path_buf();
+
+    // Seed the shared, on-disk pair both processes will read.
+    let seed = store_at(&root);
+    seed.put(ACCESS_HANDLE, EXPIRED_ACCESS)
+        .expect("seed access");
+    seed.put(REFRESH_HANDLE, SEEDED_REFRESH)
+        .expect("seed refresh");
+
+    let mut server = mockito::Server::new_async().await;
+
+    // The aged-out token is refused with the marker that says "refreshable".
+    let refused = server
+        .mock("PUT", mockito::Matcher::Any)
+        .match_header("authorization", format!("Bearer {EXPIRED_ACCESS}").as_str())
+        .with_status(401)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"errcode":"M_UNKNOWN_TOKEN","soft_logout":true}"#)
+        .expect_at_least(1)
+        .create_async()
+        .await;
+
+    // The counting endpoint. `expect(1)` is the whole test: a second arrival
+    // fails `assert_async` below and names the count it saw.
+    let refresh = server
+        .mock("POST", "/_matrix/client/v3/refresh")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(format!(
+            r#"{{"access_token":"{RENEWED_ACCESS}","refresh_token":"{ROTATED_REFRESH}","expires_in_ms":3600000}}"#
+        ))
+        .expect(1)
+        .create_async()
+        .await;
+
+    // Only the renewed token is served.
+    let served = server
+        .mock("PUT", mockito::Matcher::Any)
+        .match_header("authorization", format!("Bearer {RENEWED_ACCESS}").as_str())
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"event_id":"$xproc_ok"}"#)
+        .expect_at_least(2)
+        .create_async()
+        .await;
+
+    // Enough slack for two cold test binaries to reach the barrier.
+    let start_at = now_ms() + 4_000;
+
+    let exe = std::env::current_exe().expect("test binary path");
+    let children: Vec<std::process::Child> = (0..2)
+        .map(|_| {
+            std::process::Command::new(&exe)
+                .arg("xproc_child_entrypoint")
+                .arg("--exact")
+                .arg("--nocapture")
+                .env(ROLE_ENV, "child")
+                .env(ROOT_ENV, &root)
+                .env(BASE_ENV, server.url())
+                .env(START_ENV, start_at.to_string())
+                // Same profile home => same refresh lock path. Passed in
+                // rather than set in-process, so nothing here mutates the
+                // environment of a test running beside it.
+                .env("WAYLAND_HOME", &root)
+                .spawn()
+                .expect("spawn a second OS process")
+        })
+        .collect();
+
+    for (index, mut child) in children.into_iter().enumerate() {
+        let status = child.wait().expect("child exited");
+        assert!(
+            status.success(),
+            "child {index} failed; a loser that cannot take the lock must still \
+             end up authenticated by adopting the winner's token"
+        );
+    }
+
+    refused.assert_async().await;
+    served.assert_async().await;
+    // The symptom, named: "Expected 1 request(s) ... but received 2" means the
+    // single-use refresh token was replayed across processes.
+    refresh.assert_async().await;
+
+    // The winner's rotated pair must be what is on disk, so the loser adopted
+    // it rather than leaving a spent token behind for the next start.
+    let stored = store_at(&root);
+    assert_eq!(
+        stored.get(REFRESH_HANDLE).expect("read").as_deref(),
+        Some(ROTATED_REFRESH),
+        "the rotated refresh token must be persisted; the seeded one surviving \
+         here means the next start replays a token the homeserver already spent"
+    );
+    assert_eq!(
+        stored.get(ACCESS_HANDLE).expect("read").as_deref(),
+        Some(RENEWED_ACCESS),
+        "the renewed access token must be persisted for the next start",
+    );
+}


### PR DESCRIPTION
Two defects in the Matrix adapter, one of which makes the health surface lie in the direction the operator acts on.

## 1. A power level is not a dead credential

Both the `/sync` loop and the send path gated credential rejection on the bare status `401|403`. Matrix spends those two statuses on two different questions: 401 is *authentication*, but 403 `M_FORBIDDEN` is *authorization* — an under-privileged bot asked to redact someone else's event, with a perfectly live token.

Collapsing them publishes `AuthExpired`, which the manager projects onto `HealthState::Unauthenticated` and which `TokenSource` **latches**, so it can never be walked back. One refused redaction marked the channel permanently unauthenticated while every later send kept succeeding — and channel reload cannot raise a power level. `is_credential_rejection` is now the single predicate both call sites gate on.

## 2. Token renewal instead of dying

An expired access token now renews rather than killing the adapter.

## The test that could not fail

`only_401_and_403_are_auth_rejections` asserted `matches!` against a pattern written inline **in the test**, referenced no production code, and would have stayed green through any change to the real classification. It now calls the predicate.

Likewise the refresh-race test passed with `ExclusiveFileLock` removed from `TokenSource::renew` — the winner finished its POST inside the few ms of launch skew, so the loser adopted and never POSTed. One POST either way, so the assertion carrying the obligation could not fail on the defect it exists to catch. `RendezvousStore` now parks the first refresh-token read until the sibling reaches the same read, so without the lock both processes POST and the test fails. Only a store read is delayed; no lock is skipped and no shipping code is conditioned on test state.

Refs FerroxLabs/wayland#936
