### PR TITLE
fix(config): stop the browser merge dropping the loopback grant

### DIFF
--- a/crates/wcore-config/src/config.rs
+++ b/crates/wcore-config/src/config.rs
@@ -5345,14 +5345,49 @@ fn merge_config_files_with_trust(
     // qualifies — and merging them separately would synthesise a
     // project-denies/operator-allows pairing that neither layer wrote.
     let default_browser_policy = crate::browser::BrowserPolicyConfig::default();
+    // `loopback` is resolved SEPARATELY from the three fields above it, and is
+    // deliberately NOT part of their unit.
+    //
+    // `default_action` and the two origin lists are one decision — an
+    // allowlist only means something alongside the action it qualifies. A
+    // loopback grant is not part of that decision: it is an independent
+    // local-only capability (gh#911) that says nothing about which REMOTE
+    // origins are reachable.
+    //
+    // Folding it into the triple made it vanish in BOTH directions. A project
+    // that set only `[browser.policy.loopback]` failed the triple's predicate,
+    // so the whole project policy — grant included — was discarded; and a
+    // project that set any origin list won the triple as a unit, discarding
+    // the OPERATOR's grant. The capability landed with the loopback field and
+    // this predicate was never extended to mention it, so the feature was
+    // inert for project-level config in either direction.
+    //
+    // Same presence-over-default shape as `camoufox_download` below, and for
+    // the same reason this block is field-wise at all: a setting one layer
+    // never mentioned must not disappear because of one it did.
+    //
+    // This is on the TRUSTED path only. `restrict_untrusted_project_config`
+    // builds from `ConfigFile::default()` and never forwards `browser`, so an
+    // untrusted project reaches this point with no grant to promote. Locked by
+    // `an_untrusted_project_cannot_enable_a_loopback_grant`.
+    let loopback = if project.browser.policy.loopback != default_browser_policy.loopback {
+        project.browser.policy.loopback.clone()
+    } else {
+        global.browser.policy.loopback.clone()
+    };
+    let policy_triple = if project.browser.policy.default_action
+        != default_browser_policy.default_action
+        || !project.browser.policy.allowed_origins.is_empty()
+        || !project.browser.policy.denied_origins.is_empty()
+    {
+        project.browser.policy
+    } else {
+        global.browser.policy
+    };
     let browser = crate::browser::BrowserConfig {
-        policy: if project.browser.policy.default_action != default_browser_policy.default_action
-            || !project.browser.policy.allowed_origins.is_empty()
-            || !project.browser.policy.denied_origins.is_empty()
-        {
-            project.browser.policy
-        } else {
-            global.browser.policy
+        policy: crate::browser::BrowserPolicyConfig {
+            loopback,
+            ..policy_triple
         },
         stealth: crate::browser::StealthConfig {
             preferred_provider: if project.browser.stealth.preferred_provider

--- a/crates/wcore-config/tests/browser_merge_trust_test.rs
+++ b/crates/wcore-config/tests/browser_merge_trust_test.rs
@@ -188,6 +188,23 @@ fn download_only_project_body() -> String {
     )
 }
 
+/// An operator global that allows one origin AND holds a loopback grant.
+fn operator_global_policy_with_loopback() -> String {
+    format!(
+        "[browser.policy]\ndefault_action = \"allow\"\nallowed_origins = [\"{OPERATOR_ORIGIN}\"]\n\n\
+         [browser.policy.loopback]\nenabled = true\nschema_version = 1\n\
+         session_scope = \"operator-scope\"\nports = [3000]\n"
+    )
+}
+
+/// A project block that configures ONLY a loopback grant — it says nothing
+/// about `default_action` or either origin list.
+fn loopback_only_project_body() -> String {
+    "[browser.policy.loopback]\nenabled = true\nschema_version = 1\n\
+     session_scope = \"project-scope\"\nports = [4000]\n"
+        .to_owned()
+}
+
 // ── 1. Cross-field clobbering (trusted path) ─────────────────────────────────
 
 /// A trusted project that configures only `[browser.camoufox_download]` must
@@ -340,5 +357,94 @@ fn the_same_project_bodies_do_take_effect_when_the_workspace_is_trusted() {
         widened.browser.policy.default_action, "allow",
         "control failed: the policy-widening fixture does not take effect even \
          when trusted, so the untrusted arm proves nothing"
+    );
+}
+
+/// A trusted project that configures ONLY `[browser.policy.loopback]` must
+/// keep that grant AND the operator's policy it never mentioned.
+///
+/// Red arm: with `loopback` folded into the origin-triple predicate, a project
+/// that sets only a grant fails the predicate, the whole project policy is
+/// discarded, and `enabled` comes back false — the capability is inert.
+#[test]
+#[serial(browser_merge_trust_env)]
+fn a_project_that_configures_only_loopback_keeps_that_grant() {
+    let config = load(
+        &operator_global_policy(),
+        &loopback_only_project_body(),
+        Trust::Granted,
+    );
+
+    assert!(
+        config.browser.policy.loopback.enabled,
+        "the trusted project's [browser.policy.loopback] grant was dropped \
+         because it did not also set default_action or an origin list"
+    );
+    assert_eq!(
+        config.browser.policy.loopback.ports,
+        vec![4000],
+        "the grant survived as a flag but lost its port list"
+    );
+    // The other half: the operator's policy must not have been clobbered.
+    assert_eq!(
+        config.browser.policy.allowed_origins,
+        vec![OPERATOR_ORIGIN.to_string()],
+        "the operator's origin allowlist was dropped by a project config that \
+         mentioned only [browser.policy.loopback]"
+    );
+}
+
+/// The opposite direction. A trusted project that sets an origin list wins the
+/// origin triple, and that must NOT take the operator's loopback grant with it.
+///
+/// Red arm: with the unit merge, `project.browser.policy` replaces the global
+/// wholesale and `enabled` comes back false.
+#[test]
+#[serial(browser_merge_trust_env)]
+fn a_project_policy_override_does_not_drop_the_operator_loopback_grant() {
+    let config = load(
+        &operator_global_policy_with_loopback(),
+        "[browser.policy]\nallowed_origins = [\"https://project.example.com\"]\n",
+        Trust::Granted,
+    );
+
+    assert!(
+        config.browser.policy.loopback.enabled,
+        "the operator's loopback grant was dropped because the project set an \
+         unrelated origin allowlist"
+    );
+    assert_eq!(
+        config.browser.policy.loopback.ports,
+        vec![3000],
+        "the operator's grant survived as a flag but lost its port list"
+    );
+    // And the project's own override still took effect, so this cannot pass
+    // by hard-wiring the global.
+    assert_eq!(
+        config.browser.policy.allowed_origins,
+        vec!["https://project.example.com".to_string()],
+        "the trusted project's origin override was itself dropped; this arm \
+         would then pass for the wrong reason"
+    );
+}
+
+/// Trust gate. Resolving `loopback` independently must not become a route for
+/// an UNTRUSTED project to grant itself local network authority.
+#[test]
+#[serial(browser_merge_trust_env)]
+fn an_untrusted_project_cannot_enable_a_loopback_grant() {
+    let config = load(
+        &operator_global_policy(),
+        &loopback_only_project_body(),
+        Trust::Untrusted,
+    );
+
+    assert!(
+        !config.browser.policy.loopback.enabled,
+        "an untrusted project granted itself a loopback capability"
+    );
+    assert!(
+        config.browser.policy.loopback.ports.is_empty(),
+        "an untrusted project supplied loopback ports"
     );
 }


### PR DESCRIPTION
A same-day regression in a capability that is shipping in v0.13.1.

## The defect

`BrowserPolicyConfig` carries four fields. The project/global merge predicate in `config.rs` tested three of them:

```rust
policy: if project.browser.policy.default_action != default_browser_policy.default_action
    || !project.browser.policy.allowed_origins.is_empty()
    || !project.browser.policy.denied_origins.is_empty()
{ project.browser.policy } else { global.browser.policy },
```

`policy` resolves as a **unit**, so leaving `loopback` out of the predicate loses the gh#911 grant in *both* directions:

- a project that sets **only** `[browser.policy.loopback]` fails the predicate, so the entire project policy — grant included — is discarded, and the capability is inert; and
- a project that sets **any** origin list wins the unit, discarding the **operator's** grant with it.

The `loopback` field was added to the struct when the capability landed and this predicate was never extended, so project-level config could not use the feature at all.

## The fix

`loopback` is resolved presence-over-default on its own, outside the origin triple.

That triple is genuinely one decision — an allowlist only means something beside the action it qualifies — but a loopback grant is an independent local-only capability that says nothing about which remote origins are reachable. It now uses the same shape as `camoufox_download` directly below it, for the same stated reason that block is field-wise at all: *a setting one layer never mentioned must not disappear because of one it did.*

## No new authority

`restrict_untrusted_project_config` builds from `ConfigFile::default()` and never forwards `browser` — verified by reading the whole function, which contains no reference to it. An untrusted project therefore reaches this merge with no grant to promote. That property is now pinned rather than assumed, by `an_untrusted_project_cannot_enable_a_loopback_grant`.

## Red arm

Production change reverted, tests kept, `touch`ed so cargo could not serve a stale binary:

```
Summary 3 tests run: 1 passed, 2 failed
  FAIL a_project_policy_override_does_not_drop_the_operator_loopback_grant
  FAIL a_project_that_configures_only_loopback_keeps_that_grant
        panicked: the trusted project's [browser.policy.loopback] grant was
        dropped because it did not also set default_action or an origin list
```

Both fail **on the symptom**, not on a compile break. The untrusted arm passes in the red run too — deliberately: it guards this change against opening a hole, so it should not depend on the fix.

With the fix restored: **8/8 pass** (5 pre-existing + 3 new). `cargo fmt` clean; `clippy -p wcore-config --all-targets -D warnings` clean.

## How this was found

An agent sweeping open issues flagged it while re-grading gh#911. I verified it against `main` before acting rather than taking the report at face value — including one search that returned empty and would have had me report a test file as missing, until the positive control showed my query was broken, not the file absent.
