### PR TITLE
fix(browser): name both fresh-install walls, and grade the sidecar launch wiring

### DIFF
--- a/crates/wcore-agent/tests/browser_sidecar_launch_wiring_test.rs
+++ b/crates/wcore-agent/tests/browser_sidecar_launch_wiring_test.rs
@@ -1,0 +1,353 @@
+//! Residual (a) — the browser sidecar WIRING, graded end to end.
+//!
+//! Three tests already grade the supervisor's launch FUNCTION, and all three
+//! hand-build a `SupervisorConfig` and call `BrowserSupervisor::ensure_ready`
+//! directly:
+//!
+//!   * `wcore-browser/tests/camoufox_provisioning_wiring_test.rs`
+//!   * `wcore-browser/tests/missing_sidecar_diagnosis_test.rs`
+//!   * `wcore-agent/tests/browser_e2e_test.rs` — which builds the tool it
+//!     drives inline ("We replicate the wiring inline here"), with a
+//!     `BrowserSupervisor::new()` whose `sidecar_program` is `None`, so its
+//!     `ensure_ready` returns on its first line and the launch path is never
+//!     entered.
+//!
+//! What none of them touches is the LINKS between those functions, so all
+//! three stay green while any of these is severed:
+//!
+//!   1. `wcore_browser::adapter::from_spec` building
+//!      `SupervisorConfig::local_camoufox` for the camoufox backend — the only
+//!      production code that ever sets `sidecar_program` to something. Cut it
+//!      and nothing is ever launched.
+//!   2. the same function attaching `egress_policy` (gh#1117) — cut it and the
+//!      sidecar starts with no PROXY_* in its environment and resolves its own
+//!      DNS, silently.
+//!   3. `BrowserTool::ensure_session` calling `supervisor.ensure_ready()` — cut
+//!      it and the tool talks to a sidecar port nobody ever started.
+//!
+//! This file drives the real chain — plugin-registered `BrowserToolSpec` →
+//! `HostBrowserRegistrar::reify_all` → `spec_to_core` → `from_spec` →
+//! `BrowserTool::execute_with_ctx` → `ensure_session` → `ensure_ready` →
+//! `launch_camoufox_program` — and asserts on the LAUNCHED PROCESS: a stub
+//! sidecar that records the environment it was handed before it answers the
+//! health poll. Nothing is mocked below the tool surface, no network is
+//! contacted, and `@askjo/camofox-browser` does not have to be installed.
+//!
+//! **Unix only** — the stub sidecar is a `#!`-script and the executable bit is
+//! a Unix concept, exactly as in `camoufox_provisioning_wiring_test`. Windows
+//! is a gap here, not a pass.
+
+#![cfg(unix)]
+
+use std::os::unix::fs::PermissionsExt as _;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use serde_json::json;
+use wcore_agent::plugins::adapters::browser_adapter::HostBrowserRegistrar;
+use wcore_browser::sidecar_prefs::{LOOPBACK_PROXY_PREF, PREF_FILE_NAME};
+use wcore_browser::tool::BrowserTool;
+use wcore_plugin_api::browser_spec::{BrowserPolicySpec, BrowserProviderHint, BrowserToolSpec};
+use wcore_plugin_api::registry::browser::BrowserToolRegistrar;
+use wcore_tools::Tool;
+use wcore_tools::context::ToolContext;
+
+/// A literal public IP rather than a hostname: `BrowserPolicy`'s resolution
+/// gate fails closed on a host that cannot resolve, and a hostname fixture
+/// would make this test require working DNS on the runner.
+const TARGET: &str = "https://93.184.216.34/";
+
+/// The file Firefox itself installs in the directory the loopback pref has to
+/// be written into. `sidecar_prefs` locates the install BY this marker, so the
+/// fake install below has to carry it.
+const FIREFOX_PREF_MARKER: &str = "channel-prefs.js";
+
+// ── environment ───────────────────────────────────────────────────────────
+
+/// Restores every variable it set, including back to *unset*.
+struct EnvGuard(Vec<(&'static str, Option<std::ffi::OsString>)>);
+
+impl EnvGuard {
+    fn new() -> Self {
+        Self(Vec::new())
+    }
+    fn set(&mut self, key: &'static str, value: impl AsRef<std::ffi::OsStr>) {
+        self.0.push((key, std::env::var_os(key)));
+        unsafe { std::env::set_var(key, value) };
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        for (key, prior) in self.0.drain(..).rev() {
+            match prior {
+                Some(v) => unsafe { std::env::set_var(key, v) },
+                None => unsafe { std::env::remove_var(key) },
+            }
+        }
+    }
+}
+
+// ── fixtures ──────────────────────────────────────────────────────────────
+
+/// The same question `BrowserSupervisor::resolve_sidecar_program` asks of the
+/// configured program, minus the `which` crate (not a dependency of this
+/// crate). Only used as a precondition, never as the thing under test.
+fn resolves_on_path(program: &str) -> bool {
+    let Some(path) = std::env::var_os("PATH") else {
+        return false;
+    };
+    std::env::split_paths(&path).any(|dir| dir.join(program).is_file())
+}
+
+fn free_port() -> u16 {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    listener.local_addr().unwrap().port()
+}
+
+/// A stand-in sidecar. `launch_camoufox_program` passes NO arguments, so the
+/// port and the marker path are baked in.
+///
+/// It records the PROXY_* environment it was handed **before** it binds its
+/// socket, so a health poll that succeeds implies the record is already on
+/// disk — the assertion can never race the process.
+fn write_stub_sidecar(dir: &Path, port: u16, marker: &Path) -> PathBuf {
+    let script = format!(
+        r#"#!/usr/bin/env python3
+import http.server, json, os, socketserver
+with open({marker:?}, "w") as fh:
+    json.dump({{k: v for k, v in os.environ.items() if k.startswith("PROXY_")}}, fh)
+class H(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200); self.send_header("Content-Length", "2"); self.end_headers()
+        self.wfile.write(b"ok")
+    def log_message(self, *a): pass
+socketserver.TCPServer.allow_reuse_address = True
+socketserver.TCPServer(("127.0.0.1", {port}), H).serve_forever()
+"#,
+        marker = marker.to_str().unwrap(),
+    );
+    let path = dir.join("stub-camofox-browser");
+    std::fs::write(&path, script).unwrap();
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+    path
+}
+
+/// A directory shaped like a Camoufox install: the marker file `sidecar_prefs`
+/// searches for, plus the executable an operator would point
+/// `CAMOUFOX_EXECUTABLE_PATH` at. Lets the gh#1117 loopback containment step
+/// run for real without a 300 MB browser on the runner.
+fn fake_camoufox_install(root: &Path) -> PathBuf {
+    let pref_dir = root.join("defaults").join("pref");
+    std::fs::create_dir_all(&pref_dir).unwrap();
+    std::fs::write(pref_dir.join(FIREFOX_PREF_MARKER), "// stand-in\n").unwrap();
+    let exe = root.join("camoufox-bin");
+    std::fs::write(&exe, "#!/bin/sh\n").unwrap();
+    exe
+}
+
+/// The spec the `wayland-browser` plugin registers, with the operator's policy
+/// already copied onto it. Camoufox is forced because the camoufox branch of
+/// `from_spec` is what is under test.
+///
+/// ORDERING TRAP: `BrowserTool::execute_with_ctx` runs `policy_check` BEFORE
+/// `ensure_session`, so a deny-by-default policy would make every assertion
+/// below pass or fail for a reason that has nothing to do with the sidecar.
+/// The policy here allows the navigation target so the op reaches the wiring.
+fn plugin_spec() -> BrowserToolSpec {
+    BrowserToolSpec {
+        tool_namespace: "Browser".into(),
+        preferred_provider: BrowserProviderHint::Camoufox,
+        policy: BrowserPolicySpec {
+            default_action: "allow".into(),
+            allowed_origins: vec!["93.184.216.34".into()],
+            denied_origins: vec![],
+            loopback: Default::default(),
+        },
+        allow_cloud: false,
+    }
+}
+
+/// The production reification path: exactly what `AgentBootstrap` calls after
+/// `PluginRunner::initialize_all` returns.
+fn reify_from_plugin_registration() -> Arc<BrowserTool> {
+    let mut host = HostBrowserRegistrar::default();
+    host.host_register(plugin_spec()).unwrap();
+    let mut tools = host.reify_all();
+    assert_eq!(tools.len(), 1, "one registered spec must reify to one tool");
+    tools.pop().unwrap()
+}
+
+async fn navigate(tool: &Arc<BrowserTool>) -> wcore_types::tool::ToolResult {
+    tool.execute_with_ctx(
+        json!({ "op": { "kind": "navigate", "url": TARGET } }),
+        &ToolContext::test_default(),
+    )
+    .await
+}
+
+// ── arms ──────────────────────────────────────────────────────────────────
+
+/// THE WIRING. A browser op on a tool built the way the engine builds it
+/// launches the configured sidecar, behind the egress proxy, with loopback
+/// contained.
+///
+/// The assertion is the launched PROCESS — a record only the child can have
+/// written — not a return value, because every link under test is one whose
+/// removal still returns `Ok`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial_test::serial(browser_sidecar_wiring_env)]
+async fn a_browser_op_launches_the_configured_sidecar_through_the_real_adapter() {
+    let tmp = tempfile::tempdir().unwrap();
+    let port = free_port();
+    let marker = tmp.path().join("sidecar-launched.json");
+    let stub = write_stub_sidecar(tmp.path(), port, &marker);
+    let install = tmp.path().join("camoufox-install");
+    let camoufox_exe = fake_camoufox_install(&install);
+    let pref_file = install.join("defaults").join("pref").join(PREF_FILE_NAME);
+
+    let mut env = EnvGuard::new();
+    env.set("WAYLAND_HOME", tmp.path());
+    env.set("WAYLAND_CAMOUFOX_URL", format!("http://127.0.0.1:{port}"));
+    env.set("WAYLAND_CAMOUFOX_BIN", &stub);
+    env.set("CAMOUFOX_EXECUTABLE_PATH", &camoufox_exe);
+    // Pin the fail-closed posture: containment below must genuinely succeed,
+    // not be waived. Otherwise the pref assertion could pass vacuously.
+    env.set("WAYLAND_BROWSER_ALLOW_UNPROXIED_SIDECAR", "0");
+
+    // PRECONDITIONS. Without these the launch assertion could be satisfied by
+    // a sidecar somebody else started, or by a stale file.
+    assert!(
+        !marker.exists(),
+        "the launch record exists before the test ran"
+    );
+    assert!(
+        std::net::TcpStream::connect(("127.0.0.1", port)).is_err(),
+        "port {port} is already served; a reused external sidecar would make this vacuous"
+    );
+    assert!(
+        !pref_file.exists(),
+        "the loopback pref exists before the test ran"
+    );
+
+    let tool = reify_from_plugin_registration();
+    let result = navigate(&tool).await;
+
+    // 1. IT LAUNCHED. Only `launch_camoufox_program` can produce this file,
+    //    and it is only reached if `from_spec` set `sidecar_program` AND
+    //    `ensure_session` called `ensure_ready`.
+    assert!(
+        marker.is_file(),
+        "the configured sidecar was never launched — no launch record at {}. \
+         Tool result was: {}",
+        marker.display(),
+        result.content
+    );
+
+    // 2. IT LAUNCHED BEHIND CORE'S EGRESS GATE (gh#1117). PROXY_* reaches the
+    //    child only when `from_spec` attached `egress_policy`, which is what
+    //    makes the supervisor start a proxy at all.
+    let recorded: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&marker).unwrap()).unwrap();
+    let proxy_host = recorded.get("PROXY_HOST").and_then(|v| v.as_str());
+    assert_eq!(
+        proxy_host,
+        Some("127.0.0.1"),
+        "the sidecar was started without Core's egress proxy in its environment: {recorded}"
+    );
+    let proxy_port: u16 = recorded
+        .get("PROXY_PORT")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default()
+        .parse()
+        .unwrap_or(0);
+    assert_ne!(proxy_port, 0, "PROXY_PORT is not a live port: {recorded}");
+    assert_ne!(
+        proxy_port, port,
+        "PROXY_PORT points at the sidecar itself, not at Core's proxy: {recorded}"
+    );
+
+    // 3. AND WITH LOOPBACK CONTAINED — the launch-path half of gh#1117, which
+    //    only runs because `egress_policy` was attached upstream.
+    let pref = std::fs::read_to_string(&pref_file).unwrap_or_else(|e| {
+        panic!(
+            "the loopback pref was not written to {}: {e}",
+            pref_file.display()
+        )
+    });
+    assert!(
+        pref.contains(LOOPBACK_PROXY_PREF),
+        "the pref file does not set {LOOPBACK_PROXY_PREF}: {pref}"
+    );
+
+    // 4. And the op got PAST both gates it had to pass to get here, so none of
+    //    the above was reached by an error path.
+    assert!(
+        !result.content.contains("policy:"),
+        "the op was policy-denied, so it never reached the sidecar wiring: {}",
+        result.content
+    );
+    assert!(
+        !result
+            .content
+            .contains(wcore_browser::install::CAMOUFOX_SIDECAR_PACKAGE),
+        "the op was answered with the not-installed message: {}",
+        result.content
+    );
+
+    drop(tool);
+}
+
+/// CONTROL, and the known-positive for the launch-record query above.
+///
+/// Identical wiring, one variable changed: the configured sidecar program
+/// cannot resolve. The launch record must then be ABSENT and the tool must
+/// answer with the missing-dependency message — which is itself a second,
+/// independent reading of the same chain (the message is built inside
+/// `ensure_ready`, so the tool can only be quoting it if `ensure_session`
+/// called it). Without this arm, arm 1 would also pass against an
+/// implementation that wrote the record for any reason at all.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial_test::serial(browser_sidecar_wiring_env)]
+async fn an_unresolvable_sidecar_program_launches_nothing_and_is_reported_as_missing() {
+    let tmp = tempfile::tempdir().unwrap();
+    let port = free_port();
+    let marker = tmp.path().join("sidecar-launched.json");
+    // Written but NOT installed anywhere `which` can find it, and configured
+    // under a name that has no directory separator, so `which` must search
+    // PATH and fail.
+    let _stub = write_stub_sidecar(tmp.path(), port, &marker);
+    let absent = "wcore-br-wiring-camofox-browser-that-does-not-exist";
+    assert!(
+        !resolves_on_path(absent),
+        "{absent} resolves on this host; this arm would be vacuous"
+    );
+
+    let mut env = EnvGuard::new();
+    env.set("WAYLAND_HOME", tmp.path());
+    env.set("WAYLAND_CAMOUFOX_URL", format!("http://127.0.0.1:{port}"));
+    env.set("WAYLAND_CAMOUFOX_BIN", absent);
+    env.set("WAYLAND_BROWSER_ALLOW_UNPROXIED_SIDECAR", "0");
+
+    let tool = reify_from_plugin_registration();
+    let result = navigate(&tool).await;
+
+    assert!(
+        !marker.exists(),
+        "nothing resolvable was configured, yet a sidecar was launched"
+    );
+    assert!(
+        result.is_error,
+        "expected an error, got: {}",
+        result.content
+    );
+    assert!(
+        result
+            .content
+            .contains(wcore_browser::install::CAMOUFOX_SIDECAR_PACKAGE),
+        "the tool must surface the supervisor's missing-dependency remedy; got: {}",
+        result.content
+    );
+
+    drop(tool);
+}

