### PR TITLE
perf(test): hoist the tool-mention regexes out of the per-literal path

### DIFF
--- a/crates/wcore-cli/tests/remedy_advertisements.rs
+++ b/crates/wcore-cli/tests/remedy_advertisements.rs
@@ -74,6 +74,7 @@
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::LazyLock;
 
 use regex::Regex;
 use wcore_config::config::ConfigFile;
@@ -1199,11 +1200,25 @@ fn real_tool_names() -> BTreeSet<String> {
 /// [`advertised_tool_names_resolve_to_a_real_tool`]; the shape of this pattern
 /// is a measurement, not a guess.
 fn advertised_tool_mentions(text: &str) -> Vec<String> {
-    let via = Regex::new(r"\bvia\s+`?([a-z][a-z0-9]*(?:_[a-z0-9]+)+)`?").unwrap();
-    let ticked =
-        Regex::new(r"\b(?:use|using|run|invoke|call)\s+`([a-z][a-z0-9]*(?:_[a-z0-9]+)+)`").unwrap();
-    via.captures_iter(text)
-        .chain(ticked.captures_iter(text))
+    // Compiled ONCE, not per call.
+    //
+    // This function runs once per string literal, and
+    // `advertised_tool_names_resolve_to_a_real_tool` sweeps every string
+    // literal in all ~1224 production sources. Building these two regexes on
+    // each call put a full regex compilation on every literal in the workspace.
+    //
+    // Measured on an idle box before this change: `real_tool_names()` 227ms,
+    // source discovery 6ms, and the scan loop **68.67s** of a 68.90s test —
+    // i.e. essentially the whole runtime, and it was regex CONSTRUCTION rather
+    // than matching. That put the test over nextest's 60s terminate budget, so
+    // its CI outcome was decided by runner speed rather than by the code.
+    static VIA: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"\bvia\s+`?([a-z][a-z0-9]*(?:_[a-z0-9]+)+)`?").unwrap());
+    static TICKED: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"\b(?:use|using|run|invoke|call)\s+`([a-z][a-z0-9]*(?:_[a-z0-9]+)+)`").unwrap()
+    });
+    VIA.captures_iter(text)
+        .chain(TICKED.captures_iter(text))
         .map(|c| c[1].to_string())
         .collect()
 }


### PR DESCRIPTION
`advertised_tool_mentions` built **two regexes on every call**, and it is called once per string literal across all ~1224 production sources. So the sweep paid a full regex compilation for every string literal in the workspace.

## Profiled first, then fixed

On an idle box with healthy disk, instrumenting the three phases of `advertised_tool_names_resolve_to_a_real_tool`:

```
TIMING real_tool_names       227.07ms
TIMING production_sources      6.15ms  (1224 files)
TIMING scan_loop          68,667.77ms   <-- essentially the entire test
```

68.67s of a 68.90s test, and it was regex **construction**, not matching. Worth stating plainly because both plausible alternatives were wrong: `strip_test_modules` and `string_literals` are each a single linear pass, and I checked them before touching anything.

## The fix

Both regexes hoisted into `LazyLock`. Nothing else changes.

| | before | after |
|---|---|---|
| `advertised_tool_names_resolve_to_a_real_tool` | **74.50s** | **0.93s** |
| whole `remedy_advertisements` file (8 tests) | 68.90s | **6.10s** |

**Output is byte-identical** — `remedy-gate: 1 advertised tool names, 1 resolved` before and after. This is not a narrowing of what the sweep reads.

## Why it mattered beyond the clock

That test is one of three `wcore-cli` tests sitting just past nextest's 60s terminate budget on `main`:

| test | on `main` |
|---|---|
| `deterministic_openai_loop::packaged_f04_run_is_repeatable_and_content_addressed` | 63.55s |
| `harness_cli_surface::auth_add_list_remove_is_a_full_crud_round_trip` | 67.70s |
| `remedy_advertisements::advertised_tool_names_resolve_to_a_real_tool` | 74.50s |

Their CI outcome was decided by how fast the runner was that day, and they had been written off collectively as "known pre-existing timeouts — environmental". **Two of the three now have real, findable causes and fixes** (the other is `auth list` doing one Argon2id derivation per provider slug, FerroxLabs/wayland-core#283, 67.70s → 19.06s).

## Red arm

A perf change's real risk is not that it fails — it is that the sweep silently stops matching and becomes vacuous while getting faster. So the mutation breaks the hoisted regex, and the extractor control must fail:

| Mutation | Result |
|---|---|
| Hoisted `VIA` regex changed to a pattern that cannot match | **FAILED** — `the extractor no longer reads the phrasing this check was built for; left: [], right: ["piper_download"]` |

Target asserted to be **code, not a comment** before mutating (line 1216, printed). Restored with `git checkout --` then `touch`ed; back to green.

Gates: `cargo fmt --all --check` clean, `cargo clippy -p wcore-cli --all-targets -- -D warnings` 0 errors, `remedy_advertisements` 8/8 passing.

Closes FerroxLabs/wayland#1059
