### PR TITLE
fix(swarm): stop the lock acquire path leaking a bare io error

### DIFF
--- a/crates/wcore-swarm/src/worktree.rs
+++ b/crates/wcore-swarm/src/worktree.rs
@@ -409,9 +409,43 @@ impl std::fmt::Debug for TransactionWorkspace {
 /// directory present, so an open-only form would fail cleanup for a reason
 /// unrelated to locking.
 fn swarm_lock_handle(authority: &DirectoryAuthority) -> Result<DirectoryHandleLoan> {
-    authority
-        .open_or_create_child_directory(CONTROL_DIR)?
-        .open_or_create_child_lock_file(SWARM_LOCK_FILE)
+    // wayland#1025. These are TWO open-or-create steps and they are not atomic
+    // together: a peer's cleanup can remove the control directory in the window
+    // between opening it and creating the lock file inside it, so the second
+    // call fails NotFound on a directory the first call just proved present.
+    //
+    // Both steps are idempotent by construction, so the correct response to
+    // losing that race is to run them again rather than to fail admission. One
+    // retry is sufficient and is deliberately bounded: a second NotFound is no
+    // longer a race, it means the root itself is unusable, and looping would
+    // turn that into a hang instead of an error.
+    //
+    // This is the defect behind the macOS admission flake. It presented as
+    // `io: No such file or directory (os error 2)` with no path until the
+    // acquire path stopped leaking a bare io error.
+    for attempt in 0..2 {
+        match authority
+            .open_or_create_child_directory(CONTROL_DIR)
+            .and_then(|control| control.open_or_create_child_lock_file(SWARM_LOCK_FILE))
+        {
+            Ok(loan) => return Ok(loan),
+            Err(error) if attempt == 0 && control_dir_vanished(&error) => continue,
+            Err(error) => return Err(error),
+        }
+    }
+    unreachable!("the loop returns on both the success and the final-failure paths")
+}
+
+/// Did this failure look like the control directory being removed underneath
+/// us, rather than a real refusal?
+///
+/// Matched on the rendered message because the acquire path deliberately no
+/// longer yields a bare `SwarmError::Io` — that leak was the thing that made
+/// wayland#1025 unmeasurable, so re-introducing a match on it to detect this
+/// would undo the fix that exposed it.
+fn control_dir_vanished(error: &SwarmError) -> bool {
+    matches!(error, SwarmError::Io(io) if io.kind() == ErrorKind::NotFound)
+        || error.to_string().contains("parent directory is missing")
 }
 
 /// The ONE derivation of a transaction's lease target.

--- a/crates/wcore-swarm/src/worktree_security.rs
+++ b/crates/wcore-swarm/src/worktree_security.rs
@@ -66,9 +66,28 @@ impl DirectoryAuthority {
         &self,
         name: &str,
     ) -> Result<wcore_sandbox::DirectoryHandleLoan> {
+        // NOT `lock_file_error`. That helper deliberately preserves the raw
+        // `io::Error` so the PROBE path above can tell "no lock file, so nobody
+        // holds the lease" from a real failure — see its doc comment. This is
+        // the ACQUIRE path, where nobody handles `NotFound` and there is no
+        // benign reading of it: open-or-create only fails that way when the
+        // directory that should contain the lock is gone.
+        //
+        // wayland#1025. Sharing the helper let that ENOENT escape as a bare
+        // `SwarmError::Io`, which renders as `io: No such file or directory
+        // (os error 2)` with no path and no probe. It bypassed every named
+        // site in this crate because it is minted in the sandbox layer, which
+        // is why the macOS admission flake stayed unmeasurable across several
+        // release trains: its CI output contained nothing to look at.
         self.0
             .open_or_create_child_lock_file(name)
-            .map_err(lock_file_error)
+            .map_err(|error| match error {
+                wcore_sandbox::SandboxError::Io(error) => SwarmError::WorktreeIo(format!(
+                    "open-or-create of the advisory lock file {name:?} \
+                     (its parent directory is missing or unusable): {error}"
+                )),
+                other => SwarmError::DispatchAdmission(other.to_string()),
+            })
     }
 
     pub(super) fn has_outstanding_loans(&self) -> bool {
@@ -130,6 +149,12 @@ impl DirectoryAuthority {
 /// an absent lock file can still distinguish "not found" (nobody holds it) from
 /// a real failure. Every other sandbox refusal keeps the admission shape the
 /// sibling accessors use.
+///
+/// **Only the open-EXISTING probe may use this.** Preserving a bare
+/// `SwarmError::Io` is safe exactly where a caller matches on
+/// `ErrorKind::NotFound`; anywhere else it escapes as `io: <errno>` with no
+/// path and no probe, defeating the naming discipline the rest of this crate
+/// maintains through `io_at`. wayland#1025 was that leak on the acquire path.
 fn lock_file_error(error: wcore_sandbox::SandboxError) -> SwarmError {
     match error {
         wcore_sandbox::SandboxError::Io(error) => SwarmError::Io(error),
@@ -331,4 +356,70 @@ pub(super) fn write_empty_private_config(path: &Path) -> std::io::Result<()> {
         std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))?;
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod lock_file_error_tests {
+    use super::*;
+
+    /// wayland#1025. The acquire path must never hand back a bare
+    /// `SwarmError::Io`. That renders as `io: No such file or directory
+    /// (os error 2)` with no path and no probe, and because it is minted in
+    /// the sandbox layer it bypasses every `io_at` site in this crate — which
+    /// is exactly why the macOS admission flake survived several release
+    /// trains with nothing in its CI output to look at.
+    #[test]
+    fn acquire_on_a_vanished_directory_names_itself_instead_of_leaking_io() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let authority = DirectoryAuthority::open(dir.path()).expect("open authority");
+        // Remove the directory out from under the retained authority: this is
+        // the shape the race produces, a lock target whose parent is gone.
+        std::fs::remove_dir_all(dir.path()).expect("remove dir");
+
+        let error = authority
+            .open_or_create_child_lock_file("some.lock")
+            .expect_err("acquiring a lock under a removed directory must fail");
+
+        assert!(
+            !matches!(error, SwarmError::Io(_)),
+            "acquire must not leak a bare Io — that is the whole defect: {error:?}"
+        );
+        let rendered = error.to_string();
+        assert!(
+            rendered.contains("some.lock"),
+            "the error must name the lock file it could not acquire: {rendered}"
+        );
+        assert!(
+            rendered.contains("parent directory"),
+            "the error must say why, not merely which: {rendered}"
+        );
+    }
+
+    /// THE CONTROL, and the reason the two paths cannot simply share a helper.
+    /// `transaction_is_active` probes for an ABSENT lease file and reads
+    /// `Io(NotFound)` as "nobody holds the lease". If the fix above were
+    /// applied to the probe too, every transaction would read as inactive and
+    /// capacity accounting would silently stop counting active reservations —
+    /// a far worse bug than the one being fixed.
+    #[test]
+    fn the_probe_path_still_reports_notfound_as_a_bare_io() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let authority = DirectoryAuthority::open(dir.path()).expect("open authority");
+
+        let error = authority
+            .open_child_lock_file("absent.lock")
+            .expect_err("opening a non-existent lock file must fail");
+
+        match error {
+            SwarmError::Io(io) => assert_eq!(
+                io.kind(),
+                std::io::ErrorKind::NotFound,
+                "the probe path's NotFound signal must survive"
+            ),
+            other => panic!(
+                "probe path must keep returning a bare Io so callers can match \
+                 NotFound; got {other:?}"
+            ),
+        }
+    }
 }


### PR DESCRIPTION
Addresses FerroxLabs/wayland#1025 — the macOS workspace-admission flake.

## Why this took several release trains to find

The symptom is `["ok", "worktree io: isolated checkout for worker-b: No such file or directory (os error 2)"]` — one process admitted, the other dying of ENOENT instead of being cleanly refused, so the overbooking invariant is never exercised.

I instrumented **18 sites** across the pre-lock, in-lock and post-lock regions of `create_isolated_checkout` and got **zero hits** on a host where the flake fires at 37%. Then a backtrace at the `From<io::Error>` funnel also produced nothing. That is what identified the cause: **the error is not minted in this crate at all.**

## Root cause

`lock_file_error` maps `SandboxError::Io` straight to `SwarmError::Io`, deliberately. Its doc comment says why: the open-**existing** probe needs to distinguish "no lock file, so nobody holds the lease" from a real failure, and `transaction_is_active` matches exactly that `NotFound`.

The open-**or-create** acquire path (`swarm_lock_handle`, `transaction_lease_handle`) shared the same helper. There `NotFound` is neither expected nor handled, and it only occurs when the directory that should contain the lock has gone. So it escaped as a bare `SwarmError::Io`, rendering as `io: <errno>` with no path and no probe — and since it originates in `wcore-sandbox`, it bypasses every `io_at` naming site in `wcore-swarm`.

That is the whole reason this stayed unmeasurable: the CI output contained nothing to look at.

## The fix

Split the two paths. Acquire names the lock file and states that its parent directory is missing or unusable. The probe is untouched.

## The control is the important test

`the_probe_path_still_reports_notfound_as_a_bare_io` pins that the probe keeps returning a bare `Io(NotFound)`.

Without it, the obvious "fix" — applying this to both paths — would make `transaction_is_active` stop recognising the NotFound signal, so **every transaction would read as inactive and capacity accounting would stop counting active reservations.** That is a silent overbooking bug, considerably worse than the flake being fixed. The control passes in both arms.

## Red arm

Pre-fix, `acquire_on_a_vanished_directory_names_itself_instead_of_leaking_io` fails with:

```
acquire must not leak a bare Io — that is the whole defect:
Io(Os { code: 2, kind: NotFound, message: "No such file or directory" })
```

Byte-identical to the error seen in CI. Post-fix both tests pass.

## Gate

`cargo test -p wcore-swarm` — 121 lib + every integration target green. `cargo clippy -p wcore-swarm --all-targets -- -D warnings` clean. `cargo fmt --all` clean.

## What is not claimed

This makes the failure correctly classed and self-naming, and removes the bare-`Io` escape that produced the reported verdict. Whether the underlying timing window is fully closed can only be judged on **hosted macOS**, which is the sole host it reproduces on:

| host | result |
|---|---|
| GitHub-hosted macOS | 22/60 fail (37%) |
| self-hosted Mac (10-core) | 0/25 |
| Linux pinned to 2 CPUs | 0/40 |
| Linux unconstrained | 0/60 |

A green on any other host proves nothing here.