### PR TITLE
fix(tools): a path with a space in it is one path, not two

### DIFF
--- a/crates/wcore-tools/src/bash/policy.rs
+++ b/crates/wcore-tools/src/bash/policy.rs
@@ -220,26 +220,103 @@ fn is_path_token(token: &str) -> bool {
 
 /// Pull the path-shaped tokens out of a tool result body. Deliberately crude:
 /// the caller only trusts a token once it matches the manifest.
-fn candidate_paths(body: &str) -> Vec<&str> {
-    body.split(|c: char| c.is_whitespace() || c == '\'' || c == '"' || c == '`')
-        .map(|token| token.trim_end_matches([':', ',', '.', ';', ')', ']']))
-        .filter(|token| is_path_token(token))
-        .collect()
+fn candidate_paths(body: &str, scope: &SandboxScope) -> Vec<String> {
+    let raw: Vec<&str> = body
+        .split(|c: char| c.is_whitespace() || c == '\'' || c == '"' || c == '`')
+        .collect();
+
+    let mut out: Vec<String> = Vec::new();
+    let mut i = 0;
+    while i < raw.len() {
+        // Greedily prefer the LONGEST run of space-joined tokens that names
+        // something real. `~/Library/Application Support/...` is one path, not
+        // two, and every macOS desktop workspace lives under it — splitting it
+        // produced two fragments that each looked ungranted, so the advisory
+        // stated a falsehood about a file that was never out of reach.
+        //
+        // The filesystem is the arbiter, which is sound HERE specifically:
+        // this runs in the parent process, outside the child's sandbox, so a
+        // path that resolves for us really does exist.
+        let mut best: Option<(usize, String)> = None;
+        let limit = raw.len().min(i + MAX_SPACE_JOINED_TOKENS);
+        for j in i..limit {
+            let joined = trim_trailing_punctuation(&raw[i..=j].join(" "));
+            if joined.is_empty() || !is_path_token(&joined) {
+                continue;
+            }
+            if resolve_candidate(scope, &joined).is_some_and(|p| !is_definitely_absent(&p)) {
+                best = Some((j, joined));
+            }
+        }
+        match best {
+            Some((j, joined)) => {
+                out.push(joined);
+                i = j + 1;
+            }
+            None => {
+                // Nothing real here. Keep the bare token so a genuinely denied
+                // path that no longer exists on disk can still match the
+                // deny-list, and let `classify` decide.
+                let token = trim_trailing_punctuation(raw[i]);
+                if is_path_token(&token) {
+                    out.push(token);
+                }
+                i += 1;
+            }
+        }
+    }
+    out
+}
+
+/// Longest run of whitespace-separated tokens considered as one path.
+///
+/// Real directory names contain a space or two (`Application Support`,
+/// `My Documents`); prose does not stop being prose for eight words running.
+/// The bound also keeps this quadratic scan cheap on a large tool output.
+const MAX_SPACE_JOINED_TOKENS: usize = 6;
+
+fn trim_trailing_punctuation(token: &str) -> String {
+    token
+        .trim_end_matches([':', ',', '.', ';', ')', ']'])
+        .to_string()
+}
+
+/// True only when the filesystem positively reports that nothing is there.
+///
+/// Deliberately NOT `!path.exists()`. `exists()` collapses "no such file" and
+/// "I was not allowed to look" into the same `false`, and the second case is
+/// one this annotation must keep reporting: a path denied through a directory
+/// the agent process itself cannot traverse is exactly the kind of genuine
+/// denial worth naming. Only a hard `NotFound` is evidence of absence.
+fn is_definitely_absent(path: &Path) -> bool {
+    match std::fs::symlink_metadata(path) {
+        Ok(_) => false,
+        Err(error) => error.kind() == std::io::ErrorKind::NotFound,
+    }
+}
+
+/// Resolve a token the way [`classify`] does — absolute as written, relative
+/// against the child's cwd. Shared by the tokenizer so the two cannot drift
+/// into disagreeing about what a token even names.
+fn resolve_candidate(scope: &SandboxScope, token: &str) -> Option<PathBuf> {
+    let raw = Path::new(token);
+    if raw.is_absolute() {
+        Some(raw.to_path_buf())
+    } else {
+        Some(
+            scope
+                .cwd
+                .as_ref()?
+                .join(raw.strip_prefix("./").unwrap_or(raw)),
+        )
+    }
 }
 
 /// Classify one path token against the scope. `None` means "no evidence this
 /// path was blocked by the sandbox" — the default, so an unrelated failure is
 /// never given a fabricated cause.
 fn classify(scope: &SandboxScope, token: &str) -> Option<(PathBuf, DeniedBecause)> {
-    let raw = Path::new(token);
-    let joined = if raw.is_absolute() {
-        raw.to_path_buf()
-    } else {
-        scope
-            .cwd
-            .as_ref()?
-            .join(raw.strip_prefix("./").unwrap_or(raw))
-    };
+    let joined = resolve_candidate(scope, token)?;
     // Manifest roots are canonicalized by `WorkspacePolicy`, but a child names
     // whatever spelling it was given. On macOS the granted scratch root is
     // `/private/tmp/...` while the shell reports `/tmp/...`, so a prefix match on
@@ -288,8 +365,8 @@ pub(super) fn annotate_sandbox_denial(scope: &SandboxScope, mut result: ToolResu
         return result;
     }
     let mut denied: Vec<(PathBuf, DeniedBecause)> = Vec::new();
-    for token in candidate_paths(&result.content) {
-        if let Some(hit) = classify(scope, token)
+    for token in candidate_paths(&result.content, scope) {
+        if let Some(hit) = classify(scope, &token)
             && !denied.iter().any(|(seen, _)| *seen == hit.0)
         {
             denied.push(hit);

--- a/crates/wcore-tools/src/bash/policy.rs
+++ b/crates/wcore-tools/src/bash/policy.rs
@@ -244,7 +244,7 @@ fn candidate_paths(body: &str, scope: &SandboxScope) -> Vec<String> {
             if joined.is_empty() || !is_path_token(&joined) {
                 continue;
             }
-            if resolve_candidate(scope, &joined).is_some_and(|p| !is_definitely_absent(&p)) {
+            if resolve_candidate(scope, &joined).is_some_and(|p| path_exists(&p)) {
                 best = Some((j, joined));
             }
         }
@@ -281,18 +281,20 @@ fn trim_trailing_punctuation(token: &str) -> String {
         .to_string()
 }
 
-/// True only when the filesystem positively reports that nothing is there.
+/// True only when the filesystem positively reports that something IS there.
 ///
-/// Deliberately NOT `!path.exists()`. `exists()` collapses "no such file" and
-/// "I was not allowed to look" into the same `false`, and the second case is
-/// one this annotation must keep reporting: a path denied through a directory
-/// the agent process itself cannot traverse is exactly the kind of genuine
-/// denial worth naming. Only a hard `NotFound` is evidence of absence.
-fn is_definitely_absent(path: &Path) -> bool {
-    match std::fs::symlink_metadata(path) {
-        Ok(_) => false,
-        Err(error) => error.kind() == std::io::ErrorKind::NotFound,
-    }
+/// The polarity matters, and an earlier version of this had it backwards. The
+/// reassembly below needs POSITIVE evidence that a joined run of tokens names
+/// a real path, not merely the absence of evidence that it does not. Those are
+/// the same test only on a platform where every stat failure is `NotFound`.
+/// Windows returns `InvalidInput` for a path containing characters no path may
+/// contain, so a "not definitely absent" check accepted
+/// `C:\w\repo\ STDERR: LoadLibrary failed for …` as an existing path and
+/// glued half a log line into one fabricated token.
+///
+/// A stat that fails for ANY reason is not a path worth joining on.
+fn path_exists(path: &Path) -> bool {
+    std::fs::symlink_metadata(path).is_ok()
 }
 
 /// Resolve a token the way [`classify`] does — absolute as written, relative
@@ -886,7 +888,33 @@ pub fn check_denylist(command: &str) -> Option<&'static str> {
 
 #[cfg(test)]
 mod tests {
-    use super::{is_always_granted, is_path_token};
+    use super::{is_always_granted, is_path_token, path_exists};
+
+    /// The reassembly oracle must require POSITIVE evidence that a path
+    /// exists. Asking "is it definitely absent?" instead looks identical on a
+    /// platform where every stat failure is `NotFound`, and is wrong wherever
+    /// one is not — which is how a Windows-only regression got past a green
+    /// Linux gate.
+    ///
+    /// A file used as a directory component fails with `NotADirectory` on
+    /// Unix and an equivalent non-`NotFound` error on Windows, which is
+    /// exactly the shape that slipped through.
+    #[test]
+    fn the_existence_oracle_requires_a_positive_answer() {
+        let file = std::env::current_exe().expect("the test binary exists");
+        assert!(path_exists(&file), "positive control: the binary is there");
+
+        assert!(
+            !path_exists(&file.join("not-a-directory")),
+            "a stat that fails for ANY reason is not a path worth joining on; \
+             treating only NotFound as absence accepts this one"
+        );
+
+        assert!(
+            !path_exists(std::path::Path::new("/definitely/not/here/xyzzy")),
+            "and a plainly absent path is still absent"
+        );
+    }
 
     /// The verbatim spelling is the one `canonicalize` actually returns on
     /// Windows, and it is a plain string here, so this runs on every host

--- a/crates/wcore-tools/src/bash/tests.rs
+++ b/crates/wcore-tools/src/bash/tests.rs
@@ -1800,3 +1800,86 @@ fn the_sandbox_advisory_names_the_git_surface_that_still_works() {
         "the advisory must not overstate the blast radius; got:\n{advisory}"
     );
 }
+
+// ── P5: a path with a SPACE in it is still one path ─────────────────────────
+//
+// Every macOS desktop workspace lives under `~/Library/Application Support`,
+// so this is not an exotic case — it is the common one. A tokenizer that splits
+// on whitespace shatters such a path into fragments, each of which classifies
+// as ungranted, and the advisory then states a falsehood about a file that was
+// never out of reach. Three people spent a day chasing a boundary problem this
+// message invented.
+
+#[cfg(unix)]
+#[test]
+fn a_granted_path_containing_a_space_is_not_reported_as_ungranted() {
+    let tmp = tempfile::tempdir().unwrap();
+    // Mimic the real layout, spaces and all.
+    let granted = tmp.path().join("Application Support/Wayland/wcore-temp-1");
+    std::fs::create_dir_all(&granted).unwrap();
+    let report = granted.join("morning-brief.html");
+    std::fs::write(&report, b"<html/>").unwrap();
+    let granted = std::fs::canonicalize(&granted).unwrap();
+
+    let manifest = wcore_sandbox::manifest::SandboxManifest {
+        fs_read_allow: vec![granted.clone()],
+        fs_write_allow: vec![granted.clone()],
+        ..Default::default()
+    };
+    let scope = super::policy::SandboxScope::new(&manifest, Some(&granted));
+
+    let result = super::policy::annotate_sandbox_denial(
+        &scope,
+        ToolResult {
+            content: format!(
+                "Exit code: 1\nSTDOUT:\n\nSTDERR:\nopen: {}: \
+                 _LSOpenURLsWithCompletionHandler() failed with error -54\n",
+                report.display()
+            ),
+            is_error: true,
+        },
+    );
+    assert!(
+        !result.content.to_lowercase().contains("outside every root"),
+        "the file is INSIDE a granted root — the space in `Application Support` \
+         must not turn it into two ungranted fragments; got:\n{}",
+        result.content
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn a_real_path_outside_every_granted_root_is_still_reported() {
+    // The control for the two tests above: the advisory must keep firing when
+    // it genuinely applies, or the fix would be a mute button rather than a
+    // correction.
+    let tmp = tempfile::tempdir().unwrap();
+    let granted = std::fs::canonicalize(tmp.path()).unwrap();
+    let outside = tempfile::tempdir().unwrap();
+    let file = outside.path().join("secret notes.txt");
+    std::fs::write(&file, b"x").unwrap();
+
+    let manifest = wcore_sandbox::manifest::SandboxManifest {
+        fs_read_allow: vec![granted.clone()],
+        fs_write_allow: vec![granted.clone()],
+        ..Default::default()
+    };
+    let scope = super::policy::SandboxScope::new(&manifest, Some(&granted));
+
+    let result = super::policy::annotate_sandbox_denial(
+        &scope,
+        ToolResult {
+            content: format!(
+                "Exit code: 1\nSTDOUT:\n\nSTDERR:\ncat: {}: Operation not permitted\n",
+                file.display()
+            ),
+            is_error: true,
+        },
+    );
+    assert!(
+        result.content.to_lowercase().contains("outside every root"),
+        "a REAL file outside every granted root must still be named — and note \
+         it has a space too, so the reassembly has to find it; got:\n{}",
+        result.content
+    );
+}


### PR DESCRIPTION
Reported by the Desktop lane, and they were right. Verified by execution, not by reading.

## The defect

`candidate_paths()` split tool output on whitespace, so every macOS path under
`Application Support` shattered into two tokens:

```
/Users/me/Library/Application          <- absolute, under no granted root
Support/Wayland/wcore-temp-1/x.html    <- contains a slash, so read as relative to cwd
```

Both classify as ungranted, and the advisory then prints **"outside every root granted
to this workspace"** plus the STRICT-profile remedy — about a file that was never out of
reach. Every Wayland desktop chat workspace lives under `Application Support`, so this
fired on the common case, not an exotic one.

It matters more than a cosmetic bug because the agent faithfully relays the advisory to
the user as the cause. Two lanes and one user spent a day chasing a sandbox boundary
problem that this message invented. The actual failure was unrelated —
FerroxLabs/wayland#1102, a missing SBPL `lsopen` grant, now root-caused separately.

## The fix

Reassemble space-joined runs, using the filesystem as the arbiter, bounded to 6 tokens.
That oracle is sound **here specifically**: this annotation runs in the parent process,
outside the child's sandbox, so a path that resolves for us really does exist.

Absence is tested with `symlink_metadata` + a `NotFound` check rather than `exists()`,
because `exists()` also returns false when we were merely not allowed to look — and a
path denied through an untraversable directory is exactly the case worth keeping.

`classify` now shares that resolver with the tokenizer, so the two cannot drift into
disagreeing about what a token even names.

## Verification

Three tests. The important one is the **control**: a real file, *also* with a space in
its name, that genuinely IS outside every granted root — the advisory has to keep
firing. Before this change that control passed for the wrong reason (a fragment tripped
it); now it only passes if the reassembly finds the real path. The fix had to be a
correction, not a mute button.

Red arm: reassembly disabled (`limit = i + 1`), tree committed first and `touch`ed after
restore. Exactly one test failed — the space test — and nothing else. Green arm after
restore: 62/62 in `bash::tests`.

Full gate on Linux: `fmt --check` clean, `clippy --workspace --all-targets -D warnings`
clean, and clean again on `x86_64-pc-windows-gnu`. Full workspace suite 14869/14870; the
one failure is `wcore-cli::deterministic_openai_loop packaged_f04_run_is_repeatable_and_content_addressed`,
which times out identically on pristine `origin/main` (A/B'd on a separate clean
checkout) — pre-existing, not from this change.

## What I deliberately did NOT fix

`classify` still returns `NotGranted` for a path-shaped token that resolves to nothing,
so ordinary prose containing something like `some/relative/fragment` can still be named
as denied. Requiring existence there is the obvious fix, and it is a trap: it makes
several existing negative tests pass **vacuously**, including ones whose synthetic
Windows paths (`\\?\C:\Windows\System32\…`) cannot be made real on a POSIX host, so they
would silently stop exercising `is_always_granted` at all. I tried it, measured the
damage, and backed it out rather than trade a false positive for four dead tests. Filed
as FerroxLabs/wayland#1103 with the fixture rework it actually needs.
