### PR TITLE
fix(deps): bump h2 to 0.4.16 for RUSTSEC-2026-0258

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3342,9 +3342,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
Addresses FerroxLabs/wayland#1081. **This unblocks the whole repo** — please land it ahead of the other open PRs.

## Why this is urgent rather than routine

`RUSTSEC-2026-0258` was published on 2026-08-17 against `h2 0.4.14`. `cargo audit` is a step inside `CI (Array)`, which is a required status context, so from the moment that advisory landed **every PR in this repository fails** — no commit has to change for a green tree to go red.

It surfaced on PR #291, a documentation-only edit to `CHANGELOG.md`. A docs change cannot break the dependency audit, which is what identified this as advisory-database drift rather than a defect in that PR.

`h2` is our HTTP/2 implementation, reached through hyper/reqwest, so it is on the path of every outbound provider request. The advisory class — unbounded empty DATA frames — is peer-driven resource exhaustion.

## Why the diff is two lines

`cargo update -p h2` produces a **21-line** change: alongside the h2 bump it rewrites unrelated `windows-sys` dependency edges, including a **downgrade** from `0.59.0` to `0.52.0`. None of that is required by the advisory, and collateral transitive movement is not something a security patch should smuggle in.

`h2 0.4.16` turns out to have a dependency set identical to `0.4.14`, so editing only `version` and `checksum` is sufficient and `cargo metadata --locked` accepts the result — meaning cargo agrees this lockfile is fully resolved and would not rewrite it.

## Verified before pushing

```
$ cargo metadata --locked          exit 0   (lockfile is complete and self-consistent)
$ cargo audit
    Scanning Cargo.lock for vulnerabilities (1036 crate dependencies)
warning: 6 allowed warnings found
                                   exit 0   (0 occurrences of RUSTSEC-2026-0258)
$ cargo check --workspace --all-targets
    Finished `dev` profile          exit 0
```

Dependency count is **identical at 1036** before and after, and the 6 remaining allowed warnings are the same pre-existing set (`bincode`, `ttf-parser`, `lexical-core` and friends) that the failing run also reported — so nothing was silently suppressed to make this pass.

One thing not to be misled by when reading the original failing log: it also contains

```
error: couldn't check if the package is yanked: registry: request could not be completed in the allotted timeframe
```

That is a transient registry timeout during the yank check, not the failure. The failure is `error: 1 vulnerability found!`.
