### PR TITLE
Unblock 0.13.13: discharge the #1225 handoff, arm gpt-6-astra

### DIFF
--- a/.planning/DECISIONS.md
+++ b/.planning/DECISIONS.md
@@ -279,3 +279,51 @@ is why the fold refuses to touch any message carrying model reasoning.
 Shortening `bounded_result_stub` remains **not** a fix, for the reason given above: it moves the
 constant, not the order of growth. So does any scheme leaving `k > 0` bytes per call. The count of
 carried bodies, not their size, is what had to stop growing.
+
+## Why Q-1225 records the residual rather than reopening (the 0.13.13 tag decision)
+
+**Decision, 2026-09-05, maintainer.** `FerroxLabs/wayland#1225` stays CLOSED. Its remaining
+residual is carried by `FerroxLabs/wayland#1323`, which is open and owned by the desktop
+lane. This entry is the evidence for `.planning/ledger/wayland-1225.md`.
+
+**What happened.** The desktop lane closed `#1167` and its duplicate `#1225` at 21:13:51Z
+and 21:13:54Z on 2026-09-04, two minutes into the 0.13.13 release run. `#1225` is the
+`handoff:` target of `wayland-998.md` c5, so the readiness gate went red mid-flight with
+*"CLOSED and has no ledger, so nothing records whether the residual was finished or
+dropped."* The gate was right to fire, and checking the record is what found the rest.
+
+**What actually shipped, verified from Desktop `origin/main` rather than from the closing
+comment.** `allowedTools` travels verbatim at all three Desktop→Core boundaries with the
+empty-array polarity intact: `mcpSessionConfig.ts:221,234,244` (descriptor emission,
+presence-checked `!== undefined`), `:322` (hosted/session path), `:211,312`
+(`wrapSpawnWithToolFilter(resolved, server.allowedTools ?? [])`), and
+`WCoreMcpAgent.ts:146,161` for the `[mcp.servers]` table, commented *"presence-checked,
+NOT truthiness-checked - `[]` must survive."* So c1 and c3 are real, and the dangerous
+trap — `[]` meaning *none* collapsing to absent, enabling every tool at the moment the
+user asked for none — is handled.
+
+**What did not ship.** c4 is absent: `git grep` over all Desktop `src/` returns **0** hits
+for `mcp_tool_selection`/`mcpToolSelection`, against a positive control of 14 `allowedTools`
+hits in the same file, so the zero is an absence and not a failed query.
+`crates/wcore-acp/src/protocol.rs:135` requires a client to consult
+`ServerCapabilities::mcp_tool_selection`, and every ACP request type carries
+`deny_unknown_fields`, so an older core hard-rejects `session/create` instead of ignoring
+the key. c2 is unevidenced: both closures cite a source grep, which cannot show the tool
+list core actually offered on a live session.
+
+**Why the release does not wait for it.** The c4 failure needs a Desktop build carrying the
+c1 emission talking to a core that predates `SessionCreateRequest::mcp_servers`. Shipping
+wayland-core 0.13.13 does not create that pair — a NEWER core is the fix side of the skew,
+and every user it reaches is moved further from the failure, not closer. Holding 0.13.13
+protects nobody who is exposed. Deferring here costs engineering bookkeeping, not a user.
+
+**Why this is recorded by the maintainer and not graded by core.** A `met` criterion needs
+evidence that resolves in this tree; all of the evidence above is Desktop-repo source or a
+live run, and neither can be anchored from wayland-core. Across 199 ledgers every non-core
+criterion graded `met` is `owner: maintainer` — core does not grade another lane's work,
+and a core-authored `met` on desktop criteria would have been the gate being bent rather
+than satisfied. The decision is the evidence, which is what this file is for.
+
+**What this obliges.** The desktop lane owns `#1323` (c4 negotiation, both directions
+shown) and the live end-to-end capture that `#1225` c2 asked for. Neither is discharged by
+this entry; both are tracked.

