### PR TITLE
fix(browser): make denials followable and stop claiming DNS-rebinding protection

### DIFF
--- a/crates/wcore-agent/src/plugins/adapters/browser_adapter.rs
+++ b/crates/wcore-agent/src/plugins/adapters/browser_adapter.rs
@@ -18,10 +18,10 @@ use std::sync::Arc;
 use wcore_browser::adapter::{
     BrowserToolSpec as CoreBrowserToolSpec, from_spec as core_from_spec, make_policy,
 };
-use wcore_browser::policy::PolicyAction;
+use wcore_browser::policy::{LoopbackCapability, PolicyAction};
 use wcore_browser::selection::ProviderHint as CoreProviderHint;
 use wcore_browser::tool::BrowserTool;
-use wcore_plugin_api::browser_spec::{BrowserProviderHint, BrowserToolSpec};
+use wcore_plugin_api::browser_spec::{BrowserLoopbackSpec, BrowserProviderHint, BrowserToolSpec};
 use wcore_plugin_api::registry::browser::BrowserToolRegistrar;
 
 /// Captures every `BrowserToolSpec` registered by a `wayland-browser` plugin.
@@ -77,7 +77,8 @@ pub fn spec_to_core(s: &BrowserToolSpec) -> CoreBrowserToolSpec {
         },
         s.policy.allowed_origins.clone(),
         s.policy.denied_origins.clone(),
-    );
+    )
+    .with_loopback(loopback_spec_to_core(&s.policy.loopback));
     CoreBrowserToolSpec {
         tool_namespace: s.tool_namespace.clone(),
         preferred_provider: match s.preferred_provider {
@@ -88,6 +89,21 @@ pub fn spec_to_core(s: &BrowserToolSpec) -> CoreBrowserToolSpec {
         },
         policy,
         allow_cloud: s.allow_cloud,
+    }
+}
+
+/// Translate the plugin-api loopback mirror into the core grant (gh#911).
+///
+/// A straight field copy on purpose: this function must not decide anything.
+/// `wcore_browser::policy::LoopbackCapability::authorize` owns every
+/// validation gate, so there is exactly one place that can say yes and the
+/// mirror cannot widen authority by drifting.
+fn loopback_spec_to_core(s: &BrowserLoopbackSpec) -> LoopbackCapability {
+    LoopbackCapability {
+        enabled: s.enabled,
+        schema_version: s.schema_version,
+        session_scope: s.session_scope.clone(),
+        ports: s.ports.clone(),
     }
 }
 
@@ -108,6 +124,12 @@ pub fn apply_config_policy(
         spec.policy.default_action = policy.default_action.clone();
         spec.policy.allowed_origins = policy.allowed_origins.clone();
         spec.policy.denied_origins = policy.denied_origins.clone();
+        spec.policy.loopback = BrowserLoopbackSpec {
+            enabled: policy.loopback.enabled,
+            schema_version: policy.loopback.schema_version,
+            session_scope: policy.loopback.session_scope.clone(),
+            ports: policy.loopback.ports.clone(),
+        };
     }
 }
 
@@ -125,6 +147,7 @@ mod tests {
                 default_action: "allow".into(),
                 allowed_origins: vec!["*.example.com".into()],
                 denied_origins: vec!["*.evil.example".into()],
+                loopback: BrowserLoopbackSpec::default(),
             },
             allow_cloud: false,
         }
@@ -178,5 +201,33 @@ mod tests {
         assert_eq!(core.preferred_provider, CoreProviderHint::Camoufox);
         assert_eq!(core.policy.allowed_origins.len(), 1);
         assert_eq!(core.policy.denied_origins.len(), 1);
+    }
+
+    /// gh#911 — the grant has to survive `config -> mirror -> core`. This is
+    /// the seam that made the reporter of gh#900 believe browser policy had
+    /// its own config resolver: a field that stops here is invisible.
+    #[test]
+    fn apply_config_policy_carries_the_loopback_grant_to_core() {
+        let mut specs = vec![fixture_spec("Browser")];
+        let cfg = wcore_config::browser::BrowserPolicyConfig {
+            default_action: "deny".into(),
+            allowed_origins: vec![],
+            denied_origins: vec![],
+            loopback: wcore_config::browser::BrowserLoopbackConfig {
+                enabled: true,
+                schema_version: 1,
+                session_scope: "chat-42".into(),
+                ports: vec![3000],
+            },
+        };
+        apply_config_policy(&cfg, &mut specs);
+        let core = spec_to_core(&specs[0]);
+        assert!(core.policy.loopback.enabled);
+        assert_eq!(core.policy.loopback.session_scope, "chat-42");
+        assert_eq!(core.policy.loopback.ports, vec![3000]);
+        // And it is load-bearing, not just carried: the granted port passes
+        // and an ungranted one on the same host does not.
+        assert!(core.policy.check_url("http://localhost:3000/").is_ok());
+        assert!(core.policy.check_url("http://localhost:9377/").is_err());
     }
 }

--- a/crates/wcore-agent/tests/browser_e2e_test.rs
+++ b/crates/wcore-agent/tests/browser_e2e_test.rs
@@ -90,6 +90,7 @@ fn build_tool_pointed_at(server_uri: &str, allowed_host: &str) -> Arc<BrowserToo
             default_action: "allow".into(),
             allowed_origins: vec![allowed_host.to_string()],
             denied_origins: vec![],
+            loopback: Default::default(),
         },
         allow_cloud: false,
     };
@@ -131,6 +132,7 @@ async fn host_registrar_captures_wayland_browser_spec() {
                 default_action: "allow".into(),
                 allowed_origins: vec!["example.com".into()],
                 denied_origins: vec![],
+                loopback: Default::default(),
             },
             allow_cloud: false,
         })

