### PR TITLE
fix(vfs): pin the jailed read to one kernel object (#1105)

### DIFF
--- a/crates/wcore-tools/src/lib.rs
+++ b/crates/wcore-tools/src/lib.rs
@@ -207,6 +207,11 @@ pub mod url_safety;
 pub mod unsaved_work;
 // W8a A.3: VirtualFs trait + RealFs / InMemoryFs / SandboxedFs (X2).
 pub mod vfs;
+// #1105: the platform half of `VirtualFs::read_pinned` — a read whose leaf is
+// resolved exactly once, relative to a retained parent-directory handle, so
+// the object the jail approved is the object the bytes come from. Crate-
+// internal: `RealFs::read_pinned` is the only supported way in.
+pub(crate) mod vfs_pinned;
 // T3-3.5 (sub-wave 5): video_analyze tool — AI video analysis via a
 // pluggable VideoAnalysisBackend (NullVideoBackend fails loud).
 pub mod video_analyze_tool;

--- a/crates/wcore-tools/src/vfs.rs
+++ b/crates/wcore-tools/src/vfs.rs
@@ -55,6 +55,16 @@ pub enum VfsError {
     NotFound { path: PathBuf },
     #[error("refused: {path:?} is a protected secret path")]
     SecretDenied { path: PathBuf },
+    /// The open did not land on the object the containment check approved.
+    ///
+    /// Raised by the handle-pinned read path (`vfs_pinned`) when the name it
+    /// was handed resolves to something other than the ordinary file the jail
+    /// cleared — a symlink, a directory, a device, or a parent directory that
+    /// was replaced between the two steps. Distinct from `OutsideSandbox`
+    /// because nothing about the REQUEST was out of bounds; the filesystem
+    /// changed underneath it.
+    #[error("refused: {path:?} did not resolve to the approved object: {reason}")]
+    PathRaced { path: PathBuf, reason: String },
 }
 
 /// Strong content identity used by conditional filesystem mutations.
@@ -287,6 +297,33 @@ pub trait VirtualFs: Send + Sync {
     async fn remove_file(&self, path: &Path) -> Result<(), VfsError>;
     async fn metadata(&self, path: &Path) -> Result<VfsMetadata, VfsError>;
 
+    /// Read a file with the check and the use bound to ONE kernel object
+    /// (FerroxLabs/wayland#1105).
+    ///
+    /// `read` takes a pathname and resolves it. A caller that has already
+    /// decided a path is permitted — `SandboxedFs`, which canonicalizes and
+    /// compares against its root and its standing grants — therefore hands
+    /// back a NAME, and the backend resolves it a second time. Anything that
+    /// can write in the directory can swap the leaf between those two
+    /// resolutions, and the approved object and the read object are then
+    /// different objects.
+    ///
+    /// An implementor of this method must resolve the leaf exactly once,
+    /// relative to a RETAINED parent directory handle, without following a
+    /// symlink at the leaf or at the parent, and read the bytes from that same
+    /// descriptor. Where that is impossible the default below applies and the
+    /// jail refuses rather than falling back to `read` — a fallback would be a
+    /// silent downgrade to the window this method exists to close.
+    async fn read_pinned(&self, path: &Path) -> Result<Vec<u8>, VfsError> {
+        Err(VfsError::Io(io::Error::new(
+            io::ErrorKind::Unsupported,
+            format!(
+                "handle-pinned reads are not implemented for {}",
+                path.display()
+            ),
+        )))
+    }
+
     /// Observe bytes and the VFS/path object identity in one implementation-
     /// owned read-only operation. Durable receipts use this instead of `read`
     /// so matching bytes alone can never resolve an uncertain effect.
@@ -382,6 +419,12 @@ impl VirtualFs for RealFs {
             size: m.len(),
             is_dir: m.is_dir(),
         })
+    }
+    async fn read_pinned(&self, path: &Path) -> Result<Vec<u8>, VfsError> {
+        let path = path.to_path_buf();
+        tokio::task::spawn_blocking(move || crate::vfs_pinned::pinned_read_bytes(&path))
+            .await
+            .map_err(|error| VfsError::Io(io::Error::other(error)))?
     }
     async fn observe_file(&self, path: &Path) -> Result<IdentifiedFileObservation, VfsError> {
         let path = path.to_path_buf();
@@ -531,7 +574,12 @@ fn c_name(name: &OsStr) -> io::Result<CString> {
 }
 
 #[cfg(unix)]
-fn openat_file(parent: &fs::File, name: &OsStr, flags: i32, mode: u32) -> io::Result<fs::File> {
+pub(crate) fn openat_file(
+    parent: &fs::File,
+    name: &OsStr,
+    flags: i32,
+    mode: u32,
+) -> io::Result<fs::File> {
     let name = c_name(name)?;
     // SAFETY: `name` is a live NUL-terminated string, `parent` remains open,
     // and ownership of a successful descriptor is transferred exactly once.
@@ -702,7 +750,7 @@ fn observe_real_file_windows(path: &Path) -> Result<IdentifiedFileObservation, V
 /// that into a refusal (the `is_dir` check below fails) instead of a silent
 /// traversal.
 #[cfg(windows)]
-fn open_windows_directory(path: &Path) -> io::Result<fs::File> {
+pub(crate) fn open_windows_directory(path: &Path) -> io::Result<fs::File> {
     use std::os::windows::fs::OpenOptionsExt as _;
 
     const FILE_FLAG_BACKUP_SEMANTICS: u32 = 0x0200_0000;
@@ -717,7 +765,7 @@ fn open_windows_directory(path: &Path) -> io::Result<fs::File> {
 /// Everything the identity token and the type refusals are derived from, read
 /// once from a single retained handle.
 #[cfg(windows)]
-struct WindowsObjectIdentity {
+pub(crate) struct WindowsObjectIdentity {
     volume_serial: u32,
     file_index: u64,
     /// 128-bit `FILE_ID_INFO` identity. `None` where the volume cannot serve it
@@ -725,12 +773,14 @@ struct WindowsObjectIdentity {
     /// records that explicitly so a receipt written with one is never silently
     /// compared against a receipt written without.
     file_id: Option<[u8; 16]>,
-    attributes: u32,
+    pub(crate) attributes: u32,
     links: u32,
 }
 
 #[cfg(windows)]
-fn windows_object_identity(handle: &fs::File) -> Result<WindowsObjectIdentity, VfsError> {
+pub(crate) fn windows_object_identity(
+    handle: &fs::File,
+) -> Result<WindowsObjectIdentity, VfsError> {
     use std::os::windows::io::AsRawHandle as _;
     use windows_sys::Win32::Storage::FileSystem::{
         BY_HANDLE_FILE_INFORMATION, FILE_ID_INFO, FileIdInfo, GetFileInformationByHandle,
@@ -982,7 +1032,10 @@ mod windows_identity_token_tests {
 /// kernel refuse a directory at open time and `FILE_OPEN_REPARSE_POINT` opens a
 /// symlink/junction as itself so the caller's attribute check can refuse it.
 #[cfg(windows)]
-fn open_windows_child_no_follow(parent: &fs::File, leaf: &OsStr) -> io::Result<fs::File> {
+pub(crate) fn open_windows_child_no_follow(
+    parent: &fs::File,
+    leaf: &OsStr,
+) -> io::Result<fs::File> {
     use std::os::windows::ffi::OsStrExt as _;
     use std::os::windows::io::{AsRawHandle as _, FromRawHandle as _};
     use windows_sys::Wdk::Foundation::OBJECT_ATTRIBUTES;
@@ -1250,6 +1303,14 @@ impl VirtualFs for InMemoryFs {
             size: bytes.bytes.len() as u64,
             is_dir: false,
         })
+    }
+    /// An in-memory map has no kernel objects and no pathname walk, so the key
+    /// lookup IS the pinned read. Load-bearing rather than decorative:
+    /// `SandboxedFs<InMemoryFs>` is a real configuration in the test suite, and
+    /// leaving it on the trait default would make every jailed read there
+    /// refuse.
+    async fn read_pinned(&self, path: &Path) -> Result<Vec<u8>, VfsError> {
+        self.read(path).await
     }
     async fn observe_file(&self, path: &Path) -> Result<IdentifiedFileObservation, VfsError> {
         let files = self.files.read();
@@ -1595,9 +1656,23 @@ fn lex_normalize(path: &Path, base: &Path) -> PathBuf {
 
 #[async_trait]
 impl<F: VirtualFs + 'static> VirtualFs for SandboxedFs<F> {
+    /// Reads go through [`VirtualFs::read_pinned`], never `read` (#1105).
+    ///
+    /// `contain_read` decides about the OBJECT it canonicalized; handing the
+    /// resulting NAME to a path-based `read` lets the backend resolve it a
+    /// second time, and anything able to write in the directory can swap the
+    /// leaf in between. Measured on this tree before the change: 30,241 of
+    /// 85,051 jailed reads returned bytes from outside the granted root while
+    /// a second thread flipped the leaf between a regular file and a symlink.
+    ///
+    /// There is deliberately NO fallback to `self.inner.read` when a backend
+    /// answers `Unsupported`. A fallback would be a silent downgrade back to
+    /// that window, and it would be invisible because the read would still
+    /// succeed. An out-of-tree `VirtualFs` implementor therefore has to
+    /// implement `read_pinned` to be readable through a jail.
     async fn read(&self, path: &Path) -> Result<Vec<u8>, VfsError> {
         let p = self.contain_read(path).await?;
-        self.inner.read(&p).await
+        self.inner.read_pinned(&p).await
     }
     async fn write(&self, path: &Path, contents: &[u8]) -> Result<(), VfsError> {
         let p = self.contain(path).await?;
@@ -1692,6 +1767,14 @@ impl<F: VirtualFs + 'static> VirtualFs for SecretDenyFs<F> {
     async fn read(&self, path: &Path) -> Result<Vec<u8>, VfsError> {
         self.guard(path)?;
         self.inner.read(path).await
+    }
+    /// Forwards the pin so the workspace posture — `SandboxedFs<SecretDenyFs
+    /// <RealFs>>` — keeps reaching `RealFs::read_pinned`. Without this the
+    /// layer in the middle would swallow the capability and every jailed read
+    /// in the default posture would refuse.
+    async fn read_pinned(&self, path: &Path) -> Result<Vec<u8>, VfsError> {
+        self.guard(path)?;
+        self.inner.read_pinned(path).await
     }
     async fn write(&self, path: &Path, contents: &[u8]) -> Result<(), VfsError> {
         self.guard(path)?;

--- a/crates/wcore-tools/src/vfs_pinned.rs
+++ b/crates/wcore-tools/src/vfs_pinned.rs
@@ -1,0 +1,202 @@
+//! Handle-pinned file read — the "use" half of `VirtualFs::read_pinned`
+//! (FerroxLabs/wayland#1105).
+//!
+//! `SandboxedFs` decides whether a path is permitted by canonicalizing it and
+//! comparing the result against its root and its standing read grants. That
+//! decision is about an OBJECT, but what it can pass on is a NAME. If the
+//! backend then resolves that name a second time, anything able to create a
+//! file in the directory can swap the leaf in between, and the object that was
+//! approved is not the object that gets read. Snyk demonstrated exactly this
+//! against another agent with `renameat2(RENAME_EXCHANGE)` and noted that more
+//! `lstat`/`realpath` checks cannot fix it, because the check stays split from
+//! the use.
+//!
+//! This module removes the second resolution of the leaf. The parent directory
+//! is opened once as a RETAINED handle with symlinks refused, the leaf is
+//! opened RELATIVE to that handle with symlinks refused, its type is checked
+//! from the open descriptor, and the bytes are read from that same descriptor.
+//! There is no pathname left for anyone to redirect.
+//!
+//! **What this does NOT close, deliberately.** The parent is opened by
+//! pathname, so the kernel still walks the components ABOVE it ambiently. An
+//! attacker who can rename a directory higher up and drop a symlink in its
+//! place still wins. Closing that needs a directory handle retained from the
+//! moment the grant is made and `openat2(RESOLVE_BENEATH)` (Linux 5.6+)
+//! beneath it, which changes the shape of a grant and is not this change.
+//!
+//! **Platform behaviour, recorded rather than assumed.**
+//! * Unix (Linux, macOS): `O_NOFOLLOW` on both opens plus `O_DIRECTORY` on the
+//!   parent. `O_NOFOLLOW` is POSIX and behaves identically on both.
+//! * Windows: `O_NOFOLLOW` does not exist and would be a no-op if it did, so
+//!   the equivalent is built from `NtCreateFile` with `RootDirectory` (the only
+//!   `openat` Windows offers), `FILE_OPEN_REPARSE_POINT` to open a
+//!   symlink/junction as ITSELF rather than traversing it, and an explicit
+//!   `FILE_ATTRIBUTE_REPARSE_POINT` refusal afterwards. This reuses the exact
+//!   primitives `vfs::observe_real_file_windows` already uses. It is
+//!   compile-verified from Linux via `--target x86_64-pc-windows-gnu`; a
+//!   cross-target lint sees `cfg(windows)` code and proves nothing about
+//!   `NtCreateFile` runtime semantics.
+//! * Anything else: `Unsupported`, which `SandboxedFs::read` turns into a
+//!   refusal. There is no such CI target today; a fallback to a path-based read
+//!   would be a silent downgrade and is worse than an honest error.
+
+use std::io;
+use std::path::Path;
+
+use crate::vfs::VfsError;
+
+/// Read `path`'s bytes with the leaf resolved exactly once, relative to a
+/// retained parent-directory handle.
+///
+/// Blocking. Callers on an async runtime must wrap this in `spawn_blocking`.
+pub(crate) fn pinned_read_bytes(path: &Path) -> Result<Vec<u8>, VfsError> {
+    #[cfg(unix)]
+    {
+        pinned_read_unix(path)
+    }
+    #[cfg(windows)]
+    {
+        pinned_read_windows(path)
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        Err(VfsError::Io(io::Error::new(
+            io::ErrorKind::Unsupported,
+            format!(
+                "handle-pinned reads are unavailable on this platform: {}",
+                path.display()
+            ),
+        )))
+    }
+}
+
+#[cfg(any(unix, windows))]
+fn raced(path: &Path, reason: &str) -> VfsError {
+    VfsError::PathRaced {
+        path: path.to_path_buf(),
+        reason: reason.to_owned(),
+    }
+}
+
+/// Split into (parent directory, leaf name). A path with no file name — the
+/// filesystem root, or one ending in `..` — names no readable object.
+#[cfg(any(unix, windows))]
+fn split_leaf(path: &Path) -> Result<(&Path, &std::ffi::OsStr), VfsError> {
+    let leaf = path.file_name().ok_or_else(|| {
+        VfsError::Io(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("a pinned read requires a file name: {}", path.display()),
+        ))
+    })?;
+    // `file_name()` returning `Some` guarantees a parent exists, but an empty
+    // one ("x.txt" with no directory) is not something we can open as a dir.
+    let parent = path.parent().filter(|p| !p.as_os_str().is_empty());
+    let parent = parent.ok_or_else(|| {
+        VfsError::Io(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "a pinned read requires an anchored parent directory: {}",
+                path.display()
+            ),
+        ))
+    })?;
+    Ok((parent, leaf))
+}
+
+#[cfg(unix)]
+fn pinned_read_unix(path: &Path) -> Result<Vec<u8>, VfsError> {
+    use std::io::Read as _;
+    use std::os::unix::fs::OpenOptionsExt as _;
+
+    let (parent_path, leaf) = split_leaf(path)?;
+
+    // The parent's own final component must not be a symlink and must be a
+    // directory. Both are true of the canonical path `SandboxedFs` produced at
+    // check time, so a violation here means the directory was replaced since.
+    let parent = std::fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_DIRECTORY | libc::O_CLOEXEC)
+        .open(parent_path)
+        .map_err(|error| match error.raw_os_error() {
+            Some(libc::ELOOP) | Some(libc::ENOTDIR) => raced(
+                path,
+                "the parent directory was replaced by a symlink or a non-directory",
+            ),
+            _ => VfsError::Io(error),
+        })?;
+
+    // O_NOFOLLOW: a symlink at the leaf is ELOOP, never a traversal.
+    // O_NONBLOCK: a FIFO opens immediately instead of blocking for a writer,
+    // so a planted pipe cannot wedge the turn before the type check runs.
+    let mut file = crate::vfs::openat_file(
+        &parent,
+        leaf,
+        libc::O_RDONLY | libc::O_NOFOLLOW | libc::O_CLOEXEC | libc::O_NONBLOCK,
+        0,
+    )
+    .map_err(|error| match error.raw_os_error() {
+        Some(libc::ELOOP) => raced(path, "a symlink was in place of the approved file"),
+        _ => VfsError::Io(error),
+    })?;
+
+    // Type is read from the OPEN descriptor, not from the name, so it describes
+    // the object the bytes will come from. Unlike `observe_unix_file` this does
+    // NOT require `nlink == 1`: that is a compare-exchange rule, and an
+    // ordinary hardlinked file (`.git` object stores, package caches) is
+    // perfectly readable.
+    let metadata = file.metadata()?;
+    if !metadata.is_file() {
+        return Err(raced(
+            path,
+            "the approved name resolved to a directory, device or pipe rather \
+             than a regular file",
+        ));
+    }
+
+    let mut bytes = Vec::new();
+    file.read_to_end(&mut bytes)?;
+    Ok(bytes)
+}
+
+#[cfg(windows)]
+fn pinned_read_windows(path: &Path) -> Result<Vec<u8>, VfsError> {
+    use std::io::Read as _;
+
+    const FILE_ATTRIBUTE_DIRECTORY: u32 = 0x0000_0010;
+    const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x0000_0400;
+
+    let (parent_path, leaf) = split_leaf(path)?;
+
+    // `FILE_FLAG_OPEN_REPARSE_POINT` is what makes this the `O_NOFOLLOW`
+    // equivalent for the parent: a junction or directory symlink planted here
+    // opens as ITSELF, and the attribute check below refuses it instead of
+    // silently traversing to wherever it points.
+    let parent = crate::vfs::open_windows_directory(parent_path).map_err(VfsError::Io)?;
+    let parent_identity = crate::vfs::windows_object_identity(&parent)?;
+    if parent_identity.attributes & FILE_ATTRIBUTE_REPARSE_POINT != 0
+        || parent_identity.attributes & FILE_ATTRIBUTE_DIRECTORY == 0
+    {
+        return Err(raced(
+            path,
+            "the parent directory was replaced by a reparse point or a non-directory",
+        ));
+    }
+
+    // `NtCreateFile` with `RootDirectory` resolves the name inside the retained
+    // handle only — no pathname walk, so nothing to redirect. `FILE_NON_
+    // DIRECTORY_FILE` refuses a directory at open time and
+    // `FILE_OPEN_REPARSE_POINT` opens a symlink as itself.
+    let mut file = crate::vfs::open_windows_child_no_follow(&parent, leaf).map_err(VfsError::Io)?;
+    let identity = crate::vfs::windows_object_identity(&file)?;
+    if identity.attributes & (FILE_ATTRIBUTE_DIRECTORY | FILE_ATTRIBUTE_REPARSE_POINT) != 0 {
+        return Err(raced(
+            path,
+            "the approved name resolved to a reparse point or a directory \
+             rather than a regular file",
+        ));
+    }
+
+    let mut bytes = Vec::new();
+    file.read_to_end(&mut bytes)?;
+    Ok(bytes)
+}

--- a/crates/wcore-tools/tests/path_grant_race_test.rs
+++ b/crates/wcore-tools/tests/path_grant_race_test.rs
@@ -20,17 +20,16 @@
 //! for a read-only folder the user picked.
 
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::{Duration, Instant};
-use wcore_tools::vfs::{RealFs, SandboxedFs, VfsError, VfsMetadata, VirtualFs};
-use wcore_tools::workspace_policy::WorkspacePolicy;
+use wcore_tools::vfs::{SandboxedFs, VfsError, VfsMetadata, VirtualFs};
 
+#[cfg(unix)]
 const BENIGN: &[u8] = b"<html>morning brief</html>";
+#[cfg(unix)]
 const SENTINEL: &[u8] = b"SENTINEL-OUTSIDE-THE-GRANT-0dd7f1";
 
-fn local_policy(root: &Path) -> WorkspacePolicy {
-    WorkspacePolicy::contained(root).with_local_operator_principal()
+#[cfg(unix)]
+fn local_policy(root: &Path) -> wcore_tools::workspace_policy::WorkspacePolicy {
+    wcore_tools::workspace_policy::WorkspacePolicy::contained(root).with_local_operator_principal()
 }
 
 /// THE REPRODUCTION.
@@ -50,6 +49,11 @@ fn local_policy(root: &Path) -> WorkspacePolicy {
 #[cfg(unix)]
 #[test]
 fn a_leaf_swapped_for_a_symlink_between_the_check_and_the_open_is_refused() {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::time::{Duration, Instant};
+    use wcore_tools::vfs::RealFs;
+
     let ws = tempfile::tempdir().unwrap();
     let granted = tempfile::tempdir().unwrap();
     let elsewhere = tempfile::tempdir().unwrap();

--- a/crates/wcore-tools/tests/path_grant_race_test.rs
+++ b/crates/wcore-tools/tests/path_grant_race_test.rs
@@ -188,10 +188,7 @@ async fn the_jail_refuses_rather_than_falling_back_when_the_backend_cannot_pin()
 
     // Positive control: the backend really can serve these bytes by path, so
     // the refusal below is the jail declining to and not a broken fixture.
-    assert_eq!(
-        UnpinnableFs.read(&canonical).await.unwrap(),
-        b"in".to_vec()
-    );
+    assert_eq!(UnpinnableFs.read(&canonical).await.unwrap(), b"in".to_vec());
 
     let error = jail
         .read(&inside)

--- a/crates/wcore-tools/tests/path_grant_race_test.rs
+++ b/crates/wcore-tools/tests/path_grant_race_test.rs
@@ -1,0 +1,204 @@
+//! FerroxLabs/wayland#1105 — the path-grant check-then-open window.
+//!
+//! `SandboxedFs::contain_read` canonicalizes a path, compares the canonical
+//! form against the granted roots, and then hands the PATH back to the inner
+//! filesystem, which resolves it a second time. Check and use are two separate
+//! resolutions of the same name, so an actor who can write inside the granted
+//! folder can swap the leaf between them.
+//!
+//! The ESCAPE-by-symlink variant is already closed (see
+//! `a_symlink_out_of_a_granted_folder_is_still_refused` in path_grant_test.rs):
+//! a symlink that is in place WHEN we canonicalize resolves outside the grant
+//! and is refused. What this file is about is the swap performed AFTER that
+//! canonicalize and BEFORE the open, which is the class Snyk demonstrated
+//! against OpenClaw with `renameat2(RENAME_EXCHANGE)` and explicitly stated
+//! more `lstat`/`realpath` checks cannot fix.
+//!
+//! Threat model, stated so these tests are not read as claiming more than they
+//! prove: this needs an actor who can already create files inside the granted
+//! folder. That is real for a shared or agent-writable directory and not real
+//! for a read-only folder the user picked.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, Instant};
+use wcore_tools::vfs::{RealFs, SandboxedFs, VfsError, VfsMetadata, VirtualFs};
+use wcore_tools::workspace_policy::WorkspacePolicy;
+
+const BENIGN: &[u8] = b"<html>morning brief</html>";
+const SENTINEL: &[u8] = b"SENTINEL-OUTSIDE-THE-GRANT-0dd7f1";
+
+fn local_policy(root: &Path) -> WorkspacePolicy {
+    WorkspacePolicy::contained(root).with_local_operator_principal()
+}
+
+/// THE REPRODUCTION.
+///
+/// One thread flips `<granted>/report.html` between a regular file holding
+/// benign bytes and a symlink pointing at a sentinel file OUTSIDE the granted
+/// root. Both flips are a `rename` onto the same name, which is atomic, so the
+/// name always resolves to one of the two objects and never to nothing.
+///
+/// The other thread reads that name through the jail. Every `Ok` must be the
+/// benign bytes. A single `Ok(SENTINEL)` is the check-then-open window being
+/// won: the containment check saw the regular file, the open resolved the
+/// symlink, and bytes from outside the grant reached the caller.
+///
+/// GUARD: `libc::O_NOFOLLOW` on the leaf `openat` in `vfs_pinned.rs`. Drop it
+/// and the sentinel comes back.
+#[cfg(unix)]
+#[test]
+fn a_leaf_swapped_for_a_symlink_between_the_check_and_the_open_is_refused() {
+    let ws = tempfile::tempdir().unwrap();
+    let granted = tempfile::tempdir().unwrap();
+    let elsewhere = tempfile::tempdir().unwrap();
+
+    let secret = elsewhere.path().join("outside-the-grant.txt");
+    std::fs::write(&secret, SENTINEL).unwrap();
+    let secret = std::fs::canonicalize(&secret).unwrap();
+
+    let granted_root = std::fs::canonicalize(granted.path()).unwrap();
+    let report = granted_root.join("report.html");
+    std::fs::write(&report, BENIGN).unwrap();
+
+    let policy = Arc::new(local_policy(ws.path()));
+    let jail = SandboxedFs::new(RealFs, ws.path().to_path_buf())
+        .with_read_grants(policy.session_read_grant_handle());
+    policy
+        .grant_session_read_root(granted.path(), false)
+        .unwrap();
+
+    // Sanity: the ordinary granted read works, so a "no escape observed"
+    // verdict below cannot be an artefact of the read never succeeding at all.
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .build()
+        .unwrap();
+    assert_eq!(
+        runtime.block_on(jail.read(&report)).unwrap(),
+        BENIGN.to_vec(),
+        "positive control: the granted folder is readable at all"
+    );
+
+    let stop = Arc::new(AtomicBool::new(false));
+    let swapper = {
+        let stop = Arc::clone(&stop);
+        let report: PathBuf = report.clone();
+        let secret = secret.clone();
+        let staging_evil = report.with_extension("evil");
+        let staging_benign = report.with_extension("benign");
+        std::thread::spawn(move || {
+            while !stop.load(Ordering::Relaxed) {
+                let _ = std::fs::remove_file(&staging_evil);
+                if std::os::unix::fs::symlink(&secret, &staging_evil).is_ok() {
+                    let _ = std::fs::rename(&staging_evil, &report);
+                }
+                let _ = std::fs::remove_file(&staging_benign);
+                if std::fs::write(&staging_benign, BENIGN).is_ok() {
+                    let _ = std::fs::rename(&staging_benign, &report);
+                }
+            }
+        })
+    };
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let mut attempts = 0_u64;
+    let mut escapes = 0_u64;
+    let mut refusals = 0_u64;
+    let mut benign_reads = 0_u64;
+    runtime.block_on(async {
+        while Instant::now() < deadline {
+            attempts += 1;
+            match jail.read(&report).await {
+                Ok(bytes) if bytes == SENTINEL => escapes += 1,
+                Ok(bytes) => {
+                    assert_eq!(
+                        bytes,
+                        BENIGN.to_vec(),
+                        "a successful granted read must return the object the \
+                         containment check approved, not a third thing"
+                    );
+                    benign_reads += 1;
+                }
+                Err(_) => refusals += 1,
+            }
+        }
+    });
+    stop.store(true, Ordering::Relaxed);
+    swapper.join().unwrap();
+
+    assert!(
+        benign_reads > 0,
+        "the race loop never once read the benign object ({attempts} attempts, \
+         {refusals} refusals) — the test is measuring nothing"
+    );
+    assert_eq!(
+        escapes, 0,
+        "path-grant TOCTOU: {escapes} of {attempts} reads returned bytes from \
+         OUTSIDE the granted root. The containment check approved a regular \
+         file and the open resolved a symlink planted after it."
+    );
+}
+
+/// THE FAIL-OPEN GUARD.
+///
+/// `SandboxedFs::read` must route through the handle-pinned read and must NOT
+/// fall back to the path-based `read` when a backend cannot pin. A fallback
+/// would be a silent downgrade to the exact window this issue is about, and it
+/// would be invisible, because the read would still succeed.
+///
+/// GUARD: the ABSENCE of an `Err(Unsupported) => self.inner.read(&p)` arm in
+/// `SandboxedFs::read`. Add one and this test fails.
+#[tokio::test]
+async fn the_jail_refuses_rather_than_falling_back_when_the_backend_cannot_pin() {
+    /// A backend that reads fine by path but leaves `read_pinned` at the trait
+    /// default. Stands in for any out-of-tree `VirtualFs` implementor.
+    struct UnpinnableFs;
+
+    #[async_trait::async_trait]
+    impl VirtualFs for UnpinnableFs {
+        async fn read(&self, path: &Path) -> Result<Vec<u8>, VfsError> {
+            Ok(std::fs::read(path)?)
+        }
+        async fn write(&self, _path: &Path, _contents: &[u8]) -> Result<(), VfsError> {
+            unreachable!("not exercised by this test")
+        }
+        async fn exists(&self, path: &Path) -> Result<bool, VfsError> {
+            Ok(path.exists())
+        }
+        async fn list(&self, _dir: &Path) -> Result<Vec<PathBuf>, VfsError> {
+            unreachable!("not exercised by this test")
+        }
+        async fn remove_file(&self, _path: &Path) -> Result<(), VfsError> {
+            unreachable!("not exercised by this test")
+        }
+        async fn metadata(&self, _path: &Path) -> Result<VfsMetadata, VfsError> {
+            unreachable!("not exercised by this test")
+        }
+    }
+
+    let ws = tempfile::tempdir().unwrap();
+    let inside = ws.path().join("in.txt");
+    std::fs::write(&inside, b"in").unwrap();
+    let canonical = std::fs::canonicalize(&inside).unwrap();
+
+    let jail = SandboxedFs::new(UnpinnableFs, ws.path().to_path_buf());
+
+    // Positive control: the backend really can serve these bytes by path, so
+    // the refusal below is the jail declining to and not a broken fixture.
+    assert_eq!(
+        UnpinnableFs.read(&canonical).await.unwrap(),
+        b"in".to_vec()
+    );
+
+    let error = jail
+        .read(&inside)
+        .await
+        .expect_err("a jail must refuse rather than silently read by path");
+    assert!(
+        matches!(&error, VfsError::Io(io) if io.kind() == std::io::ErrorKind::Unsupported),
+        "the refusal must name the missing capability, got: {error}"
+    );
+}

--- a/crates/wcore-tools/tests/vfs_pinned_read_test.rs
+++ b/crates/wcore-tools/tests/vfs_pinned_read_test.rs
@@ -1,0 +1,217 @@
+//! Deterministic per-guard tests for the handle-pinned read (#1105).
+//!
+//! `path_grant_race_test.rs` proves the window is real and that the fix closes
+//! it, but a wall-clock race cannot say WHICH guard did the closing. Each test
+//! here targets exactly one refusal in `vfs_pinned.rs` and carries a positive
+//! control through the ordinary path-based `RealFs::read` on the same fixture,
+//! so a refusal is the guard talking and never a broken fixture.
+
+use wcore_tools::vfs::{RealFs, VfsError, VirtualFs};
+
+/// GUARD: `O_NOFOLLOW` on the leaf `openat` (unix) / `FILE_OPEN_REPARSE_POINT`
+/// plus the `FILE_ATTRIBUTE_REPARSE_POINT` refusal (windows).
+///
+/// This is the single guard the race in `path_grant_race_test.rs` depends on:
+/// the swapped-in object there is a symlink, and refusing to follow it at open
+/// time is what stops the bytes coming from outside the grant.
+#[cfg(unix)]
+#[tokio::test]
+async fn a_symlinked_leaf_is_refused_by_the_pinned_read() {
+    let dir = tempfile::tempdir().unwrap();
+    let dir = std::fs::canonicalize(dir.path()).unwrap();
+    let real = dir.join("real.txt");
+    std::fs::write(&real, b"real bytes").unwrap();
+    let link = dir.join("link.txt");
+    std::os::unix::fs::symlink(&real, &link).unwrap();
+
+    // Positive control: the fixture is sound and the bytes are reachable by
+    // name, so the refusal below is a decision and not an absent file.
+    assert_eq!(
+        RealFs.read(&link).await.unwrap(),
+        b"real bytes".to_vec(),
+        "positive control: the ordinary path-based read follows the symlink"
+    );
+
+    let error = RealFs
+        .read_pinned(&link)
+        .await
+        .expect_err("a pinned read must not follow a symlink at the leaf");
+    assert!(
+        matches!(&error, VfsError::PathRaced { .. }),
+        "the refusal must name the identity mismatch, got: {error}"
+    );
+
+    // And the guard is narrow: the real file still reads.
+    assert_eq!(
+        RealFs.read_pinned(&real).await.unwrap(),
+        b"real bytes".to_vec()
+    );
+}
+
+/// GUARD: `O_DIRECTORY | O_NOFOLLOW` on the parent open (unix).
+///
+/// The leaf guard alone is not enough — swapping the DIRECTORY the leaf lives
+/// in redirects the read just as effectively, and it is a swap the leaf's own
+/// `O_NOFOLLOW` cannot see.
+#[cfg(unix)]
+#[tokio::test]
+async fn a_symlinked_parent_is_refused_by_the_pinned_read() {
+    let dir = tempfile::tempdir().unwrap();
+    let dir = std::fs::canonicalize(dir.path()).unwrap();
+    let real_dir = dir.join("realdir");
+    std::fs::create_dir(&real_dir).unwrap();
+    std::fs::write(real_dir.join("file.txt"), b"in the real dir").unwrap();
+    let link_dir = dir.join("linkdir");
+    std::os::unix::fs::symlink(&real_dir, &link_dir).unwrap();
+
+    let through_link = link_dir.join("file.txt");
+    assert_eq!(
+        RealFs.read(&through_link).await.unwrap(),
+        b"in the real dir".to_vec(),
+        "positive control: the ordinary path-based read traverses the linked dir"
+    );
+
+    let error = RealFs
+        .read_pinned(&through_link)
+        .await
+        .expect_err("a pinned read must not traverse a symlinked parent");
+    assert!(
+        matches!(&error, VfsError::PathRaced { .. }),
+        "the refusal must name the identity mismatch, got: {error}"
+    );
+
+    assert_eq!(
+        RealFs
+            .read_pinned(&real_dir.join("file.txt"))
+            .await
+            .unwrap(),
+        b"in the real dir".to_vec(),
+        "the same bytes through the real directory are still readable"
+    );
+}
+
+/// GUARD: the ABSENCE of `observe_unix_file`'s `metadata.nlink() != 1`
+/// refusal.
+///
+/// That rule belongs to compare-exchange, where a second name for the same
+/// inode defeats the rename-based commit. It has no business on an ordinary
+/// read: hardlinks are everywhere in `.git` object stores and package caches,
+/// and copying the CAS refusal across would break reading them. This test is
+/// what stops that copy-paste.
+#[cfg(unix)]
+#[tokio::test]
+async fn a_hardlinked_file_is_still_readable_through_the_pinned_read() {
+    let dir = tempfile::tempdir().unwrap();
+    let dir = std::fs::canonicalize(dir.path()).unwrap();
+    let original = dir.join("original.txt");
+    std::fs::write(&original, b"two names, one inode").unwrap();
+    let second = dir.join("second.txt");
+    std::fs::hard_link(&original, &second).unwrap();
+    assert_eq!(
+        std::fs::metadata(&original)
+            .map(|m| std::os::unix::fs::MetadataExt::nlink(&m))
+            .unwrap(),
+        2,
+        "fixture check: the file really does have two links"
+    );
+
+    for name in [&original, &second] {
+        assert_eq!(
+            RealFs.read_pinned(name).await.unwrap(),
+            b"two names, one inode".to_vec(),
+            "a hardlinked regular file is an ordinary readable file"
+        );
+    }
+}
+
+/// GUARD: the `metadata.is_file()` refusal, taken from the OPEN descriptor,
+/// plus `O_NONBLOCK` on the `openat`.
+///
+/// A FIFO planted where a regular file was is not an escape — it is a wedge.
+/// Without `O_NONBLOCK` the `open` itself blocks until someone writes, which
+/// hangs the turn with no error to report; without `is_file` the read fails
+/// with an incidental `EWOULDBLOCK` rather than the honest refusal. Both
+/// mutations fail this test.
+#[cfg(unix)]
+#[tokio::test]
+async fn a_fifo_is_refused_instead_of_hanging_the_turn() {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt as _;
+    use std::time::Duration;
+
+    let dir = tempfile::tempdir().unwrap();
+    let dir = std::fs::canonicalize(dir.path()).unwrap();
+    let fifo = dir.join("pipe");
+    let name = CString::new(fifo.as_os_str().as_bytes()).unwrap();
+    // SAFETY: `name` is a live NUL-terminated path inside a fresh temp dir.
+    assert_eq!(unsafe { libc::mkfifo(name.as_ptr(), 0o600) }, 0);
+
+    // Positive control: an ordinary regular file in the same directory reads,
+    // so the refusal below is about the object's type and not the directory.
+    std::fs::write(dir.join("plain.txt"), b"plain").unwrap();
+    assert_eq!(
+        RealFs.read_pinned(&dir.join("plain.txt")).await.unwrap(),
+        b"plain".to_vec()
+    );
+
+    let outcome = tokio::time::timeout(Duration::from_secs(5), RealFs.read_pinned(&fifo))
+        .await
+        .expect("a pinned read of a FIFO must return, not block waiting for a writer");
+    let error = outcome.expect_err("a FIFO is not a readable regular file");
+    assert!(
+        matches!(&error, VfsError::PathRaced { .. }),
+        "the refusal must name the type mismatch, got: {error}"
+    );
+}
+
+/// The pinned read is not allowed to be stricter than the ordinary read for
+/// anything legitimate. Ordinary files, empty files, binary content and files
+/// reached through a directory the caller named exactly all still work.
+#[tokio::test]
+async fn ordinary_files_read_identically_through_both_paths() {
+    let dir = tempfile::tempdir().unwrap();
+    let dir = std::fs::canonicalize(dir.path()).unwrap();
+    let cases: [(&str, &[u8]); 3] = [
+        ("empty.txt", b""),
+        ("text.txt", b"hello\nworld\n"),
+        ("binary.bin", &[0_u8, 1, 2, 255, 254]),
+    ];
+    for (name, bytes) in cases {
+        let path = dir.join(name);
+        std::fs::write(&path, bytes).unwrap();
+        assert_eq!(
+            RealFs.read_pinned(&path).await.unwrap(),
+            RealFs.read(&path).await.unwrap(),
+            "{name}: the pinned read must return exactly what the ordinary read does"
+        );
+        assert_eq!(RealFs.read_pinned(&path).await.unwrap(), bytes.to_vec());
+    }
+}
+
+/// A missing file must still be reported as missing. `FileHistory` treats
+/// `ErrorKind::NotFound` as "no cursor yet"; if the pinned read reported an
+/// absent file as some other error, that would become a hard failure instead
+/// of a fresh start.
+#[tokio::test]
+async fn a_missing_file_is_still_not_found() {
+    let dir = tempfile::tempdir().unwrap();
+    let dir = std::fs::canonicalize(dir.path()).unwrap();
+
+    let error = RealFs
+        .read_pinned(&dir.join("nope.txt"))
+        .await
+        .expect_err("an absent file cannot be read");
+    assert!(
+        matches!(&error, VfsError::Io(io) if io.kind() == std::io::ErrorKind::NotFound),
+        "an absent leaf must be NotFound, got: {error}"
+    );
+
+    let error = RealFs
+        .read_pinned(&dir.join("nodir").join("nope.txt"))
+        .await
+        .expect_err("an absent parent cannot be read either");
+    assert!(
+        matches!(&error, VfsError::Io(io) if io.kind() == std::io::ErrorKind::NotFound),
+        "an absent parent must be NotFound, got: {error}"
+    );
+}

--- a/docs/json-stream-protocol.md
+++ b/docs/json-stream-protocol.md
@@ -753,6 +753,26 @@ Because of (6), the honest UI is a prompt that says what will happen for *this*
 file, with "always allow this folder" as a convenience — not a setup step the
 user is told has succeeded.
 
+**What a grant does and does not protect, stated precisely** — the host is the
+party choosing which folder to hand over, so it needs this to choose well.
+
+* The `Read` tool resolves a granted file exactly once, relative to a retained
+  directory handle, refusing a symlink at the leaf and at the parent. Bytes
+  therefore come from the object that was checked, not from a name that could
+  be re-pointed after the check (FerroxLabs/wayland#1105).
+* That pin covers the file's own name and its immediate directory. Components
+  **above** the granted folder are still resolved by the kernel from a
+  pathname, so someone able to rename a directory higher up the tree can still
+  redirect the read. Do not grant a folder whose ancestors are writable by
+  anyone you would not grant the folder to.
+* `exists`, `metadata` and directory listing remain path-based. They disclose
+  presence, size and file names, never file contents.
+* `Grep` shells out to `rg`, which opens the paths itself. Nothing inside the
+  agent can pin that, so a grep over a granted folder carries the ordinary
+  check-then-use exposure of any external process.
+* A grant is still never a write grant, and never widens what may be read to
+  include a secret inside the granted folder.
+
 #### 2.3.3 `grant_path` / `revoke_path` — the flow with no pending call
 
 `always_path` rides an approval, so it only serves the **agent-initiated** case:


### PR DESCRIPTION
Closes #1105. Stacked on #302 — base retargets to `main` when #302 lands. Touches no contract files, so it can land immediately after #302 without a corpus regen.

## The defect

#302 made a granted folder readable by checking the path against the grant list and then opening it. Between the check and the open, the path can change identity — the classic TOCTOU window. A `renameat2(RENAME_EXCHANGE)` on a component swaps a granted directory for one that was never granted, and the open that follows lands outside the grant while the check that authorized it already passed.

`4afdca01` reproduces the window as a failing test before the fix.

## The change

The jailed read is pinned to **one kernel object** rather than re-resolved from a string. The path is opened once and every subsequent operation is performed against that handle, so there is no second resolution for a rename to race. Identity is pinned by `{dev, ino}` rather than by path text.

## Verification

Linux, hetzner, full workspace: **14,898 tests run, 14,893 passed.**

None of the failures are defects in this change:
- `pipeline_test::no_barrier_fast_item_finishes_all_stages_before_slow_finishes_stage_one` — already filed as #1101, flaky at roughly 1 run in 11 on both arms.
- Both `dangerous_expiry_*` tests pass 3 runs out of 3 when re-run serially on a quiet box; they failed only while three suites ran concurrently.
- `conformance_matrix::every_reference_backend_passes_the_same_harness_or_reports_why_it_did_not` fails identically on the pristine merge base (37edc244) — `WAYLAND_EXEC_SSH_TARGET` unset and no cloud credential on the host.

`cargo fmt --check` clean; `clippy --workspace --all-targets --all-features` clean. `2d4e504c` keeps the race test's unix-only fixtures off the Windows build.