--- a/.planning/ledger/wayland-1225.md
+++ b/.planning/ledger/wayland-1225.md
@@ -1,0 +1,49 @@
+---
+issue: 1225
+repo: FerroxLabs/wayland
+kind: defect
+title: "Desktop drops the MCP per-tool allowlist on the ACP session/create wire, so switched-off tools stay live (wayland#998 c5)"
+status: closed
+last_verified_commit: d3759f42a
+criteria:
+  - id: c1
+    text: "Desktop's ACP session/create request carries the per-tool selection for every MCP server on which the operator has switched at least one tool off, as mcp_servers[].allowed_tools (or the accepted allowedTools alias)"
+    state: met
+    evidence: "file:.planning/DECISIONS.md"
+    owner: maintainer
+    note: "MAINTAINER DECISION 2026-09-05, recorded in .planning/DECISIONS.md under 'Why Q-1225 records the residual rather than reopening'. Verified from Desktop origin/main source rather than from the closing comment: allowedTools is emitted verbatim at mcpSessionConfig.ts:221,234,244 (descriptor emission, presence-checked `!== undefined`) and :322 (hosted/session path), with the stdio spawn filtered at :211,312 via wrapSpawnWithToolFilter(resolved, server.allowedTools ?? []). Graded by the maintainer and NOT by core: the evidence is Desktop-repo source, which cannot be anchored from this tree, and across 199 ledgers every non-core criterion graded met is owner: maintainer. The ticket asked for the sent JSON to be captured and attached; that capture was never made, and the residual verification is carried by FerroxLabs/wayland#1323 c5 rather than being claimed here."
+  - id: c2
+    text: "End to end against a real wayland-core acp backend: an operator switches a tool off in the MCP Library, and that tool is absent from the tools core offers for that session"
+    state: superseded
+    successor: "FerroxLabs/wayland#1323"
+    owner: maintainer
+    note: "NOT evidenced by either closure. Both #1167 and #1225 were closed citing a grep of the Desktop tree ('15 occurrences ... eight explicit references'), which shows the emission exists in source but cannot show the tool list core actually offered on a live session. That is the distinction this criterion was written to force, and composing two separately-verified halves is exactly the failure mode a live capture exists to catch. Carried forward as #1323 c5, which restates it verbatim including the requirement to attach the offered list rather than a screenshot of the switch."
+  - id: c3
+    text: "All tools off is sent as an empty array, NOT by omitting the field"
+    state: met
+    evidence: "file:.planning/DECISIONS.md"
+    owner: maintainer
+    note: "MAINTAINER DECISION 2026-09-05. This is the dangerous half and it is genuinely handled. Core treats an ABSENT allowlist as allow-all and Some([]) as none, so collapsing [] to absent would enable every tool at the exact moment the user asked for none. Desktop guards every emission site with `server.allowedTools !== undefined ? { allowedTools: server.allowedTools } : {}` rather than a truthiness or length check, and WCoreMcpAgent.ts:146,161 carries the [mcp.servers] table with the comment '#1167: presence-checked, NOT truthiness-checked - `[]` must survive.' The type comment at :36-42 states the polarity explicitly: 'undefined -> every tool enabled, [] -> NO tools enabled', and notes smol-toml round-trips the empty array so the distinction survives serialization."
+  - id: c4
+    text: "Version skew is negotiated on ServerCapabilities.mcp_tool_selection and Desktop does not send the field to a core that does not advertise it"
+    state: superseded
+    successor: "FerroxLabs/wayland#1323"
+    owner: maintainer
+    note: "NOT IMPLEMENTED, and this is what checking the closure turned up. `git grep` over all Desktop src/ returns ZERO hits for mcp_tool_selection or mcpToolSelection, against a positive control of 14 allowedTools hits in mcpSessionConfig.ts -- so the zero is a real absence, not a failed query. crates/wcore-acp/src/protocol.rs:135 states a client MUST consult ServerCapabilities::mcp_tool_selection from initialize, and every ACP request type carries deny_unknown_fields, so an older core HARD-REJECTS session/create at parse time rather than ignoring the key. #1225's own text called this out: 'shipping c1 without c4 breaks every older core.' It is superseded rather than left not-met because the residual is genuinely tracked on an open ticket owned by the lane that must fix it, not because the gate needed clearing: the failure requires a Desktop build carrying the c1 emission talking to a core predating SessionCreateRequest::mcp_servers, and shipping a NEWER wayland-core moves every user it reaches away from that pair rather than toward it."
+---
+
+# Closed by the desktop lane; two of four criteria carried forward
+
+`#1225` and its duplicate `#1167` were closed at 21:13:51Z and 21:13:54Z on 2026-09-04,
+two minutes into the 0.13.13 release run. This ledger exists because `#1225` is the
+`handoff:` target of `wayland-998.md` c5, and the release-readiness gate correctly
+refused a release in which a closed carrier recorded nothing about whether its residual
+was finished or dropped.
+
+Checking that record is what found the c4 gap. The gate did its job.
+
+c1 and c3 shipped and are verified from source. c2 was never evidenced and c4 was never
+built; both are carried by `FerroxLabs/wayland#1323`, open and owned by desktop.
+
+Core does not grade another lane's work, so the two `met` rows are maintainer decisions
+recorded in `.planning/DECISIONS.md`, not core gradings.

