### PR TITLE
fix(release): advance the npm next dist-tag when a stable supersedes it

### DIFF
--- a/.github/workflows/npm-dist-tag-sync.yml
+++ b/.github/workflows/npm-dist-tag-sync.yml
@@ -1,0 +1,63 @@
+name: npm dist-tag sync
+
+# Point an npm dist-tag at a version that is ALREADY PUBLISHED.
+#
+# This publishes nothing. It exists because a dist-tag can drift out of step
+# with the registry — `next` sat on 0.12.26-rc.2 across eight stable releases —
+# and correcting that otherwise requires a human with a publish token on their
+# own machine. `release.yml` now advances `next` on every stable publish, so
+# this is for repairing existing drift and for deliberately parking a tag.
+
+on:
+  workflow_dispatch:
+    inputs:
+      dist_tag:
+        description: "dist-tag to move (e.g. next)"
+        required: true
+        type: string
+      version:
+        description: "already-published version to point it at (e.g. 0.13.7)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Move the dist-tag
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          DIST_TAG: ${{ inputs.dist_tag }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          if [ -z "${NPM_TOKEN:-}" ]; then
+            echo "::error::NPM_TOKEN is not set — refusing to report success for a tag that did not move."
+            exit 1
+          fi
+          # The version must ALREADY exist. Pointing a tag at an unpublished
+          # version is the one way this job could make things worse.
+          if ! npm view "@ferroxlabs/wayland-core@${VERSION}" version >/dev/null 2>&1; then
+            echo "::error::@ferroxlabs/wayland-core@${VERSION} is not published — nothing to point ${DIST_TAG} at."
+            exit 1
+          fi
+          echo "before: $(npm view @ferroxlabs/wayland-core dist-tags --json)"
+          npm dist-tag add "@ferroxlabs/wayland-core@${VERSION}" "${DIST_TAG}"
+          echo "after:  $(npm view @ferroxlabs/wayland-core dist-tags --json)"
+          # Read it back. `dist-tag add` exiting 0 is not evidence the registry
+          # agrees, and this job exists precisely because a tag was wrong.
+          ACTUAL="$(npm view "@ferroxlabs/wayland-core" "dist-tags.${DIST_TAG}")"
+          if [ "${ACTUAL}" != "${VERSION}" ]; then
+            echo "::error::${DIST_TAG} reads back as ${ACTUAL}, expected ${VERSION}."
+            exit 1
+          fi
+          echo "${DIST_TAG} -> ${VERSION} confirmed by read-back"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1223,3 +1223,36 @@ jobs:
           done
           ( cd npm-dist/wayland-core && npm publish --provenance --access public --tag "${NPM_DIST_TAG}" )
           echo "Published @ferroxlabs/wayland-core@${VERSION} (dist-tag ${NPM_DIST_TAG}) + platform packages"
+
+          # A stable release SUPERSEDES an older `next`, and nothing here used to
+          # say so. The case statement above only ever WRITES `next` for a
+          # pre-release; a stable publish writes `latest` and leaves `next`
+          # pointing wherever the last RC left it, forever.
+          #
+          # Measured consequence: `next` sat on 0.12.26-rc.2 (published
+          # 2026-08-05) across EIGHT stable releases — 0.13.0, .1, .2, .3, .4,
+          # .5, .6 and .7 — so for three weeks
+          # `npm install @ferroxlabs/wayland-core@next` served a release
+          # candidate from the previous minor line, and any tooling pinned to
+          # `@next` was pinned to it too.
+          #
+          # Only ever moves `next` FORWARD: if an RC newer than this stable is
+          # deliberately parked there, `sort -V` picks the RC and this no-ops.
+          # `dist-tag add` on the version already tagged is also a no-op, so a
+          # re-run cannot thrash the tag.
+          if [ "${NPM_DIST_TAG}" = "latest" ]; then
+            CURRENT_NEXT="$(npm view @ferroxlabs/wayland-core dist-tags.next 2>/dev/null || true)"
+            if [ -z "${CURRENT_NEXT}" ]; then
+              echo "dist-tag next: not set — nothing to advance"
+            elif [ "${CURRENT_NEXT}" = "${VERSION}" ]; then
+              echo "dist-tag next: already ${VERSION}"
+            else
+              NEWEST="$(printf '%s\n%s\n' "${CURRENT_NEXT}" "${VERSION}" | sort -V | tail -1)"
+              if [ "${NEWEST}" = "${VERSION}" ]; then
+                npm dist-tag add "@ferroxlabs/wayland-core@${VERSION}" next
+                echo "dist-tag next advanced: ${CURRENT_NEXT} -> ${VERSION}"
+              else
+                echo "dist-tag next left at ${CURRENT_NEXT}: newer than ${VERSION}"
+              fi
+            fi
+          fi


### PR DESCRIPTION
`next` has pointed at `0.12.26-rc.2` since 2026-08-05. **Eight** stable releases shipped past it — 0.13.0 through 0.13.7 — so for three weeks `npm install @ferroxlabs/wayland-core@next` served a release candidate from the previous minor line, and anything pinned to `@next` was pinned to that RC.

## Cause

The publish step picks exactly one tag:

```bash
case "${VERSION}" in
  *-*) NPM_DIST_TAG="next" ;;
  *)   NPM_DIST_TAG="latest" ;;
esac
```

A pre-release **writes** `next`. A stable writes `latest` and never touches `next`, so whatever the last RC left there stays until a human moves it by hand with a publish token on their own machine. Nothing in the repo said that was a step, so it never happened.

## Changes

- **`release.yml`** advances `next` after a stable publish, and only ever **forward**. If an RC newer than the stable is deliberately parked there, `sort -V` picks the RC and this no-ops. `dist-tag add` on the already-tagged version is also a no-op, so a re-run cannot thrash the tag.
- **`npm-dist-tag-sync.yml`** — a new `workflow_dispatch` job that points an existing dist-tag at an already-published version. Publishes nothing. It repairs drift that has already happened (including this one) without a token on a laptop.

## Fails closed in both directions that matter

- refuses when `NPM_TOKEN` is absent, rather than reporting success for a tag that did not move;
- refuses to point a tag at a version that is not published;
- **reads the tag back** and fails if the registry disagrees — `dist-tag add` exiting 0 is not evidence, and this job exists precisely because a tag was wrong.

Both files parse (`yaml.safe_load`). No Rust touched.