--- a/crates/wcore-browser/src/config_hint.rs
+++ b/crates/wcore-browser/src/config_hint.rs
@@ -134,8 +134,50 @@ fn config_target_block() -> String {
 
 /// The full remediation message shown when the browser tool denies solely
 /// because it is in its fail-closed default posture.
+///
+/// ## Why this message also reports the BACKEND (`br-default`)
+///
+/// A fresh install has two independent things wrong with it, and
+/// `BrowserTool::dispatch` can only ever report the first: the policy check
+/// (`tool.rs`, `policy_check`) runs BEFORE `ensure_session`, so the sidecar is
+/// never probed and the not-installed diagnosis is unreachable. An operator
+/// who follows this message verbatim therefore fixes the policy, restarts —
+/// `configured_camoufox_download` and friends are `OnceLock`-cached per
+/// process — and walks straight into a SECOND wall the first message never
+/// mentioned.
+///
+/// Core does not bundle a browser. The Camoufox sidecar is a separate npm
+/// package, auto-provisioning is off by default and has no built-in artifact
+/// (`binary.rs`, `provision_camoufox`), so on a fresh machine nothing installs
+/// it. That is deliberate — Core does not fetch executable code from the
+/// network unpinned — but it means the remedy is TWO steps, and a message that
+/// prints only one is not followable.
+///
+/// So the backend is resolved here, at message-build time, and the second step
+/// is named in the same breath as the first when it is actually outstanding.
+/// It is deliberately NOT printed when a backend does resolve: telling an
+/// operator to install software they already have is how a real instruction
+/// gets skimmed past.
 pub fn disabled_by_default_hint() -> String {
-    format!(
+    disabled_by_default_hint_for(crate::install::resolve_any().is_some())
+}
+
+/// The POLICY half of [`disabled_by_default_hint`], with no backend paragraph.
+///
+/// For surfaces that report the backend separately and would otherwise print
+/// the same install line twice -- `--doctor` has a `browser backend` row of its
+/// own directly above its `browser policy` row.
+pub fn policy_disabled_hint() -> String {
+    disabled_by_default_hint_for(true)
+}
+
+/// The body of [`disabled_by_default_hint`], with the host probe lifted out.
+///
+/// Split so both branches are gradable without mutating `PATH` or
+/// `WAYLAND_CAMOUFOX_BIN` in a test process. The binding to the real probe is
+/// graded separately by [`tests::the_hint_reports_the_backend_this_host_has`].
+pub(crate) fn disabled_by_default_hint_for(backend_installed: bool) -> String {
+    let mut out = format!(
         "Browser tool is disabled by default. \
          Add allowed domains to enable it.\n\n\
          {}\n\
@@ -143,7 +185,17 @@ pub fn disabled_by_default_hint() -> String {
          Alternatively, permit all origins — not recommended, exposes SSRF risk:\n\n\
          {ENABLE_BY_DEFAULT_ACTION_TOML}",
         config_target_block()
-    )
+    );
+    if !backend_installed {
+        let backend = &crate::install::CAMOUFOX;
+        out.push_str(&format!(
+            "\nOpening the policy is not the only step on this machine. wayland-core does \
+             not bundle a browser and nothing installs one for you, so the next browser op \
+             would stop here even with the policy above applied:\n\n{}\n",
+            backend.not_installed(&backend.configured_program(), None)
+        ));
+    }
+    out
 }
 
 /// Remediation for a loopback denial (gh#826 / gh#911).
@@ -207,6 +259,91 @@ mod tests {
         assert!(
             hint.contains(ENABLE_BY_DEFAULT_ACTION_TOML),
             "hint dropped the default_action snippet:\n{hint}"
+        );
+    }
+
+    /// `br-default` — the fresh-install journey has TWO walls and the policy
+    /// wall is the only one `dispatch` can ever reach, because `policy_check`
+    /// runs before `ensure_session`. An operator who applies this snippet and
+    /// restarts must not be ambushed by a missing sidecar nobody mentioned, so
+    /// when no backend resolves the message has to name that step too — with
+    /// the same install line `--doctor` and the runtime refusal print, not a
+    /// second hand-written one that can drift.
+    #[test]
+    fn the_disabled_hint_names_the_second_wall_when_no_backend_is_installed() {
+        let hint = disabled_by_default_hint_for(false);
+        assert!(
+            hint.contains(ENABLE_BY_ALLOWLIST_TOML),
+            "the backend paragraph displaced the policy remedy:\n{hint}"
+        );
+        assert!(
+            hint.contains(crate::install::CAMOUFOX_SIDECAR_PACKAGE),
+            "the message never names the package that installs the sidecar, so an operator \
+             who applies the policy snippet hits an unannounced second wall:\n{hint}"
+        );
+        assert!(
+            hint.contains(crate::install::CAMOUFOX_SIDECAR_ENV),
+            "the message never names the env override the supervisor actually reads:\n{hint}"
+        );
+        let lowered = hint.to_ascii_lowercase();
+        assert!(
+            lowered.contains("does not bundle"),
+            "the message must say plainly that Core ships no browser. Without that an \
+             operator reasonably concludes the install is broken rather than \
+             incomplete:\n{hint}"
+        );
+        assert!(
+            lowered.contains("not the only step"),
+            "the message must say the policy edit alone is insufficient; naming the install \
+             line further down is easy to read as optional background:\n{hint}"
+        );
+    }
+
+    /// The inverse, and the reason the probe exists at all: an operator who
+    /// already has the sidecar must not be told to install it. A message that
+    /// prints every remedy unconditionally trains readers to skim past the one
+    /// that applies.
+    #[test]
+    fn the_disabled_hint_stays_quiet_about_install_when_a_backend_resolves() {
+        assert_eq!(
+            policy_disabled_hint(),
+            disabled_by_default_hint_for(true),
+            "the policy-only entry point drifted from the backend-installed branch"
+        );
+        let hint = disabled_by_default_hint_for(true);
+        assert!(
+            hint.contains(ENABLE_BY_ALLOWLIST_TOML),
+            "the policy remedy went missing:\n{hint}"
+        );
+        assert!(
+            !hint.contains(crate::install::CAMOUFOX_SIDECAR_PACKAGE),
+            "a host that HAS the backend is still told to install it:\n{hint}"
+        );
+        assert!(
+            !hint.to_ascii_lowercase().contains("does not bundle"),
+            "a host that HAS the backend is still told Core ships no browser:\n{hint}"
+        );
+    }
+
+    /// WIRING, not the function. The two bodies above prove what each branch
+    /// says; this proves the public message actually consults the real host
+    /// probe to choose between them, on whatever host it runs.
+    ///
+    /// The `assert_ne` is the control: without it this test would still pass if
+    /// the two branches were made identical, i.e. if the feature were deleted.
+    #[test]
+    fn the_hint_reports_the_backend_this_host_has() {
+        assert_ne!(
+            disabled_by_default_hint_for(true),
+            disabled_by_default_hint_for(false),
+            "the two branches are identical, so the equality below proves nothing"
+        );
+        let installed = crate::install::resolve_any().is_some();
+        assert_eq!(
+            disabled_by_default_hint(),
+            disabled_by_default_hint_for(installed),
+            "the public hint does not reflect this host: `install::resolve_any()` says \
+             installed={installed}, but the emitted message is the other branch"
         );
     }
 

--- a/crates/wcore-cli/src/doctor/mod.rs
+++ b/crates/wcore-cli/src/doctor/mod.rs
@@ -111,7 +111,12 @@ pub async fn run(
     let version = &report.version;
     println!("wayland-core doctor v{version}\n");
 
-    let checks = &report.checks;
+    // `br-default`: the browser-policy row is config-derived, so it is added
+    // here rather than in `collect()` -- which takes no config and is shared
+    // verbatim with the TUI `/doctor` surface (that surface has its own
+    // config-posture section, `scan_config_health`).
+    let owned_checks = with_config_rows(report.checks, cli_args);
+    let checks = &owned_checks;
 
     let mut passed = 0usize;
     let mut failed = 0usize;
@@ -290,6 +295,98 @@ async fn check_browser_binary() -> CheckResult {
 /// in the PASS detail and in the install hints, both of which come from the
 /// compiled-in backend list rather than from this string.
 const BROWSER_BACKEND_LABEL: &str = "browser backend";
+
+/// The policy row label. Sits directly under [`BROWSER_BACKEND_LABEL`] because
+/// the two rows answer the same question -- "will a browser op work?" -- and
+/// either one alone gives the wrong answer.
+const BROWSER_POLICY_LABEL: &str = "browser policy";
+
+/// `br-default` -- insert the config-derived rows into a [`collect`] report.
+///
+/// Kept as its own function, taking and returning the row list, so the WIRING
+/// is gradable: that the policy row is present at all, and that it lands
+/// immediately after the backend row rather than at the bottom of the table.
+/// Adjacency is the entire point. `[PASS] browser backend -> /usr/bin/...` on a
+/// machine where every URL is refused is a true statement that reads as a clean
+/// bill of health, and a reader who sees it stops reading.
+fn with_config_rows(
+    mut checks: Vec<CheckResult>,
+    cli_args: &wcore_config::config::CliArgs,
+) -> Vec<CheckResult> {
+    let row = check_browser_policy(cli_args);
+    match checks.iter().position(|c| c.label == BROWSER_BACKEND_LABEL) {
+        Some(i) => checks.insert(i + 1, row),
+        None => checks.push(row),
+    }
+    checks
+}
+
+/// Report whether the operator's `[browser.policy]` actually permits anything.
+///
+/// The doctor used to probe only whether a browser BINARY resolves, and on a
+/// host with the sidecar installed it printed `[PASS] browser backend` while
+/// `BrowserPolicy` refused every URL the tool was asked for -- the fail-closed
+/// default posture, which is deliberate design and is NOT relaxed here. What
+/// was missing is that nothing said so before the user hit it: the denial is
+/// only reachable by running a browser op and reading the tool card.
+///
+/// The verdict is deliberately the same predicate `wcore_browser`'s own
+/// `denial_message` uses to decide the posture is the fail-closed default
+/// (`default_action` deny AND no allowed origins), and the hints are that same
+/// module's [`wcore_browser::config_hint::policy_disabled_hint`] verbatim, so
+/// the doctor cannot advertise a remedy the tool would not.
+fn check_browser_policy(cli_args: &wcore_config::config::CliArgs) -> CheckResult {
+    match wcore_config::config::Config::resolve(cli_args) {
+        // Not a WARN: with no config there is no policy to report, and
+        // inventing a verdict from the compiled defaults would claim to have
+        // read a file that never loaded.
+        Err(e) => CheckResult {
+            label: BROWSER_POLICY_LABEL,
+            outcome: Outcome::Skip {
+                reason: format!("config did not resolve: {e}"),
+            },
+        },
+        Ok(cfg) => browser_policy_row(&cfg.browser.policy),
+    }
+}
+
+/// The verdict for one resolved [`wcore_config::browser::BrowserPolicyConfig`].
+///
+/// Split from [`check_browser_policy`] so both branches are gradable without a
+/// resolvable config on the host running the tests.
+fn browser_policy_row(policy: &wcore_config::browser::BrowserPolicyConfig) -> CheckResult {
+    let denies_everything = policy.default_action.trim().eq_ignore_ascii_case("deny")
+        && policy.allowed_origins.is_empty();
+    if !denies_everything {
+        return CheckResult {
+            label: BROWSER_POLICY_LABEL,
+            outcome: Outcome::Pass {
+                detail: format!(
+                    "default_action={}, {} allowed origin(s)",
+                    policy.default_action.trim(),
+                    policy.allowed_origins.len()
+                ),
+            },
+        };
+    }
+    // WARN, never FAIL: fail-closed is the intended posture for an operator who
+    // does not want the browser, and a doctor that exits 1 on the default
+    // install would be crying wolf.
+    CheckResult {
+        label: BROWSER_POLICY_LABEL,
+        outcome: Outcome::Warn {
+            detail: "default_action=deny with no allowed_origins — every URL is refused".into(),
+            // The POLICY half only: the `browser backend` row directly above
+            // carries the install line, and printing it twice on one screen
+            // teaches the reader to skip the block.
+            hints: wcore_browser::config_hint::policy_disabled_hint()
+                .lines()
+                .filter(|line| !line.trim().is_empty())
+                .map(str::to_string)
+                .collect(),
+        },
+    }
+}
 
 async fn check_which(prog: &'static str, hints: &[String]) -> CheckResult {
     match which(prog).await {
@@ -1032,6 +1129,133 @@ fn grim_hints() -> Vec<String> {
 mod tests {
     use super::*;
     use serial_test::serial;
+
+    // -- `br-default`: the browser-policy row ----------------------------
+    //
+    // A fresh install cannot run a browser op for two independent reasons:
+    // the sidecar is not shipped, and `[browser.policy]` denies every URL.
+    // `--doctor` reported the first and was silent about the second, so on a
+    // host where somebody HAD installed the sidecar the whole table read
+    // clean while every navigation was refused. Neither test below relaxes
+    // the fail-closed default -- that is recorded design -- they only require
+    // the doctor to say it out loud, with the remedy the tool itself prints.
+
+    fn deny_all_policy() -> wcore_config::browser::BrowserPolicyConfig {
+        wcore_config::browser::BrowserPolicyConfig::default()
+    }
+
+    /// The default posture is the fresh-install posture, so this is the row
+    /// almost every reader gets. It must WARN, and it must carry a remedy
+    /// that names the section the loader reads and a file that exists.
+    #[test]
+    fn the_policy_row_warns_when_the_default_posture_refuses_every_url() {
+        let policy = deny_all_policy();
+        // Control: this really is the shipped default, not a value the test
+        // arranged. If either of these ever changes, the WARN below is about
+        // a posture no user has.
+        assert_eq!(policy.default_action, "deny");
+        assert!(policy.allowed_origins.is_empty());
+
+        let row = browser_policy_row(&policy);
+        let Outcome::Warn { detail, hints } = row.outcome else {
+            panic!(
+                "the doctor reports the fail-closed default browser policy as {:?}. A reader \
+                 sees a clean table on a machine where every browser op is refused.",
+                row.outcome
+            )
+        };
+        assert!(
+            detail.contains("deny"),
+            "the WARN detail never says the policy denies: {detail}"
+        );
+        let hints = hints.join("\n");
+        assert!(
+            hints.contains("[browser.policy]"),
+            "the doctor's remedy does not name the section the loader reads. A key written \
+             at `[browser]` parses cleanly and is silently discarded:\n{hints}"
+        );
+        assert!(
+            hints.contains("allowed_origins"),
+            "the doctor's remedy never names the setting to add:\n{hints}"
+        );
+        assert!(
+            !hints.contains("npm install"),
+            "the policy row repeats the sidecar install line that the `browser backend` row \
+             directly above already prints. One screen, the same instruction twice, is how a \
+             reader learns to skip the block:\n{hints}"
+        );
+        let global = wcore_config::config::global_config_path();
+        assert!(
+            hints.contains(&global.display().to_string()),
+            "the doctor's remedy names no resolved config file, so a reader has nowhere to \
+             put it -- the gh#900 defect, reproduced on a second surface:\n{hints}"
+        );
+    }
+
+    /// The inverse: an operator who HAS allow-listed something, or who has
+    /// flipped the default, must not be nagged. A row that warns
+    /// unconditionally carries no information.
+    #[test]
+    fn the_policy_row_passes_once_the_operator_has_opened_it() {
+        let mut allowlisted = deny_all_policy();
+        allowlisted.allowed_origins = vec!["example.com".into()];
+        assert!(
+            matches!(
+                browser_policy_row(&allowlisted).outcome,
+                Outcome::Pass { .. }
+            ),
+            "an allow-listed origin still reports as denied"
+        );
+
+        let mut allow_all = deny_all_policy();
+        allow_all.default_action = "allow".into();
+        assert!(
+            matches!(browser_policy_row(&allow_all).outcome, Outcome::Pass { .. }),
+            "`default_action = \"allow\"` still reports as denied"
+        );
+    }
+
+    /// WIRING, not the function. Two things a passing `browser_policy_row`
+    /// cannot prove: that the row reaches the printed table at all, and that
+    /// it sits next to the backend row. Adjacency is the point -- `[PASS]
+    /// browser backend` immediately above is what made the silence readable
+    /// as health.
+    #[test]
+    fn the_policy_row_lands_directly_under_the_backend_row() {
+        let seeded = vec![
+            check_version("9.9.9"),
+            CheckResult {
+                label: BROWSER_BACKEND_LABEL,
+                outcome: Outcome::Pass {
+                    detail: "Camoufox sidecar -> /somewhere/camofox-browser".into(),
+                },
+            },
+            skip("wlrctl", "Linux-only"),
+        ];
+        let rows = with_config_rows(seeded, &wcore_config::config::CliArgs::default());
+
+        let backend = rows
+            .iter()
+            .position(|r| r.label == BROWSER_BACKEND_LABEL)
+            .expect("backend row survived");
+        let policy = rows
+            .iter()
+            .position(|r| r.label == BROWSER_POLICY_LABEL)
+            .unwrap_or_else(|| {
+                panic!(
+                    "no browser-policy row reached the doctor table; the function may be \
+                     correct but nothing calls it. Rows: {:?}",
+                    rows.iter().map(|r| r.label).collect::<Vec<_>>()
+                )
+            });
+        assert_eq!(
+            policy,
+            backend + 1,
+            "the policy row is not adjacent to the backend row; a reader who stops at \
+             `[PASS] browser backend` never reaches it. Rows: {:?}",
+            rows.iter().map(|r| r.label).collect::<Vec<_>>()
+        );
+    }
 
     /// gh#491 — `--doctor` must recommend the browser backend this binary
     /// actually compiled, and must not recommend one it did not.

--- a/crates/wcore-cli/tests/doctor_smoke.rs
+++ b/crates/wcore-cli/tests/doctor_smoke.rs
@@ -79,6 +79,49 @@ fn doctor_includes_universal_checks() {
     );
 }
 
+/// `br-default` WIRING, through the real binary.
+///
+/// `doctor::with_config_rows` has unit coverage, but a unit test on it cannot
+/// notice if nothing in `run()` calls it -- the browser-policy verdict would be
+/// perfectly correct and never printed. This drives the shipped `--doctor`
+/// command and reads the rendered table.
+///
+/// Deliberately verdict-agnostic: the row is WARN on a default install, PASS
+/// once an operator opens the policy, and SKIP where the config does not
+/// resolve. All three are honest; a MISSING row is the defect.
+#[test]
+fn doctor_prints_a_browser_policy_row_adjacent_to_the_backend_row() {
+    let out = run_doctor();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    // Row lines are the ones the printer prefixes with `[PASS] `/`[WARN] `/...
+    let rows: Vec<&str> = stdout.lines().filter(|l| l.starts_with('[')).collect();
+    let backend = rows
+        .iter()
+        .position(|l| l.contains("browser backend"))
+        .unwrap_or_else(|| {
+            panic!(
+                "no 'browser backend' row at all; the table is not what this test reads:\n{stdout}"
+            )
+        });
+    let policy = rows
+        .iter()
+        .position(|l| l.contains("browser policy"))
+        .unwrap_or_else(|| {
+            panic!(
+                "`--doctor` prints no 'browser policy' row. The doctor probes only whether a \
+                 browser BINARY resolves, so on a host with the sidecar installed it reports \
+                 `[PASS] browser backend` while `[browser.policy]` refuses every URL:\n{stdout}"
+            )
+        });
+    assert_eq!(
+        policy,
+        backend + 1,
+        "the policy row is not the row immediately after the backend row; a reader who stops \
+         at `[PASS] browser backend` never reaches it:\n{stdout}"
+    );
+}
+
 #[test]
 fn doctor_exit_code_is_deterministic() {
     // Don't assert WHICH code — that depends on whether the dev

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -377,6 +377,57 @@ Available capability flag: `capabilities.browser_suite` (W8c.1). The
 engine emits `browser_event` and `browser_policy_denied` while ops
 run; see `docs/json-stream-protocol.md` §§1.N+6 and 1.N+7.
 
+### Two things a fresh install needs before a browser op works
+
+Neither is done for you, and both are deliberate. A first browser op on
+an untouched install is refused, and the tool card names whichever step
+is outstanding.
+
+**1. Install the sidecar.** Core does *not* bundle a browser. It drives
+the Camoufox sidecar, a separate npm package:
+
+```bash
+npm install -g @askjo/camofox-browser
+```
+
+Already have one somewhere else? Point `WAYLAND_CAMOUFOX_BIN` at the
+`camofox-browser` executable instead. Auto-download
+(`[browser.camoufox_download]`) is off by default and has no built-in
+artifact: Core never fetches executable code from the network without an
+operator-supplied URL *and* a pinned SHA-256 per platform.
+
+**2. Open the policy.** `[browser.policy]` is fail-closed since v0.2.1 —
+`default_action = "deny"` with no `allowed_origins`, so every URL that
+reaches `Browser::navigate` / `download` / `new_tab { url }` is refused.
+This is the SSRF posture, not an oversight; the fix is to name the
+origins you intend to visit, including any search engine you expect the
+agent to use:
+
+```toml
+[browser.policy]
+# Glob patterns supported. This is an allow-list: an origin that is not
+# named here stays refused.
+allowed_origins = ["example.com", "*.mysite.com"]
+```
+
+Or, not recommended (it re-opens the SSRF surface):
+
+```toml
+[browser.policy]
+default_action = "allow"
+```
+
+Put it in a file the loader actually reads — the global
+`config.toml` under the app config dir (`wayland-core --config-path`) or
+`<project dir>/.wayland-core.toml`. A bare `config.toml` in the working
+directory is **not** a config source in any layer.
+
+Loopback (`http://localhost:…`) is refused even by an allow-list; it
+needs the separate port-scoped grant at `[browser.policy.loopback]`.
+
+`wayland-core --doctor` reports both steps: a `browser backend` row for
+the sidecar and a `browser policy` row directly under it.
+
 ## Computer use (W8c.2)
 
 `Cua::*` tools are registered by the `wayland-cua` plugin (via


### PR DESCRIPTION
## The defect

On a fresh machine the browser tool has **two** walls, and only one of them was ever reportable.

`BrowserTool::dispatch` runs `policy_check` **before** `ensure_session`. The default policy refuses the URL, so the sidecar is never probed — which makes `install::BackendInstall::not_installed` (the message that already names the package to install) **unreachable code on the exact host that needs it**. The user reads the policy hint, edits config, restarts, and hits a second wall that nothing had mentioned.

`doctor` made it worse by printing `[PASS] browser backend` on a host where every URL would be refused, because it only checked whether a binary resolves.

## What this changes

- `config_hint.rs` — the hint now names **both** walls: the policy grant *and*, when no backend resolves, the install step. It does not claim protection the live path does not have.
- `doctor/mod.rs` — a browser **policy** row adjacent to the backend row, so `[PASS]` can no longer mean "a binary exists on a host that refuses every URL".
- `docs/tools.md` — documents the two-wall fresh-install path.

## How it is graded

The new test grades the **wiring**, not the launch function. Three mutations were applied to the call sites; each produced **2 new tests RED / 11 existing tests GREEN** — no pre-existing test caught any of the three links.

Mutation 2 surfaced more than a test gap: severing the `egress_policy` line launched the sidecar with an **empty `PROXY_*` set — uncontained** — and nothing in the existing suite could see it.

New coverage: 14 `config_hint` unit tests, 2 `browser_sidecar_launch_wiring_test` integration tests, 4 `browser_config_hint_roundtrip` tests, plus a `doctor_smoke` policy-row test.

## What this does NOT close

It does **not** make Camoufox present by default. `[browser.camoufox_download].enabled` is `false`, there is no bundled artifact, and provisioning needs an operator-pinned URL + SHA-256 per platform because Core does not fetch executable code from the network unpinned. Bundling the package at install time is a **packaging** change for the release lane, not a code change here. This PR makes the fresh-install path *legible*; it does not make it *automatic*.

## Gate

Full gate on Linux (`hetzner-dsm`), commit `1bfd628e`:

| gate | exit |
|---|---|
| contract generate + check | 0 |
| `cargo fmt --all --check` | 0 |
| `cargo check --workspace --all-targets` | 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | 0 |
| `cargo clippy --target x86_64-pc-windows-gnu` | 0 |
| `cargo clippy --target aarch64-apple-darwin` | 0 |

`nextest --workspace --profile ci`: **15,902 tests, 15,901 passed**. The single failure is `wcore-exec-backend::conformance_matrix` (`container: … Failure { code: "exit-125" }`) — the Docker daemon on that box, in a crate this diff does not touch. Pre-existing and environmental.