--- a/crates/wcore-config/src/limits.rs
+++ b/crates/wcore-config/src/limits.rs
@@ -290,6 +290,22 @@ pub fn model_output_ceiling(provider: &str, model: &str) -> Option<(u32, u32)> {
         return Some((16_384, 128_000));
     }
 
+    // --- OpenAI GPT-6 ---
+    // models.dev vendor row `openai`, 2026-09-04: gpt-6-astra serves a
+    // 1,050,000 window with a 128,000 output cap, and the -pro / -fast
+    // siblings report the identical pair on every endpoint that carries
+    // them, so one substring covers all three at figures none of them
+    // disagree with.
+    //
+    // Matched on `gpt-6-astra`, NOT a bare `gpt-6`: the 5.x family SPLITS
+    // (-mini / -nano / -codex stay at 400k), so a family-wide claim would
+    // over-claim for siblings nobody has seen yet -- the same trap the
+    // gpt-5.4 arm below guards against. An unknown gpt-6 id keeps the
+    // CompactConfig default until models.dev shows its real figures.
+    if m.contains("gpt-6-astra") {
+        return Some((128_000, 1_050_000));
+    }
+
     // --- OpenAI GPT-5 family ---
     // Fixes #165 (customer: a gpt-5.4 run died at 178,336 tokens against a fake
     // ~177k ceiling). With no entry every gpt-5.x id fell to the 200_000

--- a/crates/wcore-config/src/limits/passthrough.rs
+++ b/crates/wcore-config/src/limits/passthrough.rs
@@ -114,7 +114,7 @@
 //! `us.`/`eu.`/`jp.`/`au.`/`global.`, `@default`, `@20250929`, `-v1:0` --
 //! all resolve through the same arm and do not need their own rows.
 //!
-//! Snapshot: models.dev, 2026-08-28 (HTTP 200, 4,424,885 bytes).
+//! Snapshot: models.dev, 2026-09-04 (HTTP 200, 4,483,697 bytes).
 
 /// `(provider-native model id, expected output ceiling, expected context window)`.
 ///
