### PR TITLE
fix(journal): collapse an explicit null Thinking.extra like an absent one (core#425)

### DIFF
--- a/.planning/ledger/wayland-core-425.md
+++ b/.planning/ledger/wayland-core-425.md
@@ -1,0 +1,52 @@
+---
+issue: 425
+repo: FerroxLabs/wayland-core
+kind: defect
+title: "PreparedContentBlockV1::Thinking.extra still uses the pre-23B-H1 Option::is_none skip guard, re-opening the null-collapse class in the provider-request digest preimage"
+status: open
+last_verified_commit: 6e4eca07
+criteria:
+  - id: c1
+    text: "A test builds an LlmRequest whose assistant message carries ContentBlock::Thinking with extra = Some(Value::Null), snapshots it and decodes it. On unmodified 6e4eca07 the decode returns Err whose message is exactly 'prepared provider request snapshot is not canonical' -- asserted on the string, not merely on Err. After the fix it returns Ok. The failing pre-fix run is recorded with its error text."
+    state: not-met
+    owner: core
+    note: "Filed 2026-09-03. Anchored at 6e4eca07, which does NOT carry the fix, so every criterion is not-met here by construction. RED ARM ALREADY RUN, by reverting only the predicate to Option::is_none on the fix branch: `an explicit null extra must survive recovery: invalid journal state transition: prepared provider request snapshot is not canonical` -- the predicted string verbatim. GREEN ARM: 5 passed / 0 failed. The red arm carries its own control: a_tool_use_block_with_an_explicit_null_extra_still_decodes stays OK in the red arm, because ToolUse.extra has no skip_serializing_if at all -- so the red is attributable to the predicate and not to the test harness. Flip with a post-merge sync anchored at the merge commit."
+  - id: c2
+    text: "The fix is the PREDICATE, not the caller: the skip_serializing_if on the Thinking arm no longer names Option::is_none but a predicate true for both None and Some(Value::Null), and to_value -> from_value -> to_value is byte-identical at extra = None, Some(Null) and Some(object). Rejecting a Some(Null) at the writer does NOT satisfy this."
+    state: not-met
+    owner: core
+    note: "Implemented as is_absent_or_explicitly_null, deliberately NOT by reusing model::is_absent_json_value: that one consults LEGACY_EFFECT_RECEIPT_ENCODING so pre-23B-H1 effect_receipt bytes can still be read, and sharing it would make this field's encoding silently revert whenever a legacy receipt is being decoded. The bijection is pinned by a_thinking_block_re_encodes_identically_at_every_shape_of_extra, which fails on the pre-fix predicate at the Some(Null) shape."
+  - id: c3
+    text: "No already-written digest moves: the two currently-reachable shapes encode byte-identically before and after, so no journal on disk becomes unreadable. The existing wayland#1170 backward-compat test passes unmodified."
+    state: not-met
+    owner: core
+    note: "prepared_provider_request_snapshot_keeps_a_thinking_block_without_extra_byte_identical is untouched and passes in BOTH arms -- green and red -- which is exactly the shape of evidence this criterion wants: the fix is invisible to the shapes that already exist on disk."
+  - id: c4
+    text: "No legacy-recovery shim is added, and the reason is proven rather than asserted: every non-test construction site of ContentBlock::Thinking either sets extra: None or builds it via a map that can only yield a JSON object. If any site can yield Some(Value::Null), this criterion FAILS and the ticket escalates to a live defect needing a read-path shim."
+    state: not-met
+    owner: core
+    note: "This criterion also disposed of a mistake in the first cut of the fix's own test, which asserted the decoded message equalled the input -- i.e. that Some(Null) is PRESERVED. It is not, and must not be: preserving it is what would require the shim this criterion forbids. The test now asserts the collapse explicitly (extra decodes as None, and the field never reaches the wire) so a change that quietly starts preserving it has to come past those lines."
+  - id: c5
+    text: "Reachability is stated honestly and not graded by a run that cannot exist. This is LATENT: no producer emits Some(Value::Null) at 6e4eca07, so there is no live end-to-end reproduction and none may be claimed. Any text asserting a user-visible recovery failure fails this criterion."
+    state: not-met
+    owner: core
+    note: "The single production producer builds extra with a map that yields an object or None. What justifies the ticket is that the guard against repeating a known permanent-data-loss defect (23B-01: journals written successfully, never readable again) was the SHAPE of one map at one call site, with no test on the null arm. The three tests are that guard."
+  - id: c6
+    text: "Class sweep, pinned so it can fail later: every Option<serde_json::Value> field carrying a skip_serializing_if whose value reaches a state_payload_digest preimage is enumerated, and each is either null-collapsing or carries an inline comment saying why Option::is_none is safe there. On 6e4eca07 that is four production hits: reducer.rs Thinking.extra, model.rs:745, model.rs:1131 and model.rs:1133. A sweep that does not name all four does not satisfy this."
+    state: not-met
+    owner: core
+    note: "NOT DONE BY THE FIRST PR, deliberately and stated rather than quietly folded in: the PR closes the one hit that was wrong (Thinking.extra) and leaves the sweep as remaining work. model.rs:745 and :1131/:1133 already use is_absent_json_value and are the 23B-H1 remedy sites, so the expected outcome is that they pass -- but 'expected to pass' is not a graded sweep, and recording it as met on that basis is the exact failure this ledger exists to catch."
+---
+
+# The absence of the attribute is what made the sibling safe
+
+`ToolUse.extra` survives `Some(Value::Null)` today, and not because anyone
+handled it. It survives because it carries no `skip_serializing_if` at all, so
+its encoding is already a bijection. `Thinking.extra` carried one, and the
+predicate it named collapsed only half of the values that must collapse.
+
+The failure that follows is not a lost field. `decode_prepared_provider_request_snapshot`
+re-encodes and compares for exact equality, so any divergence becomes a
+permanent `InvalidTransition` refusal of recovery -- the write succeeds and the
+conversation is never readable again. That check is the blast radius, not the
+shield.

--- a/crates/wcore-agent/src/session_journal/reducer.rs
+++ b/crates/wcore-agent/src/session_journal/reducer.rs
@@ -1991,6 +1991,16 @@ struct PreparedMessageV1 {
     timestamp: Option<chrono::DateTime<chrono::Utc>>,
     cache_breakpoint: Option<wcore_types::message::MessageCacheHint>,
 }
+/// `skip_serializing_if` for a field where absence and an explicit null must
+/// encode identically, so that encode -> decode -> encode is a bijection over
+/// the field's whole domain.
+///
+/// Unlike `model::is_absent_json_value` this has no legacy branch, because no
+/// already-written journal can carry the collapsed form of the field that uses
+/// it. See the note on `PreparedContentBlockV1::Thinking::extra`.
+fn is_absent_or_explicitly_null(value: &Option<serde_json::Value>) -> bool {
+    matches!(value, None | Some(serde_json::Value::Null))
+}
 
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(tag = "type", deny_unknown_fields)]
@@ -2023,7 +2033,29 @@ enum PreparedContentBlockV1 {
         /// for every block without metadata, so journals written before this
         /// field existed still decode under `deny_unknown_fields` and no
         /// already-written digest changes.
-        #[serde(default, skip_serializing_if = "Option::is_none")]
+        ///
+        /// The predicate must collapse `Some(Value::Null)` too, and NOT be
+        /// `Option::is_none`. With `is_none`, an explicit null encodes as
+        /// `"extra":null` and decodes back to `Some(Null)`, which re-encodes
+        /// WITHOUT the field -- so the canonicality re-check at
+        /// [`decode_prepared_provider_request_snapshot`] refuses the snapshot
+        /// permanently with "prepared provider request snapshot is not
+        /// canonical". That is the same class as the 23B-H1 `effect_receipt`
+        /// defect (journals written successfully, never readable again),
+        /// remedied there by `is_absent_json_value`. This field was added
+        /// later, for wayland#1170, and never got the remedy. See core#425.
+        ///
+        /// Deliberately NOT `model::is_absent_json_value`: that one consults
+        /// the `LEGACY_EFFECT_RECEIPT_ENCODING` thread-local, which exists so
+        /// journals that already hold the pre-23B-H1 `effect_receipt` bytes
+        /// can be re-read. No journal can hold `"extra":null` for a Thinking
+        /// block, so tying this field to that toggle would make its encoding
+        /// silently revert whenever a legacy receipt is being decoded.
+        ///
+        /// The sibling `ToolUse.extra` needs no predicate at all: it has no
+        /// `skip_serializing_if`, so it round-trips `Some(Null)` already. The
+        /// ABSENCE of the attribute is what makes it safe.
+        #[serde(default, skip_serializing_if = "is_absent_or_explicitly_null")]
         extra: Option<serde_json::Value>,
     },
     #[serde(rename = "image")]

