### PR TITLE
fix(exec-backend): publish signing seeds atomically and exclusively (wayland#1298)

### DIFF
--- a/.planning/ledger/wayland-1298.md
+++ b/.planning/ledger/wayland-1298.md
@@ -1,0 +1,51 @@
+---
+issue: 1298
+repo: FerroxLabs/wayland
+kind: defect
+title: "Signing seeds are published with a non-atomic write: a torn read refuses permanently, and #1250's recorded root cause is refuted by reproduction"
+status: open
+last_verified_commit: 6e4eca07
+criteria:
+  - id: c1
+    text: "Both seed writers publish through one helper that stages to a per-call temporary file and links it into place, so no reader can observe a partial seed. Measured by a concurrency test that FAILS against the pre-fix body and passes after, not by inspection."
+    state: not-met
+    owner: core
+    note: "Filed 2026-09-03 while regrading #1250. Anchored at 6e4eca07, which does NOT carry the fix, so every criterion is not-met here BY CONSTRUCTION -- the anchor names the tree the grade was taken on, and grading met against a tree without the fix is the defect this ledger exists to prevent. RED ARM ALREADY RUN, against the verbatim pre-fix body at 6e4eca07 with the new tests grafted on: 16 threads on one fresh path, round 0 of 24, `round 0: concurrent first use refused: receipt is invalid: backend signing seed at /tmp/.tmp78v9pY/container.key is not 32 bytes` -- the production signature verbatim. Green arm on the fix branch: 5 passed / 0 failed. Flip to met with a post-merge sync anchored at the merge commit."
+  - id: c2
+    text: "Publication is exclusive: N concurrent first-use callers all return the seed that was actually persisted. Measured by the same test asserting every returned seed equals the file's contents."
+    state: not-met
+    owner: core
+    note: "This criterion was earned the hard way and is NOT redundant with c1. The first attempt at the fix used write-then-rename, which is atomic but not EXCLUSIVE: last writer wins the file, so an earlier racer returns a seed the disk does not have and signs with an identity that changes on its next start. Its own concurrency test caught it (`caller 0 returned a seed that is not the persisted one`). Publication is now `hard_link`, which fails with AlreadyExists rather than overwriting."
+  - id: c3
+    text: "The seed is never reachable under its real name at a mode other than 0600. Measured on unix by reading the published file's mode."
+    state: not-met
+    owner: core
+    note: "The pre-fix order was create-write-chmod, so `fs::write` created the file at the umask default and the private key was world-readable until `set_permissions` ran. The mode is now set on the staging file, before it is reachable under the real name."
+  - id: c4
+    text: "A corrupt (non-32-byte) seed is still refused rather than silently regenerated, and the refusal names the recovery. Measured by a test asserting the message and that the file survives the refusal."
+    state: not-met
+    owner: core
+    note: "Deliberately NOT self-healing: regenerating would rotate an identity behind the operator's back. But once we can no longer PRODUCE a short file, the error means something else corrupted it, and the operator needs to be told that deleting it is the way back. Before this, a crash mid-write bricked that backend permanently with no stated recovery."
+  - id: c5
+    text: "The refuted \"state dir removed by a sibling\" attribution is corrected in every file that asserts it, each naming the torn write instead. Graded by a grep returning zero occurrences of the refuted claim, with a control proving the query matches."
+    state: not-met
+    owner: core
+    note: "CORRECTED SCOPE: FOUR files, not six. The refuted ATTRIBUTION -- 'that is the race that failed conformance_matrix at e37e72f0b ... its state dir had just been removed by a sibling' -- appears in tests/conformance_matrix.rs, tests/container_wedge.rs, tests/container_orphan_scan.rs and tests/live_equivalence.rs. src/registry.rs and tests/fail_closed_matrix.rs were re-read and are NOT wrong: they describe the env var redirecting a sibling's record/load/list calls, which is a real and separate hazard, and neither attributes the seed failure. The issue body said six; that was my overcount and it is corrected here rather than forced to fit. A deleted state dir CANNOT emit `is not 32 bytes`: fs::read fails and control falls through to create-and-write. The criterion requires a control because an empty grep reads exactly like a corrected file."
+  - id: c6
+    text: "The three unguarded fail_closed_matrix.rs tests stop writing into the operator's real config directory during a test run. Graded by a test-env-globals check rather than by inspection."
+    state: not-met
+    owner: core
+    note: "fail_closed_matrix.rs has 13 tests and one StateDirGuard at :564. The tests at :361, :411 and :500 call reference_backends at :364/:414/:502 with no guard, so registry::state_dir() falls through to wayland_config_dir()/exec-backend and all three race the same keys/*.key in the operator's real config dir. Nothing serialises them -- the \"Run serially\" text at :20-21 is prose about a different assertion, and quoting it as a guard would be the doc-comment-as-live-code trap."
+---
+
+# The error string is the evidence
+
+`backend signing seed at <path> is not 32 bytes` has exactly one emitter, and reading that function
+settles the root cause without running anything: the error is reachable only when the file EXISTS
+and reads at a length other than 32. A deleted state dir makes `fs::read` fail, and control falls
+through to create-and-write. So the recorded cause -- a sibling removing the state dir -- cannot
+produce the signature it was written to explain. A torn write can, and does: 16 threads reproduced
+it on the first round against the pre-fix body.
+
+The crate already had the right pattern in `registry::record`, commented "a cancel racing a run must
+never read a half file". The two seed writers were the sites that did not get it.

--- a/crates/wcore-exec-backend/src/backends/mod.rs
+++ b/crates/wcore-exec-backend/src/backends/mod.rs
@@ -382,16 +382,56 @@ pub fn local_node_attribution() -> Option<crate::node::attribution::NodeAttribut
 pub fn load_or_create_seed(backend_id: &str) -> Result<[u8; 32]> {
     crate::contract::validate_identifier("backend_id", backend_id)?;
     let dir: PathBuf = crate::registry::state_dir().join("keys");
-    std::fs::create_dir_all(&dir)?;
     let path = dir.join(format!("{backend_id}.key"));
-    if let Ok(bytes) = std::fs::read(&path) {
+    load_or_create_seed_at(&path, "backend signing seed")
+}
+
+/// Read a persisted 32-byte seed, or generate and publish one ATOMICALLY.
+///
+/// The write is write-then-rename, for the same reason `registry::record`
+/// already is ("a cancel racing a run must never read a half file"): a bare
+/// `fs::write` truncates and then fills, so a concurrent reader inside that
+/// window sees a short file. This is not theoretical for a seed — the length
+/// check below turns a short read into a HARD error rather than a retry, so a
+/// torn write does not merely race, it REFUSES:
+///
+/// ```text
+/// backend signing seed at <path> is not 32 bytes
+/// ```
+///
+/// and after a crash or power loss mid-write it refuses FOREVER, because a
+/// truncated file is never regenerated. Two ordinary wayland-core processes
+/// sharing one machine reach this path concurrently by design — the product
+/// supports independent CLI processes over one state dir — so the window is
+/// reachable in production, not only under a test harness.
+///
+/// The mode is set on the temporary file BEFORE the rename, so the key is
+/// never momentarily world-readable. The previous order — create, write,
+/// then chmod — published a private key at the umask default first.
+///
+/// The temporary name is unique per CALL (pid plus a process-local counter),
+/// so no two writers can collide on the staging file either; `rename(2)` over
+/// an existing path is atomic, so the loser of the race simply publishes an
+/// identical-length file and every reader sees one whole seed or the other,
+/// never a fragment.
+pub(crate) fn load_or_create_seed_at(path: &std::path::Path, what: &str) -> Result<[u8; 32]> {
+    let dir = path.parent().ok_or_else(|| {
+        ExecError::Receipt(format!("{what} path {} has no directory", path.display()))
+    })?;
+    std::fs::create_dir_all(dir)?;
+    if let Ok(bytes) = std::fs::read(path) {
         if bytes.len() == 32 {
             let mut seed = [0u8; 32];
             seed.copy_from_slice(&bytes);
             return Ok(seed);
         }
+        // Kept a hard error rather than silently regenerating: rotating an
+        // identity behind the operator's back is worse than refusing. Now
+        // that we can no longer PRODUCE a short file, this means the file was
+        // corrupted by something else, so the message says how to recover.
         return Err(ExecError::Receipt(format!(
-            "backend signing seed at {} is not 32 bytes",
+            "{what} at {} is not 32 bytes; it is corrupt. Delete it to have a \
+             new identity generated.",
             path.display()
         )));
     }
@@ -400,13 +440,175 @@ pub fn load_or_create_seed(backend_id: &str) -> Result<[u8; 32]> {
         use rand::RngCore as _;
         rand::rngs::OsRng.fill_bytes(&mut seed);
     }
-    std::fs::write(&path, seed)?;
+    // The staging name must be unique per CALL, not per process: two threads
+    // in one process sharing a staging path would tear it exactly as they
+    // would have torn the target, which is the failure this helper exists to
+    // remove.
+    static STAGING_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let ticket = STAGING_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let staging = path.with_extension(format!("key.tmp.{}.{ticket}", std::process::id()));
+    std::fs::write(&staging, seed)?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt as _;
-        let _ = std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600));
+        let _ = std::fs::set_permissions(&staging, std::fs::Permissions::from_mode(0o600));
     }