--- a/crates/wcore-agent/tests/gh900_gh826_followable_hint_test.rs
+++ b/crates/wcore-agent/tests/gh900_gh826_followable_hint_test.rs
@@ -1,0 +1,341 @@
+//! gh#900 and gh#826 — "the product's own remediation text is not followable".
+//!
+//! Both reports are the same failure with different endings.
+//!
+//! **gh#900.** The reporter edited a `config.toml` in four successive
+//! throwaway `wcore-temp-*` workspaces, confirmed the browser block was
+//! present each time, and the tool kept returning the same fail-closed
+//! denial. They concluded the browser policy had its own broken config
+//! resolver. It does not. The message said "add allowed domains to your
+//! config.toml" and named no location, and in a desktop session the working
+//! directory IS a throwaway workspace — so `<cwd>/config.toml` is where that
+//! sentence leads. A bare `config.toml` in the working directory is not a
+//! config source in any layer (the project layer is `.wayland-core.toml`; a
+//! plain `config.toml` is read only under the app config dir), so the edits
+//! landed where the loader never looks, silently.
+//!
+//! **gh#826.** A loopback denial carried no remediation at all. With nothing
+//! true to say, the denial got relayed with an invented fix — "enable
+//! allowLoopbackHostnames in sandbox settings" — and a user went looking for
+//! a setting that has never existed in this product. The cure is not better
+//! prose; it is a real setting plus a message that names it.
+//!
+//! **What makes these guards rather than string assertions.** No test here
+//! writes to a path it computed itself. Each one reads the path back OUT of
+//! the message a human sees, writes the printed snippet THERE, and then drives
+//! the REAL resolver (`Config::resolve_with_provenance`) plus the real
+//! bootstrap policy copy and the real mirror→core conversion through to
+//! `BrowserPolicy::check_url`. If a message ever again names a location the
+//! loader does not read, or a setting the gate does not honour, the write
+//! lands nowhere and the decision is Deny.
+//!
+//! [`control_a_bare_config_toml_in_the_workspace_is_not_read`] is the negative
+//! control: the SAME journey with the file placed where the pre-fix wording
+//! led. Without it, a fix that defaulted the browser policy to allow-all would
+//! pass everything above while destroying the fail-closed posture.
+
+use std::ffi::{OsStr, OsString};
+use std::path::{Path, PathBuf};
+
+use serial_test::serial;
+use wcore_agent::plugins::adapters::browser_adapter::{apply_config_policy, spec_to_core};
+use wcore_browser::config_hint::{
+    ALLOWLIST_ADMITTED_URL, ENABLE_BY_ALLOWLIST_TOML, ENABLE_LOOPBACK_TOML, LOOPBACK_ADMITTED_URL,
+    LOOPBACK_REFUSED_PORT_URL, LOOPBACK_REFUSED_PRIVATE_URL, disabled_by_default_hint,
+    loopback_blocked_hint,
+};
+use wcore_browser::policy::BrowserPolicy;
+use wcore_config::config::{CliArgs, Config};
+use wcore_plugin_api::browser_spec::{
+    BrowserPolicySpec, BrowserProviderHint, BrowserToolSpec as MirrorSpec,
+};
+
+// ---------------------------------------------------------------------------
+// Environment scaffolding
+// ---------------------------------------------------------------------------
+
+struct EnvGuard {
+    saved: Vec<(&'static str, Option<OsString>)>,
+}
+
+impl EnvGuard {
+    fn set(values: &[(&'static str, Option<&OsStr>)]) -> Self {
+        let saved = values
+            .iter()
+            .map(|(key, _)| (*key, std::env::var_os(key)))
+            .collect();
+        for (key, value) in values {
+            // SAFETY: every test in this binary is in the same `serial` group
+            // and restores the environment through this guard on drop.
+            unsafe {
+                match value {
+                    Some(value) => std::env::set_var(key, value),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
+        Self { saved }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        for (key, value) in self.saved.drain(..).rev() {
+            // SAFETY: see `EnvGuard::set`.
+            unsafe {
+                match value {
+                    Some(value) => std::env::set_var(key, value),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
+    }
+}
+
+/// The reporter's topology: a long-lived config home plus a per-chat throwaway
+/// working directory.
+fn desktop_session() -> (tempfile::TempDir, tempfile::TempDir, EnvGuard) {
+    let home = tempfile::tempdir().expect("temp home");
+    let workspace = tempfile::tempdir().expect("temp workspace");
+    let guard = EnvGuard::set(&[
+        ("WAYLAND_HOME", Some(home.path().as_os_str())),
+        // Observed-but-ignored by the resolver; unset so it cannot confuse the
+        // reading of this test's result either way.
+        ("WAYLAND_CONFIG_PATH", None),
+        ("XDG_DATA_HOME", None),
+    ]);
+    (home, workspace, guard)
+}
+
+/// Sentinel proving the resolver really read OUR temp global file. hetzner and
+/// CI hosts can carry a real `~/.wayland`; without this, a passing decision
+/// could be coming from some other machine-wide config entirely.
+const GLOBAL_SENTINEL_MAX_TOKENS: u32 = 4321;
+
+/// Pull a config file path back out of the text a human reads.
+///
+/// Deliberately naive — someone scanning the message for "the file to edit"
+/// does the same thing. A message that names no path yields `None`, which is
+/// itself the gh#900 defect.
+///
+/// Known limit: whitespace-delimited, so it would truncate a path containing a
+/// space. `WAYLAND_HOME` is pinned to a temp dir here and every platform's temp
+/// root is space-free, so it cannot bite. If it ever does, the result is the
+/// loud symptom panic below quoting the truncated path, not a silent pass.
+fn config_path_named_in(hint: &str) -> Option<PathBuf> {
+    hint.split_whitespace()
+        .map(|token| token.trim_matches(|c| c == '`' || c == ',' || c == '.'))
+        .find(|token| {
+            token.ends_with("config.toml")
+                && Path::new(token)
+                    .parent()
+                    .is_some_and(|parent| parent != Path::new(""))
+        })
+        .map(PathBuf::from)
+}
+
+/// The journey: resolve the real config with the working directory set to a
+/// throwaway workspace, then drive the merged `[browser]` block through the
+/// real bootstrap copy and the real mirror→core conversion.
+fn policy_after_resolving(home: &Path, workspace: &Path) -> BrowserPolicy {
+    let cli = CliArgs {
+        provider: Some("anthropic".to_string()),
+        api_key: Some("test-key-not-a-real-credential".to_string()),
+        project_dir: Some(workspace.to_path_buf()),
+        ..CliArgs::default()
+    };
+    let resolved = Config::resolve_with_provenance(&cli).expect("resolving config");
+    assert_eq!(
+        resolved.value.max_tokens,
+        GLOBAL_SENTINEL_MAX_TOKENS,
+        "the resolver did not read the temp global config at {}; every other \
+         measurement in this test would be about some other machine's config",
+        home.display()
+    );
+
+    // What the `wayland-browser` plugin shell registers before the operator's
+    // config is applied: deny-all. Anything the edit fails to reach leaves this
+    // untouched.
+    let mut specs = vec![MirrorSpec {
+        tool_namespace: "Browser".into(),
+        preferred_provider: BrowserProviderHint::Auto,
+        policy: BrowserPolicySpec::default(),
+        allow_cloud: false,
+    }];
+    apply_config_policy(&resolved.value.browser.policy, &mut specs);
+    spec_to_core(&specs[0]).policy
+}
+
+/// Seed the operator's pre-existing config. Written to the file the RESOLVER
+/// reads, never to the file the MESSAGE names, so the liveness assertion above
+/// stays honest even when those two disagree — which is the failure under test.
+fn seed_existing_global_config(home: &Path) {
+    std::fs::write(
+        home.path_join_config(),
+        format!("[default]\nmax_tokens = {GLOBAL_SENTINEL_MAX_TOKENS}\n"),
+    )
+    .unwrap();
+}
+
+trait HomeConfig {
+    fn path_join_config(&self) -> PathBuf;
+}
+impl HomeConfig for Path {
+    fn path_join_config(&self) -> PathBuf {
+        self.join("config.toml")
+    }
+}
+
+/// Append the snippet the message printed to the file the message named.
+/// Nothing here is a path the test chose.
+fn follow_the_message(hint: &str, snippet: &str) -> PathBuf {
+    let named = config_path_named_in(hint).unwrap_or_else(|| {
+        panic!(
+            "the message names no config file location. Someone in a throwaway workspace \
+             has nowhere to put the snippet, which is exactly gh#900:\n{hint}"
+        )
+    });
+    std::fs::create_dir_all(named.parent().expect("named path has a parent")).unwrap();
+    let mut existing = std::fs::read_to_string(&named).unwrap_or_default();
+    existing.push('\n');
+    existing.push_str(snippet);
+    std::fs::write(&named, existing).unwrap();
+    named
+}
+
+// ---------------------------------------------------------------------------
+// gh#900 — following the disabled-by-default message works
+// ---------------------------------------------------------------------------
+
+#[test]
+#[serial]
+fn following_the_disabled_message_from_a_temp_workspace_enables_the_tool() {
+    let (home, workspace, _env) = desktop_session();
+    seed_existing_global_config(home.path());
+
+    let hint = disabled_by_default_hint();
+    let named = follow_the_message(&hint, ENABLE_BY_ALLOWLIST_TOML);
+
+    let policy = policy_after_resolving(home.path(), workspace.path());
+    policy
+        .check_url(ALLOWLIST_ADMITTED_URL)
+        .unwrap_or_else(|e| {
+            panic!(
+                "the operator followed the product's own denial message exactly — wrote its \
+                 snippet to the file it named, {} — and the browser tool is STILL disabled: \
+                 {ALLOWLIST_ADMITTED_URL} refused: {e}\nmessage was:\n{hint}",
+                named.display()
+            )
+        });
+}
+
+/// Negative control — the pre-fix journey, pinned. "your config.toml" with no
+/// location, read from inside a `wcore-temp-*` workspace, means
+/// `<cwd>/config.toml`. That file must still be inert, or the tests above
+/// would pass for a reason that has nothing to do with the message.
+#[test]
+#[serial]
+fn control_a_bare_config_toml_in_the_workspace_is_not_read() {
+    let (home, workspace, _env) = desktop_session();
+    seed_existing_global_config(home.path());
+
+    std::fs::write(
+        workspace.path().join("config.toml"),
+        ENABLE_BY_ALLOWLIST_TOML,
+    )
+    .unwrap();
+
+    let policy = policy_after_resolving(home.path(), workspace.path());
+    assert!(
+        policy.check_url(ALLOWLIST_ADMITTED_URL).is_err(),
+        "a bare config.toml in the working directory is now a config source. If that is \
+         intended, the gh#900 remediation text may name it — but this control, and the \
+         reasoning in every test above, must be rewritten first."
+    );
+}
+
+// ---------------------------------------------------------------------------
+// gh#826 — the loopback message names a setting that exists and works
+// ---------------------------------------------------------------------------
+
+#[test]
+#[serial]
+fn following_the_loopback_message_actually_reaches_loopback() {
+    let (home, workspace, _env) = desktop_session();
+    seed_existing_global_config(home.path());
+
+    // The message a user sees when they try to open something on localhost.
+    let hint = loopback_blocked_hint("loopback hostname blocked: localhost");
+    let named = follow_the_message(&hint, ENABLE_LOOPBACK_TOML);
+
+    let policy = policy_after_resolving(home.path(), workspace.path());
+    policy.check_url(LOOPBACK_ADMITTED_URL).unwrap_or_else(|e| {
+        panic!(
+            "the loopback denial named a setting and a file — {} — and following it verbatim \
+             STILL cannot reach {LOOPBACK_ADMITTED_URL}: {e}\n\
+             This is gh#826: the product describing a control that does not deliver.\n\
+             message was:\n{hint}",
+            named.display()
+        )
+    });
+
+    // The grant must not have widened anything else on the way through. These
+    // two are the promises the same message makes in prose.
+    assert!(
+        policy.check_url(LOOPBACK_REFUSED_PORT_URL).is_err(),
+        "the loopback grant opened an ungranted port ({LOOPBACK_REFUSED_PORT_URL}); the \
+         message promises only the listed ports become reachable"
+    );
+    assert!(
+        policy.check_url(LOOPBACK_REFUSED_PRIVATE_URL).is_err(),
+        "the loopback grant reached a private RFC 1918 address \
+         ({LOOPBACK_REFUSED_PRIVATE_URL}); the message promises those stay blocked"
+    );
+}
+
+/// gh#826's specific ending: the invented setting. Nothing the product prints
+/// may name it, and — more usefully — the settings the product DOES print must
+/// be reachable in the config surface, which the test above proves by driving
+/// them. This one pins the fabrication itself so it cannot come back as text.
+#[test]
+#[serial]
+fn no_message_names_the_setting_that_never_existed() {
+    let messages = [
+        disabled_by_default_hint(),
+        loopback_blocked_hint("loopback hostname blocked: localhost"),
+        loopback_blocked_hint("loopback IP blocked: 127.0.0.1"),
+    ];
+    for hint in messages {
+        let lowered = hint.to_lowercase();
+        for invented in ["allowloopbackhostnames", "sandbox settings"] {
+            assert!(
+                !lowered.contains(invented),
+                "a remediation message names {invented:?}, which is not a setting this \
+                 product has. That fabrication is gh#826:\n{hint}"
+            );
+        }
+    }
+}
+
+/// The loopback message must carry the SPECIFIC gate that refused. "Loopback
+/// is blocked" alone is what left the reporter guessing; "port 9377 is not in
+/// the granted ports [3000]" is actionable.
+#[test]
+#[serial]
+fn the_loopback_message_keeps_the_reason_the_gate_gave() {
+    let (home, workspace, _env) = desktop_session();
+    seed_existing_global_config(home.path());
+    let hint = loopback_blocked_hint("loopback hostname blocked: localhost");
+    follow_the_message(&hint, ENABLE_LOOPBACK_TOML);
+
+    let policy = policy_after_resolving(home.path(), workspace.path());
+    let err = policy
+        .check_url(LOOPBACK_REFUSED_PORT_URL)
+        .expect_err("ungranted port must be refused");
+    let reason = err.to_string();
+    assert!(
+        reason.contains("9377") && reason.contains("3000"),
+        "the refusal names neither the port asked for nor the ports granted, so a reader \
+         cannot tell what to change: {reason}"
+    );
+}

--- a/crates/wcore-agent/tests/plugin_single_reification_call_site.rs
+++ b/crates/wcore-agent/tests/plugin_single_reification_call_site.rs
@@ -80,6 +80,7 @@ fn fixture_browser_spec(ns: &str) -> BrowserToolSpec {
             default_action: "allow".into(),
             allowed_origins: vec!["*.example.com".into()],
             denied_origins: vec![],
+            loopback: Default::default(),
         },
         allow_cloud: false,
     }

--- a/crates/wcore-browser/src/config_hint.rs
+++ b/crates/wcore-browser/src/config_hint.rs
@@ -13,6 +13,32 @@
 //! hint gets **no diagnostic at all** and the tool stays disabled forever
 //! (`27-C2(a)`).
 //!
+//! ## Naming the FILE, not just the section (gh#900)
+//!
+//! Naming the section correctly is only half of a followable instruction. The
+//! reporter of gh#900 read "add allowed domains to your config.toml", and in a
+//! desktop session the working directory is a throwaway `wcore-temp-*`
+//! workspace — so they created `<cwd>/config.toml` in four different
+//! workspaces in turn. A bare `config.toml` in the working directory is not a
+//! config source in ANY layer: the project layer is `.wayland-core.toml` (or
+//! `.wayland-core/config.toml`) and a plain `config.toml` is read only under
+//! the app config dir. Their edits landed where the loader never looks, no
+//! diagnostic was emitted, and they reasonably concluded the browser tool had
+//! its own broken config resolver. [`config_targets`] resolves the real paths
+//! from the same functions the loader calls, so the message cannot name a
+//! location the loader does not read.
+//!
+//! ## Naming a setting that EXISTS (gh#826)
+//!
+//! A loopback denial used to carry no remediation at all — just "loopback
+//! hostname blocked: localhost". With nothing true to say, an assistant
+//! relaying that denial invented a plausible-sounding one, and a user went
+//! looking for "allowLoopbackHostnames in sandbox settings", which has never
+//! existed anywhere in this product. [`loopback_blocked_hint`] closes that gap
+//! by naming the real `[browser.policy.loopback]` grant, and
+//! [`ENABLE_LOOPBACK_TOML`] is round-tripped through the real loader so the
+//! named setting is provably the one that works.
+//!
 //! The snippets below are the single source of truth for what the hint
 //! prints. `wcore-agent/tests/browser_config_hint_roundtrip.rs` parses THESE
 //! constants through the real `ConfigFile` serde types, pushes the result
@@ -48,15 +74,96 @@ pub const ALLOWLIST_REFUSED_URL: &str = "https://not-on-the-list.test/";
 /// A URL only [`ENABLE_BY_DEFAULT_ACTION_TOML`] admits.
 pub const DEFAULT_ACTION_ADMITTED_URL: &str = "https://anything-at-all.test/";
 
+/// Project-layer config filename. The documented layout; `.wayland-core/config.toml`
+/// is also accepted by the loader but only one form should ever be advertised.
+pub const PROJECT_CONFIG_FILENAME: &str = ".wayland-core.toml";
+
+/// TOML that grants the gh#911 loopback capability for one local port. Must
+/// parse into a policy that admits [`LOOPBACK_ADMITTED_URL`] and still refuses
+/// [`LOOPBACK_REFUSED_PORT_URL`] and [`LOOPBACK_REFUSED_PRIVATE_URL`].
+pub const ENABLE_LOOPBACK_TOML: &str = "\
+[browser.policy.loopback]
+enabled = true
+schema_version = 1
+# Any label identifying who/what this grant is for; it is reported back in
+# the allow decision. Must not be empty.
+session_scope = \"local-dev\"
+# Only these ports are reachable on loopback. There is no all-ports value.
+ports = [3000]
+";
+
+/// A URL [`ENABLE_LOOPBACK_TOML`] promises to admit.
+pub const LOOPBACK_ADMITTED_URL: &str = "http://localhost:3000/";
+
+/// Same host, ungranted port — the grant is a port allow-list, not a
+/// "localhost is open now" switch. (9377 is the Camoufox sidecar.)
+pub const LOOPBACK_REFUSED_PORT_URL: &str = "http://localhost:9377/";
+
+/// A loopback grant must not become an SSRF hole into the local network.
+pub const LOOPBACK_REFUSED_PRIVATE_URL: &str = "http://192.168.0.1:3000/";
+
+/// The config files the loader actually reads, most-specific last, resolved
+/// through the very functions `resolve_config_files` calls.
+///
+/// Returned rather than formatted so the round-trip guard can write to these
+/// paths and prove the advice works, instead of asserting on prose.
+pub fn config_targets() -> Vec<String> {
+    vec![
+        wcore_config::config::global_config_path()
+            .display()
+            .to_string(),
+        format!("<project dir>/{PROJECT_CONFIG_FILENAME}"),
+    ]
+}
+
+/// The `Edit one of:` block shared by every remediation message. Naming the
+/// real resolved global path is the gh#900 fix.
+fn config_target_block() -> String {
+    let mut out = String::from("Edit one of these files (the only ones the loader reads):\n");
+    for target in config_targets() {
+        out.push_str("  - ");
+        out.push_str(&target);
+        out.push('\n');
+    }
+    out.push_str(
+        "A plain `config.toml` in the current working directory is NOT read \
+         (in a desktop session that is a throwaway workspace).\n",
+    );
+    out
+}
+
 /// The full remediation message shown when the browser tool denies solely
 /// because it is in its fail-closed default posture.
 pub fn disabled_by_default_hint() -> String {
     format!(
         "Browser tool is disabled by default. \
-         Add allowed domains to your config.toml to enable it:\n\n\
+         Add allowed domains to enable it.\n\n\
+         {}\n\
          {ENABLE_BY_ALLOWLIST_TOML}\n\
          Alternatively, permit all origins — not recommended, exposes SSRF risk:\n\n\
-         {ENABLE_BY_DEFAULT_ACTION_TOML}"
+         {ENABLE_BY_DEFAULT_ACTION_TOML}",
+        config_target_block()
+    )
+}
+
+/// Remediation for a loopback denial (gh#826 / gh#911).
+///
+/// `refusal` is the reason `BrowserPolicy` produced, which already names the
+/// specific gate that refused (no grant / wrong `schema_version` / empty
+/// `session_scope` / ungranted port). This wraps it with the real setting to
+/// change, so the message a user reads always names a control that exists.
+pub fn loopback_blocked_hint(refusal: &str) -> String {
+    format!(
+        "{refusal}\n\n\
+         Loopback is blocked by default. It is reachable only through an explicit, \
+         port-scoped grant — there is no sandbox-wide switch and no setting named \
+         anything else.\n\n\
+         {}\n\
+         {ENABLE_LOOPBACK_TOML}\n\
+         Only the ports listed above become reachable. Private (RFC 1918), \
+         link-local and cloud-metadata addresses stay blocked, and a public \
+         hostname that resolves to 127.0.0.1 is still refused as DNS rebinding.",
+        config_target_block()
     )
 }
 
@@ -85,7 +192,11 @@ mod tests {
     /// `browser.policy.*`; a key at `[browser]` level is silently discarded.
     #[test]
     fn snippets_never_name_the_bare_browser_section() {
-        for snippet in [ENABLE_BY_ALLOWLIST_TOML, ENABLE_BY_DEFAULT_ACTION_TOML] {
+        for snippet in [
+            ENABLE_BY_ALLOWLIST_TOML,
+            ENABLE_BY_DEFAULT_ACTION_TOML,
+            ENABLE_LOOPBACK_TOML,
+        ] {
             assert!(
                 !snippet.lines().any(|l| l.trim() == "[browser]"),
                 "snippet names [browser]; the loader reads [browser.policy]:\n{snippet}"
@@ -107,5 +218,66 @@ mod tests {
 
         let allow_all = crate::BrowserPolicy::new(crate::PolicyAction::Allow, vec![], vec![]);
         assert!(allow_all.check_url(DEFAULT_ACTION_ADMITTED_URL).is_ok());
+    }
+
+    /// gh#900 — every remediation message must name a real file. A message
+    /// that says only "your config.toml" sent the reporter to
+    /// `<cwd>/config.toml` four times, which no layer reads.
+    #[test]
+    fn both_hints_name_an_absolute_config_file() {
+        let global = wcore_config::config::global_config_path();
+        for hint in [
+            disabled_by_default_hint(),
+            loopback_blocked_hint("loopback hostname blocked: localhost"),
+        ] {
+            assert!(
+                hint.contains(&global.display().to_string()),
+                "hint names no resolved global config path, so a reader in a throwaway \
+                 workspace has nowhere to put the snippet:\n{hint}"
+            );
+            assert!(
+                hint.contains(PROJECT_CONFIG_FILENAME),
+                "hint never names the project config filename:\n{hint}"
+            );
+        }
+    }
+
+    /// gh#826 — the loopback message must name the grant that exists and must
+    /// carry the specific gate that refused, so a reader never has to guess a
+    /// setting name.
+    #[test]
+    fn loopback_hint_names_the_real_grant_and_keeps_the_refusal() {
+        let refusal = "loopback hostname blocked: localhost; \
+                       loopback capability refused: port 9377 is not in the granted ports [3000]";
+        let hint = loopback_blocked_hint(refusal);
+        assert!(
+            hint.contains(refusal),
+            "hint dropped the specific refusal:\n{hint}"
+        );
+        assert!(
+            hint.contains(ENABLE_LOOPBACK_TOML),
+            "hint dropped the loopback grant snippet:\n{hint}"
+        );
+        assert!(
+            hint.contains("[browser.policy.loopback]"),
+            "hint never names the loopback setting:\n{hint}"
+        );
+    }
+
+    /// The loopback snippet must drive the local policy type to exactly the
+    /// three decisions it advertises. Anchoring on the text alone would let
+    /// the snippet and the gate drift apart — which is how gh#826 happened.
+    #[test]
+    fn loopback_snippet_drives_the_local_policy_type() {
+        let granted = crate::BrowserPolicy::new(crate::PolicyAction::Deny, vec![], vec![])
+            .with_loopback(crate::policy::LoopbackCapability {
+                enabled: true,
+                schema_version: crate::policy::LOOPBACK_CAPABILITY_VERSION,
+                session_scope: "local-dev".into(),
+                ports: vec![3000],
+            });
+        assert!(granted.check_url(LOOPBACK_ADMITTED_URL).is_ok());
+        assert!(granted.check_url(LOOPBACK_REFUSED_PORT_URL).is_err());
+        assert!(granted.check_url(LOOPBACK_REFUSED_PRIVATE_URL).is_err());
     }
 }

--- a/crates/wcore-browser/src/config_hint.rs
+++ b/crates/wcore-browser/src/config_hint.rs
@@ -161,8 +161,9 @@ pub fn loopback_blocked_hint(refusal: &str) -> String {
          {}\n\
          {ENABLE_LOOPBACK_TOML}\n\
          Only the ports listed above become reachable. Private (RFC 1918), \
-         link-local and cloud-metadata addresses stay blocked, and a public \
-         hostname that resolves to 127.0.0.1 is still refused as DNS rebinding.",
+         link-local and cloud-metadata addresses stay blocked when they appear \
+         literally in the URL. The host is NOT re-checked after DNS resolution, \
+         so do not rely on this gate to stop a name that resolves inward.",
         config_target_block()
     )
 }
@@ -261,6 +262,30 @@ mod tests {
         assert!(
             hint.contains("[browser.policy.loopback]"),
             "hint never names the loopback setting:\n{hint}"
+        );
+    }
+
+    /// The hint must not promise DNS-rebinding protection while
+    /// `BrowserPolicy::check_resolved_host` has no production caller.
+    ///
+    /// The guard exists and is unit-tested, but every call site is in
+    /// `#[cfg(test)]` or `tests/` -- so on the executed path a public hostname
+    /// that resolves to a loopback or private address is never re-checked.
+    /// Claiming otherwise in a refusal message tells the operator they are
+    /// protected by something that does not run. If the guard is ever wired
+    /// into the live navigation path, update the hint AND this test together.
+    #[test]
+    fn loopback_hint_claims_no_protection_the_live_path_does_not_have() {
+        let hint = loopback_blocked_hint("loopback hostname blocked: localhost");
+        let lowered = hint.to_ascii_lowercase();
+        assert!(
+            !lowered.contains("rebinding"),
+            "the hint promises DNS-rebinding protection, but check_resolved_host \
+             has no production caller, so nothing re-checks the resolved host:\n{hint}"
+        );
+        assert!(
+            lowered.contains("not re-checked after dns resolution"),
+            "the hint must state the real boundary so an operator is not misled:\n{hint}"
         );
     }
 

--- a/crates/wcore-browser/src/policy.rs
+++ b/crates/wcore-browser/src/policy.rs
@@ -3,7 +3,9 @@
 //! ## Hard-coded blocks (always-on, regardless of allow / deny lists)
 //!
 //!   * RFC 1918 private ranges (10/8, 172.16/12, 192.168/16).
-//!   * Loopback (127/8, `localhost`, `*.localhost`, `::1`).
+//!   * Loopback (127/8, `localhost`, `*.localhost`, `::1`) — the ONE
+//!     hard block with a recoverable escape hatch; see
+//!     [`LoopbackCapability`] and the "Loopback capability" section below.
 //!   * Cloud metadata endpoint (169.254.169.254 — AWS / GCP / Azure /
 //!     OpenStack share this address).
 //!   * Link-local IPv4 (169.254/16) and IPv6 (`fe80::/10`).
@@ -33,6 +35,26 @@
 //!   * `Allow` — explicit-block list still applies; everything else passes.
 //!   * `Ask` — unknown origins route to `Suspend` so the orchestration
 //!     layer can request HITL approval (S4 suspend pattern).
+//!
+//! ## Loopback capability (gh#911)
+//!
+//! Loopback was previously a dead end: `http://localhost:3000` was refused
+//! with no recovery path at all, so an operator wanting to drive a local dev
+//! server had nothing to turn on. [`LoopbackCapability`] is the recoverable,
+//! versioned, scope-bearing grant that reopens exactly that door and nothing
+//! else. It is deliberately NOT a sandbox disable:
+//!
+//!   * It fails closed on absent, version-mismatched, unscoped or portless
+//!     grant data — every validation failure keeps loopback blocked.
+//!   * It authorizes only the ports the operator enumerated. A grant for
+//!     `3000` does not reach the Camoufox sidecar on `9377`.
+//!   * It relaxes ONLY loopback (`localhost`, `*.localhost`, 127/8, `::1`,
+//!     IPv4-mapped loopback). RFC 1918, link-local, cloud metadata, IPv6 ULA
+//!     and `0.0.0.0/8` all stay refused with a grant in hand — including at
+//!     the granted port, so a grant cannot be spent across categories.
+//!   * It never relaxes [`check_resolved_host`]. A public hostname that
+//!     resolves to 127.0.0.1 is still a rebinding attack, grant or no grant.
+//!   * `denied_origins` still wins over an authorized grant.
 //!
 //! ## DNS rebinding (TOFU cache)
 //!
@@ -97,6 +119,86 @@ pub enum PolicyOutcome {
 /// at the gate. The list is intentionally minimal: HTTP + HTTPS only.
 const ALLOWED_SCHEMES: &[&str] = &["http", "https"];
 
+/// Schema version of the loopback capability grant. A grant carrying any
+/// other value — including the `0` a missing field deserializes to — is
+/// refused, so unknown producer data fails closed rather than being
+/// interpreted under the wrong schema (gh#911 acceptance: "Unknown or
+/// malformed capability data fails closed").
+pub const LOOPBACK_CAPABILITY_VERSION: u32 = 1;
+
+/// Explicit, scoped, human-granted authority to reach loopback.
+///
+/// Every field is required to be affirmatively set: [`Default`] is the
+/// no-authority value and each validation gate below refuses rather than
+/// assumes. See the crate-level "Loopback capability" section for the
+/// threat model this shape is answering.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct LoopbackCapability {
+    /// Master switch. `false` (default) keeps loopback hard-blocked.
+    pub enabled: bool,
+    /// Must equal [`LOOPBACK_CAPABILITY_VERSION`].
+    pub schema_version: u32,
+    /// The session / profile this grant was issued for. Carried into the
+    /// decision text so a consumer can report which target authorized the
+    /// access. Empty is refused: an unattributable grant is not explicit
+    /// human authority.
+    pub session_scope: String,
+    /// Ports this grant authorizes on loopback. Empty is refused — there is
+    /// deliberately no "all ports" spelling, because that is the broad
+    /// sandbox disable gh#911 rules out.
+    pub ports: Vec<u16>,
+}
+
+impl LoopbackCapability {
+    /// `Ok(scope)` when this grant authorizes `port`; `Err(why)` naming the
+    /// specific gate that refused otherwise. The `Err` text is operator-facing
+    /// — it is what a stuck operator reads to find out what is wrong with the
+    /// grant they just wrote.
+    pub fn authorize(&self, port: Option<u16>) -> Result<&str, String> {
+        if !self.enabled {
+            return Err(
+                "no loopback capability granted (browser.policy.loopback.enabled is false)".into(),
+            );
+        }
+        if self.schema_version != LOOPBACK_CAPABILITY_VERSION {
+            return Err(format!(
+                "loopback capability refused: schema_version {} is not the supported \
+                 version {LOOPBACK_CAPABILITY_VERSION}",
+                self.schema_version
+            ));
+        }
+        if self.session_scope.trim().is_empty() {
+            return Err(
+                "loopback capability refused: session_scope is empty, so the grant names no \
+                 session or profile to attribute the access to"
+                    .into(),
+            );
+        }
+        if self.ports.is_empty() {
+            return Err(
+                "loopback capability refused: ports is empty, and there is no \
+                 all-ports spelling — enumerate the local ports the grant covers"
+                    .into(),
+            );
+        }
+        let Some(port) = port else {
+            return Err(
+                "loopback capability refused: URL has no port and no known default \
+                 for its scheme, so it cannot be matched against the granted ports"
+                    .into(),
+            );
+        };
+        if !self.ports.contains(&port) {
+            return Err(format!(
+                "loopback capability refused: port {port} is not in the granted ports {:?}",
+                self.ports
+            ));
+        }
+        Ok(self.session_scope.trim())
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BrowserPolicy {
     /// What to do when no rule matches. Default `Deny` (fail-closed) as
@@ -114,6 +216,10 @@ pub struct BrowserPolicy {
     /// DNS-rebinding TOFU cache. Pinned hostname → first-seen IP. On
     /// subsequent resolution of the same hostname, if the IP differs the
     /// request is refused. Cleared when the policy is dropped.
+    /// Recoverable local-only loopback grant (gh#911). Absent / malformed
+    /// grant data leaves loopback hard-blocked.
+    #[serde(default)]
+    pub loopback: LoopbackCapability,
     #[serde(skip)]
     dns_cache: Arc<Mutex<HashMap<String, IpAddr>>>,
 }
@@ -127,6 +233,7 @@ impl Default for BrowserPolicy {
             default_action: PolicyAction::Deny,
             allowed_origins: Vec::new(),
             denied_origins: Vec::new(),
+            loopback: LoopbackCapability::default(),
             dns_cache: Arc::new(Mutex::new(HashMap::new())),
         }
     }
@@ -137,6 +244,7 @@ impl PartialEq for BrowserPolicy {
         self.default_action == other.default_action
             && self.allowed_origins == other.allowed_origins
             && self.denied_origins == other.denied_origins
+            && self.loopback == other.loopback
     }
 }
 
@@ -152,8 +260,17 @@ impl BrowserPolicy {
             default_action,
             allowed_origins,
             denied_origins,
+            loopback: LoopbackCapability::default(),
             dns_cache: Arc::new(Mutex::new(HashMap::new())),
         }
+    }
+
+    /// Attach a loopback grant. Separate from [`new`](Self::new) so that
+    /// every existing construction site keeps the no-authority default and
+    /// granting loopback is always a visible, deliberate call.
+    pub fn with_loopback(mut self, loopback: LoopbackCapability) -> Self {
+        self.loopback = loopback;
+        self
     }
 
     /// Check a URL. Convenience wrapper returning `Result<(), PolicyError>`
@@ -193,17 +310,49 @@ impl BrowserPolicy {
         // 2. Hostname checks (IP literals + loopback names + legacy IPv4
         //    encodings + IPv4-mapped IPv6).
         if let Some(host) = parsed.host_str() {
-            if let Some(reason) = blocked_host_reason(host) {
-                return PolicyOutcome::Deny { reason };
-            }
+            let hard_block = blocked_host_reason(host);
 
-            // 3. Denied origins (suffix glob).
+            // 2a. The loopback capability (gh#911) is the ONE recoverable
+            //     hard block. It is consulted only for canonical loopback
+            //     spellings, so a grant cannot be spent on RFC 1918,
+            //     link-local, metadata, ULA, `0.0.0.0/8`, or an obfuscated
+            //     legacy encoding of 127.0.0.1 — those return below with
+            //     their original reason regardless of what was granted.
+            let loopback_scope = if hard_block.is_some() && is_canonical_loopback_host(host) {
+                match self.loopback.authorize(parsed.port_or_known_default()) {
+                    Ok(scope) => Some(scope.to_string()),
+                    Err(why) => {
+                        return PolicyOutcome::Deny {
+                            reason: format!(
+                                "{}; {why}",
+                                hard_block.unwrap_or_else(|| "loopback blocked".into())
+                            ),
+                        };
+                    }
+                }
+            } else {
+                if let Some(reason) = hard_block {
+                    return PolicyOutcome::Deny { reason };
+                }
+                None
+            };
+
+            // 3. Denied origins (suffix glob). Still wins over an authorized
+            //    loopback grant — the deny list is unconditional.
             for pat in &self.denied_origins {
                 if origin_matches(host, pat) {
                     return PolicyOutcome::Deny {
                         reason: format!("origin {host} matches denied pattern {pat}"),
                     };
                 }
+            }
+
+            // An authorized grant IS the explicit allow decision for this
+            // host and port. Requiring the operator to ALSO allow-list
+            // `localhost` would mean the recovery path Desktop offers still
+            // does not work on its own, which is the gh#911 defect.
+            if loopback_scope.is_some() {
+                return PolicyOutcome::Allow;
             }
 
             // 4. Allowed origins gate (if non-empty, must match).
@@ -296,6 +445,7 @@ impl BrowserPolicy {
             default_action: self.default_action,
             allowed_origins: self.allowed_origins.clone(),
             denied_origins: self.denied_origins.clone(),
+            loopback: self.loopback.clone(),
             dns_cache: Arc::clone(&self.dns_cache),
         };
         reqwest::redirect::Policy::custom(move |attempt| {
@@ -353,6 +503,44 @@ fn blocked_host_reason(host: &str) -> Option<String> {
     }
 
     None
+}
+
+/// `true` only for hosts that unambiguously ARE loopback and can therefore be
+/// reopened by a [`LoopbackCapability`].
+///
+/// Polarity matters here: this is an ALLOW-relaxation predicate, so every
+/// uncertain input must answer `false`. Deliberately excluded:
+///
+///   * `0.0.0.0` and the rest of `0.0.0.0/8`, which many stacks route to the
+///     local host but which is not a loopback address,
+///   * every non-loopback category — `blocked_host_reason` keeps refusing
+///     those with their own reason even at a granted port.
+///
+/// On the legacy IPv4 encodings (`0177.0.0.1`, `2130706433`, `127.1`, ...):
+/// measured, `Url::parse` canonicalizes every one of them to `127.0.0.1`
+/// before `evaluate` reads `host_str()`, so they never arrive here in their
+/// obfuscated form. Strict-parsing (rather than consulting
+/// `parse_ipv4_loose`) is therefore not a filter against them — it is the
+/// guarantee that the address this predicate judges is byte-for-byte the
+/// address the request will actually reach. Obfuscation cannot widen a grant
+/// because it cannot change the destination.
+fn is_canonical_loopback_host(host: &str) -> bool {
+    let host_lc = host.to_ascii_lowercase();
+    if host_lc == "localhost" || host_lc.ends_with(".localhost") {
+        return true;
+    }
+    let ip_str = host
+        .strip_prefix('[')
+        .and_then(|s| s.strip_suffix(']'))
+        .unwrap_or(host);
+    // STRICT parse only — `parse_ipv4_loose` is intentionally not consulted.
+    match IpAddr::from_str(ip_str) {
+        Ok(IpAddr::V4(v4)) => v4.is_loopback(),
+        Ok(IpAddr::V6(v6)) => {
+            v6.is_loopback() || ipv4_mapped(v6).is_some_and(|v4| v4.is_loopback())
+        }
+        Err(_) => false,
+    }
 }
 
 /// Reusable IP-literal block-list check. Split out from

--- a/crates/wcore-browser/src/tool.rs
+++ b/crates/wcore-browser/src/tool.rs
@@ -491,37 +491,7 @@ impl Tool for BrowserTool {
             // must NOT be replaced with the friendly hint — operators need the specific reason.
             // Those paths produce reasons like "cloud metadata endpoint blocked: ..." which do
             // NOT start with "default_action=Deny".
-            let msg = if let BrowserOpError::PolicyDenied { ref reason, .. } = e {
-                // gh#826/gh#911: a loopback denial is the one hard block with a
-                // real recovery path, so it gets the grant instructions rather
-                // than a bare reason. Matched on the loopback reason prefixes
-                // `BrowserPolicy` emits (`loopback hostname blocked:` /
-                // `loopback IP blocked:`) — NOT on the URL, so a private-IP or
-                // metadata denial can never be answered with loopback advice.
-                if reason.starts_with("loopback hostname blocked:")
-                    || reason.starts_with("loopback IP blocked:")
-                {
-                    crate::config_hint::loopback_blocked_hint(reason)
-                } else if reason.starts_with("default_action=Deny")
-                    && self.policy.allowed_origins.is_empty()
-                    && self.policy.default_action == crate::policy::PolicyAction::Deny
-                {
-                    // 27-C2(a): the section header here MUST be the one the
-                    // config loader reads (`[browser.policy]`). It named
-                    // `[browser]`, which `#[serde(default)]` silently drops,
-                    // so following this hint verbatim left the tool disabled
-                    // with no diagnostic. The text now comes from
-                    // `config_hint`, whose snippets are round-tripped through
-                    // the real loader by
-                    // `wcore-agent/tests/browser_config_hint_roundtrip.rs`.
-                    crate::config_hint::disabled_by_default_hint()
-                } else {
-                    format!("policy: {e}")
-                }
-            } else {
-                format!("policy: {e}")
-            };
-            return err(msg);
+            return err(denial_message(&e, &self.policy));
         }
 
         let sub = input.get("sub_agent").and_then(|s| s.as_str());
@@ -547,6 +517,45 @@ impl Tool for BrowserTool {
     }
 }
 
+/// Choose the operator-facing text for a policy refusal.
+///
+/// Extracted from `dispatch` so the ROUTING is testable, not just the message
+/// bodies. Two branches are remediation text for a specific recoverable
+/// posture; picking the wrong one is how a user ends up following advice that
+/// cannot apply to their denial, which is how gh#826 happened.
+fn denial_message(e: &BrowserOpError, policy: &BrowserPolicy) -> String {
+    let BrowserOpError::PolicyDenied { reason, .. } = e else {
+        return format!("policy: {e}");
+    };
+    // gh#826/gh#911: a loopback denial is the one hard block with a real
+    // recovery path, so it gets the grant instructions rather than a bare
+    // reason. Matched on the loopback reason prefixes `BrowserPolicy` emits —
+    // NOT on the URL — so a private-IP or metadata denial can never be
+    // answered with loopback advice.
+    if reason.starts_with("loopback hostname blocked:")
+        || reason.starts_with("loopback IP blocked:")
+    {
+        return crate::config_hint::loopback_blocked_hint(reason);
+    }
+    // F-023: when the policy denies solely because no origins are allow-listed
+    // (the fail-closed default posture), surface the config hint. SSRF-class
+    // denials must keep their specific reason.
+    //
+    // 27-C2(a): the section header in that hint MUST be the one the config
+    // loader reads (`[browser.policy]`). It named `[browser]`, which
+    // `#[serde(default)]` silently drops, so following it verbatim left the
+    // tool disabled with no diagnostic. The text comes from `config_hint`,
+    // whose snippets are round-tripped through the real loader by
+    // `wcore-agent/tests/browser_config_hint_roundtrip.rs`.
+    if reason.starts_with("default_action=Deny")
+        && policy.allowed_origins.is_empty()
+        && policy.default_action == crate::policy::PolicyAction::Deny
+    {
+        return crate::config_hint::disabled_by_default_hint();
+    }
+    format!("policy: {e}")
+}
+
 impl Drop for BrowserTool {
     fn drop(&mut self) {
         // Inform supervisor about every session we opened so the lifecycle
@@ -565,6 +574,88 @@ mod tests {
     use crate::policy::PolicyAction;
     use crate::provider::{BrowserProvider, BrowserSession, OpResult, SessionCtx};
     use async_trait::async_trait;
+
+    /// gh#826 routing guard. The remediation bodies are proven elsewhere; what
+    /// is proven here is that each denial CLASS reaches the right body. A
+    /// loopback denial answered with allow-list advice, or a metadata denial
+    /// answered with loopback advice, is the defect that made a user hunt for
+    /// a setting that does not exist.
+    #[test]
+    fn denial_message_routes_each_class_to_the_right_remedy() {
+        fn denied(reason: &str, policy: &BrowserPolicy) -> String {
+            denial_message(
+                &BrowserOpError::PolicyDenied {
+                    url: "http://irrelevant.test/".into(),
+                    reason: reason.into(),
+                },
+                policy,
+            )
+        }
+        let fail_closed = BrowserPolicy::new(PolicyAction::Deny, vec![], vec![]);
+
+        // Loopback -> the loopback grant instructions.
+        for reason in [
+            "loopback hostname blocked: localhost",
+            "loopback IP blocked: 127.0.0.1",
+        ] {
+            let msg = denied(reason, &fail_closed);
+            assert!(
+                msg.contains("[browser.policy.loopback]"),
+                "a loopback denial did not get the loopback grant instructions: {msg}"
+            );
+            assert!(
+                msg.contains(reason),
+                "the specific refusal was dropped: {msg}"
+            );
+        }
+
+        // Fail-closed default -> the allow-list instructions, and NOT the
+        // loopback ones (loopback is not what is wrong here).
+        let msg = denied(
+            "default_action=Deny and no rules matched origin example.com",
+            &fail_closed,
+        );
+        assert!(
+            msg.contains("disabled by default"),
+            "the fail-closed default denial lost its config hint: {msg}"
+        );
+        assert!(
+            !msg.contains("[browser.policy.loopback]"),
+            "an allow-list problem was answered with loopback advice: {msg}"
+        );
+
+        // SSRF class -> the specific reason, and NO remediation at all. There
+        // is deliberately no way to enable these, so any advice would be false.
+        for reason in [
+            "cloud metadata endpoint blocked: 169.254.169.254 (169.254.169.254)",
+            "RFC 1918 private IP blocked: 10.0.0.1",
+            "link-local IP blocked: 169.254.1.1",
+        ] {
+            let msg = denied(reason, &fail_closed);
+            assert!(msg.contains(reason), "specific reason dropped: {msg}");
+            assert!(
+                !msg.contains("[browser.policy.loopback]") && !msg.contains("disabled by default"),
+                "an unfixable SSRF denial was given remediation advice, which would send \
+                 the reader after a setting that cannot help: {msg}"
+            );
+        }
+    }
+
+    /// The non-`PolicyDenied` arm must keep the plain formatting it had.
+    #[test]
+    fn denial_message_passes_through_non_denial_errors() {
+        let policy = BrowserPolicy::default();
+        let msg = denial_message(
+            &BrowserOpError::PolicySuspended {
+                url: "https://ask.test/".into(),
+            },
+            &policy,
+        );
+        assert_eq!(
+            msg,
+            "policy: policy suspended: ask required for https://ask.test/"
+        );
+    }
 
     struct OkBackend;
 

--- a/crates/wcore-browser/src/tool.rs
+++ b/crates/wcore-browser/src/tool.rs
@@ -492,7 +492,17 @@ impl Tool for BrowserTool {
             // Those paths produce reasons like "cloud metadata endpoint blocked: ..." which do
             // NOT start with "default_action=Deny".
             let msg = if let BrowserOpError::PolicyDenied { ref reason, .. } = e {
-                if reason.starts_with("default_action=Deny")
+                // gh#826/gh#911: a loopback denial is the one hard block with a
+                // real recovery path, so it gets the grant instructions rather
+                // than a bare reason. Matched on the loopback reason prefixes
+                // `BrowserPolicy` emits (`loopback hostname blocked:` /
+                // `loopback IP blocked:`) — NOT on the URL, so a private-IP or
+                // metadata denial can never be answered with loopback advice.
+                if reason.starts_with("loopback hostname blocked:")
+                    || reason.starts_with("loopback IP blocked:")
+                {
+                    crate::config_hint::loopback_blocked_hint(reason)
+                } else if reason.starts_with("default_action=Deny")
                     && self.policy.allowed_origins.is_empty()
                     && self.policy.default_action == crate::policy::PolicyAction::Deny
                 {

--- a/crates/wcore-browser/tests/loopback_capability_test.rs
+++ b/crates/wcore-browser/tests/loopback_capability_test.rs
@@ -1,0 +1,429 @@
+//! gh#911 — adversarial suite for the recoverable local-only loopback
+//! capability, and gh#826's "the named setting must exist" guard.
+//!
+//! The capability reopens exactly one hard block. Every test below is an
+//! attempt to spend a grant on something it was not issued for; each must
+//! stay refused. The one positive arm proves the grant is not decorative —
+//! without it the whole file would pass against a policy that simply blocks
+//! everything, which is the vacuity trap for a fail-closed gate.
+//!
+//! Terminology: "granted" always means the fixture grant below — schema
+//! version 1, scope `local-dev`, port 3000 and nothing else.
+
+use std::net::{IpAddr, Ipv4Addr};
+
+use wcore_browser::policy::{
+    BrowserPolicy, LOOPBACK_CAPABILITY_VERSION, LoopbackCapability, PolicyAction, PolicyOutcome,
+};
+
+/// The grant an operator following the product's own remediation text writes.
+fn grant() -> LoopbackCapability {
+    LoopbackCapability {
+        enabled: true,
+        schema_version: LOOPBACK_CAPABILITY_VERSION,
+        session_scope: "local-dev".into(),
+        ports: vec![3000],
+    }
+}
+
+/// Fail-closed baseline policy (`default_action = deny`, no origin lists)
+/// carrying the fixture grant. Deliberately NOT `default_action = allow`: the
+/// grant has to be sufficient authority on its own, because the recovery path
+/// Desktop offers is a single action.
+fn granted_policy() -> BrowserPolicy {
+    BrowserPolicy::new(PolicyAction::Deny, vec![], vec![]).with_loopback(grant())
+}
+
+fn denied(policy: &BrowserPolicy, url: &str) -> String {
+    match policy.evaluate(url) {
+        PolicyOutcome::Deny { reason } => reason,
+        other => panic!("{url} was NOT denied: {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The one positive arm. If this fails, every negative arm below is vacuous.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn granted_port_is_reachable_on_every_loopback_spelling() {
+    let policy = granted_policy();
+    for url in [
+        "http://localhost:3000/",
+        "http://127.0.0.1:3000/",
+        "http://127.0.0.53:3000/", // all of 127/8, not just .0.1
+        "http://[::1]:3000/",
+        "http://[::ffff:127.0.0.1]:3000/", // IPv4-mapped loopback
+        "http://app.localhost:3000/",      // *.localhost
+    ] {
+        policy.check_url(url).unwrap_or_else(|e| {
+            panic!(
+                "an explicit grant for port 3000 did not admit {url}, so gh#911 has no \
+                 working recovery path: {e}"
+            )
+        });
+    }
+}
+
+#[test]
+fn without_a_grant_loopback_is_still_blocked() {
+    let policy = BrowserPolicy::new(PolicyAction::Deny, vec![], vec![]);
+    let reason = denied(&policy, "http://localhost:3000/");
+    assert!(
+        reason.contains("loopback"),
+        "denial should still name loopback: {reason}"
+    );
+    // Even a wide-open origin policy must not reach loopback unaided — the
+    // capability is the only door.
+    let wide = BrowserPolicy::new(PolicyAction::Allow, vec!["localhost".into()], vec![]);
+    let reason = denied(&wide, "http://localhost:3000/");
+    assert!(
+        reason.contains("loopback"),
+        "default_action=allow plus an allow-list must NOT substitute for the grant: {reason}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// A grant is port-scoped, not host-scoped.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ungranted_port_on_a_granted_host_stays_blocked() {
+    let policy = granted_policy();
+    // 9377 is the Camoufox sidecar this crate drives. A localhost grant that
+    // reached it would hand the agent its own browser control plane.
+    for url in [
+        "http://localhost:9377/",
+        "http://127.0.0.1:8080/",
+        "http://localhost/",       // port 80 by scheme default
+        "https://localhost/",      // port 443 by scheme default
+        "https://localhost:3000/", // right port, and it IS granted
+    ] {
+        let outcome = policy.evaluate(url);
+        let is_allowed = matches!(outcome, PolicyOutcome::Allow);
+        let expected = url == "https://localhost:3000/";
+        assert_eq!(
+            is_allowed, expected,
+            "{url}: expected allowed={expected}, got {outcome:?}"
+        );
+    }
+    let reason = denied(&policy, "http://localhost:9377/");
+    assert!(
+        reason.contains("9377") && reason.contains("[3000]"),
+        "the refusal must name the port asked for AND the ports granted, or an \
+         operator cannot tell what to change: {reason}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The grant must not leak into any other blocked category. These are the
+// gh#911 acceptance rows.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn grant_does_not_reach_private_link_local_metadata_or_ula() {
+    let policy = granted_policy();
+    // Every URL uses the GRANTED port, so a pass here would be the grant
+    // leaking across categories rather than a port mismatch.
+    for (url, want) in [
+        ("http://10.0.0.1:3000/", "RFC 1918"),
+        ("http://172.16.5.4:3000/", "RFC 1918"),
+        ("http://192.168.1.1:3000/", "RFC 1918"),
+        ("http://169.254.169.254:3000/", "cloud metadata"),
+        ("http://169.254.1.1:3000/", "link-local"),
+        ("http://[fd00::1]:3000/", "ULA"),
+        ("http://[fe80::1]:3000/", "link-local"),
+        ("http://100.64.0.1:3000/", "CGN"),
+        ("http://0.0.0.0:3000/", "0.0.0.0/8"),
+        ("http://[::ffff:169.254.169.254]:3000/", "cloud metadata"),
+        ("http://[::ffff:10.0.0.1]:3000/", "RFC 1918"),
+    ] {
+        let reason = denied(&policy, url);
+        assert!(
+            reason.contains(want),
+            "{url} was denied for the wrong reason — expected {want:?}, got {reason:?}. \
+             A loopback grant must never be spendable on this category."
+        );
+    }
+}
+
+/// `0.0.0.0` routes to the local host on many stacks, so it is the obvious
+/// way to spend a loopback grant on a host the grant never named. It is not a
+/// loopback address and must keep its own refusal.
+#[test]
+fn grant_does_not_reach_the_unspecified_address() {
+    let reason = denied(&granted_policy(), "http://0.0.0.0:3000/");
+    assert!(
+        !reason.contains("loopback capability"),
+        "0.0.0.0 must not even be evaluated against the loopback grant: {reason}"
+    );
+}
+
+/// The legacy IPv4 encodings exist to smuggle 127.0.0.1 past filters, so the
+/// obvious expectation is that a grant must not honour them. Measured, that
+/// expectation is unreachable: `Url::parse` canonicalizes every one of these
+/// spellings to `127.0.0.1` before `evaluate` ever reads the host, so the
+/// policy is judging the literal address the request will reach — which is the
+/// address and port the operator granted.
+///
+/// This test pins that as the CONTRACT rather than quietly accepting it. What
+/// matters for security is not the spelling but the destination: obfuscation
+/// must not be able to move the request to a host the grant does not cover.
+/// The two assertions below are therefore (a) these all denote granted
+/// loopback and are admitted, and (b) the same spellings at an UNGRANTED port
+/// are still refused, proving the canonicalized address is really being
+/// matched against the grant rather than short-circuited by it.
+#[test]
+fn obfuscated_loopback_spellings_are_judged_as_the_address_they_denote() {
+    let policy = granted_policy();
+    for url in [
+        "http://0177.0.0.1:3000/", // octal
+        "http://0x7f.0.0.1:3000/", // hex octet
+        "http://2130706433:3000/", // 32-bit decimal
+        "http://0x7f000001:3000/", // 32-bit hex
+        "http://127.0x1:3000/",    // two-octet form
+        "http://127.1:3000/",      // short form
+    ] {
+        let parsed = url::Url::parse(url).unwrap();
+        assert_eq!(
+            parsed.host_str(),
+            Some("127.0.0.1"),
+            "{url}: this test's premise is that the URL parser canonicalizes the host \
+             before the policy sees it; it no longer does, so the grant is now judging an \
+             obfuscated spelling and this file must be rewritten"
+        );
+        policy.check_url(url).unwrap_or_else(|e| {
+            panic!("{url} denotes granted 127.0.0.1:3000 and must be admitted: {e}")
+        });
+    }
+    // (b) The destination, not the spelling, is what the grant is matched on.
+    for url in [
+        "http://0177.0.0.1:9377/",
+        "http://2130706433:9377/",
+        "http://127.1:9377/",
+    ] {
+        let reason = denied(&policy, url);
+        assert!(
+            reason.contains("9377"),
+            "{url} resolves to a granted host on an UNGRANTED port and must be refused \
+             on the port, proving the grant is really consulted: {reason}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Malformed / unknown capability data fails closed (gh#911 acceptance).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn every_malformed_grant_fails_closed() {
+    let cases: Vec<(&str, LoopbackCapability, &str)> = vec![
+        (
+            "disabled",
+            LoopbackCapability {
+                enabled: false,
+                ..grant()
+            },
+            "enabled is false",
+        ),
+        (
+            "absent version",
+            LoopbackCapability {
+                schema_version: 0,
+                ..grant()
+            },
+            "schema_version 0",
+        ),
+        (
+            "future version",
+            LoopbackCapability {
+                schema_version: LOOPBACK_CAPABILITY_VERSION + 1,
+                ..grant()
+            },
+            "is not the supported version",
+        ),
+        (
+            "empty scope",
+            LoopbackCapability {
+                session_scope: String::new(),
+                ..grant()
+            },
+            "session_scope is empty",
+        ),
+        (
+            "whitespace scope",
+            LoopbackCapability {
+                session_scope: "   ".into(),
+                ..grant()
+            },
+            "session_scope is empty",
+        ),
+        (
+            "no ports",
+            LoopbackCapability {
+                ports: vec![],
+                ..grant()
+            },
+            "ports is empty",
+        ),
+    ];
+    for (label, cap, want) in cases {
+        let policy = BrowserPolicy::new(PolicyAction::Allow, vec!["localhost".into()], vec![])
+            .with_loopback(cap);
+        let reason = denied(&policy, "http://localhost:3000/");
+        assert!(
+            reason.contains(want),
+            "{label}: expected the refusal to name {want:?}, got {reason:?}"
+        );
+    }
+}
+
+#[test]
+fn default_capability_grants_nothing() {
+    let cap = LoopbackCapability::default();
+    assert!(!cap.enabled);
+    assert!(cap.authorize(Some(3000)).is_err());
+    // And the policy's own default must carry that no-authority value.
+    assert_eq!(
+        BrowserPolicy::default().loopback,
+        LoopbackCapability::default()
+    );
+}
+
+/// Deserializing a grant from data that omits fields must not synthesize
+/// authority — this is the "unknown producer data" path.
+#[test]
+fn deserialized_partial_grant_fails_closed() {
+    let cap: LoopbackCapability = serde_json::from_str(r#"{"enabled":true}"#).unwrap();
+    assert!(
+        cap.authorize(Some(3000)).is_err(),
+        "a grant that only says enabled=true must not authorize anything"
+    );
+    let cap: LoopbackCapability =
+        serde_json::from_str(r#"{"enabled":true,"schema_version":1,"session_scope":"s"}"#).unwrap();
+    assert!(
+        cap.authorize(Some(3000)).is_err(),
+        "a grant with no ports must not authorize anything"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Interaction with the rest of the gate.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn denied_origins_beats_an_authorized_grant() {
+    let policy = BrowserPolicy::new(PolicyAction::Deny, vec![], vec!["localhost".into()])
+        .with_loopback(grant());
+    let reason = denied(&policy, "http://localhost:3000/");
+    assert!(
+        reason.contains("denied pattern"),
+        "the deny list must be unconditional: {reason}"
+    );
+}
+
+#[test]
+fn grant_does_not_widen_anything_off_loopback() {
+    let policy = granted_policy();
+    // Public origin, granted port, fail-closed default: still denied by the
+    // default action. The grant is not a general allow.
+    let reason = denied(&policy, "http://example.com:3000/");
+    assert!(
+        reason.contains("default_action=Deny"),
+        "a loopback grant must not affect public origins: {reason}"
+    );
+}
+
+#[test]
+fn non_http_schemes_still_refused_on_granted_loopback() {
+    let policy = granted_policy();
+    for url in [
+        "file://localhost/etc/passwd",
+        "ftp://localhost:3000/",
+        "ws://localhost:3000/",
+    ] {
+        let reason = denied(&policy, url);
+        assert!(
+            reason.contains("not in allow list"),
+            "{url} must be refused at the scheme gate, before the grant: {reason}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Rebinding: the two ways a grant could be turned into a public-name attack.
+// ---------------------------------------------------------------------------
+
+/// A public hostname that resolves to 127.0.0.1 is a rebinding attack whether
+/// or not a loopback grant exists. The grant authorizes loopback NAMES the
+/// operator wrote, never arbitrary names that land there.
+#[test]
+fn grant_does_not_relax_the_resolved_ip_check() {
+    let policy = granted_policy();
+    let outcome =
+        policy.check_resolved_host("evil.example", IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)));
+    match outcome {
+        PolicyOutcome::Deny { reason } => assert!(
+            reason.contains("blocked IP"),
+            "expected a resolved-IP refusal: {reason}"
+        ),
+        other => panic!(
+            "a public hostname resolving to loopback was accepted with a loopback grant \
+             in hand: {other:?}"
+        ),
+    }
+}
+
+/// The redirect hop policy is built from a cloned snapshot. If the grant is
+/// not carried into it the snapshot silently disagrees with the parent gate —
+/// so assert the snapshot decides identically on all three interesting URLs.
+#[test]
+fn redirect_snapshot_carries_the_grant_verbatim() {
+    let policy = granted_policy();
+    // `reqwest_redirect_policy` consumes the snapshot opaquely, so drive the
+    // observable equivalent: a policy round-tripped through serde must decide
+    // the same way. This is the same field-copy the snapshot performs.
+    let json = serde_json::to_string(&policy).unwrap();
+    let restored: BrowserPolicy = serde_json::from_str(&json).unwrap();
+    assert_eq!(
+        restored.loopback, policy.loopback,
+        "the grant did not survive a policy copy; the redirect-hop snapshot \
+         performs the same copy and would silently disagree with the parent gate"
+    );
+    for url in [
+        "http://localhost:3000/",
+        "http://localhost:9377/",
+        "http://169.254.169.254:3000/",
+    ] {
+        assert_eq!(
+            matches!(restored.evaluate(url), PolicyOutcome::Allow),
+            matches!(policy.evaluate(url), PolicyOutcome::Allow),
+            "copied policy disagrees with the original on {url}"
+        );
+    }
+    // And a redirect policy can actually be built from a granted policy.
+    let _ = policy.reqwest_redirect_policy();
+}
+
+// ---------------------------------------------------------------------------
+// The scope is reported, so a consumer can say which target authorized it.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn authorize_reports_the_scope_that_granted_access() {
+    assert_eq!(grant().authorize(Some(3000)).unwrap(), "local-dev");
+    // Trimmed, so a scope written with stray whitespace reports cleanly
+    // rather than being reported with quotes-shifting padding.
+    let padded = LoopbackCapability {
+        session_scope: "  chat-42  ".into(),
+        ..grant()
+    };
+    assert_eq!(padded.authorize(Some(3000)).unwrap(), "chat-42");
+}
+
+#[test]
+fn authorize_refuses_a_url_with_no_resolvable_port() {
+    // Belt-and-braces: `port_or_known_default` returns None for schemes with
+    // no default. The gate must refuse rather than treat None as a wildcard.
+    assert!(grant().authorize(None).is_err());
+}

--- a/crates/wcore-config/src/browser.rs
+++ b/crates/wcore-config/src/browser.rs
@@ -28,6 +28,31 @@ pub struct StealthConfig {
     pub allow_cloud_fallback: bool,
 }
 
+/// Operator-facing shape of the gh#911 loopback capability grant.
+///
+/// Mirrors `wcore_browser::policy::LoopbackCapability`. Every field defaults
+/// to the no-authority value; `wcore_browser` re-validates all of them, so a
+/// grant that is absent, version-mismatched, unscoped or portless leaves
+/// loopback hard-blocked.
+///
+/// On disk (note the section — `[browser.policy]`, not `[browser]`):
+///
+/// ```toml
+/// [browser.policy.loopback]
+/// enabled = true
+/// schema_version = 1
+/// session_scope = "my-local-dev"
+/// ports = [3000]
+/// ```
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct BrowserLoopbackConfig {
+    pub enabled: bool,
+    pub schema_version: u32,
+    pub session_scope: String,
+    pub ports: Vec<u16>,
+}
+
 /// Policy mirror — `wcore_browser::BrowserPolicy` accepts these fields too.
 ///
 /// The `default_action` default is `"deny"` (fail-closed) since v0.2.1
@@ -41,6 +66,8 @@ pub struct BrowserPolicyConfig {
     pub default_action: String,
     pub allowed_origins: Vec<String>,
     pub denied_origins: Vec<String>,
+    /// Recoverable local-only loopback grant (gh#911). Off by default.
+    pub loopback: BrowserLoopbackConfig,
 }
 
 impl Default for BrowserPolicyConfig {
@@ -50,6 +77,7 @@ impl Default for BrowserPolicyConfig {
             default_action: "deny".into(),
             allowed_origins: Vec::new(),
             denied_origins: Vec::new(),
+            loopback: BrowserLoopbackConfig::default(),
         }
     }
 }
@@ -85,6 +113,7 @@ mod tests {
                 default_action: "ask".into(),
                 allowed_origins: vec!["*.example.com".into()],
                 denied_origins: vec![],
+                loopback: BrowserLoopbackConfig::default(),
             },
             download_dir: Some("/tmp/downloads".into()),
             persist_profile: false,
@@ -94,6 +123,29 @@ mod tests {
         assert_eq!(parsed.stealth.preferred_provider, BrowserProvider::Camoufox);
         assert_eq!(parsed.policy.default_action, "ask");
         assert!(parsed.stealth.allow_cloud_fallback);
+    }
+
+    /// The grant has to survive the real TOML round trip under the section
+    /// the loader reads, and it has to be OFF when nobody wrote it.
+    #[test]
+    fn loopback_grant_round_trips_and_defaults_off() {
+        let cfg: BrowserConfig = toml::from_str("").unwrap();
+        assert!(!cfg.policy.loopback.enabled);
+        assert_eq!(cfg.policy.loopback.schema_version, 0);
+        assert!(cfg.policy.loopback.ports.is_empty());
+
+        let cfg: BrowserConfig = toml::from_str(
+            "[policy.loopback]\n\
+             enabled = true\n\
+             schema_version = 1\n\
+             session_scope = \"dev\"\n\
+             ports = [3000, 5173]\n",
+        )
+        .unwrap();
+        assert!(cfg.policy.loopback.enabled);
+        assert_eq!(cfg.policy.loopback.schema_version, 1);
+        assert_eq!(cfg.policy.loopback.session_scope, "dev");
+        assert_eq!(cfg.policy.loopback.ports, vec![3000, 5173]);
     }
 
     #[test]

--- a/crates/wcore-plugin-api/src/browser_spec.rs
+++ b/crates/wcore-plugin-api/src/browser_spec.rs
@@ -35,6 +35,22 @@ pub enum BrowserProviderHint {
     Browserbase,
 }
 
+/// Mirror of `wcore_browser::policy::LoopbackCapability` (gh#911).
+///
+/// Lives here rather than in `wcore-browser` for the same reason the rest of
+/// this file does: plugin shells may not depend on `wcore-browser` (audit
+/// F2). `wcore_agent`'s `HostBrowserRegistrar` translates it, and
+/// `wcore_browser` re-validates every field, so this type carries data and
+/// grants nothing on its own.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(default)]
+pub struct BrowserLoopbackSpec {
+    pub enabled: bool,
+    pub schema_version: u32,
+    pub session_scope: String,
+    pub ports: Vec<u16>,
+}
+
 /// Serde-friendly mirror of `wcore_browser::BrowserPolicy`.
 ///
 /// `default_action` defaults to `"deny"` (fail-closed) since v0.2.1 —
@@ -48,6 +64,8 @@ pub struct BrowserPolicySpec {
     pub default_action: String,
     pub allowed_origins: Vec<String>,
     pub denied_origins: Vec<String>,
+    /// Recoverable local-only loopback grant (gh#911). Off by default.
+    pub loopback: BrowserLoopbackSpec,
 }
 
 impl Default for BrowserPolicySpec {
@@ -57,6 +75,7 @@ impl Default for BrowserPolicySpec {
             default_action: "deny".into(),
             allowed_origins: Vec::new(),
             denied_origins: Vec::new(),
+            loopback: BrowserLoopbackSpec::default(),
         }
     }
 }
@@ -86,6 +105,12 @@ mod tests {
                 default_action: "deny".into(),
                 allowed_origins: vec!["*.example.com".into()],
                 denied_origins: vec!["*.evil.example".into()],
+                loopback: BrowserLoopbackSpec {
+                    enabled: true,
+                    schema_version: 1,
+                    session_scope: "dev".into(),
+                    ports: vec![3000],
+                },
             },
             allow_cloud: false,
         };
@@ -94,6 +119,18 @@ mod tests {
         assert_eq!(parsed.tool_namespace, "Browser");
         assert_eq!(parsed.preferred_provider, BrowserProviderHint::Camoufox);
         assert_eq!(parsed.policy.allowed_origins.len(), 1);
+        // The grant must survive the wire hop the host reads it back off.
+        assert_eq!(parsed.policy.loopback.ports, vec![3000]);
+        assert_eq!(parsed.policy.loopback.session_scope, "dev");
+    }
+
+    /// A spec written by an older plugin has no `loopback` key at all. It must
+    /// deserialize to the no-authority value, never to an enabled grant.
+    #[test]
+    fn absent_loopback_key_deserializes_to_no_authority() {
+        let parsed: BrowserPolicySpec = serde_json::from_str("{}").unwrap();
+        assert_eq!(parsed.loopback, BrowserLoopbackSpec::default());
+        assert!(!parsed.loopback.enabled);
     }
 
     #[test]

--- a/crates/wcore-plugin-api/tests/browser_spec_mirror_test.rs
+++ b/crates/wcore-plugin-api/tests/browser_spec_mirror_test.rs
@@ -20,6 +20,7 @@ fn spec_fields_present_for_constructor_args() {
             default_action: "ask".into(),
             allowed_origins: vec!["*.example.com".into()],
             denied_origins: vec![],
+            loopback: Default::default(),
         },
         allow_cloud: true,
     };


### PR DESCRIPTION
Three browser defects that share one shape: **the product told the operator something that was not true of the path it actually runs.**

## 1. A security claim with no enforcement behind it

`check_resolved_host` has **no production caller** — every call site is inside `#[cfg(test)]` or under `tests/`. Positive control: `evaluate()` has four real ones (`policy.rs:279`, `policy.rs:456`, `camoufox.rs:302`, `camoufox.rs:548`), so the query that found zero is not simply broken.

The refusal hint nonetheless told operators that a public hostname resolving to `127.0.0.1` is refused as DNS rebinding. On the executed path **nothing re-checks the host after DNS resolution.** This commit states the real boundary instead and pins it with a test, so the false claim cannot come back without wiring the guard.

I have filed the missing enforcement separately rather than bolting it on here — wiring a resolved-host check into the live path is a behaviour change that deserves its own review, and shipping the honest text should not wait for it.

## 2. Denials that led nowhere

The fail-closed denial said "add allowed domains to your `config.toml`" and named no location. In a desktop session the working directory is a throwaway `wcore-temp-*` workspace, so that sentence leads to a bare `config.toml` in the cwd, which **no layer reads** (global lives under the app config dir; project is `.wayland-core.toml`). The reporter edited four such files, got no diagnostic, and reasonably concluded browser policy had its own resolver. The message now names the paths the loader itself resolves.

A loopback denial carried no remediation at all.

## 3. The branch that chose between them was ungraded

The remediation bodies were covered; the branch that *selects* between them was not — so nothing stopped a loopback denial from being answered with allow-list advice, or an unfixable metadata denial from being handed remediation it cannot act on. That is the exact shape of the original report. The selection is extracted into `denial_message` and all three classes plus the pass-through arm are graded. Behaviour is unchanged: the fallback still formats the whole error, so the URL stays in the message.

Also adds the recoverable local-only loopback capability from the core contract issue.

Refs FerroxLabs/wayland#900, FerroxLabs/wayland#826, FerroxLabs/wayland#911, FerroxLabs/wayland#899
