### PR TITLE
release: cut 0.13.13, and repoint five anchors the rebase orphaned

### DIFF
--- a/.planning/ledger/wayland-1254.md
+++ b/.planning/ledger/wayland-1254.md
@@ -4,7 +4,7 @@ repo: FerroxLabs/wayland
 kind: defect
 title: "preflight.sh prints PRE-FLIGHT PASSED on a tree CI reds: a gate's self-disclosed downgrade is discarded on the success path"
 status: closed
-last_verified_commit: 77af7f9e6
+last_verified_commit: 6d5be540b
 criteria:
   - id: c1
     text: "On a shallow clone of a tree whose full-clone python3 scripts/check-criteria-ledger.py --offline is EXIT=1, bash scripts/preflight.sh does NOT exit 0 and does NOT print PRE-FLIGHT PASSED"

--- a/.planning/ledger/wayland-1291.md
+++ b/.planning/ledger/wayland-1291.md
@@ -4,7 +4,7 @@ repo: FerroxLabs/wayland
 kind: defect
 title: "report-gate wiring: 5 self-test assertions fail on integ/f13; build-darwin-selfhosted is aggregated by nothing"
 status: closed
-last_verified_commit: ec2808a27
+last_verified_commit: 48e74f447
 criteria:
   - id: c1
     text: "The report job's aggregate gate grades the set it depends on by construction rather than by a hand-written list, every ci.yml job is either aggregated or declared not-aggregated, and the gate's prerequisites carry the gate's own admission."

--- a/.planning/ledger/wayland-1302.md
+++ b/.planning/ledger/wayland-1302.md
@@ -4,7 +4,7 @@ repo: FerroxLabs/wayland
 kind: defect
 title: "The credential-store timeout tells the operator to repair a keyring that is not broken - 104 reproductions with a healthy store"
 status: open
-last_verified_commit: b68f9c1b4
+last_verified_commit: cdf6f4d03
 criteria:
   - id: c1
     text: "The timeout distinguishes 'the store answered slowly or refused' from 'the wait expired without the store being reached', and says which. Graded by a test that drives both and asserts the two messages differ."

--- a/.planning/ledger/wayland-1303.md
+++ b/.planning/ledger/wayland-1303.md
@@ -4,7 +4,7 @@ repo: FerroxLabs/wayland
 kind: defect
 title: "Windows: a racing chunked credential write fails outright with ACCESS_DENIED (os error 5), and the caller loses a single-use refresh token"
 status: open
-last_verified_commit: 8c22e968e
+last_verified_commit: 342a93ccf
 criteria:
   - id: c1
     text: "The Windows file operation that answers ERROR_ACCESS_DENIED is identified BY FRAME rather than inferred, and the answer distinguishes lock acquisition from manifest publish."

--- a/.planning/ledger/wayland-core-414.md
+++ b/.planning/ledger/wayland-core-414.md
@@ -4,7 +4,7 @@ repo: FerroxLabs/wayland-core
 kind: defect
 title: "gate-admission.py fails 5 of its own assertions on the shipping branch, and has for some time"
 status: closed
