### PR TITLE
feat(browser): install the Camoufox sidecar instead of refusing on a fresh machine

### DIFF
--- a/crates/wcore-browser/src/binary.rs
+++ b/crates/wcore-browser/src/binary.rs
@@ -82,6 +82,22 @@ pub enum BinaryError {
     #[error("unsafe path in configuration or archive: {0}")]
     UnsafePath(String),
     #[error(
+        "Core is offline, so it will not install the Camoufox sidecar; run `npm install -g @askjo/camofox-browser` yourself"
+    )]
+    OfflineRefusal,
+    #[error(
+        "npm is not on PATH, so Core cannot install the Camoufox sidecar; install Node.js, or run `npm install -g @askjo/camofox-browser` yourself"
+    )]
+    NpmMissing,
+    #[error(
+        "`npm install -g @askjo/camofox-browser` did not finish within {0}s; raise browser.sidecar_auto_install.timeout_secs, or run it yourself"
+    )]
+    NpmTimeout(u64),
+    #[error("could not run npm: {0}")]
+    NpmSpawn(String),
+    #[error("`npm install -g @askjo/camofox-browser` failed: {0}")]
+    NpmFailed(String),
+    #[error(
         "refusing to fetch an executable over {scheme} - browser.camoufox_download artifact url {url} must use https (plain http is accepted only for a loopback host)"
     )]
     InsecureScheme { scheme: String, url: String },
@@ -125,6 +141,69 @@ impl BrowserBinaryManager {
             b = b.proxy(p);
         }
         b.build().map_err(|e| BinaryError::Network(e.to_string()))
+    }
+
+    /// Install the Camoufox sidecar from npm into a Core-owned prefix.
+    ///
+    /// This is the path that makes the browser tool work on a machine where
+    /// nobody has installed anything. It is deliberately NOT the pinned
+    /// `[browser.camoufox_download]` path: that one resolves to a
+    /// self-contained sidecar executable per platform, and no such artifact is
+    /// published upstream. `@askjo/camofox-browser` ships the control server
+    /// (measured: a 181 KB tarball with no browser in it) and its postinstall
+    /// fetches the Camoufox browser itself.
+    ///
+    /// So `--ignore-scripts` is NOT passed. Skipping the postinstall installs a
+    /// control server with no browser behind it, which fails at first
+    /// navigation instead of at install — the same two-wall shape this exists
+    /// to remove.
+    ///
+    /// The prefix is Core-owned (`<install_root>/node`) so this never needs
+    /// root and never writes to a system-wide npm root.
+    pub async fn provision_sidecar_via_npm(
+        &self,
+        program: &str,
+        timeout: std::time::Duration,
+    ) -> Result<Option<PathBuf>, BinaryError> {
+        if self.offline {
+            return Err(BinaryError::OfflineRefusal);
+        }
+        if which::which("npm").is_err() {
+            return Err(BinaryError::NpmMissing);
+        }
+        let prefix = self.install_root.join("node");
+        std::fs::create_dir_all(&prefix).map_err(|e| BinaryError::Extract(e.to_string()))?;
+        let prefix_s = prefix
+            .to_str()
+            .ok_or_else(|| BinaryError::UnsafePath(prefix.display().to_string()))?;
+
+        // Argv mode. The package name and prefix are separate argv entries, so
+        // no shell interprets them - see AGENTS.md "Shell Execution".
+        let mut cmd = wcore_config::shell::shell_command_argv(
+            "npm",
+            &[
+                "install",
+                "-g",
+                "--prefix",
+                prefix_s,
+                "--no-fund",
+                "--no-audit",
+                SIDECAR_NPM_PACKAGE,
+            ],
+        );
+        cmd.stdin(std::process::Stdio::null());
+        let output = tokio::time::timeout(timeout, cmd.output())
+            .await
+            .map_err(|_| BinaryError::NpmTimeout(timeout.as_secs()))?
+            .map_err(|e| BinaryError::NpmSpawn(e.to_string()))?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            let tail: Vec<&str> = stderr.lines().rev().take(3).collect();
+            return Err(BinaryError::NpmFailed(
+                tail.into_iter().rev().collect::<Vec<_>>().join("; "),
+            ));
+        }
+        Ok(sidecar_in_prefix(&prefix, program))
     }
 
     /// High-level: ensure the Camoufox binary is present + verified.
