### PR TITLE
test(swarm): rendezvous the heartbeat e2e instead of sampling it

### DIFF
--- a/crates/wcore-swarm/tests/heartbeat_test.rs
+++ b/crates/wcore-swarm/tests/heartbeat_test.rs
@@ -54,7 +54,24 @@ for n in 1 2 3; do
   ts=$(($(date +%s%N) / 1000000))
   printf '{"last_alive_at":%d,"step":"step-%d"}' "$ts" "$n" > .swarm-status.tmp
   mv .swarm-status.tmp .swarm-status.json
-  sleep 0.15
+  # Rendezvous (wayland#935). Block until the orchestrator has actually READ
+  # this heartbeat before emitting the next one. The previous version slept a
+  # fixed 150ms and let the observer sample at 40ms, so under full-suite load
+  # the worker could emit every heartbeat inside one poll gap and the observed
+  # count came up short while the worker had behaved perfectly.
+  #
+  # The ack lives in the worktree (the worker's cwd) because that is the only
+  # tree the delegated backend mounts into the child -- an ack in an outside
+  # tempdir is invisible to a bubblewrap worker. Dot-prefixed to match the
+  # existing `.swarm-status.json` convention, which is already written here.
+  deadline=$(( $(date +%s) + 30 ))
+  while [ ! -f ".swarm-hb-ack-$n" ]; do
+    if [ "$(date +%s)" -gt "$deadline" ]; then
+      echo "worker gave up waiting for ack-$n" >&2
+      exit 91
+    fi
+    sleep 0.01
+  done
 done
 "#;
 
@@ -63,7 +80,9 @@ done
         base_branch: "main".into(),
         worker_branch_prefix: "swarm/hb".into(),
         worker_command: vec!["bash".into(), "-c".into(), script.into()],
-        timeout: Duration::from_secs(15),
+        // Raised from 15s: the worker now waits for the observer, so its
+        // wall-clock includes the orchestrator's read latency under load.
+        timeout: Duration::from_secs(60),
         env: vec![],
     };
 
