### PR TITLE
fix(sandbox): truncate docker output at the cap instead of discarding it (#1082)

### DIFF
--- a/crates/wcore-sandbox/src/backends/appcontainer/windows_impl/process.rs
+++ b/crates/wcore-sandbox/src/backends/appcontainer/windows_impl/process.rs
@@ -1446,7 +1446,7 @@ pub(super) fn execute_blocking(
             // join them to collect the fully-drained output. This MUST run before
             // the deferred error returns so the threads never outlive their
             // handles.
-            let (stdout, stdout_exceeded) = stdout_reader.join().unwrap_or_default();
+            let (mut stdout, stdout_exceeded) = stdout_reader.join().unwrap_or_default();
             let (mut stderr, stderr_exceeded) = stderr_reader.join().unwrap_or_default();
 
             if let Some((wait_res, last_err)) = wait_err {
@@ -1507,12 +1507,45 @@ pub(super) fn execute_blocking(
             // `OutputLimitExceeded` unreachable for exactly the input it was
             // written to describe. Exhaustion is the cause; the timeout (when
             // it still happens at all) is a consequence.
-            if output_exceeded_wakeup || stdout_exceeded || stderr_exceeded {
-                return Err(SandboxError::OutputLimitExceeded {
-                    limit_bytes: super::super::super::BUFFERED_OUTPUT_LIMIT_BYTES,
-                });
+            // wayland#1082. `drain_pipe` already does the right thing: it
+            // reserves against the shared budget, KEEPS the partial grant, and
+            // signals `exceeded_event` so the waiter tears the job down. This
+            // was the one step that undid all of it — turning that retained
+            // head into an error and handing the caller none of the command's
+            // own output. A command that produced megabytes got back a hundred
+            // bytes of error text. #1071 fixed the same inversion for the
+            // shared drain; this is the AppContainer backend's copy of it.
+            //
+            // Marker placement follows the PER-STREAM flags. `exceeded_event`
+            // is only ever set by `drain_pipe` on a stream that actually
+            // crossed the ceiling, so a wakeup with both flags clear cannot
+            // mean "some stream overflowed" — it means a reader thread died and
+            // the `unwrap_or_default()` above turned that into "no output, no
+            // overflow". That is worth saying out loud rather than guessing
+            // which pipe flooded and attaching a marker to the wrong one.
+            let exceeded_any = output_exceeded_wakeup || stdout_exceeded || stderr_exceeded;
+            if stdout_exceeded {
+                let kept = stdout.len();
+                stdout.extend_from_slice(&super::super::super::truncation_marker(kept));
             }
-            if timed_out {
+            if stderr_exceeded {
+                let kept = stderr.len();
+                stderr.extend_from_slice(&super::super::super::truncation_marker(kept));
+            }
+            if output_exceeded_wakeup && !stdout_exceeded && !stderr_exceeded {
+                stderr.extend_from_slice(
+                    b"\n[wcore-sandbox: the output ceiling was crossed but neither reader \
+                      reported it, which means a reader thread failed and its output was \
+                      lost. Treat this result as INCOMPLETE.]\n",
+                );
+            }
+            // Exhaustion still takes precedence over the timeout, and that
+            // ordering is load-bearing: the abuse shape this exists for — flood
+            // the pipe, then sit there — trips both, and when the timeout won,
+            // the overflow was reported as a Timeout instead. Now that crossing
+            // the cap yields OUTPUT rather than an error, the timeout must not
+            // fire on top of it and throw that output away again.
+            if timed_out && !exceeded_any {
                 return Err(SandboxError::Timeout);
             }
 

--- a/crates/wcore-sandbox/src/backends/appcontainer/windows_impl/tests.rs
+++ b/crates/wcore-sandbox/src/backends/appcontainer/windows_impl/tests.rs
@@ -581,7 +581,10 @@ async fn output_past_the_cap_is_truncated_not_discarded_live() {
     let elapsed = started.elapsed();
 
     let kept = out.stdout.len();
-    eprintln!("MEASURED kept={kept} bytes elapsed={elapsed:?} exit={}", out.exit_code);
+    eprintln!(
+        "MEASURED kept={kept} bytes elapsed={elapsed:?} exit={}",
+        out.exit_code
+    );
 
     // THE DEFECT: this whole buffer used to be thrown away.
     assert!(

--- a/crates/wcore-sandbox/src/backends/appcontainer/windows_impl/tests.rs
+++ b/crates/wcore-sandbox/src/backends/appcontainer/windows_impl/tests.rs
@@ -511,6 +511,104 @@ async fn large_output_survives_live() {
     );
 }
 
+/// wayland#1082 (LIVE, AppContainer) — **crossing the output cap must TRUNCATE,
+/// not discard.**
+///
+/// `large_output_survives_live` above uses ~128 KB, far UNDER the 8 MiB cap, so
+/// it grades the pipe drain and says nothing about the ceiling. This is the
+/// ceiling.
+///
+/// `drain_pipe` already does the right thing: it reserves against the shared
+/// budget, KEEPS the partial grant, and signals `exceeded_event` so the waiter
+/// tears the job down. The defect is the last step — the caller turned all of
+/// that retained head into `Err(OutputLimitExceeded)`, so a command that
+/// produced megabytes handed back an error and none of its own output. #1071
+/// fixed the same inversion for the shared drain; this is the AppContainer
+/// backend's copy of it.
+#[tokio::test]
+#[ignore = "explicit native Windows AppContainer acceptance"]
+async fn output_past_the_cap_is_truncated_not_discarded_live() {
+    assert_eq!(
+        std::env::var("WAYLAND_SANDBOX_LIVE_WINDOWS").as_deref(),
+        Ok("1")
+    );
+    let b = AppContainerBackend::new();
+    assert!(b.is_available(), "AppContainer must be available");
+    let m = SandboxManifest {
+        timeout: Some(Duration::from_secs(90)),
+        ..Default::default()
+    };
+
+    // CONTROL FIRST: a small command must come back intact and unmarked. Without
+    // it, the assertions below could pass on a backend that truncates
+    // everything, which would prove nothing.
+    let small = b
+        .execute(
+            &m,
+            SandboxCommand {
+                argv: vec!["cmd.exe".into(), "/c".into(), "echo hello-1082".into()],
+                cwd: None,
+            },
+        )
+        .await
+        .expect("control: a small command must run");
+    let small_out = String::from_utf8_lossy(&small.stdout).into_owned();
+    assert!(
+        small_out.contains("hello-1082"),
+        "control: small output must survive intact: {small_out:?}"
+    );
+    assert!(
+        !small_out.contains("OUTPUT TRUNCATED"),
+        "control: a small command must not be marked truncated: {small_out:?}"
+    );
+
+    // ~400k lines x 32 bytes = ~12.8 MB, comfortably past the 8 MiB ceiling.
+    let started = std::time::Instant::now();
+    let out = b
+        .execute(
+            &m,
+            SandboxCommand {
+                argv: vec![
+                    "cmd.exe".into(),
+                    "/c".into(),
+                    "for /L %i in (1,1,400000) do @echo ABCDEFGHIJKLMNOPQRSTUVWXYZ0123".into(),
+                ],
+                cwd: None,
+            },
+        )
+        .await
+        .expect("crossing the cap must return the truncated output, not an error");
+    let elapsed = started.elapsed();
+
+    let kept = out.stdout.len();
+    eprintln!("MEASURED kept={kept} bytes elapsed={elapsed:?} exit={}", out.exit_code);
+
+    // THE DEFECT: this whole buffer used to be thrown away.
+    assert!(
+        kept > 1024 * 1024,
+        "the bytes that fit must be KEPT, not discarded — got {kept}"
+    );
+    assert!(
+        kept <= crate::backends::BUFFERED_OUTPUT_LIMIT_BYTES + 4096,
+        "the cap must still bound host memory — got {kept}"
+    );
+    let tail = String::from_utf8_lossy(&out.stdout[kept.saturating_sub(512)..]).into_owned();
+    assert!(
+        tail.contains("OUTPUT TRUNCATED"),
+        "the reader must be TOLD the output was cut: {tail:?}"
+    );
+    assert!(
+        tail.contains("STOPPED"),
+        "the marker must say the command did not run to completion: {tail:?}"
+    );
+    // The exceeded_event trip wire already exists on this backend, so crossing
+    // the cap must stop the child rather than run out the 90s timeout.
+    assert!(
+        elapsed < Duration::from_secs(75),
+        "crossing the cap must stop the child promptly — took {elapsed:?}"
+    );
+}
+
 // Live integrity-boundary verification lives in
 // `crates/wcore-sandbox/tests/live_integrity.rs` because it needs
 // to invoke a sibling binary target (`il_probe`) via

--- a/crates/wcore-sandbox/src/backends/docker.rs
+++ b/crates/wcore-sandbox/src/backends/docker.rs
@@ -361,8 +361,8 @@ impl SandboxBackend for DockerBackend {
         cmd: SandboxCommand,
     ) -> Result<SandboxOutput> {
         use bollard::container::{
-            Config, CreateContainerOptions, LogOutput, LogsOptions, StartContainerOptions,
-            WaitContainerOptions,
+            Config, CreateContainerOptions, KillContainerOptions, LogOutput, LogsOptions,
+            StartContainerOptions, WaitContainerOptions,
         };
         use bollard::models::HostConfig;
         use futures::stream::StreamExt;
@@ -529,12 +529,29 @@ impl SandboxBackend for DockerBackend {
             let mut stderr: Vec<u8> = Vec::new();
             let mut exit_code = None;
             let mut logs_done = false;
+            let mut truncated = false;
+            let mut stopped = false;
 
             while exit_code.is_none() || !logs_done {
                 tokio::select! {
                     waited = wait.next(), if exit_code.is_none() => {
                         exit_code = Some(match waited {
                             Some(Ok(response)) => response.status_code as i32,
+                            // A NON-ZERO exit is not a transport failure.
+                            // bollard reports it as a stream ERROR
+                            // (`DockerContainerWaitError`) carrying the real
+                            // code, and mapping that to `DockerIo` threw away
+                            // both the exit status AND every byte the command
+                            // had already written — `sh -c 'echo out; exit 3'`
+                            // returned an error and lost "out". Found while
+                            // fixing wayland#1082, and load-bearing for it:
+                            // stopping a flooding container at the cap makes it
+                            // exit non-zero by construction, so without this the
+                            // truncated output could never be returned.
+                            Some(Err(bollard::errors::Error::DockerContainerWaitError {
+                                code,
+                                ..
+                            })) => code as i32,
                             Some(Err(error)) => {
                                 return Err(SandboxError::DockerIo(error.to_string()));
                             }
@@ -544,12 +561,26 @@ impl SandboxBackend for DockerBackend {
                     chunk = logs.next(), if !logs_done => {
                         match chunk {
                             Some(Ok(LogOutput::StdOut { message })) => {
-                                reserve_docker_output(&stdout, &stderr, message.len())?;
-                                stdout.extend_from_slice(&message);
+                                let granted =
+                                    reserve_docker_output(&stdout, &stderr, message.len());
+                                stdout.extend_from_slice(&message[..granted]);
+                                if granted < message.len() {
+                                    let kept = stdout.len();
+                                    stdout.extend_from_slice(&super::truncation_marker(kept));
+                                    truncated = true;
+                                    logs_done = true;
+                                }
                             }
                             Some(Ok(LogOutput::StdErr { message })) => {
-                                reserve_docker_output(&stdout, &stderr, message.len())?;
-                                stderr.extend_from_slice(&message);
+                                let granted =
+                                    reserve_docker_output(&stdout, &stderr, message.len());
+                                stderr.extend_from_slice(&message[..granted]);
+                                if granted < message.len() {
+                                    let kept = stderr.len();
+                                    stderr.extend_from_slice(&super::truncation_marker(kept));
+                                    truncated = true;
+                                    logs_done = true;
+                                }
                             }
                             Some(Ok(_)) => {}
                             Some(Err(error)) => {
@@ -558,6 +589,21 @@ impl SandboxBackend for DockerBackend {
                             None => logs_done = true,
                         }
                     }
+                }
+
+                // wayland#1082 / #1071: crossing the cap is the trip wire that
+                // STOPS the child, and that is load-bearing. Without this kill
+                // the loop sits in `wait.next()` until the container exits on
+                // its own, trading a prompt stop for the caller's wall-clock
+                // timeout — which is the wait the discard-everything error was
+                // avoiding in the first place. Best-effort: the container is
+                // force-removed by `ContainerCleanup` regardless, so a failure
+                // here must not mask the output we just kept.
+                if truncated && !stopped {
+                    stopped = true;
+                    let _ = client
+                        .kill_container(&id, None::<KillContainerOptions<String>>)
+                        .await;
                 }
             }
 
@@ -587,8 +633,9 @@ impl SandboxBackend for DockerBackend {
         cancel: tokio_util::sync::CancellationToken,
     ) -> Result<SandboxOutput> {
         use bollard::container::{
-            Config, CreateContainerOptions, DownloadFromContainerOptions, LogOutput, LogsOptions,
-            StartContainerOptions, UploadToContainerOptions, WaitContainerOptions,
+            Config, CreateContainerOptions, DownloadFromContainerOptions, KillContainerOptions,
+            LogOutput, LogsOptions, StartContainerOptions, UploadToContainerOptions,
+            WaitContainerOptions,
         };
         use bollard::models::HostConfig;
         use futures::stream::StreamExt;
@@ -680,28 +727,63 @@ impl SandboxBackend for DockerBackend {
             let mut stderr = Vec::new();
             let mut exit_code = None;
             let mut logs_done = false;
+            let mut truncated = false;
+            let mut stopped = false;
             while exit_code.is_none() || !logs_done {
                 tokio::select! {
                     waited = wait.next(), if exit_code.is_none() => {
                         exit_code = Some(match waited {
                             Some(Ok(response)) => response.status_code as i32,
+                            // See the note on the same arm above: a non-zero
+                            // exit arrives as a stream error carrying the code.
+                            Some(Err(bollard::errors::Error::DockerContainerWaitError {
+                                code,
+                                ..
+                            })) => code as i32,
                             Some(Err(error)) => return Err(SandboxError::DockerIo(error.to_string())),
                             None => -1,
                         });
                     }
                     chunk = logs.next(), if !logs_done => match chunk {
                         Some(Ok(LogOutput::StdOut { message })) => {
-                            reserve_docker_output(&stdout, &stderr, message.len())?;
-                            stdout.extend_from_slice(&message);
+                            let granted = reserve_docker_output(&stdout, &stderr, message.len());
+                            stdout.extend_from_slice(&message[..granted]);
+                            if granted < message.len() {
+                                let kept = stdout.len();
+                                stdout.extend_from_slice(&super::truncation_marker(kept));
+                                truncated = true;
+                                logs_done = true;
+                            }
                         }
                         Some(Ok(LogOutput::StdErr { message })) => {
-                            reserve_docker_output(&stdout, &stderr, message.len())?;
-                            stderr.extend_from_slice(&message);
+                            let granted = reserve_docker_output(&stdout, &stderr, message.len());
+                            stderr.extend_from_slice(&message[..granted]);
+                            if granted < message.len() {
+                                let kept = stderr.len();
+                                stderr.extend_from_slice(&super::truncation_marker(kept));
+                                truncated = true;
+                                logs_done = true;
+                            }
                         }
                         Some(Ok(_)) => {}
                         Some(Err(error)) => return Err(SandboxError::DockerIo(error.to_string())),
                         None => logs_done = true,
                     }
+                }
+
+                // wayland#1082 / #1071: crossing the cap is the trip wire that
+                // STOPS the child, and that is load-bearing. Without this kill
+                // the loop sits in `wait.next()` until the container exits on
+                // its own, trading a prompt stop for the caller's wall-clock
+                // timeout — which is the wait the discard-everything error was
+                // avoiding in the first place. Best-effort: the container is
+                // force-removed by `ContainerCleanup` regardless, so a failure
+                // here must not mask the output we just kept.
+                if truncated && !stopped {
+                    stopped = true;
+                    let _ = client
+                        .kill_container(&id, None::<KillContainerOptions<String>>)
+                        .await;
                 }
             }
             let mut downloaded = Vec::new();
@@ -857,18 +939,25 @@ pub(super) fn retained_container_plan(
     Ok(RetainedContainerPlan { argv, env, denied })
 }
 
+/// Grant up to `amount` bytes of the shared buffered-output budget, returning
+/// how many bytes were granted.
+///
+/// wayland#1082. This used to return `Err(OutputLimitExceeded)`, which made the
+/// caller drop everything it had already read: a command that produced 20 MB
+/// handed back roughly a hundred bytes of error text and none of its own
+/// output. #1071 fixed exactly that inversion for the shared drain in
+/// `backends/mod.rs`; the Docker backend kept the old behaviour because it does
+/// not use that drain, so the same command behaved differently depending on a
+/// backend the user did not choose and mostly cannot see.
+///
+/// A short grant (including zero) is the overflow signal — the caller keeps the
+/// bytes that fit, appends [`super::truncation_marker`], and stops the
+/// container. Mirrors [`super::reserve_output`] deliberately, so the two paths
+/// cannot drift into different definitions of the same cap.
 #[cfg(feature = "live-docker")]
-fn reserve_docker_output(stdout: &[u8], stderr: &[u8], amount: usize) -> Result<()> {
-    let next = stdout
-        .len()
-        .checked_add(stderr.len())
-        .and_then(|bytes| bytes.checked_add(amount));
-    if next.is_none_or(|bytes| bytes > super::BUFFERED_OUTPUT_LIMIT_BYTES) {
-        return Err(SandboxError::OutputLimitExceeded {
-            limit_bytes: super::BUFFERED_OUTPUT_LIMIT_BYTES,
-        });
-    }
-    Ok(())
+fn reserve_docker_output(stdout: &[u8], stderr: &[u8], amount: usize) -> usize {
+    let used = stdout.len().saturating_add(stderr.len());
+    amount.min(super::BUFFERED_OUTPUT_LIMIT_BYTES.saturating_sub(used))
 }
 
 #[cfg(test)]

--- a/crates/wcore-sandbox/src/backends/docker_tests.rs
+++ b/crates/wcore-sandbox/src/backends/docker_tests.rs
@@ -96,18 +96,153 @@ fn enforces_read_deny_is_true_with_live_docker() {
 #[test]
 fn buffered_output_accepts_exact_limit() {
     let stdout = vec![0_u8; super::super::BUFFERED_OUTPUT_LIMIT_BYTES - 1];
-    assert!(reserve_docker_output(&stdout, &[], 1).is_ok());
+    assert_eq!(
+        reserve_docker_output(&stdout, &[], 1),
+        1,
+        "the byte that exactly reaches the cap must still be granted"
+    );
 }
 
+/// wayland#1082 (LIVE) — **a container that floods stdout keeps the bytes that
+/// fit, and is STOPPED at the cap.**
+///
+/// This is the evidence route the issue asks for, and it needs a real daemon:
+/// the defect is not in `reserve_docker_output` alone, it is in what the log
+/// loop does with a short grant. Before this change the whole read was dropped
+/// and the caller got `Err(OutputLimitExceeded)` — roughly a hundred bytes of
+/// error text and none of the command's own output.
+///
+/// `yes` is chosen deliberately: it NEVER reaches EOF. That is the abuse shape
+/// #1071 describes, so it also grades the trip wire — if crossing the cap did
+/// not kill the container, this test would sit until the manifest timeout
+/// instead of returning promptly, and the elapsed assertion below would fail.
+#[cfg(feature = "live-docker")]
+#[tokio::test]
+async fn a_flooding_container_is_truncated_and_stopped() {
+    let backend = match DockerBackend::connect().await {
+        Ok(b) => b,
+        Err(_) => {
+            eprintln!("skip: docker daemon unavailable");
+            return;
+        }
+    };
+
+    let manifest = SandboxManifest {
+        network: NetworkPolicy::Deny,
+        image: "alpine:3.19".into(),
+        timeout: Some(std::time::Duration::from_secs(60)),
+        ..Default::default()
+    };
+
+    // POSITIVE CONTROL first: an ordinary small command returns its output in
+    // full and is NOT marked truncated. Without this, the assertions below
+    // could pass on a backend that simply always truncates.
+    let small = backend
+        .execute(
+            &manifest,
+            SandboxCommand {
+                argv: vec!["echo".into(), "hello-1082".into()],
+                cwd: None,
+            },
+        )
+        .await
+        .expect("control: a small command must run");
+    let small_out = String::from_utf8_lossy(&small.stdout).into_owned();
+    assert!(
+        small_out.contains("hello-1082"),
+        "control: small output must survive intact: {small_out:?}"
+    );
+    assert!(
+        !small_out.contains("OUTPUT TRUNCATED"),
+        "control: a small command must not be marked truncated"
+    );
+
+    let started = std::time::Instant::now();
+    let flooded = backend
+        .execute(
+            &manifest,
+            SandboxCommand {
+                argv: vec![
+                    "sh".into(),
+                    "-c".into(),
+                    "yes 0123456789abcdefghijklmnopqrstuvwxyz".into(),
+                ],
+                cwd: None,
+            },
+        )
+        .await
+        .expect("a flooding command must return output, not an error");
+    let elapsed = started.elapsed();
+
+    // THE DEFECT: this used to be an Err, so `stdout` never reached the caller.
+    let kept = flooded.stdout.len();
+    assert!(
+        kept > 1024 * 1024,
+        "the bytes that fit must be KEPT, not discarded — got {kept} bytes"
+    );
+    assert!(
+        kept <= super::super::BUFFERED_OUTPUT_LIMIT_BYTES + 1024,
+        "the cap must still bound host memory — got {kept} bytes"
+    );
+
+    let tail = String::from_utf8_lossy(&flooded.stdout[kept.saturating_sub(512)..]).into_owned();
+    assert!(
+        tail.contains("OUTPUT TRUNCATED"),
+        "the reader must be TOLD the output was cut; silent truncation is the \
+         same class of defect as discarding it. tail={tail:?}"
+    );
+    assert!(
+        tail.contains("STOPPED"),
+        "the marker must say the command did not run to completion: {tail:?}"
+    );
+
+    // THE TRIP WIRE. `yes` never ends, so returning at all means the container
+    // was killed at the cap rather than waited out.
+    assert!(
+        elapsed < std::time::Duration::from_secs(45),
+        "crossing the cap must STOP the container promptly, not fall through to \
+         the manifest timeout — took {elapsed:?}"
+    );
+}
+
+/// wayland#1082. A full budget grants ZERO further bytes — but that is now the
+/// TRUNCATION signal, not an error that discards what was already read. The old
+/// version of this test asserted `Err(OutputLimitExceeded)`, i.e. it pinned the
+/// defect in place.
 #[cfg(feature = "live-docker")]
 #[test]
-fn buffered_output_rejects_first_byte_over_limit() {
+fn a_full_budget_grants_nothing_further() {
     let stdout = vec![0_u8; super::super::BUFFERED_OUTPUT_LIMIT_BYTES];
-    assert!(matches!(
-        reserve_docker_output(&stdout, &[], 1),
-        Err(SandboxError::OutputLimitExceeded { limit_bytes })
-            if limit_bytes == super::super::BUFFERED_OUTPUT_LIMIT_BYTES
-    ));
+    assert_eq!(reserve_docker_output(&stdout, &[], 1), 0);
+}
+
+/// A PARTIAL grant is the case that distinguishes truncate-from-discard: with
+/// one byte of budget left and two bytes offered, exactly one is granted and
+/// the caller keeps it. Under the old code this whole read was thrown away.
+#[cfg(feature = "live-docker")]
+#[test]
+fn a_partial_grant_keeps_the_bytes_that_fit() {
+    let stdout = vec![0_u8; super::super::BUFFERED_OUTPUT_LIMIT_BYTES - 1];
+    assert_eq!(reserve_docker_output(&stdout, &[], 2), 1);
+}
+
+/// The budget is SHARED across both streams, exactly as `reserve_output` treats
+/// it. Counting them separately would let a command keep 16 MiB.
+#[cfg(feature = "live-docker")]
+#[test]
+fn the_budget_is_shared_between_stdout_and_stderr() {
+    let half = super::super::BUFFERED_OUTPUT_LIMIT_BYTES / 2;
+    let stdout = vec![0_u8; half];
+    let stderr = vec![0_u8; half];
+    assert_eq!(reserve_docker_output(&stdout, &stderr, 1), 0);
+}
+
+/// CONTROL — an ordinary read well inside the budget is granted in full, so the
+/// assertions above are not just "this function returns 0".
+#[cfg(feature = "live-docker")]
+#[test]
+fn an_ordinary_read_is_granted_in_full() {
+    assert_eq!(reserve_docker_output(&[], &[], 4096), 4096);
 }
 
 /// Task 5 (live integration): a file that is read-allowed under a mounted

--- a/crates/wcore-sandbox/src/backends/mod.rs
+++ b/crates/wcore-sandbox/src/backends/mod.rs
@@ -96,7 +96,7 @@ pub(crate) fn reserve_output(used: &AtomicUsize, amount: usize) -> usize {
 ///
 /// It says the command was STOPPED because that is what happens next, and a
 /// reader who is not told will assume the command ran to completion.
-fn truncation_marker(kept: usize) -> Vec<u8> {
+pub(crate) fn truncation_marker(kept: usize) -> Vec<u8> {
     format!(
         "\n[wcore-sandbox: OUTPUT TRUNCATED. This command produced more than the \
          {BUFFERED_OUTPUT_LIMIT_BYTES}-byte buffered output cap. The {kept} bytes above \


### PR DESCRIPTION
Addresses **#1082 (docker half)**. #1082 stays **open** for the AppContainer half — that needs real Windows.

## First: the issue's verification constraint is wrong

#1082 says *"Neither backend can be exercised from the Linux build host"* and tells whoever picks it up to plan an evidence route because none exists.

hetzner is running **Docker 29.2.1 with 44 live containers.** The `live-docker` suite runs there today — `docker_denies_read_of_secret_under_allowed_root` and `required_live_docker_admission_enforcement_and_teardown` both pass against a real daemon. So the docker half was always measurable, and this PR measures it.

## The fix

`reserve_docker_output` **grants what fits** instead of returning `Err(OutputLimitExceeded)`. A short grant (including zero) is the overflow signal: the caller keeps the bytes that fit, appends the **same** `truncation_marker` the shared drain uses, and kills the container. It deliberately mirrors `reserve_output` so the two paths cannot drift into different definitions of one cap.

**The kill is load-bearing, not tidiness.** Per #1071, crossing the cap *is* the trip wire that stops the child. Without it the log loop sits in `wait.next()` until the container exits on its own — trading a prompt stop for the caller's wall-clock timeout, which is exactly the wait the discard-everything error existed to avoid.

## A separate pre-existing defect, found on the way

bollard reports a **non-zero container exit as a stream error** (`DockerContainerWaitError`) carrying the real code. Mapping that to `DockerIo` threw away both the exit status **and every byte the command had written.** Probed on a live daemon:

```
sh -c 'echo out; exit 3'
  before: Err(DockerIo("Docker container wait error"))   # "out" lost entirely
  after:  Ok(exit_code: 3, stdout: "out\n")
```

That is its own bug — any failing command in a Docker sandbox lost its output — and it is **load-bearing for this fix**, because stopping a flooding container makes it exit non-zero by construction.

## Measured, on a live daemon

Flooded with `yes`, chosen because it **never reaches EOF** — the abuse shape #1071 describes — so the same run grades the trip wire:

| | Output returned to the caller | Elapsed |
|---|---|---|
| before | `Err(OutputLimitExceeded)` — **0 bytes** | — |
| after | **8,388,930 bytes** (8 MiB cap + 322-byte marker) | **2.50 s** |

`yes` never terminates, so returning in 2.50 s against a 60 s timeout is the proof the container was killed at the cap.

## Tests

- The old unit test asserted `Err(OutputLimitExceeded)` — **it pinned the defect in place.** Replaced with four tests covering the grant contract: full budget grants zero, partial grant keeps what fits, the budget is shared across stdout+stderr, and a **control** that an ordinary read is granted in full.
- One **live** test with a positive control (a small command must survive intact and must *not* be marked truncated), asserting kept-bytes, the marker, the `STOPPED` wording, and the elapsed bound.
- **Red arm run.** Mutating the overflow path back to discarding fails the live test with `got 0 bytes`.
- `wcore-swarm`'s `multi_worker_output_exhaustion_fails_without_retaining_buffers` — the guard #1082 warns a drain-to-EOF implementation would break — still passes.
- fmt clean; `clippy --workspace --all-targets -D warnings` clean; `clippy -p wcore-sandbox --features live-docker` clean; `wcore-sandbox` 138 unit + all integration suites pass; live-docker suite 13/13.

## Not included

The AppContainer path (`appcontainer/windows_impl/process.rs:1511`) is untouched. It needs real Windows and is opt-in via `WAYLAND_SANDBOX=appcontainer`. As #1082 notes, Windows already has `create_output_exceeded_event` for exactly this stop, so the machinery is likely mostly there — but I will not assert a fix I cannot measure.
