### PR TITLE
fix(egress): allowlist the shipped web-search backends

### DIFF
--- a/crates/wcore-agent/src/egress/defaults.rs
+++ b/crates/wcore-agent/src/egress/defaults.rs
@@ -44,9 +44,20 @@ const WELL_KNOWN_DOMAINS: &[&str] = &[
     "minimax.io",
     "minimaxi.com", // MiniMax's second region + 401 region-failover target
     // built-in tool backends (web search / code hosts / docs APIs)
+    //
+    // Every host here backs a search provider this product SHIPS and selects
+    // itself. Omitting one does not make that backend optional, it makes it
+    // structurally unreachable: the request is refused by our own egress
+    // policy before it leaves the process, no matter what the user configures.
+    // gh#1068 — `parallel.ai` (the KEYLESS DEFAULT), `exa.ai` and
+    // `firecrawl.dev` were missing, so the default install could never run a
+    // successful primary search and two documented API keys were inert.
     "tavily.com",
     "brave.com",
     "duckduckgo.com",
+    "parallel.ai",   // keyless default: search.parallel.ai + api.parallel.ai
+    "exa.ai",        // EXA_API_KEY: api.exa.ai
+    "firecrawl.dev", // FIRECRAWL_API_KEY: api.firecrawl.dev
     "github.com",
     "gitlab.com",
     "notion.com",
@@ -185,6 +196,58 @@ mod tests {
                 &allow
             ),
             EgressVerdict::Allow
+        );
+    }
+
+    #[test]
+    fn every_shipped_search_backend_host_is_reachable() {
+        // gh#1068. These are not third-party integrations a user opts into —
+        // they are backends `build_web_search_backend` selects on its own, one
+        // of them with no key at all. A shipped default that our own egress
+        // policy refuses is unreachable by construction, and the denial was
+        // swallowed into a debug! log, so it presented as "web search is
+        // broken" with a diagnosis pointing at an unrelated backend.
+        //
+        // Default config, no user allowlist entries: exactly what a fresh
+        // install has.
+        let allow = build_allowlist(&cfg("", &[]));
+        for url in [
+            "https://search.parallel.ai/mcp",      // keyless DEFAULT backend
+            "https://api.parallel.ai/v1/search",   // PARALLEL_API_KEY
+            "https://api.exa.ai/search",           // EXA_API_KEY
+            "https://api.firecrawl.dev/v1/search", // FIRECRAWL_API_KEY
+            "https://api.tavily.com/search",       // regression guard
+        ] {
+            assert_eq!(
+                classify(&Method::POST, &u(url), &allow),
+                EgressVerdict::Allow,
+                "{url} is a shipped search backend and must not be blocked by our own policy"
+            );
+        }
+    }
+
+    #[test]
+    fn allowlisting_a_search_backend_does_not_open_unrelated_hosts() {
+        // The entries added for gh#1068 are registrable domains, so the guard
+        // that matters is that they did not widen into anything else. Without
+        // this, the test above would pass just as well if the allowlist had
+        // been replaced with "allow everything".
+        let allow = build_allowlist(&cfg("", &[]));
+        // There is no `Deny` verdict. An unknown POST destination classifies as
+        // `Exfil` (the gated class), and it is the non-interactive tool path,
+        // which has no operator to prompt, that turns this into the observed
+        // "egress denied: POST with body to a non-allowlisted host".
+        //
+        // The property under test is only that it is not silently allowed, so
+        // assert exactly that rather than pinning the specific gated class.
+        let verdict = classify(
+            &Method::POST,
+            &u("https://api.not-a-backend.example/search"),
+            &allow,
+        );
+        assert!(
+            !matches!(verdict, EgressVerdict::Allow),
+            "an unrelated host must NOT be silently allowed, got {verdict:?}"
         );
     }
 

--- a/crates/wcore-agent/src/tool_backends/chained_web.rs
+++ b/crates/wcore-agent/src/tool_backends/chained_web.rs
@@ -16,6 +16,40 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use wcore_tools::web_tools::{CrawlRequest, ExtractRequest, WebBackend, WebOutcome};
 
