### PR TITLE
chore: add dependabot.yml and CODE_OF_CONDUCT.md (last two OpenSSF badge gaps)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,32 @@
+# Dependabot version updates for wayland-core.
+#
+# Security updates are enabled separately in repo settings and are NOT governed
+# by this file - a vulnerable dependency raises a PR regardless of the schedule
+# below. This file only controls ROUTINE version bumps.
+#
+# Deliberately conservative: monthly, grouped, and capped. A small team drowning
+# in bot PRs stops reading them, which is worse than updating a month later.
+#
+# Mirrors FerroxLabs/wayland/.github/dependabot.yml, with cargo in place of npm.
+# cargo-deny and OSV already gate advisories in CI; this adds routine currency.
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 5
+    groups:
+      # One PR for all patch/minor bumps. Majors still come in separately so
+      # they get read.
+      routine:
+        update-types: [minor, patch]
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 3
+    groups:
+      actions:
+        update-types: [minor, patch]

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,67 @@
+# Code of Conduct
+
+## Our pledge
+
+We — members, contributors, and maintainers of Wayland — pledge to make
+participation in our community a harassment-free experience for everyone,
+regardless of age, body size, visible or invisible disability, ethnicity, sex
+characteristics, gender identity and expression, level of experience,
+education, socio-economic status, nationality, personal appearance, race,
+religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Taking responsibility, apologizing to those affected by our mistakes, and
+  learning from the experience
+- Focusing on what is best for the community
+
+Examples of unacceptable behavior:
+
+- Sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information (physical or email address) without
+  explicit permission
+- Spamming the issue tracker, Discord, or community channels
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Scope
+
+This Code of Conduct applies within all community spaces — the GitHub
+repository (issues, pull requests, discussions), the Wayland Discord server,
+and any space where someone represents the project — and also applies when an
+individual is officially representing the community in public spaces.
+
+## Enforcement
+
+This is a small, free, open-source project run by a tiny team. We enforce this
+Code of Conduct pragmatically and in good faith.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the maintainers at **sean@tradecanyon.com**. All complaints will be
+reviewed and investigated promptly and fairly. Maintainers are obligated to
+respect the privacy and security of the reporter of any incident.
+
+Maintainers will follow these guidelines in determining consequences:
+
+1. **Correction** — a private warning and clarity about the violation.
+2. **Warning** — consequences for continued behavior; a period of no
+   interaction with those involved.
+3. **Temporary ban** — a temporary ban from community interaction.
+4. **Permanent ban** — for a pattern of violation or egregious behavior.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+[homepage]: https://www.contributor-covenant.org


### PR DESCRIPTION
Closes the last two gaps between wayland-core and the **OpenSSF Best Practices badge**, which is a free, externally recognised credential and the only third-party validation available to us at zero cost.

The working assessment concluded both repos should pass, with five gaps, all administrative. Four are already closed:

| gap | status |
|---|---|
| Dependabot security updates disabled | enabled, both repos |
| Secret scanning disabled | enabled, both repos |
| Push protection disabled | enabled, both repos |
| `v0.12.5` stuck in Draft | deleted, along with five other stale drafts |
| **no `.github/dependabot.yml` on Core** | **this PR** |
| **no `CODE_OF_CONDUCT.md` on Core** | **this PR** |

**`CODE_OF_CONDUCT.md`** is byte-identical to the app repo's, so the two projects report the same policy and the same contact rather than drifting.

**`.github/dependabot.yml`** mirrors the app's file with `cargo` and `github-actions` in place of `npm`: monthly, grouped, capped. Deliberately conservative for the same reason stated in the app's version, that a small team drowning in bot PRs stops reading them. Security updates are governed by the repo setting, not this file, so a vulnerable dependency still raises a PR immediately regardless of the schedule. `cargo-deny` and OSV continue to gate advisories in CI; this only adds routine currency.

No code, no behaviour change.
