### PR TITLE
fix(release): poll the dist-tag read-back instead of demanding instant consistency

### DIFF
--- a/.github/workflows/npm-dist-tag-sync.yml
+++ b/.github/workflows/npm-dist-tag-sync.yml
@@ -55,9 +55,27 @@ jobs:
           echo "after:  $(npm view @ferroxlabs/wayland-core dist-tags --json)"
           # Read it back. `dist-tag add` exiting 0 is not evidence the registry
           # agrees, and this job exists precisely because a tag was wrong.
-          ACTUAL="$(npm view "@ferroxlabs/wayland-core" "dist-tags.${DIST_TAG}")"
+          #
+          # POLLED, not instant. npm's packument is CDN-cached and eventually
+          # consistent: run 32933189046 logged `+next: ...@0.13.7` (the add
+          # succeeded) and then read the OLD value back milliseconds later, so a
+          # single immediate read reported failure for a tag that had in fact
+          # moved. A guard that cries wolf is as useless as one that never fires,
+          # so this waits for convergence — but still FAILS if it never comes,
+          # which is the case it exists for.
+          ACTUAL=""
+          for attempt in $(seq 1 12); do
+            # `--prefer-online` bypasses the local metadata cache; without it a
+            # warm cache can echo our own stale read straight back at us.
+            ACTUAL="$(npm view --prefer-online "@ferroxlabs/wayland-core" "dist-tags.${DIST_TAG}" 2>/dev/null || true)"
+            if [ "${ACTUAL}" = "${VERSION}" ]; then
+              echo "${DIST_TAG} -> ${VERSION} confirmed by read-back (attempt ${attempt})"
+              break
+            fi
+            echo "read-back attempt ${attempt}: ${DIST_TAG} is '${ACTUAL:-<empty>}', waiting for the registry to converge"
+            sleep 10
+          done
           if [ "${ACTUAL}" != "${VERSION}" ]; then
-            echo "::error::${DIST_TAG} reads back as ${ACTUAL}, expected ${VERSION}."
+            echo "::error::${DIST_TAG} still reads back as '${ACTUAL:-<empty>}' after 12 attempts over ~2 minutes, expected ${VERSION}."
             exit 1
           fi
-          echo "${DIST_TAG} -> ${VERSION} confirmed by read-back"


### PR DESCRIPTION
Run [32933189046](https://github.com/FerroxLabs/wayland-core/actions/runs/32933189046) **moved `next` to 0.13.7** — the log shows `+next: @ferroxlabs/wayland-core@0.13.7` — and then **failed**:

```
before: { "next": "0.12.26-rc.2", "latest": "0.13.7" }
+next: @ferroxlabs/wayland-core@0.13.7        <- the add succeeded
after:  { "next": "0.12.26-rc.2", ... }        <- registry had not propagated
##[error]next reads back as 0.12.26-rc.2, expected 0.13.7.
```

npm's packument is CDN-cached and eventually consistent. The read-back fired milliseconds after the write and saw stale data. The registry converged shortly after and now reports `{ next: '0.13.7', latest: '0.13.7' }` — so the work was done and the job called it a failure.

That is the same dishonesty as the false green the guard was written to prevent, pointing the other way, and it is arguably worse: a check that cries wolf teaches people to ignore it.

## Change

Poll up to 12 times over ~2 minutes, with `--prefer-online` so a warm local metadata cache cannot echo our own stale read back at us. **Still fails if the tag never converges** — that is the case the guard exists for, and it is preserved.

No Rust touched. YAML parses (`yaml.safe_load`).