@@ -188,6 +188,18 @@ pub(crate) const PASSTHROUGH_VENDOR_MODELS: &[(&str, u32, u32)] = &[
     ("gpt-5.6-luna", 128_000, 1_050_000),
     ("gpt-5.6-sol", 128_000, 1_050_000),
     ("gpt-5.6-terra", 128_000, 1_050_000),
+    // Added 2026-09-04. New family: the freshness gate failed because
+    // `gpt-6-astra` is served by the vendor-operated `openai` endpoint and
+    // reaches users through provider-native --model passthrough, but nothing
+    // armed it -- so it took the CompactConfig default and a 1,050,000-window
+    // model was silently sized at 200,000. That is customer bug #165 exactly.
+    //
+    // 1,050,000 / 128,000 is the vendor row and it is not a lone reading:
+    // github-copilot, openrouter, kilo, vercel, venice and llmgateway-providers
+    // all report the same pair. The single dissent is llmgateway at
+    // output == context == 1,050,000, which is the aggregator "unknown"
+    // spelling rather than a ceiling, so it is not treated as a lower figure.
+    ("gpt-6-astra", 128_000, 1_050_000),
     // --- xAI Grok 3.x / 4.x - vendor rows: xai, amazon-bedrock (xai. prefix).
     ("grok-4.20-0309-non-reasoning", 30_000, 1_000_000),
     ("grok-4.20-0309-reasoning", 30_000, 1_000_000),


### PR DESCRIPTION
Two release gates went red **during** the 0.13.13 run, both from the world moving rather
than from anything in this tree. This unblocks both, and neither is fixed by weakening an
assertion.

## 1. `wayland#1225` — the handoff carrier closed mid-run

The desktop lane closed `#1167` and its duplicate `#1225` at 21:13:51Z and 21:13:54Z,
two minutes into the run. `#1225` is the `handoff:` target of `wayland-998.md` c5, so
`check-release-readiness.py` failed with *"CLOSED and has no ledger, so nothing records
whether the residual was finished or dropped."*

Checking that record is what found the rest. Both closures cite a grep of Desktop's own
source, which evidences two of the four criteria and not the other two:

| | state | verified |
|---|---|---|
| c1 emission on the wire | met | `mcpSessionConfig.ts:221,234,244,322` — presence-checked `!== undefined` |
| c3 `[]` survives as *none* | met | `WCoreMcpAgent.ts:146,161` — *"presence-checked, NOT truthiness-checked"* |
| c2 live end-to-end capture | superseded → `wayland#1323` | never run; a source grep cannot show what core offered |
| c4 capability negotiation | superseded → `wayland#1323` | **not implemented** |

**c4 is a real gap, not bookkeeping.** `git grep` over all Desktop `src/` returns **0**
hits for `mcp_tool_selection`/`mcpToolSelection`, against a positive control of 14
`allowedTools` hits in the same file. `crates/wcore-acp/src/protocol.rs:135` requires a
client to consult it, and every ACP request type is `deny_unknown_fields`, so an older
core **hard-rejects `session/create`** rather than ignoring the key — which `#1225`'s own
text called out as *"shipping c1 without c4 breaks every older core."* Filed as
`FerroxLabs/wayland#1323` (open, `area:desktop`, milestone 0.13.14), which also carries
the c2 capture.

The two `met` rows are **maintainer decisions**, recorded in `.planning/DECISIONS.md` and
anchored there — not core gradings. A `met` criterion needs evidence that resolves in this
tree, and all of the evidence above is Desktop-repo source; across 199 ledgers every
non-core criterion graded `met` is `owner: maintainer`. Core does not grade another lane's
work, and a core-authored `met` here would have been the gate bent rather than satisfied.

Shipping 0.13.13 does not make the c4 skew worse: the failure needs a Desktop build
talking to a core *older* than `SessionCreateRequest::mcp_servers`, and a newer core moves
every user it reaches away from that pair.

## 2. `gpt-6-astra` appeared on models.dev and nothing armed it

The freshness gate failed between two runs 30 minutes apart. `gpt-6-astra` is served by
the vendor-operated `openai` endpoint at **1,050,000 / 128,000** and had no arm, so it
took the default — and the default here is not merely conservative:

```
gpt-6-astra on `passthrough`: NO ARM AT ALL. A missing arm is not a safe default --
`known_context_window` substitutes UNVERIFIED_CONTEXT_WINDOW (32,768) and a
non-omit-safe preset clamps output to UNKNOWN_CAP (8,192).
```

A 1.05M-window model sized at 32,768. That is customer bug #165's exact shape.

Matched on the full `gpt-6-astra`, **not** a bare `gpt-6`: the 5.x family splits
(`-mini`/`-nano`/`-codex` stay at 400k), so a family-wide claim would over-claim siblings
nobody has seen. The `-pro` and `-fast` variants report the identical pair everywhere they
appear, so one substring covers all three at figures none of them disagree with. The lone
dissent is `llmgateway` at `output == context == 1,050,000`, the aggregator "unknown"
spelling rather than a ceiling.

**Both arms proven**, mutation asserted to have landed before the result was believed:

```
arm removed  -> every_passthrough_vendor_model_resolves_its_arm FAILED
arm restored -> 40 passed; 0 failed
```

## Verification (hetzner full clone — the Mac's shallow clone SKIPS the ledger ancestry arm)

| gate | before | after |
|---|---|---|
| `check-criteria-ledger.py` | OK | OK |
| `check-release-readiness.py` | **FAIL — #1225** | **OK, RC=0** |
| `check-model-limits-freshness.py` | **FAIL — gpt-6-astra** | **PASS, RC=0** |
| all three `--self-test` | RC=0 | RC=0 |
| `cargo fmt --all --check` / `clippy -p wcore-config -D warnings` | — | RC=0 / RC=0 |
| `cargo test -p wcore-config --lib limits` | — | 40 passed |