@@ -437,6 +516,30 @@ fn sanitize_version_for_filename(v: &str) -> String {
 /// Minimal SHA-256 (so we don't pull `sha2` just for this module). Lifted
 /// from FIPS 180-4 reference; ~70 lines. Verified by the `known_vectors`
 /// test against the empty-string + "abc" vectors.
+/// The npm package that provides the sidecar program on `PATH`.
+///
+/// Same package name the liveness probe, the doctor and the runtime refusal
+/// already name - see `crate::install::CAMOUFOX_SIDECAR_PACKAGE`.
+pub const SIDECAR_NPM_PACKAGE: &str = "@askjo/camofox-browser";
+
+/// Where `npm install -g --prefix P` leaves an executable.
+///
+/// Unix puts it in `P/bin/<name>`; Windows puts the shim at `P/<name>.cmd`
+/// beside `P/<name>`. Both spellings are probed rather than assumed, because a
+/// wrong guess here reads as "the install silently did nothing".
+fn sidecar_in_prefix(prefix: &Path, program: &str) -> Option<PathBuf> {
+    let candidates = if cfg!(windows) {
+        vec![
+            prefix.join(format!("{program}.cmd")),
+            prefix.join(format!("{program}.exe")),
+            prefix.join(program),
+        ]
+    } else {
+        vec![prefix.join("bin").join(program)]
+    };
+    candidates.into_iter().find(|p| p.exists())
+}
+
 pub fn sha256_hex(input: &[u8]) -> String {
     const K: [u32; 64] = [
         0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4,

--- a/crates/wcore-browser/src/supervisor.rs
+++ b/crates/wcore-browser/src/supervisor.rs
@@ -101,7 +101,19 @@ impl Default for SupervisorConfig {
             sidecar_program: None,
             startup_timeout: Duration::from_secs(15),
             camoufox_download: wcore_config::browser::CamoufoxDownloadConfig::default(),
-            sidecar_auto_install: wcore_config::browser::SidecarAutoInstall::default(),
+            // OFF here, ON in `local_camoufox`. `SidecarAutoInstall::default()`
+            // is enabled - that is the operator-facing default - but
+            // `SupervisorConfig::default()` is the PROGRAMMATIC one, reached by
+            // every test that does not name the field. Inheriting "enabled"
+            // here means any such test npm-installs into the developer's home
+            // directory over the real network; measured, two arms raced each
+            // other into ENOTEMPTY doing exactly that. A constructor whose
+            // default performs a network install is a trap regardless of who
+            // steps in it.
+            sidecar_auto_install: wcore_config::browser::SidecarAutoInstall {
+                enabled: false,
+                ..Default::default()
+            },
             binary_install_root: home_bin_dir(),
             egress_policy: None,
             allow_unproxied_sidecar: false,
@@ -695,7 +707,16 @@ impl BrowserSupervisor {
                 // npm reported success but left no shim where one belongs.
                 // Fall through to the spawn, which names the manual command.
                 Ok(None) => Ok(program.to_string()),
-                Err(error) => Err(format!("Camoufox sidecar auto-install failed: {error}")),
+                // Best effort, and a failure must still tell the caller what to
+                // DO. The pre-existing refusal names the package and
+                // WAYLAND_CAMOUFOX_BIN; reporting a raw npm error in its place
+                // reports the failure WITHOUT the remedy, which is the exact
+                // shape this whole path exists to remove.
+                Err(error) => Err(format!(
+                    "{}\nCore also tried to install it automatically, and that failed: {error}",
+                    crate::install::CAMOUFOX
+                        .not_installed(program, Some(&self.config.healthcheck_url))
+                )),
             };
         }
         match manager

--- a/crates/wcore-browser/src/supervisor.rs
+++ b/crates/wcore-browser/src/supervisor.rs
@@ -57,6 +57,11 @@ pub struct SupervisorConfig {
     /// nothing unless an operator turns it on in `[browser.camoufox_download]`
     /// and pins a SHA-256 for their platform.
     pub camoufox_download: wcore_config::browser::CamoufoxDownloadConfig,
+    /// First-use npm install of the sidecar when no pinned artifact is
+    /// configured. Enabled by default - see [`SidecarAutoInstall`].
+    ///
+    /// [`SidecarAutoInstall`]: wcore_config::browser::SidecarAutoInstall
+    pub sidecar_auto_install: wcore_config::browser::SidecarAutoInstall,
     /// Install root for auto-provisioned browser binaries.
     pub binary_install_root: PathBuf,
     /// gh#1117 — the policy Core enforces on the sidecar's OWN egress.
@@ -96,6 +101,7 @@ impl Default for SupervisorConfig {
             sidecar_program: None,
             startup_timeout: Duration::from_secs(15),
             camoufox_download: wcore_config::browser::CamoufoxDownloadConfig::default(),
+            sidecar_auto_install: wcore_config::browser::SidecarAutoInstall::default(),
             binary_install_root: home_bin_dir(),
             egress_policy: None,
             allow_unproxied_sidecar: false,
@@ -108,17 +114,28 @@ impl SupervisorConfig {
     /// Production configuration for the locally managed Camoufox sidecar.
     /// The command may be overridden by Desktop or an operator.
     ///
-    /// Core still invokes no package manager. It downloads executable code
-    /// only when the operator has explicitly enabled
-    /// `[browser.camoufox_download]` AND pinned a SHA-256 for their platform;
-    /// the default config leaves that switch off, which is the pre-existing
-    /// "never downloads" behaviour verbatim.
+    /// Two provisioning paths, in this order:
+    ///
+    /// 1. `[browser.camoufox_download]` - an operator-pinned artifact verified
+    ///    against a SHA-256 they supplied. Off by default. No package manager
+    ///    runs on this path.
+    /// 2. `[browser.sidecar_auto_install]` - `npm install -g` of
+    ///    `@askjo/camofox-browser` into a Core-owned prefix. ON by default,
+    ///    and the reason a fresh machine works at all.
+    ///
+    /// (2) DOES invoke a package manager, which this comment used to say Core
+    /// never did. That was true and it was also why the browser tool was
+    /// non-functional on any machine nobody had prepared by hand: path (1)
+    /// needs a self-contained sidecar executable per platform, and upstream
+    /// publishes no such artifact. An operator who wants the old behaviour
+    /// sets `browser.sidecar_auto_install.enabled = false`.
     pub fn local_camoufox(base_url: &str) -> Self {
         let base_url = base_url.trim_end_matches('/');
         Self {
             healthcheck_url: format!("{base_url}/health"),
             sidecar_program: Some(crate::install::CAMOUFOX.configured_program()),
             camoufox_download: configured_camoufox_download(),
+            sidecar_auto_install: configured_sidecar_auto_install(),
             allow_unproxied_sidecar: configured_allow_unproxied_sidecar(),
             ..Self::default()
         }
@@ -205,6 +222,22 @@ fn configured_camoufox_download() -> wcore_config::browser::CamoufoxDownloadConf
         .get_or_init(|| {
             wcore_config::config::load_merged_config_file(None)
                 .map(|file| file.browser.camoufox_download)
+                .unwrap_or_default()
+        })
+        .clone()
+}
+
+/// The operator's `[browser.sidecar_auto_install]` block, read once per process.
+///
+/// A config that cannot be read yields the default, which is *enabled* - the
+/// failure mode is "Core installs the sidecar", never "the browser silently
+/// stays broken".
+fn configured_sidecar_auto_install() -> wcore_config::browser::SidecarAutoInstall {
+    static CACHE: OnceLock<wcore_config::browser::SidecarAutoInstall> = OnceLock::new();
+    CACHE
+        .get_or_init(|| {
+            wcore_config::config::load_merged_config_file(None)
+                .map(|file| file.browser.sidecar_auto_install)
                 .unwrap_or_default()
         })
         .clone()
@@ -640,15 +673,31 @@ impl BrowserSupervisor {
         if which::which(program).is_ok() {
             return Ok(program.to_string());
         }
-        if !self.config.camoufox_download.enabled {
-            // Unchanged pre-existing behaviour: let the spawn below fail with
-            // the actionable "install it / set WAYLAND_CAMOUFOX_BIN" message.
-            return Ok(program.to_string());
-        }
         let manager = crate::binary::BrowserBinaryManager::new(
             self.config.binary_install_root.clone(),
             false,
         );
+        if !self.config.camoufox_download.enabled {
+            if !self.config.sidecar_auto_install.enabled {
+                // The operator turned the fresh-machine path off. Pre-existing
+                // behaviour: let the spawn below fail with the actionable
+                // "install it / set WAYLAND_CAMOUFOX_BIN" message.
+                return Ok(program.to_string());
+            }
+            // No pinned artifact, so this is a machine nobody prepared by
+            // hand. Install the sidecar rather than refusing.
+            let timeout = Duration::from_secs(self.config.sidecar_auto_install.timeout_secs);
+            return match manager.provision_sidecar_via_npm(program, timeout).await {
+                Ok(Some(path)) => path
+                    .to_str()
+                    .map(str::to_string)
+                    .ok_or_else(|| "installed sidecar path is not valid UTF-8".to_string()),
+                // npm reported success but left no shim where one belongs.
+                // Fall through to the spawn, which names the manual command.
+                Ok(None) => Ok(program.to_string()),
+                Err(error) => Err(format!("Camoufox sidecar auto-install failed: {error}")),
+            };
+        }
         match manager
             .provision_camoufox(&self.config.camoufox_download)
             .await

--- a/crates/wcore-browser/tests/camoufox_provisioning_wiring_test.rs
+++ b/crates/wcore-browser/tests/camoufox_provisioning_wiring_test.rs
@@ -101,6 +101,14 @@ fn cfg(port: u16, tmp: &std::path::Path, download: CamoufoxDownloadConfig) -> Su
         startup_timeout: Duration::from_secs(20),
         camoufox_download: download,
         binary_install_root: tmp.join("bin"),
+        // These arms grade the PINNED-artifact path. `sidecar_auto_install`
+        // now defaults ON, and leaving it on would let the disabled-download
+        // control arm satisfy itself by npm-installing the sidecar instead -
+        // which is a different path, and would stop that arm being a control.
+        sidecar_auto_install: wcore_config::browser::SidecarAutoInstall {
+            enabled: false,
+            ..Default::default()
+        },
         ..SupervisorConfig::default()
     }
 }

--- a/crates/wcore-browser/tests/camoufox_provisioning_wiring_test.rs
+++ b/crates/wcore-browser/tests/camoufox_provisioning_wiring_test.rs
@@ -101,14 +101,6 @@ fn cfg(port: u16, tmp: &std::path::Path, download: CamoufoxDownloadConfig) -> Su
         startup_timeout: Duration::from_secs(20),
         camoufox_download: download,
         binary_install_root: tmp.join("bin"),
-        // These arms grade the PINNED-artifact path. `sidecar_auto_install`
-        // now defaults ON, and leaving it on would let the disabled-download
-        // control arm satisfy itself by npm-installing the sidecar instead -
-        // which is a different path, and would stop that arm being a control.
-        sidecar_auto_install: wcore_config::browser::SidecarAutoInstall {
-            enabled: false,
-            ..Default::default()
-        },
         ..SupervisorConfig::default()
     }
 }

--- a/crates/wcore-browser/tests/sidecar_npm_install_wiring_test.rs
+++ b/crates/wcore-browser/tests/sidecar_npm_install_wiring_test.rs
@@ -1,0 +1,235 @@
+//! The fresh-machine path: `ensure_ready` must INSTALL the Camoufox sidecar
+//! when nothing on the host provides it.
+//!
+//! `[browser.camoufox_download]` resolves to a self-contained sidecar
+//! executable per platform. Upstream publishes no such artifact — it publishes
+//! the Camoufox *browser* and the `camofox-browser` *control server*
+//! separately — so that path could never be a working default, and the browser
+//! tool refused on every machine nobody had prepared by hand.
+//!
+//! These arms grade the WIRING, not the installer. A unit test of
+//! `provision_sidecar_via_npm` cannot tell whether `ensure_ready` ever reaches
+//! it; that is exactly the defect this file exists to catch, and it is the same
+//! defect `camoufox_provisioning_wiring_test.rs` was written for one path
+//! earlier.
+//!
+//! `npm` is a STUB on `PATH`, so no test here touches the network or a real
+//! registry. The stub records its argv, which is what lets the
+//! "never `--ignore-scripts`" claim below be measured rather than asserted
+//! about source.
+//!
+//! **Unix only** — the stand-in npm and sidecar are `#!`-scripts and the
+//! executable bit is a Unix concept. Windows is a gap here, not a pass.
+
+#![cfg(unix)]
+
+use std::os::unix::fs::PermissionsExt as _;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, OnceLock};
+use std::time::Duration;
+
+use wcore_browser::supervisor::{BrowserSupervisor, SupervisorConfig};
+use wcore_config::browser::{CamoufoxDownloadConfig, SidecarAutoInstall};
+
+/// A sidecar name no PATH entry can satisfy, so a successful `ensure_ready` is
+/// attributable to the install and to nothing already on the host.
+const PROGRAM: &str = "wcore-npm-sidecar-that-does-not-exist";
+
+/// A stub `npm`, prepended to `PATH` ONCE for this test binary.
+///
+/// Set once and never mutated, so the arms below cannot race each other
+/// through the process-global environment. Each arm isolates itself by
+/// install root instead: the stub derives every path it touches from the
+/// `--prefix` it was handed.
+fn stub_npm_on_path() -> &'static Path {
+    static DIR: OnceLock<PathBuf> = OnceLock::new();
+    DIR.get_or_init(|| {
+        let dir = std::env::temp_dir().join(format!("wcore-stub-npm-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let npm = dir.join("npm");
+        std::fs::write(
+            &npm,
+            format!(
+                r#"#!/usr/bin/env python3
+import sys, pathlib, os
+argv = sys.argv[1:]
+prefix = None
+for i, a in enumerate(argv):
+    if a == "--prefix" and i + 1 < len(argv):
+        prefix = argv[i + 1]
+if prefix is None:
+    sys.exit("stub npm: no --prefix in " + repr(argv))
+prefix = pathlib.Path(prefix)
+root = prefix.parent
+root.mkdir(parents=True, exist_ok=True)
+# Evidence of the call, and of exactly what argv reached npm.
+(root / "npm-argv.log").write_text("\0".join(argv))
+port = (root / "port").read_text().strip()
+bindir = prefix / "bin"
+bindir.mkdir(parents=True, exist_ok=True)
+shim = bindir / "{program}"
+shim.write_text('''#!/usr/bin/env python3
+import http.server, socketserver
+class H(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200); self.send_header("Content-Length","2"); self.end_headers()
+        self.wfile.write(b"ok")
+    def log_message(self, *a): pass
+socketserver.TCPServer.allow_reuse_address = True
+socketserver.TCPServer(("127.0.0.1", ''' + port + '''), H).serve_forever()
+''')
+os.chmod(shim, 0o755)
+"#,
+                program = PROGRAM
+            ),
+        )
+        .unwrap();
+        std::fs::set_permissions(&npm, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let old = std::env::var("PATH").unwrap_or_default();
+        unsafe {
+            std::env::set_var("PATH", format!("{}:{old}", dir.display()));
+        }
+        dir
+    })
+    .as_path()
+}
+
+fn free_port() -> u16 {
+    let l = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    l.local_addr().unwrap().port()
+}
+
+fn cfg(port: u16, root: &Path, auto: SidecarAutoInstall) -> SupervisorConfig {
+    SupervisorConfig {
+        pid_dir: root.join("pids"),
+        reaper_interval: Duration::from_millis(200),
+        healthcheck_interval: Duration::from_secs(30),
+        healthcheck_url: format!("http://127.0.0.1:{port}/health"),
+        sidecar_program: Some(PROGRAM.to_string()),
+        startup_timeout: Duration::from_secs(20),
+        // OFF, so nothing here can be satisfied by the pinned-artifact path.
+        camoufox_download: CamoufoxDownloadConfig::default(),
+        sidecar_auto_install: auto,
+        binary_install_root: root.join("bin"),
+        ..SupervisorConfig::default()
+    }
+}
+
+/// Precondition for both arms. Without it, ARM 1 could be satisfied by a host
+/// that already had the sidecar and ARM 2 would prove nothing.
+#[test]
+fn configured_program_is_genuinely_unresolvable() {
+    stub_npm_on_path();
+    assert!(
+        which::which(PROGRAM).is_err(),
+        "{PROGRAM} resolves on this host; both arms below would be vacuous"
+    );
+}
+
+/// ARM 1 — nothing on the host provides the sidecar, so `ensure_ready` installs
+/// it and spawns what it installed.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn ensure_ready_installs_the_sidecar_and_spawns_what_it_installed() {
+    stub_npm_on_path();
+    let port = free_port();
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join("bin");
+    std::fs::create_dir_all(&root).unwrap();
+    std::fs::write(root.join("port"), port.to_string()).unwrap();
+
+    let sup = Arc::new(BrowserSupervisor::with_config(cfg(
+        port,
+        tmp.path(),
+        SidecarAutoInstall::default(),
+    )));
+
+    sup.ensure_ready().await.expect(
+        "ensure_ready must install the sidecar; the configured program is not on PATH and the \
+         pinned-artifact path is disabled, so this can only succeed via the npm path",
+    );
+
+    assert_eq!(
+        sup.live_sessions().len(),
+        1,
+        "exactly one sidecar session must be tracked"
+    );
+
+    let shim = root.join("node").join("bin").join(PROGRAM);
+    assert!(
+        shim.is_file(),
+        "installed sidecar missing at {}",
+        shim.display()
+    );
+    assert_ne!(
+        std::fs::metadata(&shim).unwrap().permissions().mode() & 0o111,
+        0,
+        "installed sidecar is not executable"
+    );
+
+    // What actually reached npm. This is the arm's substantive claim.
+    let argv = std::fs::read_to_string(root.join("npm-argv.log"))
+        .expect("npm was never invoked, so ensure_ready did not reach the install path");
+    let args: Vec<&str> = argv.split('\0').collect();
+
+    for want in ["install", "-g", "--prefix", "@askjo/camofox-browser"] {
+        assert!(args.contains(&want), "npm argv missing {want:?}: {args:?}");
+    }
+    assert!(
+        args.contains(&root.join("node").to_str().unwrap()),
+        "npm must install into the Core-owned prefix, got {args:?}"
+    );
+
+    // The whole point. `--ignore-scripts` skips the package's postinstall,
+    // which is what fetches the Camoufox browser — the published tarball is
+    // 181 KB and contains no browser. Passing it would install a control
+    // server with nothing behind it and move the failure from install time to
+    // first navigation, which is the two-wall shape this path removes.
+    assert!(
+        !args.contains(&"--ignore-scripts"),
+        "npm must NOT skip the postinstall that fetches the browser: {args:?}"
+    );
+}
+
+/// ARM 2 (control) — the SAME setup with the switch off. Nothing is installed,
+/// and the operator keeps the pre-existing actionable refusal. Without this
+/// arm, ARM 1 is satisfied by an implementation that installs unconditionally
+/// and ignores the operator's opt-out.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn nothing_is_installed_when_auto_install_is_disabled() {
+    stub_npm_on_path();
+    let port = free_port();
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join("bin");
+    std::fs::create_dir_all(&root).unwrap();
+    std::fs::write(root.join("port"), port.to_string()).unwrap();
+
+    let sup = Arc::new(BrowserSupervisor::with_config(cfg(
+        port,
+        tmp.path(),
+        SidecarAutoInstall {
+            enabled: false,
+            ..SidecarAutoInstall::default()
+        },
+    )));
+
+    let err = sup
+        .ensure_ready()
+        .await
+        .expect_err("with auto-install off and no sidecar on PATH, ensure_ready must refuse");
+
+    assert!(
+        !root.join("npm-argv.log").exists(),
+        "npm ran despite the operator turning auto-install off"
+    );
+    assert!(
+        !root.join("node").join("bin").join(PROGRAM).exists(),
+        "a sidecar was installed despite the operator turning auto-install off"
+    );
+    // The refusal still has to tell the operator what to do about it.
+    let msg = err.to_string();
+    assert!(
+        msg.contains(PROGRAM) || msg.to_lowercase().contains("camofox"),
+        "the refusal must name the sidecar it could not start; got: {msg}"
+    );
+    assert!(sup.live_sessions().is_empty());
+}

--- a/crates/wcore-config/src/browser.rs
+++ b/crates/wcore-config/src/browser.rs
@@ -40,6 +40,37 @@ pub struct BinaryArtifact {
     pub archive_exe_path: String,
 }
 
+/// First-use installation of the Camoufox sidecar from npm. **ON by default.**
+///
+/// This is the difference between a browser tool that works on a fresh machine
+/// and one that does not. [`CamoufoxDownloadConfig`] stays the operator's
+/// pinned-artifact path and is still off by default; it resolves to a
+/// self-contained sidecar executable per platform, and upstream publishes no
+/// such artifact - it publishes the Camoufox *browser* and the
+/// `camofox-browser` *control server* separately. That is why the pinned path
+/// was never a working default.
+///
+/// Set `enabled = false` to restore the previous behaviour, in which the tool
+/// refuses on a fresh machine and names the manual command instead.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct SidecarAutoInstall {
+    /// Master switch. ON by default.
+    pub enabled: bool,
+    /// How long the install may run. The package's postinstall fetches the
+    /// Camoufox browser itself, which is hundreds of MB, so this is minutes.
+    pub timeout_secs: u64,
+}
+
+impl Default for SidecarAutoInstall {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            timeout_secs: 600,
+        }
+    }
+}
+
 /// Opt-in auto-provisioning of the Camoufox sidecar binary.
 ///
 /// [`Self::enabled`] defaults to **false**: Core does not fetch executable
