### PR TITLE
test(sandbox): isolate the ACL-lease sweeps in a private directory

### DIFF
--- a/crates/wcore-sandbox/src/backends/appcontainer/acl_lease.rs
+++ b/crates/wcore-sandbox/src/backends/appcontainer/acl_lease.rs
@@ -18,7 +18,7 @@ mod tests;
 use self::mutation_lock::MutationLock;
 use self::sha256::sha256_hex;
 #[cfg(test)]
-use self::storage::{TEST_LEASE_ROOT_ENV, test_lease_root};
+use self::storage::{TEST_LEASE_ROOT_ENV, private_lease_directory, test_lease_root};
 use self::storage::{
     lease_directory, lease_is_zero_length, quarantine_lease, read_validated_lease,
     recover_rewrite_temps, remove_validated_lease, rewrite_synced_lease, write_new_synced_lease,

--- a/crates/wcore-sandbox/src/backends/appcontainer/acl_lease/storage.rs
+++ b/crates/wcore-sandbox/src/backends/appcontainer/acl_lease/storage.rs
@@ -124,6 +124,47 @@ pub(super) fn test_lease_root() -> Result<PathBuf> {
     Ok(root.clone())
 }
 
+/// A lease directory that belongs to ONE test and to nothing else.
+///
+/// [`test_lease_root`] is keyed per PROCESS, and the default `cargo test`
+/// harness runs every test in this binary in ONE process, so that root is
+/// shared mutable state between tests running concurrently on different
+/// threads. `recover_dead_leases_locked` enumerates the lease directory and
+/// only then opens each entry it found, so a test that creates or removes a
+/// lease there makes another test's sweep fail on a file that existed at
+/// enumeration and was gone at open. Measured 10 failures in 10 runs of
+/// `cargo test -p wcore-sandbox --lib appcontainer_acl_lease` on Windows 11
+/// build 26200 (`#1095`): the sweeps in `tests.rs` failed with `os error 2`
+/// naming the lease that
+/// `a_lease_written_by_a_test_never_lands_in_the_production_directory` writes
+/// and then removes.
+///
+/// This is test isolation, NOT a repair of production behaviour, and the
+/// distinction is the whole reason the fix is here rather than in the sweep:
+/// every production lease write and every production sweep runs inside the
+/// same per-user machine-wide `MutationLock`, so a lease can neither appear nor
+/// vanish between a sweep's enumeration and its open. The unit tests that call
+/// `recover_dead_leases_locked` directly deliberately do NOT take that lock —
+/// it lives in the `Global\` namespace, so taking it would test the privileges
+/// of whoever ran `cargo test` rather than the repair — which is exactly why
+/// they get a directory of their own instead of a lock.
+#[cfg(test)]
+pub(super) fn private_lease_directory(local: &Path) -> Result<PathBuf> {
+    // This is the SECOND door into `lease_directory_from`, so it carries the
+    // same lock as the first: whatever a test passes here, it must not be the
+    // user's real lease root. See [`lease_root`] for what a test lease written
+    // there costs — it disabled the Windows sandbox on a real developer box
+    // until a human deleted the file.
+    if std::env::var_os("LOCALAPPDATA")
+        .is_some_and(|real| same_windows_path(local, Path::new(&real)))
+    {
+        return Err(exec_error(
+            "a private test lease directory must never be rooted at the real LOCALAPPDATA".into(),
+        ));
+    }
+    lease_directory_from(local.to_path_buf())
+}
+
 fn lease_directory_from(local: PathBuf) -> Result<PathBuf> {
     let local_root = open_directory_nofollow(&local, "LOCALAPPDATA")?;
     validate_local_canonical_path(&local_root.final_path)?;
@@ -860,6 +901,9 @@ mod tests {
     #[test]
     fn unit_tests_never_resolve_the_production_lease_directory() {
         let resolved = lease_directory().expect("test lease directory must resolve");
+        let Some(local) = std::env::var_os("LOCALAPPDATA") else {
+            return;
+        };
         let Some(production) = production_lease_directory() else {
             return;
         };
@@ -870,6 +914,12 @@ mod tests {
              user's real sandbox state, where a synthetic test profile can never \
              reconcile and disables the sandbox permanently.",
             resolved.display()
+        );
+        // The per-test door has to refuse the same destination, or the
+        // chokepoint above is only one of two ways in.
+        assert!(
+            private_lease_directory(Path::new(&local)).is_err(),
+            "private_lease_directory accepted the real LOCALAPPDATA"
         );
     }
 

--- a/crates/wcore-sandbox/src/backends/appcontainer/acl_lease/tests.rs
+++ b/crates/wcore-sandbox/src/backends/appcontainer/acl_lease/tests.rs
@@ -311,17 +311,38 @@ fn measure_locked_phase_cost_per_execution() {
 
 static SYNTHETIC_COUNTER: AtomicU64 = AtomicU64::new(0);
 
-/// Serialize the wedge tests against each other.
+/// A lease directory this test alone can reach.
 ///
-/// Deliberately a plain in-process mutex rather than [`MutationLock`]: these
-/// four tests share one per-process temp lease root, and all they need is that
-/// one of them is not deleting its lease while another enumerates the
-/// directory. Taking the real cross-process lock instead would make them depend
-/// on `SeCreateGlobalPrivilege` (its mutex lives in the `Global\` namespace),
+/// The per-process test root is shared by every test in this binary, and a
+/// recovery sweep enumerates a directory and only then opens what it found, so
+/// one test's lease creation or removal is another test's `os error 2`. See
+/// [`private_lease_directory`] for the measurement and for why the product
+/// itself has no such race.
+///
+/// Returned as a tuple so the caller has to bind the `TempDir`: it deletes the
+/// directory on drop, and a root dropped early would delete the lease the test
+/// is still working on.
+fn private_lease_root() -> (tempfile::TempDir, PathBuf) {
+    let local = tempfile::tempdir().unwrap();
+    let directory = private_lease_directory(local.path()).unwrap();
+    (local, directory)
+}
+
+/// Serialize the tests that share the process-global reclamation report sink.
+///
+/// `EMITTED_RECLAMATIONS` is one `static` for the whole test binary: any sweep
+/// that reclaims a lease pushes into it, and two tests below drain it and
+/// assert on the exact count. Since every test here now sweeps a lease
+/// directory of its own, that sink is the ONLY state they still share, and this
+/// lock guards it and nothing else.
+///
+/// Deliberately a plain in-process mutex rather than [`MutationLock`]: taking
+/// the real cross-process lock would make these tests depend on
+/// `SeCreateGlobalPrivilege` (its mutex lives in the `Global\` namespace),
 /// which would test the privileges of whoever ran `cargo test` rather than the
 /// repair. The lock is intentionally NOT poisoned-propagating: one failing
 /// assertion must not cascade into three misleading secondary failures.
-fn wedge_test_lock() -> std::sync::MutexGuard<'static, ()> {
+fn reclamation_sink_lock() -> std::sync::MutexGuard<'static, ()> {
     static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
     LOCK.lock().unwrap_or_else(|poison| poison.into_inner())
 }
@@ -335,7 +356,12 @@ fn wedge_test_lock() -> std::sync::MutexGuard<'static, ()> {
 /// owner identity provably does not exist. Using a mismatched creation time
 /// rather than an exited pid is deliberate — it cannot flake on Windows pid
 /// reuse, which would silently turn the "dead" leg into a "live" one.
-fn write_unreconcilable_lease(tag: &str, owner_live: bool, intents: Vec<AclIntent>) -> PathBuf {
+fn write_unreconcilable_lease(
+    directory: &Path,
+    tag: &str,
+    owner_live: bool,
+    intents: Vec<AclIntent>,
+) -> PathBuf {
     let sequence = SYNTHETIC_COUNTER.fetch_add(1, Ordering::Relaxed);
     let profile_name = format!(
         "{PROFILE_PREFIX}-h2{tag}-{:08x}-{sequence:04x}",
@@ -363,20 +389,23 @@ fn write_unreconcilable_lease(tag: &str, owner_live: bool, intents: Vec<AclInten
         owner_live,
         "the synthetic lease must present the owner liveness this leg is testing"
     );
-    let path = lease_directory()
-        .unwrap()
-        .join(format!("{profile_name}.toml"));
+    let path = directory.join(format!("{profile_name}.toml"));
     write_new_synced_lease(&path, &lease).unwrap();
     path
 }
 
 /// Files sitting in the quarantine directory whose name came from `lease_path`.
 ///
-/// Scoped to one lease rather than counting the whole directory: these tests
-/// share a per-process lease root, and a global count would couple them.
+/// Scoped to one lease rather than counting the whole directory: a bare count
+/// would also be satisfied by an artifact quarantined from some other lease.
+/// The quarantine directory is derived from the lease's own directory, so this
+/// follows the caller into its private lease root.
 fn quarantined_for(lease_path: &Path) -> Vec<PathBuf> {
     let name = lease_path.file_name().and_then(OsStr::to_str).unwrap();
-    let quarantine = lease_directory().unwrap().join(QUARANTINE_DIRECTORY);
+    let quarantine = lease_path
+        .parent()
+        .expect("a lease always sits in a lease directory")
+        .join(QUARANTINE_DIRECTORY);
     fs::read_dir(quarantine)
         .into_iter()
         .flatten()
@@ -392,9 +421,9 @@ fn quarantined_for(lease_path: &Path) -> Vec<PathBuf> {
 
 #[test]
 fn dead_owner_unreconcilable_lease_is_reclaimed_not_refused_forever() {
-    let _lock = wedge_test_lock();
-    let directory = lease_directory().unwrap();
-    let path = write_unreconcilable_lease("dead", false, Vec::new());
+    let _lock = reclamation_sink_lock();
+    let (_local, directory) = private_lease_root();
+    let path = write_unreconcilable_lease(&directory, "dead", false, Vec::new());
     assert!(path.exists(), "the wedge lease must start on disk");
 
     // Before F-28-02-002 was repaired this returned Err, and did so on every
@@ -422,12 +451,13 @@ fn dead_owner_unreconcilable_lease_is_reclaimed_not_refused_forever() {
 
 #[test]
 fn live_owner_unreconcilable_lease_is_honoured_not_reclaimed() {
-    let _lock = wedge_test_lock();
-    let directory = lease_directory().unwrap();
+    // No reclamation-sink lock: a live owner is skipped, so this sweep can
+    // never emit a report.
+    let (_local, directory) = private_lease_root();
     // Identical to the leg above in every respect EXCEPT that the recorded
     // owner is this running process. Reclaiming this would revoke the ACLs of a
     // container that is still executing.
-    let path = write_unreconcilable_lease("live", true, Vec::new());
+    let path = write_unreconcilable_lease(&directory, "live", true, Vec::new());
 
     unsafe { recover_dead_leases_locked(&directory) }
         .expect("a live owner's lease must be skipped, not error");
@@ -450,9 +480,9 @@ fn quarantine_directory_does_not_become_a_second_wedge() {
     // implementation that reclaimed the lease but did not allow-list its own
     // quarantine directory would refuse forever from the second pass onward —
     // the identical defect, one indirection further down.
-    let _lock = wedge_test_lock();
-    let directory = lease_directory().unwrap();
-    let path = write_unreconcilable_lease("reentry", false, Vec::new());
+    let _lock = reclamation_sink_lock();
+    let (_local, directory) = private_lease_root();
+    let path = write_unreconcilable_lease(&directory, "reentry", false, Vec::new());
     unsafe { recover_dead_leases_locked(&directory) }.unwrap();
     assert!(
         directory.join(QUARANTINE_DIRECTORY).is_dir(),
@@ -474,9 +504,9 @@ fn quarantine_directory_does_not_become_a_second_wedge() {
 /// contains the grant path because the file was MOVED verbatim, so asserting on
 /// it passes no matter what the operator is told.
 fn reclaim_and_capture_report(tag: &str, intents: Vec<AclIntent>) -> String {
-    let directory = lease_directory().unwrap();
+    let (_local, directory) = private_lease_root();
     let _ = take_emitted_reclamations();
-    let path = write_unreconcilable_lease(tag, false, intents);
+    let path = write_unreconcilable_lease(&directory, tag, false, intents);
 
     unsafe { recover_dead_leases_locked(&directory) }.unwrap();
 
@@ -504,7 +534,7 @@ fn reclamation_reports_grants_it_could_not_revoke() {
     // one that never does. Mutant M3 (adjudication `28-adj`) deletes the
     // disclosure branch so every reclamation claims nothing was left behind —
     // the negative assertion below is what catches it.
-    let _lock = wedge_test_lock();
+    let _lock = reclamation_sink_lock();
     const GRANT: &str = r"C:\f28h2-residual";
 
     let disclosed = reclaim_and_capture_report(
@@ -550,9 +580,9 @@ fn reclamation_reports_grants_it_could_not_revoke() {
 /// produces it. That the state is reachable is established by
 /// `write_new_synced_lease` creating the file before writing its content, and
 /// by `zero_length_lease_is_reachable_through_the_writer` below.
-fn write_raw_lease(tag: &str, bytes: &[u8]) -> PathBuf {
+fn write_raw_lease(directory: &Path, tag: &str, bytes: &[u8]) -> PathBuf {
     let sequence = SYNTHETIC_COUNTER.fetch_add(1, Ordering::Relaxed);
-    let path = lease_directory().unwrap().join(format!(
+    let path = directory.join(format!(
         "{PROFILE_PREFIX}-h2{tag}-{:08x}-{sequence:04x}.toml",
         std::process::id()
     ));
@@ -565,10 +595,10 @@ fn zero_length_lease_is_reclaimed_not_refused_forever() {
     // F-28-ADJ-002. Reproduced on hardware at 1b9f148f before this fix: a
     // 0-byte .toml refused all sandboxed execution, twice running, with
     // `invalid AppContainer ACL lease size 0`.
-    let _lock = wedge_test_lock();
-    let directory = lease_directory().unwrap();
+    let _lock = reclamation_sink_lock();
+    let (_local, directory) = private_lease_root();
     let _ = take_emitted_reclamations();
-    let path = write_raw_lease("zerolen", b"");
+    let path = write_raw_lease(&directory, "zerolen", b"");
     assert_eq!(fs::metadata(&path).unwrap().len(), 0);
 
     unsafe { recover_dead_leases_locked(&directory) }
@@ -615,9 +645,14 @@ fn a_non_empty_unreadable_lease_still_fails_closed() {
     // Widening the 0-byte reclamation to "anything unreadable" would silently
     // convert this deliberate fail-closed into a reclaim, which is why this
     // test sits next to it rather than in the existing ignore-gated suite.
-    let _lock = wedge_test_lock();
-    let directory = lease_directory().unwrap();
-    let path = write_raw_lease("malformed", b"version = 1\nstate = \"nonsense\"\n");
+    // No reclamation-sink lock: this sweep fails closed before it reclaims
+    // anything, so it can never emit a report.
+    let (_local, directory) = private_lease_root();
+    let path = write_raw_lease(
+        &directory,
+        "malformed",
+        b"version = 1\nstate = \"nonsense\"\n",
+    );
     assert!(fs::metadata(&path).unwrap().len() > 0);
 
     let result = unsafe { recover_dead_leases_locked(&directory) };
@@ -640,10 +675,11 @@ fn zero_length_lease_is_reachable_through_the_writer() {
     // leaves on disk between creating the file and writing its content. Proved
     // by observing the file at that exact instant rather than by reading the
     // source, and without killing anything.
-    let _lock = wedge_test_lock();
+    // No reclamation-sink lock: this test never runs a recovery sweep.
+    let (_local, directory) = private_lease_root();
     let observed = std::sync::Arc::new(std::sync::Mutex::new(None::<u64>));
     let probe = std::sync::Arc::clone(&observed);
-    let path = write_new_synced_lease_observed("window", move |path| {
+    let path = write_new_synced_lease_observed(&directory, "window", move |path| {
         *probe.lock().unwrap() = Some(fs::metadata(path).unwrap().len());
     });
     assert_eq!(
@@ -656,7 +692,11 @@ fn zero_length_lease_is_reachable_through_the_writer() {
 
 /// Drive the real writer, calling `probe` after the file exists and before its
 /// content is written.
-fn write_new_synced_lease_observed(tag: &str, probe: impl FnOnce(&Path)) -> PathBuf {
+fn write_new_synced_lease_observed(
+    directory: &Path,
+    tag: &str,
+    probe: impl FnOnce(&Path),
+) -> PathBuf {
     let sequence = SYNTHETIC_COUNTER.fetch_add(1, Ordering::Relaxed);
     let profile_name = format!(
         "{PROFILE_PREFIX}-h2{tag}-{:08x}-{sequence:04x}",
@@ -673,9 +713,7 @@ fn write_new_synced_lease_observed(tag: &str, probe: impl FnOnce(&Path)) -> Path
         lease_sha256: String::new(),
     };
     lease.refresh_digest();
-    let path = lease_directory()
-        .unwrap()
-        .join(format!("{profile_name}.toml"));
+    let path = directory.join(format!("{profile_name}.toml"));
     storage::write_new_synced_lease_with_probe(&path, &lease, probe).unwrap();
     path
 }


### PR DESCRIPTION
Closes nothing on its own — refs FerroxLabs/wayland#1095.

## Root cause

`recover_dead_leases_locked` enumerates the lease directory with `read_dir`, sorts the paths, and only **then** opens each entry it found. Every non-ignored test in `acl_lease/tests.rs` that drives that sweep did so over the **one** per-process temp lease root returned by `test_lease_root()` — and that root is shared with every other test in the binary, because the default `cargo test` harness runs the whole crate's tests as threads inside a single process.

The interfering writer is `acl_lease::storage::tests::a_lease_written_by_a_test_never_lands_in_the_production_directory`. It writes `WCore-storage-<pid>-000000000000dead.toml` into that shared root through the real writer, fsyncs it, and removes it a few milliseconds later — holding no lock at all. A sweep that enumerated the directory inside that window then failed opening a file that had just been deleted, and returned `Err` for the whole pass:

```
open AppContainer ACL lease \\?\C:\Users\...\Temp\wcore-lease-test-0000097c\Wayland\Core\
AppContainerLeases\v1\WCore-storage-0000097c-000000000000dead.toml:
The system cannot find the file specified. (os error 2)
```

That is the exact filename and error in the issue. The name is generated only by `storage::tests::test_lease(0xdead, …)`, which has exactly one caller.

The full suite showed a **second** actor as well: the non-ignored AppContainer availability probe reached from `windows_impl::tests` drives a real `ExecutionIdentity::start` — allocate profile, sweep, write lease, rewrite — into the same per-process test root. It holds the real `MutationLock` throughout; the unit tests deliberately do not. That pairing produced the `os error 32` sharing violations on `WCore-h2dead-*.toml` and on `…toml.rewrite-*.tmp`, and one `the reclamation must be reported: left 2, right 1` where a sweep reclaimed another test's lease.

## Red arm

Pristine `origin/main` @ `37edc244`, real Windows 11 build 26200, 24 cores, Rust 1.95.0 msvc, `cargo test -p wcore-sandbox --lib`:

| arm | runs | result |
|---|---|---|
| full lib suite, default parallelism | 5 | **4 red** — 219/0, 218/1, 218/1, 218/1, 216/3 |
| filter `appcontainer_acl_lease` (module **incl.** its `storage::tests`) | 10 | **10 red** — 15 passed / 1 failed every run |
| filter `appcontainer_acl_lease::tests::` (the sweeping tests **alone**) | 10 | **10 green** — 10 passed / 0 failed |
| full lib suite, `--test-threads=1` | 3 | **0** ACL-lease failures |

The third row is what identified the writer: the sweeping tests are already serialized against each other and are self-consistent; adding `storage::tests` to the same process makes them fail 10 times out of 10.

## The fix

Each test that runs a sweep now builds its lease directory inside its own `tempfile::tempdir()`, through a new `#[cfg(test)] private_lease_directory()` that wraps the existing `lease_directory_from`. The helpers (`write_unreconcilable_lease`, `write_raw_lease`, `write_new_synced_lease_observed`, `quarantined_for`) take that directory instead of reaching for the process-wide one.

No retry, no `#[ignore]`, no new global serialization: the tests stop sharing the state instead of taking turns on it.

`private_lease_directory` is a **second** door into `lease_directory_from`, so it carries the same lock as the first: it refuses the real `%LOCALAPPDATA%`, and `unit_tests_never_resolve_the_production_lease_directory` now asserts that. Without it, the guarantee that no unit test can write a synthetic lease into a developer's real sandbox state — the one that cost this program weeks — would have depended on one call site remembering to pass a `TempDir`.

## Why production is not changed

Production has no such race, and this deliberately leaves the sweep alone. Every production lease write and every production sweep runs inside the **same** per-user machine-wide `MutationLock` — `start_with_apply` holds it across create-then-write, and `recover_dead_leases_locked` runs under it — so a lease can neither appear nor vanish between a sweep's enumeration and its open. The module already relies on exactly that argument to justify reclaiming a 0-byte lease.

The unit tests break that invariant on purpose: they call `recover_dead_leases_locked` directly and do **not** take `MutationLock`, because it lives in the `Global\` namespace and taking it would test whether whoever ran `cargo test` holds `SeCreateGlobalPrivilege` rather than testing the repair. A directory of their own restores the isolation the lock would have given them, with no privilege dependency.

The in-process mutex those tests already had is kept, renamed `reclamation_sink_lock` and re-documented for what it now actually guards: the process-global `EMITTED_RECLAMATIONS` static, which two of the tests drain and assert an exact count on. It is dropped from the three tests that neither emit nor drain a reclamation report.

## After

Same box, same commands, on this branch:

| arm | runs | result |
|---|---|---|
| full lib suite, default parallelism | **30** | 30 green — 219 passed / 0 failed every run |
| filter `appcontainer_acl_lease` | **30** | 30 green — 16 passed / 0 failed every run |
| `cargo nextest run -p wcore-sandbox` (Linux) | 1 | 172 passed, 11 skipped |
| `cargo test -p wcore-sandbox` (lib + 22 integration binaries) | 1 | 23 binaries, 0 failures |

## What this evidence does and does not establish

It establishes the mechanism, not just a green run: the failure was reproduced 10/10 with a named filter, the interfering writer was isolated by subtraction (10/10 green without it, 10/10 red with it), and the error text names that writer's file. 30 clean runs of an arm that was previously red on every attempt is strong, but the base rate in the **full** suite was 4-in-5, not 1-in-1, so 30 clean full-suite runs bound the residual rate to roughly <10% per run at 95% confidence — they do not prove zero.

## Not fixed here

Under `--test-threads=1`, `windows_impl::tests::session_selection_reaches_ready_without_running_the_appcontainer_probe` fails deterministically, before and after this change alike (3/3 in both arms), with its own message: *"precondition: the probe cache must be cold at the start of this process — run this test with `cargo nextest run` (process per test)"*. It is an independent order dependency on a process-global probe cache, not part of this defect, and it passes under default parallel scheduling only because of test ordering luck.

## Gate

- `cargo fmt --all -- --check` — clean (Linux)
- `cargo clippy --workspace --all-targets -- -D warnings` — clean (Linux)
- `cargo clippy --workspace --all-targets --target x86_64-pc-windows-gnu -- -D warnings` — clean (Linux)
- `cargo clippy -p wcore-sandbox --all-targets -- -D warnings` — clean (Windows msvc, the target this code compiles for)
- `cargo nextest run --workspace` — 14867/14868 passed on Linux. The single failure is `wcore-cli::deterministic_openai_loop packaged_f04_run_is_repeatable_and_content_addressed`, a 60s timeout that is known pre-existing on pristine `origin/main` on that host and is in a different crate.
