### PR TITLE
0.13.9: the release cut — version bump, changelog, and the model arms three vendors shipped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,82 @@
+## [0.13.9](https://github.com/FerroxLabs/wayland-core/compare/v0.13.8...v0.13.9) (2026-08-28)
+
+**Release highlights.** A cycle spent grading our own guards rather than writing
+new ones — including the ones that turned out to be passing without running. No
+breaking changes.
+
+**A command floor below approval and `--force`.** A catastrophic command is now
+refused before any shell is spawned, underneath approval and underneath
+`--force`. Three measured bypass shapes are closed plus a fourth found during
+review: a two-call symlink that reached `~/.config` with no protected component
+in either token stream. It reads the PATHS in a command — after expanding `~`,
+`$HOME` and `$WAYLAND_HOME` and after following symlinks already on disk — not a
+blocklist of command names, so `cd $HOME && cd .wayland && echo … >> config.toml`
+is refused for the same reason its absolute spelling is. Two limits are written
+into the docs rather than papered over: it cannot see a link made by the command
+it is reading, and it does not chase `eval` / `base64` / a variable holding the
+path. Those are the sandbox's job. (#693)
+
+**A red Windows leg now means something.** `retries = 2` reports a test that
+failed twice and passed once as PASSED in the run conclusion — the number
+release gates and humans read. The three tests whose Windows verdict churns are
+pinned at `retries = 0`, two of them were also stacking nextest retries on top of
+their own in-test `RACE_ATTEMPTS = 3` loop, and a checker keeps them that way.
+This makes some Windows legs go red where they used to read green with a buried
+`TRY` line. That is the intent. (#1146)
+
+**Money and failure report the truth.** A provider-reported per-call cost reaches
+the ledger, and an unpriced model says unpriced instead of `0.000000` — the
+product was printing a definite zero for a 112-round-trip session that spent real
+money (#1139). A failed fork reports the turns and tokens it actually burned and
+hands the parent the child's own diagnostic instead of a generic line naming
+three possible causes and committing to none (#1140). An explicitly-exported
+`XAI_API_KEY` outranks an ambient OAuth file (#1141).
+
+**Fixes you would have hit.** `--search` on a Flux tier alias no longer strips
+every agent tool — the array was overwritten rather than merged, measured 3/3
+broken with the flag and 2/3 correct without it (#1136). The OSV malware check
+scans the package you are actually running rather than the first token that
+looks positional (#1137). MCP servers start on Windows: engine-spawned children
+are launched with a cleared environment, and without `SYSTEMROOT`/`WINDIR` a
+child cannot initialise at all, which surfaced as an `EPERM` that reads like a
+permissions problem and is not one (#928). A Spawn fork on a tier alias no
+longer wedges on a smaller output budget than its parent (#862). Two Core
+processes on one Windows box name the process holding the AppContainer ACL lock
+instead of timing out with a dead-end message (#945). A macOS Contained TUI can
+surface a file again (#1138).
+
+**Your unsaved work.** The shell guard is bounded, can never outlast the
+caller's own timeout, and refuses on expiry instead of waving the command
+through. The old refusal told you to raise a timeout that could not help.
+(#1142)
+
+**Model limits.** `gpt-5.6` and its siblings, the whole `grok-4.x` family, and
+Google's current `gemini-3.x` text tiers had no entry, so each compacted at 200k
+against a real window of up to 1,050,000. Refreshed against models.dev vendor
+rows.
+
+**Also.** Desktop contract corpus drift no longer reddens every platform at once,
+and the remedy is safe to follow rather than a regenerate-blind trap (#1055).
+Anvil refuses to nest Flux's server-side ladder inside its own — at every seat,
+and now in the provider-chain fallbacks and the compaction path, which was
+returning contaminated mid-loop material that then replaced the entire
+conversation history (#893). A skill payload key may name its entry exactly one
+way (#694). Process-group sentinels stay parked through `EINTR` (#1054).
+
+**Known and open, filed rather than buried.** An Edit can still overwrite a save
+that lands between the guard's last check and its rename, at about 5%, and CI's
+`retries = 2` hides it — one candidate cause was tested and refuted by
+measurement (#1155). `acp serve` children get their own process group and no
+stdin, so a hard kill of the supervisor leaves them serving under PID 1 (#1156).
+`model_output_ceiling` caps DeepSeek output at 8,192 and MiniMax M3 at 128,000,
+and the arm itself is what removes the provider's own ceiling (#1157).
+
+> 0.13.7 and 0.13.8 shipped without an entry here. Their notes are on the GitHub
+> releases: [v0.13.7](https://github.com/FerroxLabs/wayland-core/releases/tag/v0.13.7)
+> (fourteen verified fixes, and the macOS transcript defect root-caused) and
+> [v0.13.8](https://github.com/FerroxLabs/wayland-core/releases/tag/v0.13.8)
+> (the browser and web search both work on a fresh install).
+
 # Changelog
 
 ## [0.13.6](https://github.com/FerroxLabs/wayland-core/compare/v0.13.5...v0.13.6) (2026-08-24)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9033,7 +9033,7 @@ dependencies = [
 
 [[package]]
 name = "wayland-browser"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "async-trait",
  "inventory",
@@ -9050,7 +9050,7 @@ dependencies = [
 
 [[package]]
 name = "wayland-cua"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "async-trait",
  "inventory",
@@ -9067,7 +9067,7 @@ dependencies = [
 
 [[package]]
 name = "wayland-honcho"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9088,7 +9088,7 @@ dependencies = [
 
 [[package]]
 name = "wayland-ijfw"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9107,7 +9107,7 @@ dependencies = [
 
 [[package]]
 name = "wayland-ollama"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "async-trait",
  "futures",
@@ -9128,7 +9128,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-acp"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "async-trait",
  "axum",
@@ -9151,7 +9151,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-agent"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9249,7 +9249,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-agents-pack"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "dirs",
  "serde",
@@ -9262,7 +9262,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-browser"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9298,7 +9298,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-budget"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "chrono",
  "fd-lock",
@@ -9313,7 +9313,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-discord"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9335,7 +9335,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-email"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9359,7 +9359,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-imessage"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9376,7 +9376,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-matrix"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9396,7 +9396,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-msteams"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -9417,7 +9417,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-signal"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9433,7 +9433,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-slack"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9456,7 +9456,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-sms"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -9479,7 +9479,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-telegram"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9498,7 +9498,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-whatsapp"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9522,7 +9522,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channels"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9542,7 +9542,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channels-registry"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "dirs",
  "hex",
@@ -9572,7 +9572,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-cli"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9666,7 +9666,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-compact"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "regex",
  "serde",
@@ -9675,7 +9675,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-config"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "anyhow",
  "argon2",
@@ -9718,7 +9718,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-cron"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9735,7 +9735,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-cua"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9771,7 +9771,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-dispatch"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "rand 0.9.4",
  "rand_distr",
@@ -9784,7 +9784,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-egress"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "async-trait",
  "http 1.4.1",
@@ -9798,7 +9798,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-eval"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "rstest",
  "serde",
@@ -9815,7 +9815,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-eval-scenarios"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "anyhow",
  "axum",
@@ -9848,7 +9848,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-evolve"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9879,7 +9879,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-exec-backend"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -9911,7 +9911,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-gateway"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9931,7 +9931,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-honcho-adapter"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "async-trait",
  "serde",
@@ -9947,7 +9947,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-mcp"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9974,7 +9974,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-memory"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10016,7 +10016,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-observability"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "chrono",
  "opentelemetry",
@@ -10040,7 +10040,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-permissions"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "anyhow",
  "chrono",
@@ -10060,7 +10060,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-plugin-api"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10087,7 +10087,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-plugin-subprocess"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "anyhow",
  "serde",
@@ -10108,7 +10108,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-plugin-wasm"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10130,7 +10130,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-pluginsrc"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "serde",
  "serde_json",
@@ -10145,7 +10145,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-pricing"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "chrono",
  "dirs",
@@ -10165,7 +10165,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-protocol"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "rstest",
  "serde",
@@ -10181,7 +10181,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-providers"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10217,7 +10217,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-replay"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "serde",
  "serde_json",
@@ -10228,7 +10228,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-repomap"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "ignore",
  "regex",
@@ -10243,7 +10243,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-safety"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -10257,7 +10257,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-sandbox"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "async-trait",
  "bollard",
@@ -10284,7 +10284,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-skills"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10323,7 +10323,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-swarm"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "dunce",
  "fd-lock",
@@ -10349,7 +10349,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-tools"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10403,7 +10403,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-types"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "async-trait",
  "chrono",
@@ -10417,7 +10417,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-user-model"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "async-trait",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,7 +152,7 @@ members = [
 exclude = ["templates/**", "examples/**"]
 
 [workspace.package]
-version = "0.13.8"
+version = "0.13.9"
 edition = "2024"
 rust-version = "1.95"
 license = "Apache-2.0"

--- a/crates/wcore-config/src/limits.rs
+++ b/crates/wcore-config/src/limits.rs
@@ -124,7 +124,11 @@ pub fn model_output_ceiling(_provider: &str, model: &str) -> Option<(u32, u32)> 
         {
             return Some((16_384, 128_000));
         }
-        if (m.contains("gpt-5.4") || m.contains("gpt-5.5"))
+        // 5.6 joins 5.4/5.5 (models.dev, vendor row `openai`, 2026-08-28):
+        // gpt-5.6 and its -luna / -sol / -terra siblings all serve 1,050,000.
+        // Without this arm they fell to the 400k catch below and every 5.6 run
+        // compacted at 40% of its real window.
+        if (m.contains("gpt-5.4") || m.contains("gpt-5.5") || m.contains("gpt-5.6"))
             && !m.contains("-mini")
             && !m.contains("-nano")
             && !m.contains("-codex")
@@ -132,6 +136,28 @@ pub fn model_output_ceiling(_provider: &str, model: &str) -> Option<(u32, u32)> 
             return Some((128_000, 1_050_000));
         }
         return Some((128_000, 400_000));
+    }
+
+    // --- xAI Grok 4.x ---
+    // Added 2026-08-28. With no arm the whole 4.x family fell to the
+    // `CompactConfig` default and compacted a 1M-window model at 200k.
+    //
+    // The OUTPUT figures here are the vendor's own, NOT the conservative
+    // under-claim this table uses elsewhere, and that is deliberate: adding an
+    // arm REVOKES `should_omit_max_tokens`, so until now these ids sent no
+    // max_tokens at all and got xAI's natural ceiling. An arm that "errs low"
+    // would not be free here — it would be the first thing ever to cut their
+    // output. Vendor rows (models.dev provider `xai`, 2026-08-28) are the only
+    // source for these ids; no reseller serves them.
+    //
+    // The split is real: 4.20/4.3 are 1M-window / 30k-output; 4.5 and 4.6 are
+    // 500k both ways. Longest-match first so `grok-4.5` never falls into the
+    // 4.x arm and loses 470k of output.
+    if m.contains("grok-4.5") || m.contains("grok-4.6") {
+        return Some((500_000, 500_000));
+    }
+    if m.contains("grok-4") {
+        return Some((30_000, 1_000_000));
     }
 
     // --- xAI Grok 3.x ---
@@ -149,6 +175,26 @@ pub fn model_output_ceiling(_provider: &str, model: &str) -> Option<(u32, u32)> 
     // -native-audio / -live realtime variants: ~8k output) — an over-claim
     // would 400 them, so they are excluded and fail open to the unknown path.
     if (m.contains("gemini-2.5-pro") || m.contains("gemini-2.5-flash"))
+        && !m.contains("-image")
+        && !m.contains("-tts")
+        && !m.contains("-native-audio")
+        && !m.contains("-live")
+    {
+        return Some((65_536, 1_048_576));
+    }
+
+    // --- Google Gemini 3.x (text family) ---
+    // Added 2026-08-28. Google's CURRENT generation had no arm at all, so
+    // gemini-3.1-pro, 3.5-flash, 3.6-flash and 3.7-flash each compacted at the
+    // 200k default against a real 1,048,576 window.
+    //
+    // Same numbers and the SAME exclusion list as 2.5, and for the same reason:
+    // `google` and `google-vertex` agree at 65_536 / 1_048_576 for every text
+    // tier (models.dev, 2026-08-28), while the specialty variants are much
+    // smaller and would 400 on an over-claim — `-image` is 32_768/131_072 or
+    // less, `-tts` is an 8k window, and the `-live` / live-translate variants
+    // are smaller again.
+    if m.contains("gemini-3")
         && !m.contains("-image")
         && !m.contains("-tts")
         && !m.contains("-native-audio")
@@ -532,6 +578,99 @@ mod tests {
             model_output_ceiling("gemini", "gemini-2.5-flash-live"),
             None
         );
+    }
+
+    #[test]
+    fn gpt_5_6_gets_the_large_window_and_its_small_siblings_do_not() {
+        // Refreshed 2026-08-28: 5.6 serves 1,050,000 exactly as 5.4/5.5 do.
+        // Before this arm every 5.6 id fell to the 400k catch and compacted at
+        // 40% of its real window.
+        for id in ["gpt-5.6", "gpt-5.6-luna", "gpt-5.6-sol", "gpt-5.6-terra"] {
+            assert_eq!(
+                model_output_ceiling("openai", id),
+                Some((128_000, 1_050_000)),
+                "{id} must report the 1.05M window"
+            );
+        }
+        // The exclusion list is load-bearing and must apply to 5.6 too: the
+        // small variants are 400k, and claiming 1.05M for them would 400 near
+        // the top.
+        for id in ["gpt-5.6-mini", "gpt-5.6-nano", "gpt-5.6-codex"] {
+            assert_eq!(
+                model_output_ceiling("openai", id),
+                Some((128_000, 400_000)),
+                "{id} must stay at the 400k window"
+            );
+        }
+    }
+
+    #[test]
+    fn grok_4_family_splits_by_version_and_does_not_shadow_grok_3() {
+        // Added 2026-08-28. Vendor rows (models.dev provider `xai`) are the
+        // only source for these ids: 4.20/4.3 are 1M-window / 30k-output;
+        // 4.5 and 4.6 are 500k both ways.
+        for id in ["grok-4.5", "grok-4.6"] {
+            assert_eq!(
+                model_output_ceiling("xai", id),
+                Some((500_000, 500_000)),
+                "{id} is 500k both ways"
+            );
+        }
+        // ORDERING IS LOAD-BEARING. `grok-4.5` also contains `grok-4`, so
+        // moving the general arm above the 4.5/4.6 one would silently cut
+        // their output from 500,000 to 30,000. This assertion is what fails if
+        // the arms are reordered.
+        for id in [
+            "grok-4.3",
+            "grok-4.20-0309-reasoning",
+            "grok-4.20-multi-agent-0309",
+        ] {
+            assert_eq!(
+                model_output_ceiling("xai", id),
+                Some((30_000, 1_000_000)),
+                "{id} is the 1M-window / 30k-output tier"
+            );
+        }
+        // The 3.x arm is untouched, and 4.x must not have swallowed it.
+        assert_eq!(
+            model_output_ceiling("xai", "grok-3"),
+            Some((64_000, 131_072))
+        );
+    }
+
+    #[test]
+    fn gemini_3_text_family_resolves_and_its_specialty_variants_fail_open() {
+        // Added 2026-08-28: Google's CURRENT generation had no arm at all and
+        // compacted at the 200k default against a real 1,048,576 window.
+        for id in [
+            "gemini-3-flash-preview",
+            "gemini-3.1-pro-preview",
+            "gemini-3.1-flash-lite",
+            "gemini-3.5-flash",
+            "gemini-3.6-flash",
+            "gemini-3.7-flash",
+        ] {
+            assert_eq!(
+                model_output_ceiling("gemini", id),
+                Some((65_536, 1_048_576)),
+                "{id} must report the Gemini 3.x text-family limits"
+            );
+        }
+        // Same exclusions as 2.5, and they matter more here: the 3.x image and
+        // live tiers are 131_072 or smaller, so an over-claim would 400 them.
+        for id in [
+            "gemini-3-pro-image",
+            "gemini-3.1-flash-image-preview",
+            "gemini-3.1-flash-tts-preview",
+            "gemini-3.1-flash-live-preview",
+            "gemini-3.5-live-translate-preview",
+        ] {
+            assert_eq!(
+                model_output_ceiling("gemini", id),
+                None,
+                "{id} must fail open rather than inherit the text-family window"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Release-time refresh of `model_output_ceiling` against models.dev, vendor rows only — the standing rule in AGENTS.md §11. The automated freshness gate covers `CATALOGUE_CEILINGS` and says so; the `if`-chain families it cannot parse were verified by hand, which is what found these.

Three families had ids with **no arm at all**, so each fell to the `CompactConfig` default and compacted at 200k against a much larger real window:

| family | was | is |
|---|---|---|
| `gpt-5.6`, `-luna`, `-sol`, `-terra` | 400,000 (the 5.x catch) | 128,000 / **1,050,000** |
| `grok-4.20`, `grok-4.3` | no arm → 200k default | 30,000 / **1,000,000** |
| `grok-4.5`, `grok-4.6` | no arm → 200k default | **500,000 / 500,000** |
| `gemini-3.x` text tiers | no arm → 200k default | 65,536 / **1,048,576** |

The Grok outputs are the vendor's own figures, not the conservative under-claim this table uses elsewhere, and that is deliberate: adding an arm **revokes** `should_omit_max_tokens`, so until now these ids sent no `max_tokens` at all and got xAI's natural ceiling. An arm that "errs low" would not be free here — it would be the first thing ever to cut their output.

## What was deliberately NOT changed

* **DeepSeek v4-flash** output stays 8,192 against a 384,000 vendor figure, and **MiniMax M3** stays 128,000 against 512,000. Both are documented decisions, and both are now the same omit-revoking shape as the Grok note — a design question, filed as #1157 rather than changed silently.
* **`claude-sonnet-4-5`**: the `anthropic` vendor row now reads 1,000,000 while every Bedrock / Vertex / reseller row still reads 200,000. `model_output_ceiling` does not read its `_provider` argument, so raising it would ceiling-death a Bedrock user. 200,000 stands until the lookup is provider-aware.

## Verification

Ordering is load-bearing — `grok-4.5` also contains `grok-4` — and is pinned by assertion, not by comment. Both new arms were red-armed:

* reorder the two Grok arms → `grok_4_family_splits_by_version_and_does_not_shadow_grok_3` FAILS
* delete the `gemini-3` arm → `gemini_3_text_family_resolves_and_its_specialty_variants_fail_open` FAILS
* restore → `wcore-config` 809/809, clippy `-D warnings` clean, and the freshness gate self-test reaches PASS/FAIL/REPORT/SKIP.

---

## Also carries the 0.13.9 cut

`[workspace.package] version` 0.13.8 → 0.13.9, `Cargo.lock` regenerated (55 workspace entries move; zero `0.13.8` left), and a `CHANGELOG.md` entry.

The version has to be in the tree before the tag: `release.yml`'s `prepare-release` compares the release core (X.Y.Z with `-rc.N` / `-wayland-<suffix>` stripped) against `[workspace.package] version` and fails a MISMATCHED base, because on 2026-08-04 the workspace still read 0.12.25 while the RC was to be tagged v0.12.26-rc.1 — that would have published a binary whose own `--version` contradicted the signed manifest shipped beside it, with no gate anywhere saying so.

Verified the bump is safe to make here: nothing pins the version string except doc comments (`grep 0.13.8` across `crates/` outside `Cargo.lock` returns four prose references and no fixture). The Desktop contract corpus carries a `version` field on the `ready` frame but does not pin its value.

The changelog also records, in the entry itself, that 0.13.7 and 0.13.8 shipped without one and points at their GitHub releases — better than a file that silently skips two versions.