### PR TITLE
A skill payload key must name its entry canonically (#694 hardening)

### DIFF
--- a/crates/wcore-skills/src/promote.rs
+++ b/crates/wcore-skills/src/promote.rs
@@ -601,19 +601,45 @@ pub(crate) fn staging_root_for(skills_root: &Path) -> PathBuf {
     }
 }
 
-/// Join `rel` under `base`, rejecting absolute paths and any `..` component.
+/// Join `rel` under `base`, rejecting absolute paths, any `..` component, and
+/// any `.` component.
+///
+/// `Component::CurDir` used to be accepted here. It is refused now because this
+/// function is the WRITER for payload-supplied keys, while fences elsewhere
+/// identify the same entries by comparing the key STRING (for example
+/// `loader::generated_provenance_in_files`, which asks `rel == "manifest.json"`).
+/// Accepting `.` meant `"./manifest.json"` and `"manifest.json"` resolved to the
+/// same file while comparing as different strings — one spelling written, a
+/// different spelling matched. On a branch that gated an evidence fence behind
+/// such a match, the `./` spelling walked straight past it and produced a
+/// promotion grant with `evidence: None`.
+///
+/// Normalising instead of refusing would NOT close that gap: it fixes the path
+/// the write lands on and leaves every string-keyed matcher still looking at the
+/// raw spelling. Refusing is what makes the writer and those matchers agree by
+/// construction, so a payload can only ever name an entry one way.
 fn resolve_under(base: &Path, rel: &str) -> Option<PathBuf> {
     let p = Path::new(rel);
     if p.is_absolute() {
         return None;
     }
+    let mut normal = PathBuf::new();
     for c in p.components() {
         match c {
-            std::path::Component::Normal(_) | std::path::Component::CurDir => {}
+            std::path::Component::Normal(part) => normal.push(part),
             _ => return None,
         }
     }
-    Some(base.join(p))
+    // A leading `.` is refused by the loop above, but `Path::components()`
+    // NORMALISES AWAY an interior one -- `"nested/./SKILL.md"` yields exactly
+    // the components of `"nested/SKILL.md"`, so the loop cannot see it, and
+    // `base.join(rel)` would then write through the raw spelling. Requiring the
+    // re-rendered components to reproduce `rel` is what catches that: any key
+    // that is not already canonical names a file some other key also names.
+    if normal.as_os_str() != p.as_os_str() {
+        return None;
+    }
+    Some(base.join(normal))
 }
 
 /// Best-effort directory fsync, so a rename's effects survive a power loss.
@@ -699,4 +725,72 @@ fn tree_stats(dir: &Path) -> Result<(usize, u64), GovernError> {
         }
     }
     Ok((files.len(), bytes))
+}
+
+#[cfg(test)]
+mod resolve_under_tests {
+    use super::resolve_under;
+    use std::path::Path;
+
+    /// A payload key may name an entry exactly ONE way.
+    ///
+    /// `resolve_under` is the writer for payload-supplied keys, while fences
+    /// elsewhere identify the same entries by comparing the key STRING. When
+    /// `.` was accepted, `"./manifest.json"` and `"manifest.json"` landed on the
+    /// same file yet compared as different strings, so a fence keyed on the
+    /// canonical spelling never saw the prefixed one.
+    ///
+    /// The canonical arms are the known-positive control: without them a
+    /// `resolve_under` that refused EVERYTHING would satisfy the refusals below
+    /// and grade nothing.
+    #[test]
+    fn a_dot_prefixed_key_cannot_name_the_same_file_as_its_canonical_spelling() {
+        let base = Path::new("/tmp/base");
+
+        // Control: the canonical spellings still resolve.
+        assert_eq!(
+            resolve_under(base, "manifest.json"),
+            Some(base.join("manifest.json")),
+            "control: a canonical key must still resolve, or the refusals below prove nothing"
+        );
+        assert_eq!(
+            resolve_under(base, "nested/SKILL.md"),
+            Some(base.join("nested/SKILL.md")),
+            "control: a nested canonical key must still resolve"
+        );
+
+        // The bypass spelling, and its relatives, are refused outright.
+        for rel in [
+            "./manifest.json",
+            "./SKILL.md",
+            "././manifest.json",
+            "nested/./SKILL.md",
+            "./nested/SKILL.md",
+        ] {
+            assert_eq!(
+                resolve_under(base, rel),
+                None,
+                "{rel} resolves to the same file as its canonical spelling but compares as a \
+                 different string, so a string-keyed fence would not see it"
+            );
+        }
+
+        // Pre-existing guarantees must not regress.
+        assert_eq!(
+            resolve_under(base, "../escape"),
+            None,
+            "`..` must stay refused"
+        );
+        assert_eq!(
+            resolve_under(base, "nested/../escape"),
+            None,
+            "an interior `..` must stay refused"
+        );
+        #[cfg(unix)]
+        assert_eq!(
+            resolve_under(base, "/etc/passwd"),
+            None,
+            "an absolute path must stay refused"
+        );
+    }
 }

