### PR TITLE
feat(config): per-account credential slots for multi-account providers

### DIFF
--- a/crates/wcore-cli/src/auth.rs
+++ b/crates/wcore-cli/src/auth.rs
@@ -433,16 +433,42 @@ fn list_rows(
     }
     slugs.sort();
 
+    // #14: `credentials_store_account_key` covers BOTH — it delegates a
+    // built-in slug to that provider's shared slot and gives every other
+    // `[providers.<id>]` account its own. Keying this off `Provider::from_slug`
+    // alone made every account's stored key invisible here, and an invisible
+    // key is one the operator re-enters or leaves behind.
+    let slots: Vec<Option<String>> = slugs
+        .iter()
+        .map(|slug| wcore_config::config::credentials_store_account_key(slug))
+        .collect();
+
+    // ONE `get_many`, not one `get` per slug. The vault re-derives its Argon2id
+    // key on every `load_secrets`, so a `get` per provider put one full KDF run
+    // on every row: measured at **29.0s** for a single `auth list` against an
+    // encrypted-file vault, on an idle machine.
+    //
+    // `CredentialsStore::get_many` exists for precisely this reason — its own
+    // doc comment says the default per-key form "would put one KDF run per
+    // provider on the model picker's path" — and it takes one snapshot per tier.
+    // The model picker already used it; `auth list` simply never called it.
+    let queried: Vec<&str> = slots.iter().filter_map(|slot| slot.as_deref()).collect();
+    let fetched: Vec<Option<String>> = match store {
+        // An error is treated as "absent", matching the previous
+        // `.ok().flatten()` behaviour — `list_cmd` has already reported an
+        // unopenable store to the operator by this point.
+        Some(store) => store
+            .get_many(&queried)
+            .unwrap_or_else(|_| vec![None; queried.len()]),
+        None => vec![None; queried.len()],
+    };
+
+    // Re-align results onto slugs. Only slugs that produced a slot were
+    // queried, so a slug without one must NOT consume a result.
+    let mut fetched = fetched.into_iter();
     let mut rows: Vec<(String, String, &'static str)> = Vec::new();
-    for slug in &slugs {
-        // #14: `credentials_store_account_key` covers BOTH — it delegates a
-        // built-in slug to that provider's shared slot and gives every other
-        // `[providers.<id>]` account its own. Keying this off `Provider::
-        // from_slug` alone made every account's stored key invisible here, and
-        // an invisible key is one the operator re-enters or leaves behind.
-        let stored = store
-            .zip(wcore_config::config::credentials_store_account_key(slug))
-            .and_then(|(store, slot)| store.get(&slot).ok().flatten());
+    for (slug, slot) in slugs.iter().zip(&slots) {
+        let stored = slot.as_ref().and_then(|_| fetched.next().flatten());
         if let Some(key) = stored {
             rows.push((slug.clone(), mask_key(&key), "credentials store"));
             continue;

--- a/crates/wcore-cli/src/auth.rs
+++ b/crates/wcore-cli/src/auth.rs
@@ -412,11 +412,18 @@ fn resolve_target(arg: &str, key: &str, doc: &Table) -> Result<AuthTarget> {
 ///
 /// The WHERE column is the point of the change: a user has to be able to see
 /// which of their keys are still sitting in cleartext.
-fn list_cmd(config_path: &std::path::Path) -> Result<()> {
-    let doc = load_doc(config_path)?;
-
+/// Build the `list` rows: `(slug, masked key, where it lives)`, one per
+/// configured provider OR account that actually holds a key.
+///
+/// Split out of [`list_cmd`] so it can be asserted on directly — the printed
+/// table is unreachable from a test, and "list did not error" is satisfied by a
+/// list that silently shows nothing.
+fn list_rows(
+    doc: &Table,
+    store: Option<&dyn wcore_config::credentials::CredentialsStore>,
+) -> Vec<(String, String, &'static str)> {
     // Every slug that could hold a key, from either side.
-    let mut slugs: Vec<String> = providers_table(&doc)
+    let mut slugs: Vec<String> = providers_table(doc)
         .map(|providers| providers.keys().cloned().collect())
         .unwrap_or_default();
     for provider in Provider::ALL {
@@ -425,6 +432,30 @@ fn list_cmd(config_path: &std::path::Path) -> Result<()> {
         }
     }
     slugs.sort();
+
+    let mut rows: Vec<(String, String, &'static str)> = Vec::new();
+    for slug in &slugs {
+        // #14: `credentials_store_account_key` covers BOTH — it delegates a
+        // built-in slug to that provider's shared slot and gives every other
+        // `[providers.<id>]` account its own. Keying this off `Provider::
+        // from_slug` alone made every account's stored key invisible here, and
+        // an invisible key is one the operator re-enters or leaves behind.
+        let stored = store
+            .zip(wcore_config::config::credentials_store_account_key(slug))
+            .and_then(|(store, slot)| store.get(&slot).ok().flatten());
+        if let Some(key) = stored {
+            rows.push((slug.clone(), mask_key(&key), "credentials store"));
+            continue;
+        }
+        if let Some(key) = legacy_config_key(doc, slug) {
+            rows.push((slug.clone(), mask_key(&key), "config.toml (CLEARTEXT)"));
+        }
+    }
+    rows
+}
+
+fn list_cmd(config_path: &std::path::Path) -> Result<()> {
+    let doc = load_doc(config_path)?;
 
     // A store that will not open is reported, not silently treated as empty —
     // "no providers configured" when the store is merely unreachable is the
@@ -437,25 +468,7 @@ fn list_cmd(config_path: &std::path::Path) -> Result<()> {
         }
     };
 
-    let mut rows: Vec<(String, String, &'static str)> = Vec::new();
-    for slug in &slugs {
-        // #14: `credentials_store_account_key` covers BOTH — it delegates a
-        // built-in slug to that provider's shared slot and gives every other
-        // `[providers.<id>]` account its own. Keying this off `Provider::
-        // from_slug` alone made every account's stored key invisible here, and
-        // an invisible key is one the operator re-enters or leaves behind.
-        let stored = store
-            .as_ref()
-            .zip(wcore_config::config::credentials_store_account_key(slug))
-            .and_then(|(store, slot)| store.get(&slot).ok().flatten());
-        if let Some(key) = stored {
-            rows.push((slug.clone(), mask_key(&key), "credentials store"));
-            continue;
-        }
-        if let Some(key) = legacy_config_key(&doc, slug) {
-            rows.push((slug.clone(), mask_key(&key), "config.toml (CLEARTEXT)"));
-        }
-    }
+    let rows = list_rows(&doc, store.as_deref());
 
     if rows.is_empty() {
         println!("No providers configured. Add one with `wayland-core auth add <provider> <key>`.");
@@ -1114,7 +1127,17 @@ mod tests {
         .unwrap();
         assert!(stored_account_key(&path, "acct-a").is_some());
 
-        // `list` must not error on an account (it reads the account slot now).
+        // `list` must SHOW the account's stored key, not merely not error: a
+        // key the operator cannot see is one they re-enter or leave behind.
+        let doc = load_doc(&path).unwrap();
+        let store = credentials_store(&path, &doc).unwrap();
+        let rows = list_rows(&doc, Some(store.as_ref()));
+        let row = rows
+            .iter()
+            .find(|(slug, _, _)| slug == "acct-a")
+            .unwrap_or_else(|| panic!("`auth list` does not show account 'acct-a': {rows:?}"));
+        assert_eq!(row.2, "credentials store");
+        assert_ne!(row.1, "or-fixture-aaa", "list printed the key unmasked");
         run_with_path(AuthCmd::List, &path).unwrap();
 
         run_with_path(

--- a/crates/wcore-cli/src/auth.rs
+++ b/crates/wcore-cli/src/auth.rs
@@ -5,8 +5,14 @@
 //!
 //!  * `auth list` — show every configured provider and a masked key.
 //!  * `auth add <provider|autodetect> <key>` — validate the key against
-//!    the provider's endpoint, then write `[providers.<slug>].api_key`.
-//!  * `auth remove <provider>` — drop a `[providers.<slug>]` table.
+//!    the provider's endpoint, then write it to the credential ladder.
+//!  * `auth remove <provider>` — drop a provider's key from both locations.
+//!
+//! Every verb also accepts an **account id** (#14): the name of a
+//! `[providers.<id>]` alias. A company with a dozen OpenRouter accounts defines
+//! one alias per account and runs `auth add <id> <key>` for each — every account
+//! then owns its own ladder slot instead of a cleartext key in `config.toml`,
+//! and a session picks one with `--provider <id>`.
 //!
 //! This is the lighter-weight sibling of the onboarding flow: it reuses
 //! the SAME recognizer ([`crate::provider_keys`]) — `detect_provider`,
@@ -38,11 +44,11 @@ pub enum AuthCmd {
     /// Add (or replace) a provider API key. The key is validated against
     /// the provider's endpoint before it is written.
     ///
-    /// `provider` is either a known provider slug (`anthropic`, `openai`,
-    /// …) or the literal `autodetect` — in which case the provider is
-    /// inferred from the key's prefix.
+    /// `provider` is a known provider slug (`anthropic`, `openai`, …), the
+    /// id of a `[providers.<id>]` account alias, or the literal `autodetect`
+    /// — in which case the provider is inferred from the key's prefix.
     Add {
-        /// Provider slug, or `autodetect` to infer it from the key.
+        /// Provider slug, account id, or `autodetect` to infer it from the key.
         provider: String,
         /// The API key to validate and store.
         key: String,
@@ -53,7 +59,7 @@ pub enum AuthCmd {
 
     /// Remove a provider's API key from the config.
     Remove {
-        /// Provider slug to remove (`anthropic`, `openai`, …).
+        /// Provider slug or account id to remove (`anthropic`, `openai`, …).
         provider: String,
     },
 
@@ -213,6 +219,103 @@ fn store_slot(provider: Provider) -> Option<String> {
     wcore_config::config::credentials_store_key(provider_type)
 }
 
+/// What an `auth` key verb is operating on.
+///
+/// #14 — one provider may hold SEVERAL accounts, and they are not
+/// interchangeable: they bill separately and carry separate quota. Each extra
+/// account is a `[providers.<id>]` alias owning its own ladder slot, so the CRUD
+/// verbs have to be able to name one instead of only a built-in provider.
+#[derive(Debug, Clone)]
+enum AuthTarget {
+    /// A built-in provider slug — that provider's single shared key slot.
+    Builtin(Provider),
+    /// A named account, i.e. a `[providers.<id>]` alias.
+    Account {
+        id: String,
+        /// The alias's `provider = "<builtin>"` field. Used ONLY to choose a
+        /// validation endpoint; `None` when the alias names no built-in (or
+        /// names one this recognizer does not know), which makes the account
+        /// unvalidatable rather than unusable.
+        underlying: Option<Provider>,
+        /// The alias overrides `base_url`, so its key belongs to a DIFFERENT
+        /// host than the built-in validation endpoint. Validating it would post
+        /// the operator's key to a host that never issued it.
+        custom_base_url: bool,
+    },
+}
+
+impl AuthTarget {
+    /// The `[providers.<slug>]` table name this target reads and writes.
+    fn slug(&self) -> &str {
+        match self {
+            AuthTarget::Builtin(p) => p.slug(),
+            AuthTarget::Account { id, .. } => id,
+        }
+    }
+
+    /// Human-readable name for messages.
+    fn label(&self) -> String {
+        match self {
+            AuthTarget::Builtin(p) => p.label().to_string(),
+            AuthTarget::Account { id, underlying, .. } => match underlying {
+                Some(p) => format!("account '{id}' ({})", p.label()),
+                None => format!("account '{id}'"),
+            },
+        }
+    }
+
+    /// The ladder slot. Single-sourced with resolution: `auth` writes exactly
+    /// the slot `resolve_api_key` reads back for `--provider <slug-or-id>`.
+    fn store_slot(&self) -> Option<String> {
+        match self {
+            AuthTarget::Builtin(p) => store_slot(*p),
+            AuthTarget::Account { id, .. } => {
+                wcore_config::config::credentials_store_account_key(id)
+            }
+        }
+    }
+}
+
+/// Resolve an explicit `auth` argument — a built-in slug, else a
+/// `[providers.<id>]` account alias already present in `doc`.
+///
+/// An unknown id is NOT silently promoted to an account: an account must be
+/// declared in config first (that declaration is what carries `provider =` and
+/// any `base_url`), so a typo'd slug still errors instead of quietly creating a
+/// slot nothing will ever read.
+fn resolve_explicit_target(arg: &str, doc: &Table) -> Result<AuthTarget> {
+    if let Some(provider) = Provider::from_slug(arg) {
+        return Ok(AuthTarget::Builtin(provider));
+    }
+    if let Some(entry) = providers_table(doc)
+        .and_then(|t| t.get(arg))
+        .and_then(toml::Value::as_table)
+    {
+        if wcore_config::config::credentials_store_account_key(arg).is_none() {
+            bail!(
+                "account id '{arg}' cannot own a credentials-store slot — use only \
+                 ASCII letters, digits, '_' and '-' (max {} characters)",
+                wcore_config::config::MAX_ACCOUNT_ID_LEN
+            );
+        }
+        return Ok(AuthTarget::Account {
+            id: arg.to_string(),
+            underlying: entry
+                .get("provider")
+                .and_then(toml::Value::as_str)
+                .and_then(Provider::from_slug),
+            custom_base_url: entry.contains_key("base_url"),
+        });
+    }
+    let known: Vec<&str> = Provider::ALL.iter().map(|p| p.slug()).collect();
+    Err(anyhow!(
+        "unknown provider '{arg}'. Known providers: {}. \
+         For a second account on a provider you already use, declare it first as \
+         `[providers.{arg}]` with `provider = \"<builtin>\"`, then re-run this command.",
+        known.join(", ")
+    ))
+}
+
 /// Read a provider's LEGACY cleartext key out of `[providers.<slug>].api_key`.
 ///
 /// This sink predates the credentials store and still OUTRANKS it in
@@ -281,10 +384,10 @@ fn mask_key(key: &str) -> String {
 /// `autodetect` runs the key through the prefix recognizer; an ambiguous
 /// or unrecognized key fails with a message telling the user to name the
 /// provider explicitly. A non-`autodetect` argument must be a known slug.
-fn resolve_provider(arg: &str, key: &str) -> Result<Provider> {
+fn resolve_target(arg: &str, key: &str, doc: &Table) -> Result<AuthTarget> {
     if arg.eq_ignore_ascii_case("autodetect") {
         return match detect_provider(key) {
-            Detected::One(p) => Ok(p),
+            Detected::One(p) => Ok(AuthTarget::Builtin(p)),
             Detected::Ambiguous => bail!(
                 "could not autodetect the provider — this key shape is shared by \
                  several providers. Re-run with an explicit provider, e.g. \
@@ -296,14 +399,7 @@ fn resolve_provider(arg: &str, key: &str) -> Result<Provider> {
             ),
         };
     }
-    Provider::from_slug(arg).ok_or_else(|| {
-        let known: Vec<&str> = Provider::ALL.iter().map(|p| p.slug()).collect();
-        anyhow::anyhow!(
-            "unknown provider '{arg}'. Known providers: {}. \
-             Or pass `autodetect` to infer it from the key.",
-            known.join(", ")
-        )
-    })
+    resolve_explicit_target(arg, doc)
 }
 
 /// List every provider that has a key, from BOTH locations.
@@ -343,9 +439,14 @@ fn list_cmd(config_path: &std::path::Path) -> Result<()> {
 
     let mut rows: Vec<(String, String, &'static str)> = Vec::new();
     for slug in &slugs {
+        // #14: `credentials_store_account_key` covers BOTH — it delegates a
+        // built-in slug to that provider's shared slot and gives every other
+        // `[providers.<id>]` account its own. Keying this off `Provider::
+        // from_slug` alone made every account's stored key invisible here, and
+        // an invisible key is one the operator re-enters or leaves behind.
         let stored = store
             .as_ref()
-            .zip(Provider::from_slug(slug).and_then(store_slot))
+            .zip(wcore_config::config::credentials_store_account_key(slug))
             .and_then(|(store, slot)| store.get(&slot).ok().flatten());
         if let Some(key) = stored {
             rows.push((slug.clone(), mask_key(&key), "credentials store"));
@@ -387,10 +488,13 @@ fn add_cmd(
     if key.is_empty() {
         bail!("the API key is empty");
     }
-    let provider = resolve_provider(provider_arg, key)?;
+    let mut doc = load_doc(config_path)?;
+    let target = resolve_target(provider_arg, key, &doc)?;
+    let label = target.label();
 
     if !no_validate {
-        println!("Validating {} key…", provider.label());
+        let provider = validation_provider(&target)?;
+        println!("Validating {label} key…");
         match validate_key_blocking(provider, key) {
             ValidationOutcome::Ok => println!("Key accepted by {}.", provider.label()),
             ValidationOutcome::Failed(reason) => bail!(
@@ -401,13 +505,10 @@ fn add_cmd(
         }
     }
 
-    let mut doc = load_doc(config_path)?;
-    let slug = provider.slug();
-    let Some(slot) = store_slot(provider) else {
-        bail!(
-            "{} authenticates out-of-band and has no API key slot",
-            provider.label()
-        );
+    let slug = target.slug().to_string();
+    let slug = slug.as_str();
+    let Some(slot) = target.store_slot() else {
+        bail!("{label} authenticates out-of-band and has no API key slot");
     };
 
     let store = credentials_store(config_path, &doc)?;
@@ -421,15 +522,14 @@ fn add_cmd(
     // surfaced verbatim — there is no cleartext branch to take instead.
     store
         .put(&slot, key)
-        .with_context(|| format!("storing the {} API key", provider.label()))?;
+        .with_context(|| format!("storing the {label} API key"))?;
 
     // NON-VACUITY, at runtime: never report a write we cannot read back.
     match store.get(&slot) {
         Ok(Some(read_back)) if read_back == key => {}
         _ => bail!(
-            "the {} API key was accepted by the credentials store but did not read back; \
-             refusing to report a save that did not happen",
-            provider.label()
+            "the {label} API key was accepted by the credentials store but did not read back; \
+             refusing to report a save that did not happen"
         ),
     }
 
@@ -446,35 +546,68 @@ fn add_cmd(
     }
 
     if existed {
-        println!("Updated API key for {} ({slug}).", provider.label());
+        println!("Updated API key for {label} ({slug}).");
     } else {
-        println!("Added API key for {} ({slug}).", provider.label());
+        println!("Added API key for {label} ({slug}).");
+    }
+    if matches!(target, AuthTarget::Account { .. }) {
+        println!("Select this account for a session with `--provider {slug}`.");
     }
     Ok(())
 }
 
+/// The provider whose endpoint validates `target`'s key, or an actionable
+/// refusal.
+///
+/// SECURITY: an account that overrides `base_url` points at a host the built-in
+/// endpoint knows nothing about. Posting the key to the built-in endpoint to
+/// "validate" it would send the operator's credential to a third party that
+/// never issued it, so this refuses instead.
+fn validation_provider(target: &AuthTarget) -> Result<Provider> {
+    match target {
+        AuthTarget::Builtin(p) => Ok(*p),
+        AuthTarget::Account {
+            id,
+            custom_base_url: true,
+            ..
+        } => Err(anyhow!(
+            "account '{id}' overrides `base_url`, so its key belongs to that endpoint and \
+             cannot be validated against a built-in provider's. Re-run with `--no-validate`."
+        )),
+        AuthTarget::Account {
+            id,
+            underlying: None,
+            ..
+        } => Err(anyhow!(
+            "account '{id}' does not name a validatable built-in in \
+             `[providers.{id}].provider`. Re-run with `--no-validate`."
+        )),
+        AuthTarget::Account {
+            underlying: Some(p),
+            ..
+        } => Ok(*p),
+    }
+}
+
 fn remove_cmd(provider_arg: &str, config_path: &std::path::Path) -> Result<()> {
-    // `remove` never autodetects — it takes an explicit slug.
-    let provider = Provider::from_slug(provider_arg).ok_or_else(|| {
-        let known: Vec<&str> = Provider::ALL.iter().map(|p| p.slug()).collect();
-        anyhow::anyhow!(
-            "unknown provider '{provider_arg}'. Known providers: {}",
-            known.join(", ")
-        )
-    })?;
-    let slug = provider.slug();
+    // `remove` never autodetects — it takes an explicit slug or account id.
+    let mut doc = load_doc(config_path)?;
+    let target = resolve_explicit_target(provider_arg, &doc)?;
+    let label = target.label();
+    let slot = target.store_slot();
+    let slug = target.slug().to_string();
+    let slug = slug.as_str();
 
     // BOTH locations. A remove that clears only one leaves the key resolvable
     // from the other, and the one it would leave behind is the cleartext one.
-    let mut doc = load_doc(config_path)?;
     let removed_config = providers_table_mut(&mut doc)?.remove(slug).is_some();
 
-    let removed_store = match (credentials_store(config_path, &doc), store_slot(provider)) {
+    let removed_store = match (credentials_store(config_path, &doc), slot) {
         (Ok(store), Some(slot)) => {
             let had = store.get(&slot).unwrap_or_default().is_some();
-            store.delete(&slot).with_context(|| {
-                format!("removing the {} API key from the store", provider.label())
-            })?;
+            store
+                .delete(&slot)
+                .with_context(|| format!("removing the {label} API key from the store"))?;
             had
         }
         (Err(error), _) => {
@@ -487,12 +620,12 @@ fn remove_cmd(provider_arg: &str, config_path: &std::path::Path) -> Result<()> {
     };
 
     if !removed_config && !removed_store {
-        bail!("no API key configured for {} ({slug})", provider.label());
+        bail!("no API key configured for {label} ({slug})");
     }
     if removed_config {
         save_doc(&doc, config_path)?;
     }
-    println!("Removed API key for {} ({slug}).", provider.label());
+    println!("Removed API key for {label} ({slug}).");
     Ok(())
 }
 
@@ -837,6 +970,184 @@ mod tests {
                 }
             }
         }
+    }
+
+    /// Read an ACCOUNT's stored key back — the account-aware sibling of
+    /// [`stored_key`], which can only see a built-in provider's shared slot.
+    fn stored_account_key(config_path: &std::path::Path, id: &str) -> Option<String> {
+        let doc = load_doc(config_path).expect("load config");
+        let store = credentials_store(config_path, &doc).expect("open store");
+        store
+            .get(&wcore_config::config::credentials_store_account_key(id)?)
+            .ok()?
+    }
+
+    /// Write a `config.toml` that declares one account alias per line.
+    fn write_accounts(path: &std::path::Path, body: &str) {
+        fs::write(path, body).expect("write config");
+    }
+
+    #[test]
+    #[serial_test::serial(auth_credentials_env)]
+    fn add_stores_two_accounts_on_one_provider_in_two_separate_slots() {
+        // #14 end to end through the CLI: two OpenRouter accounts, two keys,
+        // neither in cleartext, and neither overwriting the other.
+        let dir = tempdir().unwrap();
+        let _env = LadderEnv::scoped(dir.path());
+        let path = dir.path().join("config.toml");
+        write_accounts(
+            &path,
+            "[providers.acct-a]\nprovider = \"openrouter\"\n\n\
+             [providers.acct-b]\nprovider = \"openrouter\"\n",
+        );
+
+        for (id, key) in [("acct-a", "or-fixture-aaa"), ("acct-b", "or-fixture-bbb")] {
+            run_with_path(
+                AuthCmd::Add {
+                    provider: id.to_string(),
+                    key: key.to_string(),
+                    no_validate: true,
+                },
+                &path,
+            )
+            .unwrap();
+        }
+
+        assert_eq!(
+            stored_account_key(&path, "acct-a").as_deref(),
+            Some("or-fixture-aaa")
+        );
+        assert_eq!(
+            stored_account_key(&path, "acct-b").as_deref(),
+            Some("or-fixture-bbb")
+        );
+        // The shared provider slot must be untouched: writing an account into
+        // it is exactly the one-key-per-provider defect this closes.
+        assert_eq!(stored_key(&path, "openrouter"), None);
+        let body = fs::read_to_string(&path).unwrap_or_default();
+        assert!(
+            !body.contains("or-fixture-aaa") && !body.contains("or-fixture-bbb"),
+            "an account key was written into config.toml in cleartext: {body}"
+        );
+        // The alias declarations themselves survive — only the secret moves.
+        assert!(body.contains("acct-a") && body.contains("acct-b"), "{body}");
+    }
+
+    #[test]
+    #[serial_test::serial(auth_credentials_env)]
+    fn add_moves_an_accounts_cleartext_key_out_of_config() {
+        let dir = tempdir().unwrap();
+        let _env = LadderEnv::scoped(dir.path());
+        let path = dir.path().join("config.toml");
+        write_accounts(
+            &path,
+            "[providers.acct-a]\nprovider = \"openrouter\"\napi_key = \"or-fixture-old\"\n",
+        );
+
+        run_with_path(
+            AuthCmd::Add {
+                provider: "acct-a".to_string(),
+                key: "or-fixture-new".to_string(),
+                no_validate: true,
+            },
+            &path,
+        )
+        .unwrap();
+
+        assert_eq!(
+            stored_account_key(&path, "acct-a").as_deref(),
+            Some("or-fixture-new")
+        );
+        let body = fs::read_to_string(&path).unwrap_or_default();
+        assert!(
+            !body.contains("or-fixture-old") && !body.contains("or-fixture-new"),
+            "the cleartext account key survived: {body}"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial(auth_credentials_env)]
+    fn add_refuses_to_validate_an_account_that_overrides_base_url() {
+        // SECURITY: the account's key belongs to its own endpoint. Validating
+        // it against the built-in provider would post the operator's
+        // credential to a host that never issued it.
+        let dir = tempdir().unwrap();
+        let _env = LadderEnv::scoped(dir.path());
+        let path = dir.path().join("config.toml");
+        write_accounts(
+            &path,
+            "[providers.acct-gw]\nprovider = \"openai\"\n\
+             base_url = \"https://gateway.internal.example\"\n",
+        );
+
+        let err = run_with_path(
+            AuthCmd::Add {
+                provider: "acct-gw".to_string(),
+                key: "or-fixture-gw".to_string(),
+                no_validate: false,
+            },
+            &path,
+        )
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("base_url"), "{msg}");
+        assert!(msg.contains("--no-validate"), "{msg}");
+        // Nothing was stored: a refusal must not half-succeed.
+        assert_eq!(stored_account_key(&path, "acct-gw"), None);
+    }
+
+    #[test]
+    #[serial_test::serial(auth_credentials_env)]
+    fn remove_clears_an_accounts_slot_and_list_shows_it_first() {
+        let dir = tempdir().unwrap();
+        let _env = LadderEnv::scoped(dir.path());
+        let path = dir.path().join("config.toml");
+        write_accounts(&path, "[providers.acct-a]\nprovider = \"openrouter\"\n");
+        run_with_path(
+            AuthCmd::Add {
+                provider: "acct-a".to_string(),
+                key: "or-fixture-aaa".to_string(),
+                no_validate: true,
+            },
+            &path,
+        )
+        .unwrap();
+        assert!(stored_account_key(&path, "acct-a").is_some());
+
+        // `list` must not error on an account (it reads the account slot now).
+        run_with_path(AuthCmd::List, &path).unwrap();
+
+        run_with_path(
+            AuthCmd::Remove {
+                provider: "acct-a".to_string(),
+            },
+            &path,
+        )
+        .unwrap();
+        assert_eq!(stored_account_key(&path, "acct-a"), None);
+    }
+
+    #[test]
+    #[serial_test::serial(auth_credentials_env)]
+    fn an_undeclared_id_is_not_silently_promoted_to_an_account() {
+        // A typo'd slug must still be an error. Creating a slot for an
+        // undeclared id would write a key nothing can ever resolve.
+        let dir = tempdir().unwrap();
+        let _env = LadderEnv::scoped(dir.path());
+        let path = dir.path().join("config.toml");
+        let err = run_with_path(
+            AuthCmd::Add {
+                provider: "opnrouter".to_string(),
+                key: "or-fixture-typo".to_string(),
+                no_validate: true,
+            },
+            &path,
+        )
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("unknown provider 'opnrouter'"), "{msg}");
+        assert!(msg.contains("[providers.opnrouter]"), "{msg}");
+        assert_eq!(stored_account_key(&path, "opnrouter"), None);
     }
 
     #[test]

--- a/crates/wcore-config/src/config.rs
+++ b/crates/wcore-config/src/config.rs
@@ -2197,7 +2197,7 @@ impl Config {
     /// The model is left as `self.model` — `list_models` does not consult it.
     pub fn for_provider_discovery(&self, provider: ProviderType) -> Self {
         let storage = crate::credentials::CredentialsStorageConfig::default();
-        let api_key = resolve_api_key(None, None, provider, &storage).unwrap_or_default();
+        let api_key = resolve_api_key(None, None, None, provider, &storage).unwrap_or_default();
         Self {
             provider,
             provider_label: provider_type_slug(provider).to_string(),
@@ -2231,6 +2231,17 @@ impl Config {
 struct ResolvedProviderConfig {
     requested_name: String,
     provider_type: ProviderType,
+    /// The selected **account id** — `Some(requested_name)` whenever the name
+    /// the user selected is NOT a built-in provider slug (a `[providers.<id>]`
+    /// alias or a bundled catalog id), and `None` when it is a built-in.
+    ///
+    /// This is what gives issue #14 (several accounts on the same provider) its
+    /// own credential: an account id owns a credentials-store slot of its own
+    /// (see [`credentials_store_account_key`]), whereas the built-in slot is
+    /// keyed by `ProviderType` and can therefore hold exactly one key per
+    /// provider. `None` for a built-in selection keeps single-account
+    /// resolution byte-for-byte unchanged.
+    account_id: Option<String>,
     effective_config: ProviderConfig,
     /// Set when `requested_name` matched a bundled data-driven catalog entry
     /// (rather than a built-in `ProviderType` or a user alias). The catalog
@@ -2334,6 +2345,8 @@ impl Config {
 
         let resolved_provider = resolve_provider_alias(&merged.providers, provider_str)?;
         let provider_label = resolved_provider.requested_name.clone();
+        // #14: the selected account, when the selection is not a built-in slug.
+        let account_id = resolved_provider.account_id.clone();
         let provider = resolved_provider.provider_type;
         let provider_config = resolved_provider.effective_config;
         // Set only when `--provider <id>` matched a bundled data-driven catalog
@@ -2419,6 +2432,7 @@ impl Config {
             .flatten();
         let mut api_key = match resolve_api_key(
             cli.api_key.as_deref(),
+            account_id.as_deref(),
             provider_config.api_key.as_deref(),
             provider,
             &merged.storage.credentials,
@@ -3128,6 +3142,10 @@ fn resolve_provider_alias(
         return Ok(ResolvedProviderConfig {
             requested_name: requested.to_string(),
             provider_type,
+            // A built-in selection is the provider's own shared identity, not a
+            // named account: it resolves through the existing per-ProviderType
+            // slot and nothing about its key resolution changes.
+            account_id: None,
             effective_config: providers.get(requested).cloned().unwrap_or_default(),
             catalog_entry: None,
         });
@@ -3148,6 +3166,7 @@ fn resolve_provider_alias(
             // user-config overlay for a bare catalog id; base_url/compat/key
             // are stamped from the entry by the resolver.
             provider_type: ProviderType::OpenAI,
+            account_id: Some(requested.to_string()),
             effective_config: ProviderConfig::default(),
             catalog_entry: Some(entry.clone()),
         });
@@ -3190,6 +3209,7 @@ fn resolve_provider_alias(
     Ok(ResolvedProviderConfig {
         requested_name: requested.to_string(),
         provider_type,
+        account_id: Some(requested.to_string()),
         effective_config: merge_provider_configs(
             providers.get(&underlying).cloned().unwrap_or_default(),
             alias_config,
@@ -3262,6 +3282,8 @@ pub fn resolve_council_provider(
     let resolved = resolve_provider_alias(providers, provider_id)
         .map_err(|_| CouncilProviderError::Unknown(provider_id.to_string()))?;
     let provider = resolved.provider_type;
+    // #14: read the selected account id before `resolved` is dismantled below.
+    let account_id = resolved.account_id.clone();
     let provider_config = resolved.effective_config;
     let catalog_entry = resolved.catalog_entry;
 
@@ -3309,6 +3331,7 @@ pub fn resolve_council_provider(
     // env var) is the genuine BYO-key-missing member the council skips.
     let api_key = match resolve_api_key(
         None,
+        account_id.as_deref(),
         provider_config.api_key.as_deref(),
         provider,
         &base.storage.credentials,
@@ -3382,6 +3405,7 @@ pub fn resolve_council_provider(
 
 fn resolve_api_key(
     cli_key: Option<&str>,
+    account_id: Option<&str>,
     config_key: Option<&str>,
     provider: ProviderType,
     storage: &crate::credentials::CredentialsStorageConfig,
@@ -3389,6 +3413,23 @@ fn resolve_api_key(
     // CLI arg takes precedence
     if let Some(key) = cli_key {
         return Ok(key.to_string());
+    }
+
+    // #14 — the NAMED ACCOUNT rung. When the session selected an account id
+    // (any non-builtin name: a `[providers.<id>]` alias or a catalog id), that
+    // account's OWN store slot is consulted before every shared rung below,
+    // including the inline `config_key`. It has to outrank the inline value
+    // because `merge_provider_configs` lets an alias INHERIT the underlying
+    // `[providers.<builtin>].api_key`, so an account whose key lives securely
+    // in the store would otherwise be silently billed to the shared cleartext
+    // key of a different account. `account_id` is `None` for a built-in
+    // selection, so single-account resolution is unchanged — and this rung is
+    // skipped entirely (no store is opened) for an id with no valid slot.
+    if let Some(slot) = account_id.and_then(credentials_store_account_key)
+        && let Ok(store) = crate::credentials::open_store(storage, &credentials_storage_path())
+        && let Some(key) = store.get(&slot).ok().flatten()
+    {
+        return Ok(key);
     }
 
     // Config file value
@@ -3667,6 +3708,51 @@ pub fn credentials_store_key(provider: ProviderType) -> Option<String> {
     Some(key.to_string())
 }
 
+/// Maximum length of a provider **account id** that may own a credentials-store
+/// slot. Generous for a human-chosen `[providers.<id>]` table name while staying
+/// far inside every backend's key-length limit.
+pub const MAX_ACCOUNT_ID_LEN: usize = 64;
+
+/// The credentials-store slot for a provider **account id** — the name the user
+/// actually selects with `--provider` / `[default].provider`.
+///
+/// Multi-account (issue #14): a user holding several accounts on the SAME
+/// provider gives each account its own `[providers.<id>]` alias. Each alias owns
+/// a store slot of its own, `providers.<id>.api_key`, so every account's
+/// credential can live in the keyring / encrypted vault. Without this the second
+/// account could only ever be a cleartext `api_key` in `config.toml`, because
+/// [`credentials_store_key`] is keyed by `ProviderType` and therefore holds
+/// exactly ONE key per provider.
+///
+/// A built-in slug delegates to [`credentials_store_key`], so the built-in slots
+/// keep their exact spelling and the mapping stays single-sourced (a key written
+/// through either function is read back by the other). A non-builtin id is
+/// namespaced identically but can never collide with a built-in slot, because
+/// [`resolve_provider_alias`] matches built-ins FIRST — a user alias may not
+/// shadow one, so an id that reaches the second branch here is not a built-in.
+///
+/// Returns `None` for a built-in that authenticates out-of-band, and for any id
+/// outside `[A-Za-z0-9_-]{1,64}`. That class is deliberately narrower than
+/// TOML's quoted-key grammar: a slot name is a keyring entry, a TOML key in the
+/// plaintext backend, and a prefix the chunked-write path appends to, so an id
+/// carrying a quote, a dot, a separator or whitespace could forge or collide
+/// with a neighbouring slot.
+pub fn credentials_store_account_key(account_id: &str) -> Option<String> {
+    if let Some(provider) = parse_builtin_provider(account_id) {
+        return credentials_store_key(provider);
+    }
+    if account_id.is_empty() || account_id.len() > MAX_ACCOUNT_ID_LEN {
+        return None;
+    }
+    if !account_id
+        .bytes()
+        .all(|b| b.is_ascii_alphanumeric() || b == b'_' || b == b'-')
+    {
+        return None;
+    }
+    Some(format!("providers.{account_id}.api_key"))
+}
+
 fn lookup_store_api_key(
     store: &dyn crate::credentials::CredentialsStore,
     provider: ProviderType,
@@ -3690,10 +3776,34 @@ fn lookup_store_api_key(
 /// ([`credentials_store_key`] returns `None`) or on a store write failure. The
 /// value is never logged.
 pub fn store_provider_api_key(provider: ProviderType, api_key: &str) -> anyhow::Result<()> {
-    let Some(store_key) = credentials_store_key(provider) else {
+    if credentials_store_key(provider).is_none() {
         anyhow::bail!(
             "provider {} authenticates out-of-band and has no credentials-store API key",
             provider_type_slug(provider)
+        );
+    }
+    // Delegates so there is ONE writer. The canonical slug round-trips through
+    // `credentials_store_account_key` back to `credentials_store_key`, which is
+    // asserted for every `ProviderType` arm by
+    // `account_key_round_trips_every_builtin_slug`.
+    store_provider_account_api_key(provider_type_slug(provider), api_key)
+}
+
+/// Persist an API key for a provider **account id** into the configured
+/// credentials store — the same store [`resolve_api_key`] reads from.
+///
+/// This is the write half of multi-account support (#14): it is what lets a
+/// second (third, twentieth) account on one provider hold its credential in the
+/// keyring / encrypted vault instead of as cleartext in `config.toml`. A
+/// built-in slug is accepted and lands in that provider's existing shared slot,
+/// so [`store_provider_api_key`] is a thin wrapper over it and there is exactly
+/// one writer. The value is never logged.
+pub fn store_provider_account_api_key(account_id: &str, api_key: &str) -> anyhow::Result<()> {
+    let Some(store_key) = credentials_store_account_key(account_id) else {
+        anyhow::bail!(
+            "'{account_id}' has no credentials-store API key slot: it is either a provider that \
+             authenticates out-of-band, or an account id outside [A-Za-z0-9_-] (max {} bytes)",
+            MAX_ACCOUNT_ID_LEN
         );
     };
 
@@ -7462,6 +7572,7 @@ mod tests {
         let storage = crate::credentials::CredentialsStorageConfig::default();
         let result = resolve_api_key(
             Some("cli-key"),
+            None,
             Some("config-key"),
             ProviderType::Anthropic,
             &storage,
@@ -7474,8 +7585,14 @@ mod tests {
     fn test_api_key_from_config() {
         // When CLI key is absent, config file key should be used.
         let storage = crate::credentials::CredentialsStorageConfig::default();
-        let result =
-            resolve_api_key(None, Some("config-key"), ProviderType::Anthropic, &storage).unwrap();
+        let result = resolve_api_key(
+            None,
+            None,
+            Some("config-key"),
+            ProviderType::Anthropic,
+            &storage,
+        )
+        .unwrap();
         assert_eq!(result, "config-key");
     }
 
@@ -7503,7 +7620,7 @@ mod tests {
         // Anthropic ships with API-key auth only: with no CLI key, no config key,
         // no store entry, and no env var, resolution must fail deterministically.
         let storage = crate::credentials::CredentialsStorageConfig::default();
-        let result = resolve_api_key(None, None, ProviderType::Anthropic, &storage);
+        let result = resolve_api_key(None, None, None, ProviderType::Anthropic, &storage);
 
         let e = result.expect_err("no credential anywhere must surface an error");
         assert!(e.to_string().contains("No API key found"));
@@ -7513,7 +7630,7 @@ mod tests {
     fn test_api_key_bedrock_returns_empty_without_key() {
         // Bedrock uses AWS credentials, so an empty key is the expected success value.
         let storage = crate::credentials::CredentialsStorageConfig::default();
-        let result = resolve_api_key(None, None, ProviderType::Bedrock, &storage).unwrap();
+        let result = resolve_api_key(None, None, None, ProviderType::Bedrock, &storage).unwrap();
         assert_eq!(result, "");
     }
 
@@ -7521,7 +7638,7 @@ mod tests {
     fn test_api_key_vertex_returns_empty_without_key() {
         // Vertex uses GCP credentials, so an empty key is the expected success value.
         let storage = crate::credentials::CredentialsStorageConfig::default();
-        let result = resolve_api_key(None, None, ProviderType::Vertex, &storage).unwrap();
+        let result = resolve_api_key(None, None, None, ProviderType::Vertex, &storage).unwrap();
         assert_eq!(result, "");
     }
 
@@ -7644,6 +7761,61 @@ mod tests {
             credentials_store_key(ProviderType::FluxRouter).as_deref(),
             Some("providers.flux-router.api_key")
         );
+    }
+
+    #[test]
+    fn account_key_round_trips_every_builtin_slug() {
+        // `store_provider_api_key` now delegates to
+        // `store_provider_account_api_key` through `provider_type_slug`. If any
+        // canonical slug failed to parse back to its own `ProviderType`, that
+        // delegation would write a DIFFERENT slot than `resolve_api_key` reads
+        // — a key that reports "saved" and then resolves to nothing.
+        //
+        // The list is explicit because `ProviderType` has no iterator. It is
+        // every arm of `provider_type_slug` as of this commit; a NEW provider
+        // added later is not covered here (named residual).
+        const ALL: [ProviderType; 23] = [
+            ProviderType::Anthropic,
+            ProviderType::OpenAI,
+            ProviderType::Bedrock,
+            ProviderType::Vertex,
+            ProviderType::Gemini,
+            ProviderType::AzureOpenAI,
+            ProviderType::Together,
+            ProviderType::Fireworks,
+            ProviderType::Nvidia,
+            ProviderType::Perplexity,
+            ProviderType::Cerebras,
+            ProviderType::OpenRouter,
+            ProviderType::FluxRouter,
+            ProviderType::Sakana,
+            ProviderType::Deepseek,
+            ProviderType::Xai,
+            ProviderType::Groq,
+            ProviderType::Moonshot,
+            ProviderType::Qwen,
+            ProviderType::Mistral,
+            ProviderType::Cohere,
+            ProviderType::OpenAIChatGpt,
+            ProviderType::MiniMax,
+        ];
+        let slugs: std::collections::HashSet<&str> =
+            ALL.iter().copied().map(provider_type_slug).collect();
+        assert_eq!(slugs.len(), ALL.len(), "duplicate slug in the arm list");
+
+        for provider in ALL {
+            let slug = provider_type_slug(provider);
+            assert_eq!(
+                parse_builtin_provider(slug),
+                Some(provider),
+                "canonical slug {slug:?} does not parse back to {provider:?}"
+            );
+            assert_eq!(
+                credentials_store_account_key(slug),
+                credentials_store_key(provider),
+                "the account writer and the provider reader disagree for {slug:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/wcore-config/tests/multi_account_provider_test.rs
+++ b/crates/wcore-config/tests/multi_account_provider_test.rs
@@ -1,0 +1,266 @@
+//! Several accounts on the SAME provider (issue #14).
+//!
+//! A company with a dozen OpenRouter accounts needs each account's key to be
+//! selectable per session AND storable securely. The *selection* half already
+//! worked: one `[providers.<id>]` alias per account, picked with `--provider
+//! <id>`. The *storage* half did not — [`credentials_store_key`] is keyed by
+//! `ProviderType`, so the ladder held exactly ONE key per provider and every
+//! extra account could only be a cleartext `api_key` in `config.toml`, which is
+//! the sink `auth add` exists to empty.
+//!
+//! These drive the real resolution path ([`resolve_council_provider`], which
+//! shares `resolve_api_key` with `Config::resolve`) against a real credentials
+//! ladder, and assert on the RESOLVED key — not on the slot name, which would
+//! pass while resolution read a different slot.
+//!
+//! HOST INDEPENDENCE: every case sets `WAYLAND_HOME`, which makes `open_store`
+//! skip the process-global OS keyring by construction, and supplies a vault
+//! passphrase so there is a secure tier to write into. Identical on Linux,
+//! macOS and Windows, and it can never touch the developer's real Keychain.
+//!
+//! NO SECRET IS EVER PRINTED: the fixtures below are literals invented for the
+//! test and are not credentials for anything.
+
+use std::collections::HashMap;
+
+use serial_test::serial;
+use tempfile::tempdir;
+use wcore_config::config::{
+    Config, MAX_ACCOUNT_ID_LEN, ProviderConfig, credentials_store_account_key,
+    resolve_council_provider, store_provider_account_api_key,
+};
+
+const KEY_A: &str = "or-fixture-account-a-11111111";
+const KEY_B: &str = "or-fixture-account-b-22222222";
+const SHARED_CLEARTEXT: &str = "or-fixture-shared-cleartext-99999999";
+
+/// RAII env guard. Restores prior values on drop so one case cannot leak its
+/// fixture into the next in the same process.
+struct EnvGuard {
+    saved: Vec<(&'static str, Option<std::ffi::OsString>)>,
+}
+
+impl EnvGuard {
+    fn scoped(home: &std::path::Path) -> Self {
+        let pairs: [(&'static str, Option<String>); 5] = [
+            ("WAYLAND_HOME", Some(home.display().to_string())),
+            (
+                "WAYLAND_VAULT_PASSPHRASE",
+                Some("multi-account-test-passphrase".to_string()),
+            ),
+            ("WAYLAND_VAULT_PASSPHRASE_FD", None),
+            // An ambient key of either shape would satisfy resolution from the
+            // environment and make every assertion below vacuous.
+            ("API_KEY", None),
+            ("OPENROUTER_API_KEY", None),
+        ];
+        let saved = pairs
+            .iter()
+            .map(|(key, value)| {
+                let prior = std::env::var_os(key);
+                unsafe {
+                    match value {
+                        Some(value) => std::env::set_var(key, value),
+                        None => std::env::remove_var(key),
+                    }
+                }
+                (*key, prior)
+            })
+            .collect();
+        Self { saved }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        for (key, prior) in &self.saved {
+            unsafe {
+                match prior {
+                    Some(value) => std::env::set_var(key, value),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
+    }
+}
+
+/// One `[providers.<id>]` alias per account, all on the same built-in provider.
+fn account(underlying: &str) -> ProviderConfig {
+    ProviderConfig {
+        provider: Some(underlying.to_string()),
+        ..Default::default()
+    }
+}
+
+#[test]
+#[serial(multi_account_credentials_env)]
+fn two_accounts_on_one_provider_each_resolve_their_own_stored_key() {
+    let dir = tempdir().unwrap();
+    let _env = EnvGuard::scoped(dir.path());
+
+    store_provider_account_api_key("acct-a", KEY_A).expect("store account A");
+    store_provider_account_api_key("acct-b", KEY_B).expect("store account B");
+
+    let mut providers = HashMap::new();
+    providers.insert("acct-a".to_string(), account("openrouter"));
+    providers.insert("acct-b".to_string(), account("openrouter"));
+
+    let base = Config::default();
+    let (a, _) = resolve_council_provider(&providers, &base, "acct-a").expect("acct-a resolves");
+    let (b, _) = resolve_council_provider(&providers, &base, "acct-b").expect("acct-b resolves");
+
+    assert_eq!(
+        a.api_key, KEY_A,
+        "account 'acct-a' did not resolve its own stored credential"
+    );
+    assert_eq!(
+        b.api_key, KEY_B,
+        "account 'acct-b' did not resolve its own stored credential"
+    );
+    // The whole point: two accounts, two DIFFERENT keys, one provider.
+    assert_ne!(
+        a.api_key, b.api_key,
+        "both accounts on one provider resolved to the same key"
+    );
+    assert_eq!(
+        a.provider, b.provider,
+        "both accounts are the same provider"
+    );
+    // The label is what metering/billing attributes the spend to, so it must
+    // carry the account, not the shared provider slug.
+    assert_eq!(a.provider_label, "acct-a");
+    assert_eq!(b.provider_label, "acct-b");
+}
+
+#[test]
+#[serial(multi_account_credentials_env)]
+fn an_accounts_stored_key_is_not_shadowed_by_the_shared_provider_key() {
+    // The silent-wrong-account case. An alias INHERITS the underlying
+    // `[providers.<builtin>].api_key` through `merge_provider_configs`, so
+    // without an account rung above the inline value, account B would be
+    // charged to the shared cleartext key of a different account — with no
+    // error and no visible difference.
+    let dir = tempdir().unwrap();
+    let _env = EnvGuard::scoped(dir.path());
+
+    store_provider_account_api_key("acct-b", KEY_B).expect("store account B");
+
+    let mut providers = HashMap::new();
+    providers.insert(
+        "openrouter".to_string(),
+        ProviderConfig {
+            api_key: Some(SHARED_CLEARTEXT.to_string()),
+            ..Default::default()
+        },
+    );
+    providers.insert("acct-b".to_string(), account("openrouter"));
+
+    let base = Config::default();
+    let (b, _) = resolve_council_provider(&providers, &base, "acct-b").expect("acct-b resolves");
+
+    assert_eq!(
+        b.api_key, KEY_B,
+        "account 'acct-b' resolved a credential that is not its own"
+    );
+    assert_ne!(
+        b.api_key, SHARED_CLEARTEXT,
+        "account 'acct-b' was silently billed to the shared provider key"
+    );
+}
+
+#[test]
+#[serial(multi_account_credentials_env)]
+fn selecting_the_builtin_provider_is_unchanged_by_the_account_rung() {
+    // Negative control for the rung above: a BUILT-IN selection carries no
+    // account id, so it must still resolve exactly as before — inline config
+    // value first. Without this, "accounts work" could be true while ordinary
+    // single-account resolution silently changed.
+    let dir = tempdir().unwrap();
+    let _env = EnvGuard::scoped(dir.path());
+
+    store_provider_account_api_key("acct-a", KEY_A).expect("store account A");
+
+    let mut providers = HashMap::new();
+    providers.insert(
+        "openrouter".to_string(),
+        ProviderConfig {
+            api_key: Some(SHARED_CLEARTEXT.to_string()),
+            ..Default::default()
+        },
+    );
+    providers.insert("acct-a".to_string(), account("openrouter"));
+
+    let base = Config::default();
+    let (shared, _) =
+        resolve_council_provider(&providers, &base, "openrouter").expect("builtin resolves");
+
+    assert_eq!(shared.api_key, SHARED_CLEARTEXT);
+    assert_eq!(shared.provider_label, "openrouter");
+}
+
+#[test]
+#[serial(multi_account_credentials_env)]
+fn an_account_with_no_stored_key_still_falls_through_to_the_provider() {
+    // The documented alias-overlay semantic, asserted so a later change cannot
+    // break it silently: an alias with NO credential of its own inherits the
+    // underlying provider's, exactly as it inherits `model` and `base_url`.
+    let dir = tempdir().unwrap();
+    let _env = EnvGuard::scoped(dir.path());
+
+    let mut providers = HashMap::new();
+    providers.insert(
+        "openrouter".to_string(),
+        ProviderConfig {
+            api_key: Some(SHARED_CLEARTEXT.to_string()),
+            ..Default::default()
+        },
+    );
+    providers.insert("acct-c".to_string(), account("openrouter"));
+
+    let base = Config::default();
+    let (c, _) = resolve_council_provider(&providers, &base, "acct-c").expect("acct-c resolves");
+    assert_eq!(c.api_key, SHARED_CLEARTEXT);
+}
+
+#[test]
+fn account_slot_names_are_narrow_and_never_collide_with_a_builtin() {
+    // A slot name is a keyring entry, a TOML key in the plaintext backend, and
+    // a prefix the chunked-write path appends to. Anything that could forge or
+    // collide with a neighbouring slot gets NO slot at all.
+    assert_eq!(
+        credentials_store_account_key("acct-a").as_deref(),
+        Some("providers.acct-a.api_key")
+    );
+    assert_eq!(
+        credentials_store_account_key("Acct_B2").as_deref(),
+        Some("providers.Acct_B2.api_key")
+    );
+
+    for hostile in [
+        "",
+        "a.b",  // would read as a nested TOML path
+        "a b",  // whitespace
+        "a\"b", // quote — forges a key boundary
+        "a/b",
+        "a\nb",
+        "acct-\u{00e9}", // non-ASCII
+    ] {
+        assert_eq!(
+            credentials_store_account_key(hostile),
+            None,
+            "hostile account id {hostile:?} was granted a store slot"
+        );
+    }
+    let too_long = "a".repeat(MAX_ACCOUNT_ID_LEN + 1);
+    assert_eq!(credentials_store_account_key(&too_long), None);
+    assert!(credentials_store_account_key(&"a".repeat(MAX_ACCOUNT_ID_LEN)).is_some());
+
+    // A built-in slug delegates, so account and provider writers/readers share
+    // one slot — and an out-of-band provider still has none.
+    assert_eq!(
+        credentials_store_account_key("openrouter").as_deref(),
+        Some("providers.openrouter.api_key")
+    );
+    assert_eq!(credentials_store_account_key("bedrock"), None);
+    assert_eq!(credentials_store_account_key("vertex"), None);
+}

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -74,6 +74,61 @@ Rules:
 
 This fits scenarios like DeepSeek gateways and internal OpenAI-compatible services.
 
+---
+
+## Multiple accounts on one provider
+
+A team that holds several accounts with the *same* provider — a dozen OpenRouter
+or NVIDIA accounts, say — gives each account its own alias. An alias used this
+way is an **account**: it names one credential, it is selected per session, and
+its spend is attributed to its own name.
+
+```toml
+[providers.or-research]
+provider = "openrouter"
+
+[providers.or-production]
+provider = "openrouter"
+model = "anthropic/claude-sonnet-4-6"
+```
+
+Store each account's key in the credential ladder (OS keyring, else the
+encrypted vault) — **never** as a cleartext `api_key` in this file:
+
+```bash
+wayland-core auth add or-research  <key>
+wayland-core auth add or-production <key>
+wayland-core auth list          # shows every account and where its key lives
+```
+
+Then pick one per run, or set a default:
+
+```bash
+wayland-core --provider or-research  "Draft the outline"
+wayland-core --provider or-production "Ship it"
+```
+
+```toml
+[default]
+provider = "or-production"
+```
+
+Rules:
+
+- There is no limit on the number of accounts per provider.
+- Each account gets its own ladder slot, `providers.<id>.api_key`. Account ids
+  may use ASCII letters, digits, `_` and `-` (max 64 characters).
+- An account id may not shadow a built-in provider slug — built-ins always win.
+- An account with **no** credential of its own inherits the underlying
+  provider's, exactly as it inherits `model` and `base_url`. Give every account
+  its own key if you want its spend separated.
+- `auth add` refuses to validate an account that overrides `base_url`: the key
+  belongs to that endpoint, and posting it to the built-in provider's endpoint
+  to "check" it would send your credential to a host that never issued it. Use
+  `--no-validate` for those.
+- Selection is explicit. There is no automatic rotation or failover between
+  accounts.
+
 ### Generic / self-hosted OpenAI-compatible endpoints (vLLM, llama.cpp, LM Studio)
 
 Point `base_url` at the server's API root **without** a trailing `/v1` — the engine


### PR DESCRIPTION
## Re-grading the report first

The issue as filed ("only one API key per provider") is **half wrong**, so this fix is much narrower than the report implies.

**Already worked on `main`:** multiple named, selectable accounts per provider. `resolve_provider_alias` (`config.rs:3027`) resolves an arbitrary `[providers.<id>]` alias carrying `provider = "openrouter"`, selectable via `--provider <id>` or `[default].provider`, and `providers` is a `HashMap<String, ProviderConfig>` — there is no cap. The reporter's literal ask was mostly a documentation gap.

**Genuinely broken:** secure *storage* of those accounts' keys.

## The real defect

`credentials_store_key(provider: ProviderType)` (`config.rs:3542`) maps a whole provider to **one fixed slot** (`providers.openrouter.api_key`), so the credentials ladder physically could not hold a second OpenRouter/NVIDIA key. A second account could only ever be a cleartext `api_key` in `config.toml` — the exact sink `auth add` exists to empty.

Worse: `merge_provider_configs` makes an alias **inherit** the underlying `[providers.<builtin>].api_key`, so an account with no key of its own silently resolved and was **billed to a different account's key**. That cross-account credential bleed is the real defect, and it is what red arm 1 reproduces.

## The fix

`credentials_store_account_key(account_id)` (`config.rs:3740`) gives every non-builtin selection its own slot; a builtin slug delegates to the existing `credentials_store_key` so there stays exactly **one** mapping — asserted for all 23 `ProviderType` arms by `account_key_round_trips_every_builtin_slug`. `resolve_api_key` gains an account rung (`config.rs:3428`) placed **above** the inline config value, precisely because of the inheritance bleed. `auth add/list/remove` take an account id, refuse to auto-promote an undeclared id, validate ids to `[A-Za-z0-9_-]{1,64}` so a slot name cannot forge or collide with a neighbour, and refuse to network-validate an account that overrides `base_url`.

Builtin selections carry `account_id: None`, so single-account resolution is byte-for-byte unchanged.

## Security direction

The credential surface is **narrowed, not widened**. The new rung reads only the credentials store — no new env var is consulted anywhere — and outranks the shared/inline/env rungs for an account selection, so a securely stored account key can no longer be shadowed by the bare ambient `API_KEY`.

## Red arms

1. Neutralised the account rung at `config.rs:3428` without a compile error → `an_accounts_stored_key_is_not_shadowed_by_the_shared_provider_key` failed on the **cross-account bleed verbatim** (`left: "…shared-cleartext…" right: "…account-b…"`). The other three tests stayed green and are the correct controls.
2. Reverted `auth list` to the builtin-only lookup → the account's stored key became invisible to the operator. Targeted **by line number** because line 438 is a comment quoting the same call; the script asserted the target was code, not a comment, and verified line 438 stayed untouched as a control.

Restore integrity: files restored with `git checkout --` then `touch`ed, and the rebuilt binary proven byte-identical (sha256 `9d93b4a409aa01ba`) to the one that produced the green run — the mtime trap explicitly ruled out rather than assumed.

Closes FerroxLabs/wayland#14