-last_verified_commit: ec2808a27
+last_verified_commit: 48e74f447
 criteria:
   - id: c1
     text: "Each of the five failing assertions is either FIXED, or declared with the reason it is permanently inapplicable -- decided one at a time, not waved through as a block."

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9033,7 +9033,7 @@ dependencies = [
 
 [[package]]
 name = "wayland-browser"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "async-trait",
  "inventory",
@@ -9050,7 +9050,7 @@ dependencies = [
 
 [[package]]
 name = "wayland-cua"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "async-trait",
  "inventory",
@@ -9067,7 +9067,7 @@ dependencies = [
 
 [[package]]
 name = "wayland-honcho"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9088,7 +9088,7 @@ dependencies = [
 
 [[package]]
 name = "wayland-ijfw"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9108,7 +9108,7 @@ dependencies = [
 
 [[package]]
 name = "wayland-ollama"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "async-trait",
  "futures",
@@ -9129,7 +9129,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-acp"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "async-trait",
  "axum",
@@ -9152,7 +9152,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-agent"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9251,7 +9251,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-agents-pack"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "dirs",
  "serde",
@@ -9264,7 +9264,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-browser"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9300,7 +9300,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-budget"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "chrono",
  "fd-lock",
@@ -9315,7 +9315,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-discord"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9337,7 +9337,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-email"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9361,7 +9361,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-imessage"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9378,7 +9378,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-matrix"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9398,7 +9398,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-msteams"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -9419,7 +9419,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-signal"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9435,7 +9435,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-slack"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9458,7 +9458,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-sms"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -9481,7 +9481,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-telegram"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9500,7 +9500,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channel-whatsapp"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9524,7 +9524,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channels"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9544,7 +9544,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-channels-registry"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "dirs",
  "hex",
@@ -9575,7 +9575,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-cli"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9670,7 +9670,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-compact"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "regex",
  "serde",
@@ -9679,7 +9679,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-config"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "anyhow",
  "argon2",
@@ -9723,7 +9723,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-cron"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9740,7 +9740,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-cua"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9776,7 +9776,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-dispatch"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "rand 0.9.4",
  "rand_distr",
@@ -9789,7 +9789,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-egress"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "async-trait",
  "http 1.4.1",
@@ -9804,7 +9804,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-eval"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "rstest",
  "serde",
@@ -9821,7 +9821,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-eval-scenarios"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "anyhow",
  "axum",
@@ -9854,7 +9854,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-evolve"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9885,7 +9885,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-exec-backend"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -9917,7 +9917,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-gateway"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9937,7 +9937,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-honcho-adapter"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "async-trait",
  "serde",
@@ -9953,7 +9953,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-mcp"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9981,7 +9981,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-memory"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10023,7 +10023,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-observability"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "chrono",
  "opentelemetry",
@@ -10047,7 +10047,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-permissions"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "anyhow",
  "chrono",
@@ -10067,7 +10067,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-plugin-api"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10094,7 +10094,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-plugin-subprocess"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "anyhow",
  "serde",
@@ -10115,7 +10115,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-plugin-wasm"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10137,7 +10137,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-pluginsrc"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "serde",
  "serde_json",
@@ -10152,7 +10152,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-pricing"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "chrono",
  "dirs",
@@ -10172,7 +10172,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-protocol"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "rstest",
  "serde",
@@ -10188,7 +10188,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-providers"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10224,7 +10224,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-replay"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "serde",
  "serde_json",
@@ -10235,7 +10235,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-repomap"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "ignore",
  "regex",
@@ -10250,7 +10250,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-safety"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -10264,7 +10264,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-sandbox"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "async-trait",
  "bollard",
@@ -10291,7 +10291,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-skills"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10330,7 +10330,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-swarm"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "dunce",
  "fd-lock",
@@ -10356,7 +10356,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-tools"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10411,7 +10411,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-types"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "async-trait",
  "chrono",
@@ -10426,7 +10426,7 @@ dependencies = [
 
 [[package]]
 name = "wcore-user-model"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "async-trait",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,7 +152,7 @@ members = [
 exclude = ["templates/**", "examples/**"]
 
 [workspace.package]
-version = "0.13.12"
+version = "0.13.13"
 edition = "2024"
 rust-version = "1.95"
 license = "Apache-2.0"


### PR DESCRIPTION
Two commits: the re-anchor that unblocks the release gate, and the 0.13.13 version bump.

## 1. Five ledger anchors, orphaned by the rebase merge

`--rebase` rewrites every SHA, so a `last_verified_commit` set on a branch **cannot survive its own merge**. Five ledgers named branch-side commits that are not ancestors of `main`.

This was invisible on #452 and would have failed `prepare-release`, because `ci.yml` runs the ledger checker `--offline` while `release.yml:124` runs it **live**. The offline arm suppresses exactly this.

| ledger | was | now |
|---|---|---|
| `wayland-1254` | `77af7f9e6` | `6d5be540b` |
| `wayland-1291` | `ec2808a27` | `48e74f447` |
| `wayland-core-414` | `ec2808a27` | `48e74f447` |
| `wayland-1302` | `b68f9c1b4` | `cdf6f4d03` |
| `wayland-1303` | `8c22e968e` | `342a93ccf` |

Each verified two ways: an ancestor of HEAD, **and** carrying the claim it anchors — the clone-depth guard in `preflight.sh`, `gate-admission.py:438`, `KeyStoreReach`, and `classify_create_denial` respectively.

## 2. Cut 0.13.13

`[workspace.package] version` 0.13.12 → 0.13.13, plus the 55 lock entries tracking it.

This is the commit that makes the gate grade **this** release. `check-release-readiness.py` derives its milestone from the workspace version, so it was correctly grading 0.13.12 — the tree still *was* 0.13.12 — but would have stayed pinned there after a cut.

## Release gates at 0.13.13, before this was pushed

```
check-release-readiness.py     RC=0   0 outstanding, 41 tracked under 0.13.14
check-criteria-ledger.py LIVE  RC=0   both trackers fully covered, full clone
check-model-limits-freshness   RC=0   PASS
cargo fmt --all -- --check                                  RC=0
cargo clippy --workspace --all-targets --all-features       RC=0
cargo clippy --target x86_64-pc-windows-gnu --all-targets   RC=0
scripts/preflight.sh --self-test                            RC=0   both directions proven
cargo nextest run --workspace --profile ci                  RC=0
cargo test --workspace --lib                                RC=0
```

## How the 41 were cleared

Per-issue triage in `.planning/triage/TRIAGE-0.13.13.md`, applying: *who absorbs the pain?* An independent adversarial audit that set out to block this release returned an **empty stop-list on user impact**.

Both user-facing ship-blockers were **fixed, not deferred** — `wayland#1302` and `#1303` ship in this release. Their issues stay open in 0.13.14 because individual criteria remain (a different error-collapse wire; Windows CI coverage), not because the defects remain.

The 8 "already fixed" issues were **deferred rather than graded `met`**. Deferred issues are a `NOTE`, not a block, so the gate outcome is identical with zero fabrication risk — their criteria ask for things like "a rate measured at n≥20 on the CI image" that a mechanism fix does not satisfy.

## Known, flagged, not fixed

`core#368` passes through a handoff hole: its criteria are carried by `core#410`, which is open but milestoned **0.13.12** — a shipped release. The gate checks the carrier exists and is open, never its milestone, so it prints "0 handed to another lane with nothing tracking the remainder". **That line is not evidence.** Not user harm and not a blocker, but it is a real hole and wants its own ticket.