+    if let Err(error) = std::fs::rename(&staging, path) {
+        let _ = std::fs::remove_file(&staging);
+        return Err(error.into());
+    }
+    // Read back rather than returning the seed we generated. Two processes
+    // reaching first-use together each generate a seed and each rename; the
+    // last rename wins the FILE, so a caller that returned its own seed would
+    // be using an identity the disk does not have and would silently change
+    // identity on its next run. Reading back makes every racer converge on the
+    // one seed that was actually persisted.
+    let published = std::fs::read(path)?;
+    if published.len() != 32 {
+        return Err(ExecError::Receipt(format!(
+            "{what} at {} is not 32 bytes; it is corrupt. Delete it to have a \
+             new identity generated.",
+            path.display()
+        )));
+    }
+    let mut seed = [0u8; 32];
+    seed.copy_from_slice(&published);
     Ok(seed)
+}
+
+/// The atomic-publish contract of [`load_or_create_seed_at`].
+///
+/// These target the helper directly rather than going through
+/// [`load_or_create_seed`], which resolves its path from the process-global
+/// state dir: a test that raced on THAT path would write into whatever state
+/// dir the process happens to have, and its behaviour would depend on which
+/// other tests ran alongside it. Pointing the helper at a `TempDir` makes the
+/// concurrency the only variable.
+#[cfg(test)]
+mod seed_publish_tests {
+    use super::load_or_create_seed_at;
+
+    #[test]
+    fn concurrent_first_use_never_observes_a_partial_seed() {
+        // The wayland#1250 signature. With a bare `fs::write` the target is
+        // truncated and then filled, so a reader inside that window gets a
+        // short file and the length check turns it into a HARD refusal:
+        // `... is not 32 bytes`. Sixteen threads against one fresh path make
+        // that window overlap; the atomic publish removes it.
+        //
+        // Repeated because a single round can miss a race by luck, and a test
+        // that samples a window once is how this class survives.
+        for round in 0..24 {
+            let dir = tempfile::tempdir().expect("tempdir");
+            let path = dir.path().join("container.key");
+            let seeds = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+            let barrier = std::sync::Arc::new(std::sync::Barrier::new(16));
+            std::thread::scope(|scope| {
+                for _ in 0..16 {
+                    let path = path.clone();
+                    let seeds = std::sync::Arc::clone(&seeds);
+                    let barrier = std::sync::Arc::clone(&barrier);
+                    scope.spawn(move || {
+                        // Release them together, or they queue and never race.
+                        barrier.wait();
+                        let seed = load_or_create_seed_at(&path, "backend signing seed")
+                            .unwrap_or_else(|error| {
+                                panic!("round {round}: concurrent first use refused: {error}")
+                            });
+                        seeds.lock().expect("seeds lock").push(seed);
+                    });
+                }
+            });
+            let seeds = seeds.lock().expect("seeds lock");
+            assert_eq!(seeds.len(), 16, "round {round}: every caller must return");
+            // Every racer must end up on the seed that was actually PERSISTED,
+            // or a process is running an identity the disk does not have and
+            // will change identity on its next start.
+            let on_disk = std::fs::read(&path).expect("published seed");
+            assert_eq!(
+                on_disk.len(),
+                32,
+                "round {round}: published seed is 32 bytes"
+            );
+            for (i, seed) in seeds.iter().enumerate() {
+                assert_eq!(
+                    seed.as_slice(),
+                    on_disk.as_slice(),
+                    "round {round}: caller {i} returned a seed that is not the persisted one"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn no_staging_file_survives_a_successful_publish() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("local.key");
+        load_or_create_seed_at(&path, "backend signing seed").expect("first use");
+        let leftovers: Vec<_> = std::fs::read_dir(dir.path())
+            .expect("read dir")
+            .filter_map(|entry| entry.ok().map(|entry| entry.file_name()))
+            .filter(|name| name.to_string_lossy().contains(".tmp."))
+            .collect();
+        assert!(
+            leftovers.is_empty(),
+            "a completed publish must leave no staging file: {leftovers:?}"
+        );
+    }
+
+    #[test]
+    fn a_corrupt_seed_is_refused_with_a_recovery_instruction() {
+        // Kept a hard refusal on purpose: silently regenerating would rotate
+        // an identity behind the operator's back. The message must therefore
+        // say how to recover, because nothing else will.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("ssh.key");
+        std::fs::write(&path, [7u8; 31]).expect("seed a short file");
+        let error = load_or_create_seed_at(&path, "backend signing seed")
+            .expect_err("a 31-byte seed must be refused");
+        let message = error.to_string();
+        assert!(message.contains("is not 32 bytes"), "{message}");
+        assert!(
+            message.contains("Delete it"),
+            "the refusal must be actionable: {message}"
+        );
+        assert_eq!(
+            std::fs::read(&path).expect("still there").len(),
+            31,
+            "refusing must not destroy the file the operator may want to inspect"
+        );
+    }
+
+    #[test]
+    fn an_existing_seed_is_returned_unchanged() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("cloud.key");
+        let existing = [9u8; 32];
+        std::fs::write(&path, existing).expect("seed");
+        let seed = load_or_create_seed_at(&path, "backend signing seed").expect("load");
+        assert_eq!(seed, existing, "an existing identity must never be rotated");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn the_seed_is_never_published_world_readable() {
+        // The mode is set on the staging file BEFORE the rename. The previous
+        // order -- create, write, then chmod -- published a private key at the
+        // umask default first, so a reader in that window could take it.
+        use std::os::unix::fs::PermissionsExt as _;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("local.key");
+        load_or_create_seed_at(&path, "backend signing seed").expect("first use");
+        let mode = std::fs::metadata(&path)
+            .expect("metadata")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(
+            mode, 0o600,
+            "a signing seed must be owner-only, got {mode:o}"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/wcore-exec-backend/src/backends/mod.rs
+++ b/crates/wcore-exec-backend/src/backends/mod.rs
@@ -410,70 +410,75 @@ pub fn load_or_create_seed(backend_id: &str) -> Result<[u8; 32]> {
 /// then chmod — published a private key at the umask default first.
 ///
 /// The temporary name is unique per CALL (pid plus a process-local counter),
-/// so no two writers can collide on the staging file either; `rename(2)` over
-/// an existing path is atomic, so the loser of the race simply publishes an
-/// identical-length file and every reader sees one whole seed or the other,
-/// never a fragment.
+/// so no two writers can collide on the staging file either, and the file is
+/// published with `hard_link`, which is atomic AND exclusive: exactly one
+/// racer creates the identity and every other reads it back.
 pub(crate) fn load_or_create_seed_at(path: &std::path::Path, what: &str) -> Result<[u8; 32]> {
     let dir = path.parent().ok_or_else(|| {
         ExecError::Receipt(format!("{what} path {} has no directory", path.display()))
     })?;
     std::fs::create_dir_all(dir)?;
-    if let Ok(bytes) = std::fs::read(path) {
-        if bytes.len() == 32 {
-            let mut seed = [0u8; 32];
-            seed.copy_from_slice(&bytes);
-            return Ok(seed);
-        }
-        // Kept a hard error rather than silently regenerating: rotating an
-        // identity behind the operator's back is worse than refusing. Now
-        // that we can no longer PRODUCE a short file, this means the file was
-        // corrupted by something else, so the message says how to recover.
-        return Err(ExecError::Receipt(format!(
-            "{what} at {} is not 32 bytes; it is corrupt. Delete it to have a \
-             new identity generated.",
-            path.display()
-        )));
-    }
-    let mut seed = [0u8; 32];
-    {
-        use rand::RngCore as _;
-        rand::rngs::OsRng.fill_bytes(&mut seed);
-    }
     // The staging name must be unique per CALL, not per process: two threads
     // in one process sharing a staging path would tear it exactly as they
-    // would have torn the target, which is the failure this helper exists to
-    // remove.
+    // would have torn the target.
     static STAGING_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
-    let ticket = STAGING_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    let staging = path.with_extension(format!("key.tmp.{}.{ticket}", std::process::id()));
-    std::fs::write(&staging, seed)?;
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt as _;
-        let _ = std::fs::set_permissions(&staging, std::fs::Permissions::from_mode(0o600));
-    }
-    if let Err(error) = std::fs::rename(&staging, path) {
+
+    // Bounded: after our own publish the file exists, so one extra pass is
+    // always enough. The bound exists so that something else deleting the
+    // file in a loop cannot spin here forever.
+    for _ in 0..3 {
+        if let Ok(bytes) = std::fs::read(path) {
+            if bytes.len() == 32 {
+                let mut seed = [0u8; 32];
+                seed.copy_from_slice(&bytes);
+                return Ok(seed);
+            }
+            // Kept a hard refusal rather than silently regenerating: rotating
+            // an identity behind the operator's back is worse than stopping.
+            // Now that we can no longer PRODUCE a short file, this means
+            // something else corrupted it, so the message says how to recover.
+            return Err(ExecError::Receipt(format!(
+                "{what} at {} is not 32 bytes; it is corrupt. Delete it to have a \
+                 new identity generated.",
+                path.display()
+            )));
+        }
+        let mut fresh = [0u8; 32];
+        {
+            use rand::RngCore as _;
+            rand::rngs::OsRng.fill_bytes(&mut fresh);
+        }
+        let ticket = STAGING_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let staging = path.with_extension(format!("key.tmp.{}.{ticket}", std::process::id()));
+        std::fs::write(&staging, fresh)?;
+        #[cfg(unix)]
+        {
+            // Set on the STAGING file, before it is reachable under the real
+            // name. The previous order -- create the target, write, then chmod
+            // -- published a private key at the umask default first.
+            use std::os::unix::fs::PermissionsExt as _;
+            let _ = std::fs::set_permissions(&staging, std::fs::Permissions::from_mode(0o600));
+        }
+        // `hard_link` rather than `rename`, and that difference is the whole
+        // point. Both publish a COMPLETE file, so neither can be read torn.
+        // Only `hard_link` is also EXCLUSIVE: it fails with AlreadyExists
+        // instead of overwriting. Under `rename`, last writer wins the file,
+        // so an earlier racer returns a seed the disk does not have and signs
+        // with an identity that changes on its next start. Here the loser
+        // simply falls through and reads the winner's seed.
+        let published = std::fs::hard_link(&staging, path);
         let _ = std::fs::remove_file(&staging);
-        return Err(error.into());
+        match published {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
+            Err(error) => return Err(error.into()),
+        }
     }
-    // Read back rather than returning the seed we generated. Two processes
-    // reaching first-use together each generate a seed and each rename; the
-    // last rename wins the FILE, so a caller that returned its own seed would
-    // be using an identity the disk does not have and would silently change
-    // identity on its next run. Reading back makes every racer converge on the
-    // one seed that was actually persisted.
-    let published = std::fs::read(path)?;
-    if published.len() != 32 {
-        return Err(ExecError::Receipt(format!(
-            "{what} at {} is not 32 bytes; it is corrupt. Delete it to have a \
-             new identity generated.",
-            path.display()
-        )));
-    }
-    let mut seed = [0u8; 32];
-    seed.copy_from_slice(&published);
-    Ok(seed)
+    Err(ExecError::Receipt(format!(
+        "{what} at {} could not be established: it kept disappearing between \
+         publish and read",
+        path.display()
+    )))
 }
 
 /// The atomic-publish contract of [`load_or_create_seed_at`].

--- a/crates/wcore-exec-backend/src/node/pairing.rs
+++ b/crates/wcore-exec-backend/src/node/pairing.rs
@@ -274,32 +274,10 @@ pub(crate) fn short(s: &str) -> String {
 
 /// Load or create this host's node signing seed, alongside the backend seeds.
 pub fn load_or_create_node_seed() -> Result<[u8; 32]> {
-    let dir = crate::registry::state_dir().join("keys");
-    std::fs::create_dir_all(&dir)?;
-    let path = dir.join("node.key");
-    if let Ok(bytes) = std::fs::read(&path) {
-        if bytes.len() == 32 {
-            let mut seed = [0u8; 32];
-            seed.copy_from_slice(&bytes);
-            return Ok(seed);
-        }
-        return Err(ExecError::Receipt(format!(
-            "node signing seed at {} is not 32 bytes",
-            path.display()
-        )));
-    }
-    let mut seed = [0u8; 32];
-    {
-        use rand::RngCore as _;
-        rand::rngs::OsRng.fill_bytes(&mut seed);
-    }
-    std::fs::write(&path, seed)?;
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt as _;
-        let _ = std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600));
-    }
-    Ok(seed)
+    // Same atomic publish as the backend seeds, through the same helper --
+    // this file carried a byte-identical copy of the torn-write hazard.
+    let path = crate::registry::state_dir().join("keys").join("node.key");
+    crate::backends::load_or_create_seed_at(&path, "node signing seed")
 }
 
 #[cfg(test)]

--- a/crates/wcore-exec-backend/tests/conformance_matrix.rs
+++ b/crates/wcore-exec-backend/tests/conformance_matrix.rs
@@ -17,10 +17,19 @@ use wcore_exec_backend::reference_backends;
 /// and which nextest's process-per-test can never see -- puts every test of
 /// this binary on a thread of ONE process. The env var therefore pointed
 /// every concurrently-running sibling's registry at this `TempDir`, which was
-/// then deleted out from under them when it dropped. That is the race that
-/// failed `conformance_matrix` on ci-linux at e37e72f0b: `reference_backends`
-/// could not construct because its state dir had just been removed by a
-/// sibling finishing first (gh#1233).
+/// then deleted out from under them when it dropped, redirecting their
+/// `record`/`load`/`list` calls (gh#1233).
+///
+/// That redirection is real, and it is why this override exists. It is NOT,
+/// however, what failed `conformance_matrix` on ci-linux at e37e72f0b. That
+/// run's payload was `backend signing seed at <path> is not 32 bytes`, and
+/// reading its one emitter (`backends::load_or_create_seed`) settles it: the
+/// error is reachable ONLY when the file exists and reads at a length other
+/// than 32. A REMOVED state dir makes `fs::read` fail and falls through to
+/// create-and-write, so it cannot produce that string at all. The cause was a
+/// torn `fs::write` seen by a concurrent reader sharing one keys directory --
+/// reproduced on the first round of 16 threads against the pre-fix body, and
+/// fixed by publishing the seed atomically (gh#1298).
 ///
 /// `StateDirGuard` is the per-thread override built for exactly this; see
 /// `registry.rs`, whose doc comment names this defect. `fail_closed_matrix`

--- a/crates/wcore-exec-backend/tests/container_orphan_scan.rs
+++ b/crates/wcore-exec-backend/tests/container_orphan_scan.rs
@@ -27,10 +27,19 @@ use wcore_exec_backend::contract::ExecutionBackend;
 /// and which nextest's process-per-test can never see -- puts every test of
 /// this binary on a thread of ONE process. The env var therefore pointed
 /// every concurrently-running sibling's registry at this `TempDir`, which was
-/// then deleted out from under them when it dropped. That is the race that
-/// failed `conformance_matrix` on ci-linux at e37e72f0b: `reference_backends`
-/// could not construct because its state dir had just been removed by a
-/// sibling finishing first (gh#1233).
+/// then deleted out from under them when it dropped, redirecting their
+/// `record`/`load`/`list` calls (gh#1233).
+///
+/// That redirection is real, and it is why this override exists. It is NOT,
+/// however, what failed `conformance_matrix` on ci-linux at e37e72f0b. That
+/// run's payload was `backend signing seed at <path> is not 32 bytes`, and
+/// reading its one emitter (`backends::load_or_create_seed`) settles it: the
+/// error is reachable ONLY when the file exists and reads at a length other
+/// than 32. A REMOVED state dir makes `fs::read` fail and falls through to
+/// create-and-write, so it cannot produce that string at all. The cause was a
+/// torn `fs::write` seen by a concurrent reader sharing one keys directory --
+/// reproduced on the first round of 16 threads against the pre-fix body, and
+/// fixed by publishing the seed atomically (gh#1298).
 ///
 /// `StateDirGuard` is the per-thread override built for exactly this; see
 /// `registry.rs`, whose doc comment names this defect. `fail_closed_matrix`

--- a/crates/wcore-exec-backend/tests/container_wedge.rs
+++ b/crates/wcore-exec-backend/tests/container_wedge.rs
@@ -26,10 +26,19 @@ use wcore_exec_backend::error::ExecError;
 /// and which nextest's process-per-test can never see -- puts every test of
 /// this binary on a thread of ONE process. The env var therefore pointed
 /// every concurrently-running sibling's registry at this `TempDir`, which was
-/// then deleted out from under them when it dropped. That is the race that
-/// failed `conformance_matrix` on ci-linux at e37e72f0b: `reference_backends`
-/// could not construct because its state dir had just been removed by a
-/// sibling finishing first (gh#1233).
+/// then deleted out from under them when it dropped, redirecting their
+/// `record`/`load`/`list` calls (gh#1233).
+///
+/// That redirection is real, and it is why this override exists. It is NOT,
+/// however, what failed `conformance_matrix` on ci-linux at e37e72f0b. That
+/// run's payload was `backend signing seed at <path> is not 32 bytes`, and
+/// reading its one emitter (`backends::load_or_create_seed`) settles it: the
+/// error is reachable ONLY when the file exists and reads at a length other
+/// than 32. A REMOVED state dir makes `fs::read` fail and falls through to
+/// create-and-write, so it cannot produce that string at all. The cause was a
+/// torn `fs::write` seen by a concurrent reader sharing one keys directory --
+/// reproduced on the first round of 16 threads against the pre-fix body, and
+/// fixed by publishing the seed atomically (gh#1298).
 ///
 /// `StateDirGuard` is the per-thread override built for exactly this; see
 /// `registry.rs`, whose doc comment names this defect. `fail_closed_matrix`

--- a/crates/wcore-exec-backend/tests/fail_closed_matrix.rs
+++ b/crates/wcore-exec-backend/tests/fail_closed_matrix.rs
@@ -360,6 +360,13 @@ fn case_integrity_only_verification_does_not_establish_identity() {
 #[tokio::test]
 async fn case_denied_secret_is_decided_before_execution_and_no_value_can_be_carried() {
     let limits = reference_budget();
+    // `reference_backends` constructs all four backends, and each `::new`
+    // loads or creates its signing seed under `registry::state_dir()`. Without
+    // an override that resolves to the OPERATOR'S REAL config directory, so an
+    // ordinary test run wrote into it and raced the other unguarded tests in
+    // this binary over the same `keys/*.key` (gh#1298).
+    let _state = TempDir::new().unwrap();
+    let _state_dir = wcore_exec_backend::registry::StateDirGuard::set(_state.path());
     let task = reference_task("f25-secret-case", "f25-secret-nonce", limits);
     for reference in reference_backends(limits).unwrap() {
         let policy = reference
@@ -410,6 +417,13 @@ fn case_a_value_shaped_secret_name_is_refused() {
 #[tokio::test]
 async fn case_egress_decision_is_read_from_the_shared_policy_and_never_re_derived() {
     let limits = reference_budget();
+    // `reference_backends` constructs all four backends, and each `::new`
+    // loads or creates its signing seed under `registry::state_dir()`. Without
+    // an override that resolves to the OPERATOR'S REAL config directory, so an
+    // ordinary test run wrote into it and raced the other unguarded tests in
+    // this binary over the same `keys/*.key` (gh#1298).
+    let _state = TempDir::new().unwrap();
+    let _state_dir = wcore_exec_backend::registry::StateDirGuard::set(_state.path());
     let task = reference_task("f25-egress-case", "f25-egress-nonce", limits);
     for reference in reference_backends(limits).unwrap() {
         let policy = reference.backend.effective_policy(&task).unwrap();
@@ -499,6 +513,13 @@ fn case_no_fallback_a_refused_node_does_not_hand_its_work_to_a_healthy_one() {
 #[tokio::test]
 async fn case_no_fallback_an_unavailable_backend_refuses_rather_than_degrading() {
     let limits = reference_budget();
+    // `reference_backends` constructs all four backends, and each `::new`
+    // loads or creates its signing seed under `registry::state_dir()`. Without
+    // an override that resolves to the OPERATOR'S REAL config directory, so an
+    // ordinary test run wrote into it and raced the other unguarded tests in
+    // this binary over the same `keys/*.key` (gh#1298).
+    let _state = TempDir::new().unwrap();
+    let _state_dir = wcore_exec_backend::registry::StateDirGuard::set(_state.path());
     for reference in reference_backends(limits).unwrap() {
         let availability = reference.backend.availability().await;
         if availability.available {

--- a/crates/wcore-exec-backend/tests/live_equivalence.rs
+++ b/crates/wcore-exec-backend/tests/live_equivalence.rs
@@ -15,10 +15,19 @@ use wcore_exec_backend::{ExecutionReceipt, normalized_equivalence, reference_bac
 /// and which nextest's process-per-test can never see -- puts every test of
 /// this binary on a thread of ONE process. The env var therefore pointed
 /// every concurrently-running sibling's registry at this `TempDir`, which was
-/// then deleted out from under them when it dropped. That is the race that
-/// failed `conformance_matrix` on ci-linux at e37e72f0b: `reference_backends`
-/// could not construct because its state dir had just been removed by a
-/// sibling finishing first (gh#1233).
+/// then deleted out from under them when it dropped, redirecting their
+/// `record`/`load`/`list` calls (gh#1233).
+///
+/// That redirection is real, and it is why this override exists. It is NOT,
+/// however, what failed `conformance_matrix` on ci-linux at e37e72f0b. That
+/// run's payload was `backend signing seed at <path> is not 32 bytes`, and
+/// reading its one emitter (`backends::load_or_create_seed`) settles it: the
+/// error is reachable ONLY when the file exists and reads at a length other
+/// than 32. A REMOVED state dir makes `fs::read` fail and falls through to
+/// create-and-write, so it cannot produce that string at all. The cause was a
+/// torn `fs::write` seen by a concurrent reader sharing one keys directory --
+/// reproduced on the first round of 16 threads against the pre-fix body, and
+/// fixed by publishing the seed atomically (gh#1298).
 ///
 /// `StateDirGuard` is the per-thread override built for exactly this; see
 /// `registry.rs`, whose doc comment names this defect. `fail_closed_matrix`


### PR DESCRIPTION
Found while regrading wayland#1250 for 0.13.13. The ticket's own CI signature names a different defect than the one recorded against it.

## The defect

Both seed writers — `backends::load_or_create_seed` and the byte-identical `node::pairing::load_or_create_node_seed` — published a 32-byte Ed25519 seed with a bare `fs::write`. That truncates the target and then fills it, and the length check turns a short read into a **hard refusal** rather than a retry:

```
backend signing seed at <path> is not 32 bytes
```

- **Concurrent first use refuses.** The product supports independent CLI processes over one state dir; all four reference backends call this on construction.
- **A crash mid-write bricks that backend permanently** — a short file is never regenerated, and the message never said that deleting it is the way back.
- **The private key was momentarily world-readable** — `fs::write` created at the umask default and `set_permissions(0o600)` ran afterwards.

## Why it corrects wayland#1250's recorded cause

That string has exactly one emitter, and it is reachable **only** when the file exists and reads at length != 32. A **removed** state dir makes `fs::read` fail and falls through to create-and-write, so it cannot produce that string at all. The recorded cause — *"its state dir had just been removed by a sibling finishing first"* — is refuted by the product's own error text.

**Reproduced, not merely derived.** 16 threads against the verbatim pre-fix body at `6e4eca07`, round 0 of 24:

```
round 0: concurrent first use refused: receipt is invalid:
backend signing seed at /tmp/.tmp78v9pY/container.key is not 32 bytes
```

## The change

One shared helper. Stage to a per-call temporary file (pid + counter — two threads sharing a staging path would tear *it* instead), chmod the staging file **before** it is reachable under the real name, then publish with `hard_link`.

`hard_link` rather than `rename`, and that difference matters: **my first attempt used `rename` and its own test refuted it.** `rename` is atomic but not exclusive, so last writer wins the file and an earlier racer returns a seed the disk does not have — then signs with an identity that changes on its next start. `hard_link` fails with `AlreadyExists` instead of overwriting, so exactly one racer creates the identity and every other reads it back.

The crate already had the right pattern in `registry::record` (*"a cancel racing a run must never read a half file"*). These two sites just never got it.

The refusal stays hard — silently regenerating rotates an identity behind the operator's back — but now names the recovery.

## Also in this PR

- The refuted attribution is corrected in the **four** files that assert it. The issue body said six; it is four. `src/registry.rs` and `fail_closed_matrix.rs` were re-read and are **not** wrong — they describe the env var redirecting a sibling's `record`/`load`/`list` calls, a real and separate hazard. The ledger records the overcount rather than forcing the number to fit.
- Three `fail_closed_matrix.rs` tests (`:361`, `:411`, `:500`) called `reference_backends` with no `StateDirGuard`, so `state_dir()` resolved to the **operator's real config directory** and all three raced the same `keys/*.key` during an ordinary test run. They now take a `TempDir` override.
- `.planning/ledger/wayland-1298.md`, anchored at `6e4eca07` with every criterion `not-met` — that anchor does not carry the fix, and grading `met` against a tree without it is the defect the ledger exists to prevent. A post-merge sync flips them at the merge commit.

## Verification (hetzner, Linux)

| | |
|---|---|
| `cargo test -p wcore-exec-backend --lib` | 108 passed / 0 failed |
| `cargo test -p wcore-exec-backend --test fail_closed_matrix` | 13 passed / 0 failed |
| `cargo clippy -p wcore-exec-backend --all-targets -- -D warnings` | clean |
| `check-criteria-ledger.py` (online) | coverage OK; the only 2 problems are the pre-existing `wayland-core#113` divergences that **PR #420** fixes |
| Red arm | the concurrency test FAILS against the pre-fix body with the production string; the corrupt-seed test also fails there (no recovery hint) |

Refs wayland#1298, wayland#1250.