--- a/crates/wcore-agent/tests/session_journal_test/foundation_cases.rs
+++ b/crates/wcore-agent/tests/session_journal_test/foundation_cases.rs
@@ -329,6 +329,76 @@ fn prepared_provider_request_snapshot_keeps_a_thinking_block_without_extra_byte_
         format!("{:?}", request.messages)
     );
 }
+/// core#425. The wayland#1170 test above pins `extra: None`. It does NOT pin
+/// `extra: Some(Value::Null)`, and that is the arm that was wrong: with
+/// `skip_serializing_if = "Option::is_none"` an explicit null encodes as
+/// `"extra":null`, decodes back to `Some(Null)`, and re-encodes WITHOUT the
+/// field -- so recovery's canonicality re-check refuses the snapshot forever.
+///
+/// Same class as the 23B-H1 `effect_receipt` defect: the write succeeds and the
+/// conversation is never readable again. LATENT here -- the one production
+/// producer (`engine.rs`) builds `extra` with a `.map()` that can only yield an
+/// object -- so this test is the guard, not a regression witness.
+#[test]
+fn a_thinking_block_with_an_explicit_null_extra_still_decodes() {
+    let mut request = fully_populated_llm_request();
+    request.messages[0].content = vec![ContentBlock::Thinking {
+        thinking: "reasoning".into(),
+        extra: Some(serde_json::Value::Null),
+    }];
+
+    let snapshot = prepared_provider_request_snapshot(&request).unwrap();
+    // Against the pre-fix predicate this call returns
+    // Err(InvalidTransition("prepared provider request snapshot is not
+    // canonical")). Assert on the message, not merely on Ok: a bare unwrap
+    // would not distinguish this defect from any other decode failure.
+    let restored = decode_prepared_provider_request_snapshot(&snapshot)
+        .unwrap_or_else(|error| panic!("an explicit null extra must survive recovery: {error}"));
+    assert_eq!(
+        format!("{:?}", restored.messages),
+        format!("{:?}", request.messages)
+    );
+}
+
+/// The encoding must be a BIJECTION over the field's whole domain, not merely
+/// survivable at the two shapes a producer happens to emit today.
+#[test]
+fn a_thinking_block_re_encodes_identically_at_every_shape_of_extra() {
+    for extra in [
+        None,
+        Some(serde_json::Value::Null),
+        Some(serde_json::json!({"thoughtSignature": "s"})),
+    ] {
+        let mut request = fully_populated_llm_request();
+        request.messages[0].content = vec![ContentBlock::Thinking {
+            thinking: "reasoning".into(),
+            extra: extra.clone(),
+        }];
+        let once = prepared_provider_request_snapshot(&request).unwrap();
+        let decoded = decode_prepared_provider_request_snapshot(&once)
+            .unwrap_or_else(|error| panic!("extra={extra:?} did not decode: {error}"));
+        let twice = prepared_provider_request_snapshot(&decoded).unwrap();
+        assert_eq!(once, twice, "extra={extra:?} does not re-encode identically");
+    }
+}
+
+/// The sibling arm, pinned so nobody "tidies" a `skip_serializing_if` onto it.
+/// `ToolUse.extra` is safe precisely BECAUSE it has no such attribute; adding
+/// `Option::is_none` there would reproduce core#425 one field over.
+#[test]
+fn a_tool_use_block_with_an_explicit_null_extra_still_decodes() {
+    let mut request = fully_populated_llm_request();
+    request.messages[0].content = vec![ContentBlock::ToolUse {
+        id: "call-1".into(),
+        name: "Read".into(),
+        input: serde_json::json!({"path": "/tmp/x"}),
+        extra: Some(serde_json::Value::Null),
+    }];
+    let snapshot = prepared_provider_request_snapshot(&request).unwrap();
+    decode_prepared_provider_request_snapshot(&snapshot)
+        .unwrap_or_else(|error| panic!("ToolUse extra=null must survive recovery: {error}"));
+}
+
 #[test]
 fn prepared_provider_request_snapshot_rejects_unknown_structural_fields() {
     let request = LlmRequest {

--- a/crates/wcore-agent/tests/session_journal_test/foundation_cases.rs
+++ b/crates/wcore-agent/tests/session_journal_test/foundation_cases.rs
@@ -354,9 +354,25 @@ fn a_thinking_block_with_an_explicit_null_extra_still_decodes() {
     // would not distinguish this defect from any other decode failure.
     let restored = decode_prepared_provider_request_snapshot(&snapshot)
         .unwrap_or_else(|error| panic!("an explicit null extra must survive recovery: {error}"));
+
+    // The null COLLAPSES to absent, deliberately, and that is the whole fix:
+    // both shapes now encode the same way, so the re-check cannot disagree
+    // with the writer. Restoring `Some(Null)` on the way out would need a
+    // recovery shim like `restore_explicit_null_receipt`, and none is owed
+    // here -- `extra` is built by us as an object or None (engine.rs), never
+    // echoed raw from a provider, so a null in it carries no information to
+    // preserve. Asserting the collapse rather than eliding it, so a future
+    // change that quietly starts preserving it has to come past this line.
+    let ContentBlock::Thinking { extra, .. } = &restored.messages[0].content[0] else {
+        panic!("expected a thinking block, got {:?}", restored.messages[0].content[0]);
+    };
     assert_eq!(
-        format!("{:?}", restored.messages),
-        format!("{:?}", request.messages)
+        extra, &None,
+        "an explicit null must decode as absent, not be preserved"
+    );
+    assert!(
+        !serde_json::to_string(&snapshot).unwrap().contains("extra"),
+        "an explicit null must not reach the wire at all"
     );
 }
 


### PR DESCRIPTION
**Latent, not live.** Stated up front so nobody grades this on a reproduction that cannot exist.

## The defect

`reducer.rs` `PreparedContentBlockV1::Thinking.extra` carried `skip_serializing_if = "Option::is_none"`. With that predicate `Some(Value::Null)` encodes as `"extra":null`, decodes back to `Some(Null)`, and re-encodes **without** the field — so the canonicality re-check in `decode_prepared_provider_request_snapshot` refuses the snapshot permanently.

That check is an exact `Value` equality. It does not protect this path; it converts any re-encode divergence into a permanent `InvalidTransition`. Same class as 23B-01 (`effect_receipt`): **the write succeeds and the conversation is never readable again.**

That one was remedied with `is_absent_json_value`. This field arrived later, with the wayland#1170 fix, and never got the remedy — and #1170's own test pins `extra: None` only, so the wrong arm was never exercised.

The sibling `ToolUse.extra` survives the identical value **because it has no `skip_serializing_if` at all.** The absence of the attribute is what makes it safe.

## Verification — red arm, green arm, and a control inside the red arm

Red arm (only the predicate reverted to `Option::is_none`, tests unchanged):

```
test a_thinking_block_with_an_explicit_null_extra_still_decodes ... FAILED
test a_thinking_block_re_encodes_identically_at_every_shape_of_extra ... FAILED
test a_tool_use_block_with_an_explicit_null_extra_still_decodes ... ok      <-- control
test prepared_provider_request_snapshot_keeps_a_thinking_block_without_extra_byte_identical ... ok

an explicit null extra must survive recovery: invalid journal state transition:
  prepared provider request snapshot is not canonical
```

The predicted string, verbatim. The `ToolUse` test staying **ok** in the same red arm is the control: the red is attributable to the predicate, not to the harness. And the wayland#1170 backward-compat test passes in **both** arms — the fix is invisible to the shapes already on disk.

Green arm: **5 passed / 0 failed.**

## A correction inside this PR

My first version of the null-arm test asserted the decoded messages equalled the input — i.e. that `Some(Null)` is *preserved*. It is not, and must not be: preserving it needs a recovery shim like `restore_explicit_null_receipt`, which is exactly what c4 forbids since no journal can hold those bytes. `extra` is built by us as an object or `None` and never echoed raw from a provider, so a null in it carries nothing to preserve. The test now asserts the collapse **explicitly**, plus that the field never reaches the wire.

## Why a new predicate rather than reusing `is_absent_json_value`

That one consults `LEGACY_EFFECT_RECEIPT_ENCODING` so pre-23B-H1 receipt bytes can still be read. No journal can hold `"extra":null` for a Thinking block, so sharing it would make this field's encoding silently revert whenever a legacy receipt is being decoded.

## What this PR does NOT do

**c6, the class sweep, is left open on purpose** rather than quietly folded in. `model.rs:745`, `:1131` and `:1133` already use `is_absent_json_value` and are expected to pass — but "expected to pass" is not a graded sweep, and recording it met on that basis is the exact failure this ledger exists to catch.

## Not filed: the finding this came from

The v0.13.12 commit's line *"state_payload_digest sites still rest on that assumption"* was read as a float-parsing residual. **That reading is wrong.** Exactly one `serde_json` (1.0.150) resolves and `Cargo.toml:236` carries `float_roundtrip`, so `parse(encode(f64))` is identity everywhere the digest runs. Three independent lenses converged there, and a census dispute was settled against the tree. This is the narrower thing that survived.

Refs core#425.