@@ -150,6 +181,9 @@ pub struct BrowserConfig {
     /// Opt-in auto-download of the Camoufox sidecar binary
     /// (`[browser.camoufox_download]`). Disabled by default.
     pub camoufox_download: CamoufoxDownloadConfig,
+    /// First-use npm install of the Camoufox sidecar
+    /// (`[browser.sidecar_auto_install]`). **Enabled by default.**
+    pub sidecar_auto_install: SidecarAutoInstall,
     /// gh#1117 opt-out: use a Camoufox sidecar that is NOT behind Core's
     /// egress proxy.
     ///
@@ -210,6 +244,7 @@ mod tests {
             download_dir: Some("/tmp/downloads".into()),
             persist_profile: false,
             camoufox_download: CamoufoxDownloadConfig::default(),
+            sidecar_auto_install: SidecarAutoInstall::default(),
             allow_unproxied_sidecar: false,
         };
         let s = toml::to_string(&cfg).unwrap();

--- a/crates/wcore-config/src/config.rs
+++ b/crates/wcore-config/src/config.rs
@@ -5790,6 +5790,16 @@ fn merge_config_files_with_trust(
         } else {
             global.browser.camoufox_download
         },
+        // Same "project overrides when it set a non-default" rule as
+        // `camoufox_download` above. The default is ENABLED, so a project that
+        // says nothing inherits the working browser rather than a broken one.
+        sidecar_auto_install: if project.browser.sidecar_auto_install
+            != crate::browser::SidecarAutoInstall::default()
+        {
+            project.browser.sidecar_auto_install
+        } else {
+            global.browser.sidecar_auto_install
+        },
         // gh#1117 opt-out. A bool whose only non-default value is `true`, so
         // "project overrides when non-default" and OR are the same rule the
         // loopback grant above uses. An UNTRUSTED project cannot reach this:

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -377,6 +377,36 @@ Available capability flag: `capabilities.browser_suite` (W8c.1). The
 engine emits `browser_event` and `browser_policy_denied` while ops
 run; see `docs/json-stream-protocol.md` §§1.N+6 and 1.N+7.
 
+### Getting a browser backend
+
+`Browser::*` drives a **Camoufox sidecar** — an HTTP control server that Core
+starts and supervises. On a machine that does not already have it, Core
+installs it on first use:
+
+```bash
+npm install -g --prefix <profile>/browser/bin/node @askjo/camofox-browser
+```
+
+The prefix is Core-owned, so this never needs `sudo` and never writes to a
+system-wide npm root. `npm` must be on `PATH`; if it is not, the tool refuses
+and names the manual command.
+
+The install deliberately does **not** pass `--ignore-scripts`. That package
+ships the control server (a ~181 KB tarball with no browser in it); its
+`postinstall` is what fetches the Camoufox browser itself. Skipping it would
+install a server with nothing behind it and move the failure from install time
+to your first `Browser::navigate`.
+
+| Setting | Default | Effect |
+|---|---|---|
+| `[browser.sidecar_auto_install] enabled` | `true` | Install the sidecar on first use when it does not resolve. |
+| `[browser.sidecar_auto_install] timeout_secs` | `600` | Budget for that install. The postinstall downloads a browser, so this is minutes. |
+| `[browser.camoufox_download] enabled` | `false` | Operator-pinned artifact instead — takes precedence when on. Requires a `url` **and** a `sha256` per platform; enabling it without a digest is an error, not permission to fetch-and-trust. |
+
+Set `enabled = false` to keep the previous behaviour, in which the tool refuses
+on a fresh machine and names the manual command. `WAYLAND_CAMOUFOX_BIN` points
+Core at a `camofox-browser` you installed yourself and skips both paths.
+
 ## Computer use (W8c.2)
 
 `Cua::*` tools are registered by the `wayland-cua` plugin (via


### PR DESCRIPTION
Closes the "browser is non-functional by default" gap. The tool now **installs its sidecar on first use** instead of refusing on any machine nobody prepared by hand.

## Why the existing provisioning path could never do this

`[browser.camoufox_download]` resolves to a **self-contained sidecar executable** per platform: `resolve_sidecar_program` hands the provisioned path straight to `launch_camoufox_program`, and the existing wiring test's stand-in is *"an argument-free HTTP health server"*.

Upstream publishes no such artifact. It publishes the Camoufox **browser** (what `CAMOUFOX_DOWNLOAD_URL` points at — macOS-arm64 only) and the `camofox-browser` **control server** separately. Pinning a digest for the browser tarball would provision a Firefox fork and then try to run it as an HTTP server.

That is why the switch was off by default and why nobody had ever turned it on: **it had no artifact to point at.** The mechanism was complete; the data never existed.

## What this adds

`[browser.sidecar_auto_install]`, **on by default**, runs on first use when the sidecar does not resolve:

```
npm install -g --prefix <profile>/browser/bin/node @askjo/camofox-browser
```

- Prefix is **Core-owned** — never needs root, never writes to a system-wide npm root.
- Built in **argv mode**, so no shell interprets any of it.
- **`--ignore-scripts` is deliberately NOT passed**, and the test asserts its absence. That tarball is 181 KB with no browser in it; the package's `postinstall` is what fetches Camoufox. Skipping it installs a control server with nothing behind it and moves the failure from install time to first navigation — the same two-wall shape this removes. *(Hermes passes `--ignore-scripts` here, which is why their working default is a Chromium download and not Camoufox at all.)*

Both operator escapes preserved: the pinned-artifact path still takes precedence when enabled, and `enabled = false` restores the previous refusal, which already names the manual command.

## Two defects the suite caught in this change

Both were mine, and both are fixed in `ef373029`:

1. **A failed install reported the failure without the remedy.** The pre-existing refusal names the package and `WAYLAND_CAMOUFOX_BIN`; the new error arm replaced it with a raw npm message, and `a_missing_sidecar_is_diagnosed_as_missing_not_as_a_containment_failure` failed 3/3 on *"the remedy must name the env var the supervisor actually reads"*. The refusal is now prepended and the npm reason appended.

2. **`SupervisorConfig::default()` inherited the operator-facing default, which is enabled.** That constructor is the *programmatic* one, reached by every test that does not name the field — so unit tests npm-installed into the developer's home directory over the real network, and two arms raced each other into `ENOTEMPTY`. **Every test passed while this was happening**; what caught it was a post-run check that the home-dir npm prefix does not exist. `default()` is now off; only `local_camoufox`, the sole production constructor, turns it on.

A constructor whose default performs a network install is a trap regardless of who steps in it.

## Verification

**Graded by mutation, not by assertion.** Severing the `provision_sidecar_via_npm` call site (verified landed on code, 1 → 0 occurrences):

- new install arm → **FAIL**
- **272/273 pass** — every other arm green, including the disabled-control and the entire pinned-artifact suite

**Gate:** contract generate + check, `fmt --check`, `check --workspace --all-targets`, `clippy --workspace --all-targets -D warnings`, plus `--target x86_64-pc-windows-gnu` and `--target aarch64-apple-darwin` — all exit 0.

`wcore-browser` + `wcore-config`: **1036/1036**, and the leak instrument reports `clean: no home-dir install`.
