### PR TITLE
ci: cache Rust dependencies on the macOS leg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -402,6 +402,35 @@ jobs:
         with:
           tool: nextest
 
+      # Dependency-only cache, macOS ONLY and deliberately so.
+      #
+      # WHY macOS: workflow wall time is max(all jobs), and this job and
+      # `CI (linux-containerized)` are CO-BOTTLENECKS that trade places
+      # (measured: 67.1/61.7 on one run, 50.0/54.4 on the next). Speeding up
+      # either one alone moves the wall clock by ~0-5 minutes, because the
+      # other becomes the critical path. macOS is the leg with no cache at all.
+      #
+      # WHY NOT the self-hosted Windows runner: it already keeps `target/` warm
+      # between runs (see the matrix comment above), so a cache layer there
+      # would upload and re-download artifacts the box already has on disk.
+      #
+      # WHY dependency-only: `rust-cache` excludes workspace crates by default
+      # and prunes stale artifacts, so what it stores is third-party deps —
+      # single-digit GB — NOT this workspace's full `target/`, which measures
+      # 69-190 GB and would blow past the cache allowance, thrash on eviction,
+      # and cost more in transfer than it saves in compile.
+      #
+      # `save-if` restricts writes to the default branch: PR runs restore but
+      # never populate, so an untrusted PR cannot poison the cache other jobs
+      # read. That is a security property, not a tuning knob.
+      - name: Cache Rust dependencies (macOS)
+        if: runner.os == 'macOS'
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ci-macos
+          cache-on-failure: 'true'
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
       - name: Install cargo-audit
         uses: taiki-e/install-action@v2
         with:


### PR DESCRIPTION
Workflow wall time is max(all jobs), and CI (macos-latest) and
CI (linux-containerized) are co-bottlenecks that trade places -- measured
67.1/61.7 min on one run and 50.0/54.4 on the next. Accelerating either alone
moves the wall clock by roughly 0-5 minutes because the other takes over as the
critical path, so the macOS leg has to be attacked too, not instead.

macOS is the only leg with no cache of any kind. The self-hosted Windows runner
already keeps target/ warm between runs, so a cache layer there would upload and
re-download what the box already has on disk; it is deliberately excluded.

Dependency-only by design. rust-cache excludes workspace crates and prunes stale
artifacts, so it stores third-party deps -- single-digit GB -- rather than this
workspace's target/, which measures 69-190 GB and would exceed the cache
allowance, thrash on eviction, and cost more in transfer than it saves in
compile. Caching the whole target/ is the trap; this is not that.

save-if restricts writes to main: PR runs restore but never populate, so an
untrusted PR cannot poison a cache other jobs read.

No job names change, so all 14 required status contexts stay valid.

Acceptance test before this is considered a win: measure restored bytes, restore
duration and warm-run wall time over 5-10 runs; revert if restore exceeds ~3 min
or the median saving is under 10 min.

---

**Not merged on green alone.** This needs measuring over 5-10 runs before it counts as a win: restored bytes, restore duration, and warm-run wall time. Revert if restore exceeds ~3 min or the median saving is under 10 min.

Deliberately excluded from this PR because they change job names and would invalidate all 14 required status contexts until those are re-listed: nextest sharding (`--partition count:4/4`, ~26 min -> ~8 on the same runners) and splitting the sequential linux job into parallel jobs.