### PR TITLE
fix(providers): a 5xx naming a permanent error is not retried

### DIFF
--- a/crates/wcore-providers/src/classify.rs
+++ b/crates/wcore-providers/src/classify.rs
@@ -23,6 +23,15 @@ pub fn classify_failover(
     if let Some(s) = http_status
         && let Some(r) = classify_by_status(s)
     {
+        // #949: for a generic 5xx, "transient" is a GUESS derived from the
+        // status alone. When the body the provider already sent says otherwise
+        // in unambiguous terms, the body is the better signal — see
+        // `permanent_reason_in_5xx_body`, which is deliberately narrow.
+        if let Some(b) = body_text
+            && let Some(p) = permanent_reason_in_5xx_body(s, b)
+        {
+            return p;
+        }
         return r;
     }
     // Tier 2: body text patterns
@@ -62,6 +71,53 @@ fn classify_by_status(status: u16) -> Option<FailoverReason> {
         400 => Some(FailoverReason::Format),
         _ => None,
     }
+}
+
+/// True when no retry of the SAME request against the SAME key can succeed.
+///
+/// Deliberately excludes `Overloaded`, `RateLimit` and `Timeout`: those are the
+/// reasons a retry exists for. `Format`/`ContextOverflow` are also excluded —
+/// they are resolved by rewriting or compacting the request, which is a
+/// different recovery path, not a refusal to retry.
+fn is_permanent_reason(r: FailoverReason) -> bool {
+    matches!(
+        r,
+        FailoverReason::Auth
+            | FailoverReason::AuthPermanent
+            | FailoverReason::Billing
+            | FailoverReason::ModelNotFound
+    )
+}
+
+/// #949: a 5xx that is not an explicit overload signal, carrying a body that
+/// names an unambiguous PERMANENT failure, is permanent.
+///
+/// FluxRouter answers a model-permission rejection ("key not allowed to access
+/// model") with HTTP 500 and `"type":"auth_error"`. Classified on status alone
+/// that is `Timeout`, and `is_retryable_http_status` calls any `>= 500`
+/// transient — so the entire request context is re-sent `DEFAULT_MAX_RETRIES`
+/// times for an outcome that cannot succeed, and the user reads "the provider
+/// is flaky" when the actionable truth is "this key cannot use this model".
+///
+/// The narrowing is the point:
+///   * 503 and 529 are EXPLICIT "overloaded" signals and are never overridden.
+///     A busy server frequently describes itself in words this body tier
+///     matches, and demoting a real overload to permanent would break failover.
+///   * only a permanent reason overrides. A body-derived `Overloaded` or
+///     `RateLimit` leaves the 5xx transient, exactly as before.
+///
+/// This is not a hardcoded provider quirk: the discriminator is the body the
+/// provider already sent, matched by the same provider-neutral
+/// [`classify_by_body`] used by tier 2.
+///
+/// Both the failover classifier and `ProviderError::is_retryable` gate on this
+/// one function, so the two cannot drift into disagreeing about whether the
+/// same response is worth re-sending.
+pub fn permanent_reason_in_5xx_body(status: u16, body: &str) -> Option<FailoverReason> {
+    if !(500..=599).contains(&status) || matches!(status, 503 | 529) {
+        return None;
+    }
+    classify_by_body(body).filter(|r| is_permanent_reason(*r))
 }
 
 fn classify_by_body(body: &str) -> Option<FailoverReason> {

--- a/crates/wcore-providers/src/lib.rs
+++ b/crates/wcore-providers/src/lib.rs
@@ -258,7 +258,14 @@ impl ProviderError {
     pub fn is_retryable(&self) -> bool {
         match self {
             ProviderError::RateLimited { .. } | ProviderError::Connection(_) => true,
-            ProviderError::Api { status, .. } => crate::retry::is_retryable_http_status(*status),
+            // #949: the status alone only says "5xx, probably transient".
+            // `message` carries the body the provider sent; when that body names
+            // an unambiguous permanent failure, retrying re-sends the entire
+            // request context for an outcome that cannot succeed.
+            ProviderError::Api { status, message } => {
+                crate::retry::is_retryable_http_status(*status)
+                    && crate::classify::permanent_reason_in_5xx_body(*status, message).is_none()
+            }
             ProviderError::Http(_)
             | ProviderError::Parse(_)
             | ProviderError::PromptTooLong(_)

--- a/crates/wcore-providers/tests/permanent_5xx_body.rs
+++ b/crates/wcore-providers/tests/permanent_5xx_body.rs
@@ -1,0 +1,121 @@
+//! wayland#949: a permanent authorization failure delivered as HTTP 500 must
+//! not be re-sent as a transient server error.
+//!
+//! FluxRouter answers a model-permission rejection with `500` and a body of
+//! `"type":"auth_error"`. Classified on status alone that is `Timeout`, and
+//! `is_retryable_http_status` calls any `>= 500` transient, so the whole
+//! request context was re-sent `1 + DEFAULT_MAX_RETRIES` times for an outcome
+//! that cannot succeed.
+//!
+//! These tests grade the two PUBLIC surfaces the engine actually consults —
+//! `classify_failover` and `ProviderError::is_retryable` — not the private
+//! predicate they share. A test of the predicate alone would stay green if
+//! either call site stopped calling it.
+
+use wcore_providers::classify::classify_failover;
+use wcore_providers::{FailoverReason, ProviderError};
+
+/// The body as reported in wayland#949.
+const FLUX_AUTH_500: &str = r#"{"error":{"type":"auth_error","message":"key not allowed to access model deepseek-v4-pro"}}"#;
+
+fn api(status: u16, message: &str) -> ProviderError {
+    ProviderError::Api {
+        status,
+        message: message.to_string(),
+    }
+}
+
+#[test]
+fn flux_auth_error_at_500_classifies_as_permanent_not_timeout() {
+    let err = api(500, FLUX_AUTH_500);
+    assert_eq!(
+        classify_failover(&err, Some(500), Some(FLUX_AUTH_500), None),
+        FailoverReason::AuthPermanent,
+        "a 500 whose body says the key is not allowed to access the model is a \
+         permission failure, not a transient server error"
+    );
+}
+
+#[test]
+fn flux_auth_error_at_500_is_not_retried() {
+    assert!(
+        !api(500, FLUX_AUTH_500).is_retryable(),
+        "retrying re-sends the entire request context for an outcome that \
+         cannot succeed — this is the cost wayland#949 is about"
+    );
+}
+
+/// Control. Without this, the two tests above would pass just as well against
+/// a change that made every 5xx permanent — which would break failover.
+#[test]
+fn a_plain_500_stays_transient_and_retryable() {
+    let body = r#"{"error":{"message":"internal server error"}}"#;
+    let err = api(500, body);
+    assert_eq!(
+        classify_failover(&err, Some(500), Some(body), None),
+        FailoverReason::Timeout,
+        "an ordinary 500 must keep its transient classification"
+    );
+    assert!(err.is_retryable(), "an ordinary 500 must still be retried");
+}
+
+/// 503 and 529 are EXPLICIT overload signals. A busy server often describes
+/// itself in words the body tier matches, so demoting one to permanent would
+/// turn a recoverable overload into a hard failure.
+#[test]
+fn an_explicit_overload_status_is_never_overridden_by_its_body() {
+    for status in [503_u16, 529] {
+        let body = r#"{"error":{"type":"auth_error","message":"not allowed"}}"#;
+        let err = api(status, body);
+        assert_eq!(
+            classify_failover(&err, Some(status), Some(body), None),
+            FailoverReason::Overloaded,
+            "{status} is an explicit overload signal and must not be \
+             reclassified from its body"
+        );
+        assert!(
+            err.is_retryable(),
+            "{status} must remain retryable regardless of body text"
+        );
+    }
+}
+
+/// Only a PERMANENT body reason overrides. A body that names a transient
+/// condition must leave the 5xx exactly as it was.
+#[test]
+fn a_transient_body_reason_does_not_make_a_5xx_permanent() {
+    for body in [
+        r#"{"error":{"message":"rate limit exceeded"}}"#,
+        r#"{"error":{"message":"server is busy, try again"}}"#,
+    ] {
+        let err = api(500, body);
+        assert!(
+            err.is_retryable(),
+            "a 500 whose body names a transient condition must stay retryable: {body}"
+        );
+    }
+}
+
+/// The override is scoped to 5xx. 4xx classification is untouched.
+#[test]
+fn four_xx_classification_is_unchanged() {
+    let err = api(401, FLUX_AUTH_500);
+    assert_eq!(
+        classify_failover(&err, Some(401), Some(FLUX_AUTH_500), None),
+        FailoverReason::Auth,
+        "401 must still classify from its status"
+    );
+    assert!(!err.is_retryable(), "401 must remain non-retryable");
+}
+
+/// A 5xx with no body at all must be unaffected — the override needs evidence,
+/// and absence of a body is not evidence of permanence.
+#[test]
+fn a_5xx_with_no_body_stays_transient() {
+    let err = api(502, "");
+    assert_eq!(
+        classify_failover(&err, Some(502), None, None),
+        FailoverReason::Timeout
+    );
+    assert!(err.is_retryable());
+}


### PR DESCRIPTION
A permanent authorization failure delivered as HTTP 500 was re-sent three times before the run failed.

## What happens

FluxRouter answers a model-permission rejection ("key not allowed to access model") with **HTTP 500** and a body of `"type":"auth_error"`.

Core classifies on status first. `classify_by_status` maps any 5xx that is not 503/529 to `FailoverReason::Timeout`, and `is_retryable_http_status` treats `>= 500` as transient. Neither reads the body, so the `"type":"auth_error"` discriminator that **is present in the response** is never consulted.

Result: `1 initial + DEFAULT_MAX_RETRIES` full-context sends for an outcome that cannot succeed.

1. **Cost.** On a long agent turn that is three large prompts billed for nothing.
2. **Diagnosis.** The user sees a 5xx three times and concludes "the provider is flaky", when the actionable answer is "this key cannot use this model".
3. It makes a permanent failure look exactly like a transient provider fault, which poisons corpus reproduction.

## The fix

`permanent_reason_in_5xx_body` is the **one predicate** both the failover classifier and `ProviderError::is_retryable` gate on, so the two cannot drift into disagreeing about whether the same response is worth re-sending.

The narrowing is the whole design:

- **503 and 529 are never overridden.** They are explicit "overloaded" signals, and a busy server frequently describes itself in words the body tier matches. Demoting a real overload to permanent would break failover — so those two statuses are excluded outright.
- **Only a permanent reason overrides.** A body-derived `Overloaded` or `RateLimit` leaves the 5xx transient, exactly as before. Permanent means `Auth`, `AuthPermanent`, `Billing`, `ModelNotFound` — the reasons no retry of the same request against the same key can resolve. `Format` and `ContextOverflow` are deliberately excluded: they are fixed by rewriting or compacting the request, which is a different recovery path, not a refusal to retry.

This is **not** a hardcoded provider quirk. The discriminator is the body the provider already sent, matched by the same provider-neutral `classify_by_body` that tier 2 uses. Nothing keys on a hostname or a provider id.

## Verification

`crates/wcore-providers/tests/permanent_5xx_body.rs` — 7 tests, graded against the two **public** surfaces the engine consults (`classify_failover` and `ProviderError::is_retryable`), not the private predicate they share. A test of the predicate alone would stay green if either call site stopped calling it.

Controls are half the file, because the failure mode of this change is over-reach:

- a plain 500 stays `Timeout` and retryable
- 503/529 keep `Overloaded` and stay retryable **even with `"not allowed"` in the body**
- a 500 whose body names a transient condition stays retryable
- 401 still classifies from its status
- a 5xx with no body stays transient — the override requires evidence, and absence of a body is not evidence of permanence

### Red arm

Both enforcement sites were reverted in turn, keeping the tests:

| Mutation | Result |
|---|---|
| Remove the tier-1 body override (`classify.rs:31`) | **FAILED** — `assertion left == right failed ... left: Timeout, right: AuthPermanent` |
| Revert `is_retryable` to status-only (`lib.rs:267`) | **FAILED** — "retrying re-sends the entire request context for an outcome that cannot succeed" |

Each mutation asserted its target line was **code, not a comment** before mutating (the script prints the line number and CODE/COMMENT for every occurrence and aborts if none is code — it caught a bad needle on the first attempt and refused to run). Files restored with `git checkout --` then `touch`ed to defeat the mtime trap; `git status --porcelain` clean afterwards and both tests back to green.

Gates on hetzner: `cargo fmt --check` 0, `cargo clippy --workspace --all-targets -D warnings` 0, `cargo test -p wcore-providers` **982 passed / 0 failed**.

Closes FerroxLabs/wayland#949