@@ -78,15 +97,37 @@ done
     let handles = loop {
         tokio::select! {
             res = &mut dispatch_fut => break res.unwrap(),
-            _ = tokio::time::sleep(Duration::from_millis(40)) => {
-                // We don't have a worker_id until dispatch returns, so
-                // probe the swarm root directly for any worktree-with-
-                // status-file. This mirrors what worker_status does
-                // under the hood, just without the handle.
-                if let Some(status) = probe_any_worker_status(tmp.path())
-                    && observed.last().map(|p| p.last_alive_at) != Some(status.last_alive_at)
-                {
-                    observed.push(status);
+            _ = tokio::time::sleep(Duration::from_millis(10)) => {
+                // We have no worker_id until dispatch returns, so locate the
+                // single worker worktree and read its heartbeat through the
+                // PRODUCT reader (`heartbeat::read_status`) rather than a
+                // second, test-local JSON decode. A private copy of the read
+                // path would keep this test green through a regression in the
+                // real one.
+                let Some((worktree, status)) = probe_any_worker_status(tmp.path()) else {
+                    continue;
+                };
+                if observed.last().map(|p| p.last_alive_at) == Some(status.last_alive_at) {
+                    continue;
+                }
+                // Acknowledge the heartbeat we just read, which is what
+                // unblocks the worker to emit the next one. The worker cannot
+                // run ahead of this loop, so no heartbeat can be missed and
+                // the `>= 3` assertion below is deterministic rather than
+                // sampled (wayland#935).
+                let step = status.step.clone().unwrap_or_default();
+                observed.push(status);
+                if let Some(n) = step.strip_prefix("step-") {
+                    // The worker runs in <transaction_root>/checkout, NOT in the
+                    // transaction root itself. The root only carries the MIRROR
+                    // that `dispatch::mirror_heartbeat` republishes there for the
+                    // orchestrator to read, so an ack written to the root is
+                    // invisible to the worker -- which is exactly what the first
+                    // attempt at this rendezvous proved (worker blocked the full
+                    // 30s waiting for ack-1, observed count stuck at 1).
+                    let ack = worktree.join("checkout").join(format!(".swarm-hb-ack-{n}"));
+                    std::fs::write(&ack, b"1")
+                        .unwrap_or_else(|e| panic!("write ack {}: {e}", ack.display()));
                 }
             }
         }
@@ -125,16 +166,24 @@ done
     swarm.cleanup().await.unwrap();
 }
 
+/// Locate the single worker worktree and read its heartbeat.
+///
+/// wayland#935: this used to `std::fs::read` + `serde_json::from_slice` itself,
+/// so every intermediate observation in the e2e test went through a SECOND
+/// implementation of the read path and the product's own
+/// [`wcore_swarm::heartbeat::read_status`] was exercised exactly once, at the
+/// end. A regression in the real reader would have left this test green.
+///
+/// A malformed heartbeat is surfaced as `Err` by `read_status`, and a partial
+/// write is not possible here (the worker renames into place), so an error is
+/// treated as "nothing readable yet" and simply retried by the caller.
 #[cfg(unix)]
-fn probe_any_worker_status(repo_root: &Path) -> Option<WorkerStatusFile> {
+fn probe_any_worker_status(repo_root: &Path) -> Option<(std::path::PathBuf, WorkerStatusFile)> {
     let swarm_root = repo_root.join(".swarm-worktrees");
-    let entries = std::fs::read_dir(&swarm_root).ok()?;
-    for ent in entries.flatten() {
-        let p = ent.path().join(wcore_swarm::heartbeat::STATUS_FILE);
-        if let Ok(bytes) = std::fs::read(&p)
-            && let Ok(payload) = serde_json::from_slice::<WorkerStatusFile>(&bytes)
-        {
-            return Some(payload);
+    for ent in std::fs::read_dir(&swarm_root).ok()?.flatten() {
+        let worktree = ent.path();
+        if let Ok(Some(payload)) = wcore_swarm::heartbeat::read_status(&worktree) {
+            return Some((worktree, payload));
         }
     }
     None


### PR DESCRIPTION
`worker_writes_heartbeat_during_long_running_task` polled every 40ms and required **≥3 distinct heartbeats** from a worker emitting them 150ms apart over a ~450ms lifetime. Miss enough 40ms ticks under load and the observed count comes up short **even though the worker behaved perfectly** — all three `retries = 2` attempts exhausted.

It reddened three separate merges on 2026-07-31, each time innocent (the merging lanes touched zero `wcore-swarm` files). A required gate with a ~25% false-red rate is one people learn to re-run until it goes green, at which point it has stopped being a gate.

## The fix: rendezvous, not sampling

The worker now **blocks until the orchestrator has actually read each heartbeat** before emitting the next. It cannot run ahead of the observer, so no heartbeat can be missed.

**The `>= 3` and the monotonicity assertions are unchanged.** This makes them deterministic rather than sampled, which is the opposite of the loosening the issue explicitly warns against. The test still exists to prove a worker emits *progressive* liveness.

Side effect worth noting: the test dropped from ~2.2s to **0.33s**, because it no longer waits on wall-clock at all.

### Where the ack lives, and why that took two attempts

The ack file goes in `<transaction_root>/checkout`, because that is where the worker actually runs and the only tree the delegated backend mounts into the child.

My first attempt put it in an outside tempdir; the worker is sandboxed under bubblewrap and simply could not see it — measured, the worker blocked the full 30s waiting for `ack-1`. My second attempt put it in the transaction root, which failed the same way, because the root carries only the **mirror** that `dispatch::mirror_heartbeat` republishes there for the orchestrator to read. Recording both because the layout is not obvious from the test file.

## Second defect, fixed in passing

`probe_any_worker_status` did its own `std::fs::read` + `serde_json::from_slice`. So **every intermediate observation in this e2e test went through a second, test-local implementation of the read path**, and the product's own `heartbeat::read_status` was exercised exactly once, at the very end. A regression in the real reader would have left this test green. It now calls the product reader.

## Verification

### Red arm — the vacuity question, which is the one that matters here

The defect is a flake, so "revert the fix and watch it fail" is not available on demand — that property is precisely what is being removed. The question the issue warns about instead is whether the now-deterministic test still *grades* the invariant. So each mutation breaks the simulated product and the test must fail on the symptom:

| Mutation | Result |
|---|---|
| Worker emits only ONE heartbeat (no progressive liveness) | **FAILED** — `expected to observe >=3 distinct heartbeats, got 1` |
| Heartbeat timestamps go backwards | **FAILED** — `heartbeats should be monotonically increasing: [.. 1999999999999 .., .. 1999999999998 ..]` |

Both targets asserted to be **code, not comments**, before mutating. Restored with `git checkout --` then `touch`ed; `git status --porcelain` clean; back to green.

### What I could NOT measure — read this before crediting the fix

**I did not reproduce the original flake, so there is no measured before/after.** Interleaved arms at equal n, old and new:

| Load regime | reps | old-arm failures | new-arm failures |
|---|---|---|---|
| 24 CPU loaders (96-core box) | 20 | 0 | 0 |
| 200 CPU loaders, load avg 66 | 10 | 0 | 0 |

The control never went red, so that comparison discriminates nothing and I am not presenting it as evidence.

This is **consistent with the issue's own measurements** rather than in tension with them: it already records "the heartbeat test alone, 16 consecutive runs: 16 passed (incl. under 8 background `cargo check` jobs)", and that only the **full workspace run** (13,701 tests, 592 binaries) reproduces. Raw CPU oversubscription is evidently not the mechanism; runtime/IO contention across hundreds of concurrent test binaries is.

The faithful reproduction condition is therefore a full-suite run — which is exactly what CI does on this PR. **The real evidence for this change is the full-workspace CI runs here, not anything I ran by hand.** The justification for merging it before that evidence accumulates is mechanical: the worker cannot advance unobserved, so the sampling race is gone by construction, and the two red arms show the assertion still bites.

Refs FerroxLabs/wayland#935
