### PR TITLE
ci: keep fork PRs off the self-hosted Windows runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,26 @@ jobs:
 
   ci:
     name: CI (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
+    # A PR from a FORK must never land on a self-hosted runner. That runner is a
+    # personal Windows machine, and `pull_request` executes the fork's code on
+    # it. Approval gating helps (the repo is now `all_external_contributors`
+    # rather than `first_time_contributors`), but approval is a HUMAN gate and
+    # human gates fail open under fatigue — one plausible-looking PR approved at
+    # the wrong hour is all it takes. This makes it structural instead: a fork
+    # PR gets GitHub-hosted Windows, so coverage is preserved and only the
+    # hardware changes.
+    #
+    # The JOB NAME is deliberately untouched. `CI (Array)` is a REQUIRED status
+    # check on `main`, and `main` is strict + linear + enforce_admins. Dropping
+    # or renaming this matrix entry for forks would mean that context never
+    # reports, so a fork PR could NEVER merge — a permanent block, which is a
+    # worse outcome than the exposure being closed. Only `runs-on` varies;
+    # `matrix.os` and therefore the rendered job name are unchanged.
+    #
+    # `contains()` is used rather than `matrix.os[0]` because the matrix mixes a
+    # plain string (`macos-latest`) with a label array, and indexing a string in
+    # a GitHub expression does not do what indexing an array does.
+    runs-on: ${{ (contains(matrix.os, 'self-hosted') && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'windows-latest' || matrix.os }}
     # gh#1072. Without this the job inherits GitHub's 6-HOUR default, and this
     # is a required context, so one wedged job blocks every PR in the repo.
     # Sized from measurement, not guesswork: across the last four successful


### PR DESCRIPTION
The structural half of the self-hosted-runner exposure. The policy half is already applied (see below).

## The exposure

`wayland-core` is **PUBLIC with 13 forks**. `ci.yml` triggers on `pull_request: branches: [main]`, and the CI matrix contains `[self-hosted, Windows, X64, msvc]` with **no fork guard**. So a PR from any fork ran the full test suite — arbitrary workflow code — on a personal Windows machine.

**Already done, outside this PR:** repo approval policy tightened from `first_time_contributors` → `all_external_contributors`. That closes the window for *returning* contributors, who previously needed no approval at all.

**Why that isn't enough:** approval is a human gate, and human gates fail open under fatigue. One plausible-looking PR approved at the wrong hour is all it takes. This PR makes it structural.

## The change

One line, plus the reasoning as comments. A fork PR is routed to GitHub-hosted `windows-latest`; everything else is unchanged.

| Case | `runs-on` resolves to |
|---|---|
| internal PR, self-hosted entry | `matrix.os` — self-hosted, **unchanged** |
| **fork PR, self-hosted entry** | **`windows-latest`** |
| any PR, `macos-latest` entry | `macos-latest` |
| push to `main` | `matrix.os` — self-hosted, **unchanged** |

Coverage is preserved. Only the hardware changes, and only for forks.

## The trap this deliberately avoids

**`CI (Array)` is a REQUIRED status check on `main`**, and `main` is `strict` + `linear` + `enforce_admins`.

The obvious implementation — drop the self-hosted entry from the matrix for fork PRs — would mean that context **never reports**, so a fork PR could **never merge**. A permanent block on all outside contribution is a worse outcome than the exposure it closes.

So the job **name** is untouched: `matrix.os` still renders `CI (Array)`, and only `runs-on` varies.

`contains()` is used rather than `matrix.os[0]` because the matrix mixes a plain string (`macos-latest`) with a label array, and indexing a string in a GitHub expression does not behave like indexing an array.

## Verification, and its limits

`actionlint` reports clean — and I **positive-controlled it**, because a linter that reports nothing may simply not be looking:

- Injected a missing comma into the expression → reported at the exact column. So the clean result genuinely means **the expression parses**.
- Injected a bogus payload field (`head.repo.no_such_field`) → **reported nothing**.

So actionlint does **not** validate webhook payload field names. `github.event.pull_request.head.repo.full_name` is therefore not tool-verified here; it is the documented fork-detection idiom and I'm confident in it, but I'd rather state the gap than let a green linter imply more than it checked.

The one case that cannot be exercised before merge is an actual fork PR — by construction, since only a fork can produce one.
