### PR TITLE
fix(tools): report a policy denial the shell swallowed (#1078)

### DIFF
--- a/crates/wcore-tools/src/bash.rs
+++ b/crates/wcore-tools/src/bash.rs
@@ -17,7 +17,7 @@ use crate::context::ToolContext;
 mod policy;
 use crate::{Tool, ToolOutputSink};
 pub use policy::check_denylist;
-use policy::{SandboxScope, annotate_network_block, annotate_sandbox_denial};
+use policy::{SandboxScope, annotate_masked_read, annotate_network_block, annotate_sandbox_denial};
 
 const DEFAULT_TIMEOUT_MS: u64 = 120_000;
 const MAX_TIMEOUT_MS: u64 = 600_000;
@@ -656,9 +656,13 @@ impl Tool for BashTool {
                 is_error: true,
             },
             result = tokio::time::timeout(timeout, backend.execute(&manifest, cmd)) => match result {
-                Ok(Ok(output)) => annotate_sandbox_denial(
+                Ok(Ok(output)) => annotate_masked_read(
                     &scope,
-                    annotate_network_block(command, net, output_to_result(output)),
+                    command,
+                    annotate_sandbox_denial(
+                        &scope,
+                        annotate_network_block(command, net, output_to_result(output)),
+                    ),
                 ),
                 Ok(Err(e)) => exec_error_to_result(&e),
                 Err(_) => ToolResult { content: format!("Command timed out after {timeout_ms}ms"), is_error: true },
@@ -816,15 +820,19 @@ impl Tool for BashTool {
                     "Exit code: {}\nSTDOUT:\n{}\nSTDERR:\n{}",
                     exit_code, stdout_buf, stderr_buf
                 );
-                annotate_sandbox_denial(
+                annotate_masked_read(
                     &scope,
-                    annotate_network_block(
-                        command,
-                        net,
-                        ToolResult {
-                            content,
-                            is_error: exit_code != 0,
-                        },
+                    command,
+                    annotate_sandbox_denial(
+                        &scope,
+                        annotate_network_block(
+                            command,
+                            net,
+                            ToolResult {
+                                content,
+                                is_error: exit_code != 0,
+                            },
+                        ),
                     ),
                 )
             }

--- a/crates/wcore-tools/src/bash/policy.rs
+++ b/crates/wcore-tools/src/bash/policy.rs
@@ -264,6 +264,102 @@ fn classify(scope: &SandboxScope, token: &str) -> Option<(PathBuf, DeniedBecause
     Some((resolved, DeniedBecause::NotGranted))
 }
 
+/// Path-shaped tokens from a COMMAND, for the masked-read check.
+///
+/// Deliberately far more permissive than [`is_path_token`], and the asymmetry
+/// is the whole design. In the FAILURE path a stray token becomes a fabricated
+/// accusation, so a token must look path-shaped before it is trusted. Here a
+/// token survives only if it matches this manifest's OWN deny list, so that
+/// match IS the filter — which is what lets a bare filename through. `cat
+/// secret.txt` has no interior separator and would be dropped by
+/// [`is_path_token`], and it is precisely the case wayland#1078 is about.
+fn command_path_tokens(command: &str) -> Vec<&str> {
+    command
+        .split(|c: char| {
+            c.is_whitespace()
+                || matches!(
+                    c,
+                    '\'' | '"' | '`' | ';' | '|' | '&' | '(' | ')' | '<' | '>'
+                )
+        })
+        .map(|token| token.trim_matches(|c| matches!(c, ',' | ']' | '[')))
+        .filter(|token| token.len() >= 2 && !token.contains("://") && !token.starts_with('-'))
+        .collect()
+}
+
+/// When a sandboxed command SUCCEEDS but named a path this workspace masks,
+/// say so.
+///
+/// wayland#1078, **narrowed by measurement**. The issue reports that a denied
+/// file "reads as an empty file, successfully". That is NOT what HEAD does: a
+/// file on `fs_read_deny` is masked by binding `/dev/null` over it (bwrap,
+/// `backends/bwrap.rs`), and a `cat` of the mask fails LOUDLY with
+/// `Permission denied` — which [`annotate_sandbox_denial`] already explains,
+/// because the result is an error.
+///
+/// The real residual gap is narrower: a COMPOUND command
+/// (`cat secret.pem; echo rc=$?`, `cat x || true`, `cat x 2>/dev/null`) lets
+/// the shell swallow that failure, so the tool result carries `is_error =
+/// false` and the agent sees only emptiness with no cause. `ls -l` on a masked
+/// path is the same shape — it succeeds and prints `crw-rw-rw- … 1, 3`, which
+/// is only a tell if you already suspect the answer.
+///
+/// The containment is correct and this does NOT weaken it — the bytes never
+/// leave. What it fixes is that the agent cannot tell "denied to me" from
+/// "empty", and acts on the difference: reporting a populated file as empty,
+/// or overwriting one it believes is empty and was never allowed to see.
+///
+/// [`annotate_sandbox_denial`] cannot cover this: it returns early unless
+/// `result.is_error`, and a masked read is not an error.
+///
+/// Only [`DeniedBecause::PolicyDeny`] counts here. A `NotGranted` path on a
+/// command that SUCCEEDED is not the masked-read shape and would be pure noise.
+pub(super) fn annotate_masked_read(
+    scope: &SandboxScope,
+    command: &str,
+    mut result: ToolResult,
+) -> ToolResult {
+    if result.is_error || scope.is_unscoped() || scope.deny.is_empty() {
+        return result;
+    }
+    let mut masked: Vec<PathBuf> = Vec::new();
+    for token in command_path_tokens(command) {
+        if let Some((path, DeniedBecause::PolicyDeny)) = classify(scope, token)
+            && !masked.contains(&path)
+        {
+            masked.push(path);
+        }
+    }
+    if masked.is_empty() {
+        return result;
+    }
+
+    result.content.push_str(
+        "\n\n⚠ This command named a path this workspace's policy DENIES, and the command's \
+         own exit status did not report it:",
+    );
+    for path in &masked {
+        result
+            .content
+            .push_str(&format!("\n  • {}", path.display()));
+    }
+    // Worded for the false positive, because one is reachable: `echo secret.txt`
+    // names the path without reading it. Claiming the read happened would be a
+    // fabrication of exactly the kind `annotate_sandbox_denial` is careful to
+    // avoid, so this states the conditional and lets the reader discharge it.
+    result.content.push_str(
+        "\nA read of a denied path cannot succeed. Measured on bubblewrap it fails with \
+         'Permission denied'; a directory mask, or a backend that binds an empty file, \
+         yields nothing instead. Either way the failure or the emptiness is the POLICY and \
+         not the file's contents — do not report such a file as empty or missing, and do \
+         not overwrite it on that basis. If the command only mentioned the path without \
+         reading it, ignore this note.",
+    );
+    // Deliberately NOT an error: the command genuinely succeeded, and flipping
+    // is_error here would turn an advisory into a failed tool call.
+    result
+}
+
 /// When a sandboxed command FAILS and its output names a path this workspace's
 /// policy actually put out of reach, say so.
 ///

--- a/crates/wcore-tools/src/bash/tests.rs
+++ b/crates/wcore-tools/src/bash/tests.rs
@@ -1323,6 +1323,147 @@ fn b1_scope() -> super::policy::SandboxScope {
     super::policy::SandboxScope::new(&manifest, Some(Path::new("/w/repo")))
 }
 
+// ── wayland#1078: a masked (policy-denied) read succeeds silently ────────────
+// The bwrap backend binds /dev/null over a denied file, so `cat .env` exits 0
+// with empty output. Containment is right; the SILENCE is the defect, because
+// the agent then reports a populated file as empty and may overwrite it.
+
+/// THE DEFECT. Exit 0, empty stdout, and the denied path is named in the
+/// command — the annotation must fire even though nothing failed.
+#[test]
+fn masked_read_on_success_is_announced() {
+    let r = super::policy::annotate_masked_read(
+        &b1_scope(),
+        "cat .env",
+        ToolResult {
+            content: "Exit code: 0\nSTDOUT:\n\nSTDERR:\n".to_string(),
+            is_error: false,
+        },
+    );
+    assert!(
+        r.content.contains(".env"),
+        "the masked path must be named: {}",
+        r.content
+    );
+    assert!(
+        r.content.contains("POLICY"),
+        "must attribute the emptiness/failure to policy: {}",
+        r.content
+    );
+    assert!(
+        !r.is_error,
+        "the command genuinely succeeded — annotating must not fabricate a failure"
+    );
+}
+
+/// A bare filename has no interior separator, so `is_path_token` drops it. This
+/// is exactly the shape #1078 reports (`cat secret.txt`), so the masked-read
+/// tokenizer must be permissive and lean on the deny-list match as its filter.
+#[test]
+fn masked_read_detects_a_bare_filename_with_no_separator() {
+    let r = super::policy::annotate_masked_read(
+        &b1_scope(),
+        "cat .env",
+        ToolResult {
+            content: "Exit code: 0\n".into(),
+            is_error: false,
+        },
+    );
+    assert!(
+        r.content.contains("/w/repo/.env") || r.content.contains(".env"),
+        "bare filename must still resolve against cwd: {}",
+        r.content
+    );
+}
+
+/// CONTROL — the annotation must stay SILENT on an ordinary successful command.
+/// Without this a passing test above would prove only that the function appends
+/// text unconditionally.
+#[test]
+fn masked_read_is_silent_when_no_denied_path_is_named() {
+    let body = "Exit code: 0\nSTDOUT:\nhello\nSTDERR:\n".to_string();
+    let r = super::policy::annotate_masked_read(
+        &b1_scope(),
+        "echo hello",
+        ToolResult {
+            content: body.clone(),
+            is_error: false,
+        },
+    );
+    assert_eq!(
+        r.content, body,
+        "an unrelated success must not be annotated"
+    );
+    assert!(!r.is_error);
+}
+
+/// CONTROL — a granted path inside the workspace must not be reported as masked.
+#[test]
+fn masked_read_is_silent_for_a_granted_path() {
+    let body = "Exit code: 0\nSTDOUT:\nfn main() {}\nSTDERR:\n".to_string();
+    let r = super::policy::annotate_masked_read(
+        &b1_scope(),
+        "cat src/main.rs",
+        ToolResult {
+            content: body.clone(),
+            is_error: false,
+        },
+    );
+    assert_eq!(r.content, body, "a granted path must not be called masked");
+}
+
+/// CONTROL — a FAILED command is `annotate_sandbox_denial`'s territory. If both
+/// fired, a denied path would be explained twice in one result.
+#[test]
+fn masked_read_defers_to_the_failure_path() {
+    let body = "Exit code: 1\nSTDOUT:\nSTDERR:\ncat: .env: Operation not permitted\n".to_string();
+    let r = super::policy::annotate_masked_read(
+        &b1_scope(),
+        "cat .env",
+        ToolResult {
+            content: body.clone(),
+            is_error: true,
+        },
+    );
+    assert_eq!(r.content, body, "the failure path already annotates this");
+}
+
+/// CONTROL — nothing to attribute without a scope, so stay quiet.
+#[test]
+fn masked_read_is_silent_when_the_manifest_carried_no_scoping() {
+    let unscoped = super::policy::SandboxScope::new(
+        &wcore_sandbox::manifest::SandboxManifest::default(),
+        Some(Path::new("/w/repo")),
+    );
+    let body = "Exit code: 0\n".to_string();
+    let r = super::policy::annotate_masked_read(
+        &unscoped,
+        "cat .env",
+        ToolResult {
+            content: body.clone(),
+            is_error: false,
+        },
+    );
+    assert_eq!(r.content, body);
+}
+
+/// A command-line SWITCH must never be mistaken for a path. This is the same
+/// class of bug `is_path_token` documents (`/NOLOGO` blamed on the sandbox);
+/// the permissive tokenizer here has to drop switches too.
+#[test]
+fn masked_read_ignores_command_switches() {
+    let body = "Exit code: 0\n".to_string();
+    let r = super::policy::annotate_masked_read(
+        &b1_scope(),
+        "ls -la --color=auto",
+        ToolResult {
+            content: body.clone(),
+            is_error: false,
+        },
+    );
+    assert_eq!(r.content, body, "switches are not paths");
+}
+
 #[test]
 fn sandbox_denial_names_the_policy_denied_path_and_a_remedy() {
     let result = super::policy::annotate_sandbox_denial(

--- a/crates/wcore-tools/tests/bash_masked_read_linux.rs
+++ b/crates/wcore-tools/tests/bash_masked_read_linux.rs
@@ -1,0 +1,128 @@
+//! wayland#1078 (Linux, live bubblewrap) — **a policy denial that the command's
+//! own exit status hides.**
+//!
+//! The issue reports that a denied file "reads as an empty file, successfully".
+//! Measured against HEAD on real bubblewrap, that is NOT what happens: the
+//! `/dev/null` mask is present (`ls -l` shows `crw-rw-rw- … 1, 3`) but a `cat`
+//! of it fails LOUDLY with `Permission denied`, which `annotate_sandbox_denial`
+//! already explains because the result is an error.
+//!
+//! What remains is narrower and is what these tests pin: a COMPOUND command
+//! lets the shell swallow that failure. `cat secret.pem; echo rc=$?` exits 0,
+//! so the tool result carries `is_error = false`, `annotate_sandbox_denial`
+//! returns early, and the agent is left with emptiness and no cause. `ls -l` on
+//! a masked path is the same shape.
+//!
+//! The containment half is asserted throughout and is not weakened: the
+//! secret's bytes must never appear in any result.
+
+#![cfg(target_os = "linux")]
+
+use std::sync::Arc;
+
+use serde_json::json;
+use wcore_tools::Tool;
+use wcore_tools::bash::BashTool;
+use wcore_tools::context::ToolContext;
+use wcore_tools::workspace_policy::WorkspacePolicy;
+
+const SECRET: &str = "TOKEN=super-secret-value-1078";
+
+fn contained_ctx() -> Option<(ToolContext, std::path::PathBuf, tempfile::TempDir)> {
+    let dir = tempfile::tempdir().ok()?;
+    let root = std::fs::canonicalize(dir.path()).ok()?;
+    std::fs::write(root.join("deploy-cert.pem"), SECRET.as_bytes()).ok()?;
+    std::fs::write(root.join("readme.txt"), b"plain contents\n").ok()?;
+    let policy = Arc::new(WorkspacePolicy::contained(&root));
+    Some((
+        ToolContext::test_default().with_workspace(policy),
+        root,
+        dir,
+    ))
+}
+
+#[tokio::test]
+async fn a_denial_hidden_by_the_shell_is_still_reported() {
+    if !wcore_tools::bash::platform_enforces_read_deny() {
+        eprintln!("skip: no hard read-deny sandbox on this host");
+        return;
+    }
+    let Some((ctx, root, _keep)) = contained_ctx() else {
+        eprintln!("skip: could not build a contained workspace policy");
+        return;
+    };
+
+    // POSITIVE CONTROL: an ordinary granted read works and is NOT annotated.
+    // Without it these assertions could pass on a sandbox that refuses
+    // everything, which would prove nothing.
+    let granted = BashTool
+        .execute_with_ctx(json!({"command": "cat readme.txt"}), &ctx)
+        .await;
+    if granted.is_error {
+        eprintln!("skip: the live sandbox rejected a legitimate read: {granted:?}");
+        return;
+    }
+    assert!(
+        granted.content.contains("plain contents"),
+        "precondition: a granted file must be readable: {}",
+        granted.content
+    );
+    assert!(
+        !granted.content.contains("policy DENIES"),
+        "a granted read must not be annotated: {}",
+        granted.content
+    );
+
+    // THE GAP. The shell swallows the denial, so is_error is false and the
+    // existing failure-path annotation cannot fire.
+    let hidden = BashTool
+        .execute_with_ctx(json!({"command": "cat deploy-cert.pem; echo rc=$?"}), &ctx)
+        .await;
+    assert!(
+        !hidden.is_error,
+        "precondition: the shell must have swallowed the failure, else this \
+         test is exercising the failure path instead of the gap: {}",
+        hidden.content
+    );
+    assert!(
+        !hidden.content.contains("super-secret-value-1078"),
+        "CONTAINMENT REGRESSION: the secret leaked: {}",
+        hidden.content
+    );
+    assert!(
+        hidden.content.contains("deploy-cert.pem"),
+        "the denied path must be named: {}",
+        hidden.content
+    );
+    assert!(
+        hidden.content.contains("POLICY"),
+        "the result must attribute the outcome to policy: {}",
+        hidden.content
+    );
+
+    // The `ls -l` shape: succeeds, prints a character device, explains nothing
+    // on its own.
+    let listed = BashTool
+        .execute_with_ctx(json!({"command": "ls -l deploy-cert.pem"}), &ctx)
+        .await;
+    assert!(
+        !listed.is_error,
+        "precondition: ls of a masked path succeeds: {}",
+        listed.content
+    );
+    assert!(
+        listed.content.contains("deploy-cert.pem") && listed.content.contains("POLICY"),
+        "a masked stat must be explained too: {}",
+        listed.content
+    );
+
+    assert!(
+        root.join("deploy-cert.pem").is_file(),
+        "host file untouched"
+    );
+    let on_host = std::fs::read_to_string(root.join("deploy-cert.pem")).unwrap();
+    assert_eq!(
+        on_host, SECRET,
+        "the real file must be unchanged on the host"
+    );
+}


### PR DESCRIPTION
Closes #1078 — **with a correction to the issue's own premise.**

## What the issue says, and what actually happens

#1078 reports that a policy-denied file "reads as an **empty file, successfully**" (exit 0, no stderr, zero bytes), and that the agent therefore cannot tell "denied" from "empty".

Measured against HEAD on real bubblewrap 0.9.0, that is **not** what happens:

| Command | Actual result |
|---|---|
| `ls -l deploy-cert.pem` | exit 0, `crw-rw-rw- 1 sandbox sandbox 1, 3` — the `/dev/null` mask **is** there |
| `cat deploy-cert.pem` | **`Permission denied`, rc=1** |
| `cat readme.txt` (granted) | exit 0, real contents |

A denied read fails **loudly**, and `annotate_sandbox_denial` already explains it — because the result is an error.

Two other things fell out of reproducing it, both worth knowing:

- `cat .env` never reaches the sandbox at all. The **credential-exfiltration denylist refuses it first**, with a clear message. The issue's headline example is already handled better than it claims.
- The `crw-rw-rw- … 1, 3` tell the issue describes is real, but only on `ls`, not on read.

## The gap that IS real

A **compound** command lets the shell swallow the failure:

```
cat secret.pem; echo rc=$?     # outer exit 0
cat x || true
cat x 2>/dev/null
```

The tool result then carries `is_error = false`, `annotate_sandbox_denial` returns early on its very first line, and the agent sees emptiness with no cause. `ls -l` on a masked path is the same shape. That is what this PR fixes.

It matters for the reason the issue gives, which is unaffected by the correction: the agent acts on the difference — reports a populated file as empty, treats a step as having succeeded on no data, and can **overwrite a file it believes is empty and was never allowed to see.**

## The change

`annotate_masked_read` in `bash/policy.rs`:

- fires only on **success** (`!is_error`), which is exactly the case the existing annotation returns early on;
- scans the **command**, not the output — the output is empty, which is the whole problem;
- counts only `DeniedBecause::PolicyDeny`. A `NotGranted` path on a command that succeeded is not this shape and would be noise;
- **never sets `is_error`** — the command genuinely succeeded, and flipping it would turn an advisory into a failed tool call.

The command tokenizer is deliberately **far more permissive** than `is_path_token`, and the asymmetry is the design. In the failure path a stray token becomes a fabricated accusation (see that function's note on `/NOLOGO`), so a token must look path-shaped before it is trusted. Here a token survives only if it matches the manifest's **own deny list**, so that match is the filter — which is what lets a bare filename through. `cat secret.txt` has no interior separator and `is_path_token` would drop it.

Wording is written for the reachable false positive: `echo secret.pem` names the path without reading it, so the note states the conditional rather than asserting the read happened.

## Containment is unchanged

No change to the mask. The tests assert the secret's bytes never appear in any result and that the host file is byte-identical afterwards.

## Verification

- **7 unit tests**, of which **5 are controls asserting SILENCE** (unrelated success, granted path, failure path, unscoped manifest, command switches).
- **1 live bubblewrap integration test** with a positive control (a granted read must work and must not be annotated) — otherwise the assertions would pass on a sandbox that refuses everything.
- **Red arm run.** Mutating `annotate_masked_read` to return early immediately: the 2 defect tests fail, all 5 controls still pass. The controls are not load-bearing for a false green.
- `cargo fmt --check` clean; `cargo clippy --workspace --all-targets -D warnings` clean; `wcore-tools` 1191 unit + all integration suites pass.

Built and run on Linux (hetzner). The live test is `#![cfg(target_os = "linux")]` and self-skips where `platform_enforces_read_deny()` is false.