+/// Record on a fallback result that the primary was tried and failed.
+///
+/// Without this the degradation is invisible: the caller receives an ordinary
+/// success from DuckDuckGo and has no way to learn that the backend the user
+/// actually configured never ran. gh#1068 — a user whose `EXA_API_KEY` was
+/// being ignored was advised to set a Brave key, because the only backend
+/// anyone could see was the fallback.
+///
+/// Additive only. `payload` is splice-merged into the final result object, so
+/// a new key cannot disturb the `web` / `results` shapes callers match on. A
+/// non-object payload is passed through untouched rather than coerced.
+fn note_degraded(outcome: WebOutcome, primary: &str, fallback: &str, reason: &str) -> WebOutcome {
+    match outcome {
+        WebOutcome::Ok { mut payload } => {
+            if let Some(map) = payload.as_object_mut() {
+                map.insert(
+                    "degraded_from".to_string(),
+                    serde_json::json!({
+                        "backend": primary,
+                        "served_by": fallback,
+                        "reason": reason,
+                    }),
+                );
+            }
+            WebOutcome::Ok { payload }
+        }
+        // Both failed. The fallback's own message is the one worth surfacing,
+        // but it is misleading on its own, so carry the primary's with it.
+        WebOutcome::Err { message } => WebOutcome::Err {
+            message: format!("{message} (primary '{primary}' also failed: {reason})"),
+        },
+    }
+}
+
 /// Wraps a primary backend with a fallback (always DuckDuckGo in practice).
 /// On any primary `Err`, the same operation is retried on the fallback.
 pub struct ChainedWebBackend {
@@ -35,12 +69,21 @@ impl WebBackend for ChainedWebBackend {
         match self.primary.search(query, limit).await {
             WebOutcome::Ok { payload } => WebOutcome::Ok { payload },
             WebOutcome::Err { message } => {
-                tracing::debug!(
+                // WARN, not DEBUG: with `RUST_LOG` unset a debug! record is not
+                // written anywhere at all, so the single most useful line for
+                // diagnosing "web search is broken" did not survive the run.
+                tracing::warn!(
                     "web search: primary '{}' failed ({message}); falling back to '{}'",
                     self.primary.backend_id(),
                     self.fallback.backend_id()
                 );
-                self.fallback.search(query, limit).await
+                let out = self.fallback.search(query, limit).await;
+                note_degraded(
+                    out,
+                    self.primary.backend_id(),
+                    self.fallback.backend_id(),
+                    &message,
+                )
             }
         }
     }
@@ -110,6 +153,69 @@ mod tests {
             fb.snapshot().len(),
             1,
             "fallback must be invoked exactly once"
+        );
+    }
+
+    #[tokio::test]
+    async fn fallback_result_records_which_backend_was_skipped_and_why() {
+        // gh#1068. The whole harm was that this degradation was invisible: the
+        // caller saw a clean DuckDuckGo success and could not tell that the
+        // configured backend had been refused, so users were diagnosed against
+        // a backend that was never involved.
+        let fb = Arc::new(CapturingWebBackend::new().with_search_payload(json!({
+            "web": [{"title": "ddg", "url": "https://x/", "snippet": "ok"}]
+        })));
+        let chain = ChainedWebBackend::new(Arc::new(ErrBackend), fb);
+        let WebOutcome::Ok { payload } = chain.search("q", 5).await else {
+            panic!("fallback should have served this");
+        };
+        let note = payload
+            .get("degraded_from")
+            .expect("a served-by-fallback result must say so");
+        assert_eq!(note.get("backend").and_then(|v| v.as_str()), Some("err"));
+        assert_eq!(
+            note.get("served_by").and_then(|v| v.as_str()),
+            Some("capturing")
+        );
+        assert!(
+            note.get("reason")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default()
+                .contains("boom"),
+            "the primary's actual failure reason must survive, not just the fact of it"
+        );
+        // The note is additive: the payload callers match on is untouched.
+        assert!(payload.get("web").is_some(), "results must be unchanged");
+    }
+
+    #[tokio::test]
+    async fn a_successful_primary_is_not_marked_degraded() {
+        // Guards the obvious way to "pass" the test above — annotating always.
+        let primary = Arc::new(CapturingWebBackend::new().with_search_payload(json!({
+            "web": [{"title": "p", "url": "https://p/", "snippet": "ok"}]
+        })));
+        let chain = ChainedWebBackend::new(primary, Arc::new(CapturingWebBackend::new()));
+        let WebOutcome::Ok { payload } = chain.search("q", 5).await else {
+            panic!("primary should have served this");
+        };
+        assert!(
+            payload.get("degraded_from").is_none(),
+            "a result the primary served is not degraded"
+        );
+    }
+
+    #[tokio::test]
+    async fn when_both_fail_the_primary_reason_is_not_lost() {
+        // The fallback's own error alone is actively misleading — it names
+        // DuckDuckGo for a failure that started with the user's configured
+        // backend being refused.
+        let chain = ChainedWebBackend::new(Arc::new(ErrBackend), Arc::new(ErrBackend));
+        let WebOutcome::Err { message } = chain.search("q", 5).await else {
+            panic!("both arms fail, so this must be an Err");
+        };
+        assert!(
+            message.contains("primary 'err'"),
+            "the primary that failed first must be named: {message}"
         );
     }
 


### PR DESCRIPTION
Addresses FerroxLabs/wayland#1068. (Cross-repo keywords do not auto-close, and
closing that issue is Sean's call regardless.)

Three of the six built-in web-search backends were unreachable because our own
egress allowlist did not list the hosts they call — including the **keyless
default**. On a fresh install the primary search backend could never succeed,
and two documented API keys (`EXA_API_KEY`, `FIRECRAWL_API_KEY`) were inert no
matter what the user set.

## What changed

**1. The three missing hosts are allowlisted** (`egress/defaults.rs`).

`parallel.ai`, `exa.ai` and `firecrawl.dev` join `tavily.com` / `brave.com` /
`duckduckgo.com`, which were already there. These are not third-party
integrations a user opts into — they back providers `build_web_search_backend`
selects on its own. Omitting one doesn't make that backend optional, it makes it
structurally unreachable: the request is refused before it leaves the process.

**2. A skipped primary is no longer invisible** (`tool_backends/chained_web.rs`).

The fallback's result now carries a `degraded_from` note naming the backend that
was skipped, who served the request instead, and the actual failure reason. This
is the part that caused the user-visible harm in the report: the caller saw a
clean DuckDuckGo success, had no way to learn the configured backend had been
refused, and was consequently advised to set a *Brave* key — for a backend that
was never involved.

The note is additive. `payload` is splice-merged into the result object, so a new
key cannot disturb the `web` / `results` shapes callers match on, and a
non-object payload passes through untouched.

When *both* arms fail, the primary's reason is folded into the error rather than
dropped — the fallback's own message alone points at DuckDuckGo for a failure
that started elsewhere.

**3. The fallback log is `warn!`, not `debug!`.**

With `RUST_LOG` unset a `debug!` record is written nowhere at all, so the single
most useful line for diagnosing "web search is broken" did not survive the run.

## Tests

`every_shipped_search_backend_host_is_reachable` asserts all four keyed/keyless
search hosts classify `Allow` under a default config with no user allowlist
entries — exactly what a fresh install has.

Each new test ships with a control, because each had an obvious way to pass
vacuously:

- `allowlisting_a_search_backend_does_not_open_unrelated_hosts` — the reachability
  test would pass just as well if the allowlist had been widened to everything.
  This one caught a real error in its own first draft: I asserted the unknown
  host classified as `Ask`, and it does not — a POST to an unknown host is
  `Exfil`. There is no `Deny` verdict at all. The assertion now pins the property
  that matters (not silently allowed) rather than a class it doesn't have.
- `a_successful_primary_is_not_marked_degraded` — guards the obvious cheat of
  annotating unconditionally.
- `when_both_fail_the_primary_reason_is_not_lost`.

`cargo test -p wcore-agent --lib egress::defaults` 17 passed;
`… --lib tool_backends::chained_web` 6 passed.

## Deliberately not in scope

Fixing the egress block means queries from a default install now genuinely reach
`parallel.ai`, where previously they were refused before leaving the process. The
privacy disclosure for that already exists but is emitted at `info!`, which with
`RUST_LOG` unset goes to the log file and never to the terminal — so no log level
makes it visible where it needs to be. That needs a real first-run notice rather
than a severity bump, so I have left it alone and called it out on the issue
instead of half-fixing it.

Pre-existing, also present in shipped 0.13.0. Not a 0.13.1 regression.