--- a/crates/wcore-skills/src/promote.rs
+++ b/crates/wcore-skills/src/promote.rs
@@ -619,27 +619,37 @@ pub(crate) fn staging_root_for(skills_root: &Path) -> PathBuf {
 /// raw spelling. Refusing is what makes the writer and those matchers agree by
 /// construction, so a payload can only ever name an entry one way.
 fn resolve_under(base: &Path, rel: &str) -> Option<PathBuf> {
-    let p = Path::new(rel);
-    if p.is_absolute() {
+    // The RAW key is what is validated, not a re-rendered path.
+    // `Path::components()` normalises an interior `.` away AND re-renders with
+    // the platform separator, so comparing the re-render against `rel` refused
+    // ordinary `nested/SKILL.md` on Windows (it comes back with a backslash)
+    // while still needing a separate rule for `nested/./SKILL.md`. Reading the
+    // segments directly answers both, identically on every platform.
+    //
+    // `/` is the ONE separator a key may use. A backslash is refused
+    // everywhere, not only where it would separate: a key that names a
+    // different file depending on the host is exactly the ambiguity this
+    // function exists to remove, and no skill entry needs one.
+    if rel.is_empty() || rel.contains('\\') {
         return None;
     }
-    let mut normal = PathBuf::new();
-    for c in p.components() {
-        match c {
-            std::path::Component::Normal(part) => normal.push(part),
-            _ => return None,
+    for segment in rel.split('/') {
+        if segment.is_empty() || segment == "." || segment == ".." {
+            return None;
         }
     }
-    // A leading `.` is refused by the loop above, but `Path::components()`
-    // NORMALISES AWAY an interior one -- `"nested/./SKILL.md"` yields exactly
-    // the components of `"nested/SKILL.md"`, so the loop cannot see it, and
-    // `base.join(rel)` would then write through the raw spelling. Requiring the
-    // re-rendered components to reproduce `rel` is what catches that: any key
-    // that is not already canonical names a file some other key also names.
-    if normal.as_os_str() != p.as_os_str() {
+    // Belt and braces for the one spelling `split('/')` cannot see: on Windows
+    // `C:entry` is a single segment carrying a Prefix component, and `join`
+    // REPLACES the base with it instead of extending it. Every other refusal
+    // above is reachable on both platforms; this arm only ever fires on
+    // Windows, where a bare drive-relative key would otherwise escape.
+    if Path::new(rel)
+        .components()
+        .any(|c| !matches!(c, std::path::Component::Normal(_)))
+    {
         return None;
     }
-    Some(base.join(normal))
+    Some(base.join(rel))
 }
 
 /// Best-effort directory fsync, so a rename's effects survive a power loss.
@@ -766,6 +776,14 @@ mod resolve_under_tests {
             "././manifest.json",
             "nested/./SKILL.md",
             "./nested/SKILL.md",
+            // Second spellings of a separator: `nested\\SKILL.md` is one file on
+            // Windows and a different, single-component file on Unix.
+            "nested\\SKILL.md",
+            ".\\manifest.json",
+            // Empty segments name the same entry as the collapsed spelling.
+            "nested//SKILL.md",
+            "nested/",
+            "",
         ] {
             assert_eq!(
                 resolve_under(base, rel),
@@ -786,11 +804,18 @@ mod resolve_under_tests {
             None,
             "an interior `..` must stay refused"
         );
-        #[cfg(unix)]
         assert_eq!(
             resolve_under(base, "/etc/passwd"),
             None,
             "an absolute path must stay refused"
+        );
+        // Drive-relative on Windows: `join` would REPLACE the base rather than
+        // extend it, so the entry lands outside the staging root entirely.
+        #[cfg(windows)]
+        assert_eq!(
+            resolve_under(base, "C:entry"),
+            None,
+            "a drive-relative key must not escape the base"
         );
     }
 }


### PR DESCRIPTION
Closes the D8 half of #694: a payload key must name its entry exactly one way.

`resolve_under` is the WRITER for payload-supplied keys, while fences elsewhere identify the same entries by comparing the key STRING — `loader::generated_provenance_in_files` asks `rel == "manifest.json"`. While `.` was accepted, `"./manifest.json"` and `"manifest.json"` landed on the same file and compared as different strings, so a fence keyed on the canonical spelling never saw the prefixed one. On a branch that gated an evidence fence behind such a match, the `./` spelling walked straight past it and produced a promotion grant with `evidence: None`.

Refusing, not normalising. Normalising fixes the path the write lands on and leaves every string-keyed matcher still looking at the raw spelling; refusal is what makes the writer and those matchers agree by construction.

## The Windows leg, and the second version of this fix

The first form compared `Path::components()` re-rendered against the raw key. That was wrong in a way Linux and macOS could not show: `components()` does two things at once — it normalises an interior `.` away (what the check was for) and it re-renders with the PLATFORM separator (what it was not). On Windows the re-render of `nested/SKILL.md` comes back `nested\SKILL.md`, so the round-trip failed and **no skill with a subdirectory entry could be promoted there at all**. `CI (Array)` caught it on this branch's own control: `left: None` on `a_nested_canonical_key_must_still_resolve`.

Reading the raw segments answers both questions, identically on every platform. Two spellings the old form let through are refused as well:

- **a backslash anywhere in the key** — it names one file on Windows and a different, single-component file on Unix, which is the same "one entry, two names" ambiguity this function exists to remove, and no skill entry needs one;
- **empty segments** — `nested//SKILL.md`, a trailing `/`, which name the same entry as the collapsed spelling.

A drive-relative `C:entry` is refused by an explicit all-`Normal` component check: it is a single segment with no separator for the loop to see, and `join` would REPLACE the base with it rather than extend it. That arm only ever fires on Windows.

## Recorded so it is not re-attempted

The separate `lane/bl-694` branch was **dropped, not merged**. It has no evaluator at all — it passes `operator_attested(AUTHORITY)` — so merging it would have regressed the eval gate that is already in `main`.

## Verification

`wcore-skills` 708/708; `wcore-cli` + `wcore-pluginsrc` + `wcore-skills` 3,865/3,865 on Linux (the backslash refusal breaks no existing plugin or skill fixture). `clippy --target x86_64-pc-windows-gnu -p wcore-skills --all-targets -D warnings` clean, so the Windows-only arm is compiled and linted from here.
