### PR TITLE
docs(changelog): both 0.13.1 Windows causes were witnessed failing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@
 **Release highlights.** A fast follow-up to v0.13.0, and most of it is Windows.
 The command-execution cluster that users have been reporting since 0.12 —
 "Bash not working", "echo times out", "sandbox child timed out" — turned out to
-be two separate defects with one shared symptom. One is fixed and measured; the
-other is fixed but has not yet been witnessed failing on Windows hardware, and
-is called out as such below. Windows binaries are also Authenticode-signed for
-the first time. No breaking changes, and no barrier to rolling back.
+be two separate defects with one shared symptom. Both are fixed, and both have
+now been exercised on real Windows hardware — for one of them we reproduced the
+exact failing bytes and watched the fix remove them. Windows binaries are also
+Authenticode-signed for the first time. No breaking changes, and no barrier to
+rolling back.
 
 **Windows commands stop timing out.** Every `Bash` invocation computed an
 OS-level read-deny list by walking the entire workspace with no pruning, and the


### PR DESCRIPTION
The 0.13.1 highlights paragraph on `main` still says one of the two Windows
command-execution causes "has not yet been witnessed failing on Windows
hardware". That was true when the paragraph was written and is not true now.

It was disproved the same day by a live red arm on real Windows 11 build 26200:
driving the production shell path with and without `/S`, `cmd /c echo NESTED`
returns `4e 45 53 54 45 44 0d 0a` with the fix and `4e 45 53 54 45 44 22 0d 0a`
without it. The **published release notes were corrected in place** at the time;
this file was not, so the repo and the release have disagreed since.

Re-confirmed since, against the *published* 0.13.0 and 0.13.1 artifacts rather
than a local build (`wayland-core` run `32132781589`, same OS build the
reporters used, both zips checksum-verified against their own releases). The
non-nested control is byte-identical on both arms, so the difference is
specific to the case the fix addresses.

The detailed `/S` section further down already carries the corrected byte-level
account — only the summary paragraph above it was left stale, which is the
exact trap that made the published notes briefly contradict themselves.

Documentation only. No code, no behavior change.
